### PR TITLE
Tighten linting and harden CLI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1712,7 @@ dependencies = [
 name = "weaver-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap",
  "ortho_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,9 @@ missing_docs = "deny"
 
 [workspace.lints.rustdoc]
 missing_crate_level_docs = "deny"
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "deny"
+bare_urls = "deny"
+invalid_html_tags = "deny"
+invalid_codeblock_attributes = "deny"
+unescaped_backticks = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,5 +89,9 @@ error_impl_error = "deny"
 result_large_err = "deny"
 
 [workspace.lints.rust]
+unknown_lints = "deny"
+renamed_and_removed_lints = "deny"
 missing_docs = "deny"
+
+[workspace.lints.rustdoc]
 missing_crate_level_docs = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 rust-version = "1.85"
 
 [workspace.dependencies]
+anyhow = "1.0"
 camino = { version = "1.1", features = ["serde1"] }
 clap = { version = "4.5", features = ["derive"] }
 once_cell = "1.19"
@@ -32,19 +33,24 @@ pedantic = { level = "warn", priority = -1 }
 allow_attributes = "deny"
 allow_attributes_without_reason = "deny"
 blanket_clippy_restriction_lints = "deny"
+cognitive_complexity = "deny"
+needless_pass_by_value = "deny"
+implicit_hasher = "deny"
 
 # 2. debugging leftovers
 dbg_macro = "deny"
 print_stdout = "deny"
 print_stderr = "deny"
 
-# 3. panic-prone operations
+# 2. panic-prone operations
 unwrap_used = "deny"
 expect_used = "deny"
 indexing_slicing = "deny"
 string_slice = "deny"
 integer_division = "deny"
 integer_division_remainder_used = "deny"
+panic_in_result_fn = "deny"
+unreachable = "deny"
 
 # 4. portability
 host_endian_bytes = "deny"
@@ -52,10 +58,36 @@ little_endian_bytes = "deny"
 big_endian_bytes = "deny"
 
 # 5. nursery idiom polish
+let_underscore_must_use = "deny"
 or_fun_call = "deny"
 option_if_let_else = "deny"
-use_self = "deny"
+self_named_module_files = "deny"
+shadow_reuse = "deny"
+shadow_same = "deny"
+shadow_unrelated = "deny"
+str_to_string = "deny"
 string_lit_as_bytes = "deny"
+try_err = "deny"
+unneeded_field_pattern = "deny"
+use_self = "deny"
 
 # 6. numerical foot-guns
 float_arithmetic = "deny"
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"
+cast_precision_loss = "deny"
+lossy_float_literal = "deny"
+
+# 7. API ergonomics
+missing_const_for_fn = "deny"
+must_use_candidate = "deny"
+unused_async = "deny"
+
+# 8. Error handling
+missing_panics_doc = "deny"
+error_impl_error = "deny"
+result_large_err = "deny"
+
+[workspace.lints.rust]
+missing_docs = "deny"
+missing_crate_level_docs = "deny"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ APP ?= weaver-cli
 CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --workspace --all-targets --all-features -- -D warnings
+RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= markdownlint
 NIXIE ?= nixie
 
@@ -22,6 +23,7 @@ target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
 
 lint: ## Run Clippy with warnings denied
+	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --workspace --no-deps
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 
 fmt: ## Format Rust and Markdown sources

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,7 @@
 # Align with CodeScene’s ceiling
-cognitive-complexity-threshold = 12     # default is 25
+cognitive-complexity-threshold = 9     # default is 25 
+too-many-arguments-threshold = 4       # default is 7
+too-many-lines-threshold = 70          # default is 100
+excessive-nesting-threshold = 4        # default is off
+
+allow-expect-in-tests = true

--- a/crates/weaver-cli/Cargo.toml
+++ b/crates/weaver-cli/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = { workspace = true }
 socket2 = { version = "0.5" }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }

--- a/crates/weaver-cli/src/tests/behaviour.rs
+++ b/crates/weaver-cli/src/tests/behaviour.rs
@@ -8,11 +8,12 @@ use crate::EMPTY_LINE_LIMIT;
 
 use std::cell::RefCell;
 
+use anyhow::Result;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 #[given("a running fake daemon")]
-fn given_running_daemon(world: &RefCell<TestWorld>) {
-    world.borrow_mut().start_daemon();
+fn given_running_daemon(world: &RefCell<TestWorld>) -> Result<()> {
+    world.borrow_mut().start_daemon()
 }
 
 #[given("capability overrides force python rename")]
@@ -21,56 +22,58 @@ fn given_capability_override(world: &RefCell<TestWorld>) {
 }
 
 #[given("a running fake daemon sending malformed json")]
-fn given_malformed_daemon(world: &RefCell<TestWorld>) {
+fn given_malformed_daemon(world: &RefCell<TestWorld>) -> Result<()> {
     world
         .borrow_mut()
-        .start_daemon_with_lines(vec![String::from("not valid json")]);
+        .start_daemon_with_lines(vec![String::from("not valid json")])
 }
 
 #[given("a running fake daemon that closes without exit")]
-fn given_daemon_missing_exit(world: &RefCell<TestWorld>) {
+fn given_daemon_missing_exit(world: &RefCell<TestWorld>) -> Result<()> {
     world.borrow_mut().start_daemon_with_lines(vec![
         "{\"kind\":\"stream\",\"stream\":\"stdout\",\"data\":\"partial\"}".to_string(),
-    ]);
+    ])
 }
 
 #[given("a running fake daemon that emits empty lines")]
-fn given_daemon_with_empty_lines(world: &RefCell<TestWorld>) {
+fn given_daemon_with_empty_lines(world: &RefCell<TestWorld>) -> Result<()> {
     let mut lines = Vec::new();
     for _ in 0..EMPTY_LINE_LIMIT {
         lines.push(String::new());
     }
-    world.borrow_mut().start_daemon_with_lines(lines);
+    world.borrow_mut().start_daemon_with_lines(lines)
 }
 
 #[when("the operator runs {command}")]
-fn when_operator_runs(world: &RefCell<TestWorld>, command: String) {
-    world.borrow_mut().run(&command);
+fn when_operator_runs(world: &RefCell<TestWorld>, command: String) -> Result<()> {
+    world.borrow_mut().run(&command)
 }
 
 #[then("the daemon receives {fixture}")]
-fn then_daemon_receives(world: &RefCell<TestWorld>, fixture: String) {
-    world.borrow().assert_golden_request(&fixture);
+fn then_daemon_receives(world: &RefCell<TestWorld>, fixture: String) -> Result<()> {
+    world.borrow().assert_golden_request(&fixture)
 }
 
 #[then("stdout is {expected}")]
-fn then_stdout_is(world: &RefCell<TestWorld>, expected: String) {
+fn then_stdout_is(world: &RefCell<TestWorld>, expected: String) -> Result<()> {
     let world = world.borrow();
     let expected = expected.trim_matches('"');
-    assert_eq!(world.stdout_text(), expected);
+    assert_eq!(world.stdout_text()?, expected);
+    Ok(())
 }
 
 #[then("stderr is {expected}")]
-fn then_stderr_is(world: &RefCell<TestWorld>, expected: String) {
+fn then_stderr_is(world: &RefCell<TestWorld>, expected: String) -> Result<()> {
     let world = world.borrow();
     let expected = expected.trim_matches('"');
-    assert_eq!(world.stderr_text(), expected);
+    assert_eq!(world.stderr_text()?, expected);
+    Ok(())
 }
 
 #[then("stderr contains {snippet}")]
-fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) {
+fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) -> Result<()> {
     let world = world.borrow();
-    let stderr = world.stderr_text();
+    let stderr = world.stderr_text()?;
     let snippet = snippet.trim_matches('"');
     assert!(
         stderr.contains(snippet),
@@ -78,24 +81,26 @@ fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) {
         stderr,
         snippet
     );
+    Ok(())
 }
 
 #[then("the CLI exits with code {status}")]
-fn then_exit_code(world: &RefCell<TestWorld>, status: u8) {
-    world.borrow().assert_exit_code(status);
+fn then_exit_code(world: &RefCell<TestWorld>, status: u8) -> Result<()> {
+    world.borrow().assert_exit_code(status)
 }
 
 #[then("the CLI fails")]
-fn then_exit_failure(world: &RefCell<TestWorld>) {
-    world.borrow().assert_failure();
+fn then_exit_failure(world: &RefCell<TestWorld>) -> Result<()> {
+    world.borrow().assert_failure()
 }
 
 #[then("capabilities output is {fixture}")]
-fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) {
-    world.borrow().assert_capabilities_output(&fixture);
+fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) -> Result<()> {
+    world.borrow().assert_capabilities_output(&fixture)
 }
 
 #[scenario(path = "tests/features/weaver_cli.feature")]
-fn weaver_cli_behaviour(world: RefCell<TestWorld>) {
+fn weaver_cli_behaviour(world: RefCell<TestWorld>) -> Result<()> {
     let _ = world;
+    Ok(())
 }

--- a/crates/weaver-cli/src/tests/support.rs
+++ b/crates/weaver-cli/src/tests/support.rs
@@ -8,13 +8,14 @@ use std::cell::RefCell;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::{AppError, ConfigLoader, run_with_loader};
+use anyhow::{Context, Result, anyhow, ensure};
 use rstest::fixture;
 use weaver_config::{CapabilityDirective, CapabilityOverride, Config, SocketEndpoint};
 
@@ -45,14 +46,15 @@ pub(super) struct TestWorld {
 }
 
 impl TestWorld {
-    pub fn start_daemon(&mut self) {
-        self.start_daemon_with_lines(default_daemon_lines());
+    pub fn start_daemon(&mut self) -> Result<()> {
+        self.start_daemon_with_lines(default_daemon_lines())
     }
 
-    pub fn start_daemon_with_lines(&mut self, lines: Vec<String>) {
-        let daemon = FakeDaemon::spawn(lines);
+    pub fn start_daemon_with_lines(&mut self, lines: Vec<String>) -> Result<()> {
+        let daemon = FakeDaemon::spawn(lines)?;
         self.config.daemon_socket = SocketEndpoint::tcp("127.0.0.1", daemon.port());
         self.daemon = Some(daemon);
+        Ok(())
     }
 
     pub fn configure_capability_override(&mut self) {
@@ -63,7 +65,7 @@ impl TestWorld {
         )];
     }
 
-    pub fn run(&mut self, command: &str) {
+    pub fn run(&mut self, command: &str) -> Result<()> {
         self.stdout.clear();
         self.stderr.clear();
         self.requests.clear();
@@ -72,9 +74,10 @@ impl TestWorld {
         let exit = run_with_loader(args, &mut self.stdout, &mut self.stderr, &loader);
         self.exit_code = Some(exit);
         if let Some(daemon) = self.daemon.as_mut() {
-            self.requests = daemon.take_requests();
+            self.requests = daemon.take_requests()?;
         }
         self.daemon = None;
+        Ok(())
     }
 
     fn build_args(command: &str) -> Vec<OsString> {
@@ -90,33 +93,57 @@ impl TestWorld {
         args
     }
 
-    pub fn stdout_text(&self) -> String {
-        String::from_utf8(self.stdout.clone()).expect("stdout utf8")
+    pub fn stdout_text(&self) -> Result<String> {
+        String::from_utf8(self.stdout.clone()).context("stdout utf8")
     }
 
-    pub fn stderr_text(&self) -> String {
-        String::from_utf8(self.stderr.clone()).expect("stderr utf8")
+    pub fn stderr_text(&self) -> Result<String> {
+        String::from_utf8(self.stderr.clone()).context("stderr utf8")
     }
 
-    pub fn assert_exit_code(&self, expected: u8) {
-        let exit = self.exit_code.expect("exit code recorded");
-        assert_eq!(exit, ExitCode::from(expected));
+    pub fn assert_exit_code(&self, expected: u8) -> Result<()> {
+        let exit = self.exit_code.context("exit code recorded")?;
+        ensure!(
+            exit == ExitCode::from(expected),
+            "expected exit code {expected}, got {:?}",
+            exit
+        );
+        Ok(())
     }
 
-    pub fn assert_failure(&self) {
-        let exit = self.exit_code.expect("exit code recorded");
-        assert_eq!(exit, ExitCode::FAILURE);
+    pub fn assert_failure(&self) -> Result<()> {
+        let exit = self.exit_code.context("exit code recorded")?;
+        ensure!(
+            exit == ExitCode::FAILURE,
+            "expected failure exit code, got {:?}",
+            exit
+        );
+        Ok(())
     }
 
-    pub fn assert_golden_request(&self, fixture: &str) {
-        assert_eq!(self.requests.len(), 1, "expected single request");
-        let expected = read_fixture(fixture);
-        assert_eq!(self.requests[0], expected);
+    pub fn assert_golden_request(&self, fixture: &str) -> Result<()> {
+        ensure!(
+            self.requests.len() == 1,
+            "expected single request but found {}",
+            self.requests.len()
+        );
+        let expected = read_fixture(fixture)?;
+        let actual = self.requests.first().context("request missing")?;
+        ensure!(
+            actual == &expected,
+            "request mismatch: expected {expected:?}, got {actual:?}"
+        );
+        Ok(())
     }
 
-    pub fn assert_capabilities_output(&self, fixture: &str) {
-        let expected = read_fixture(fixture);
-        assert_eq!(self.stdout_text(), expected);
+    pub fn assert_capabilities_output(&self, fixture: &str) -> Result<()> {
+        let expected = read_fixture(fixture)?;
+        let stdout = self.stdout_text()?;
+        ensure!(
+            stdout == expected,
+            "capabilities output mismatch: expected {expected:?}, got {stdout:?}"
+        );
+        Ok(())
     }
 }
 
@@ -127,42 +154,75 @@ pub(super) struct FakeDaemon {
 }
 
 impl FakeDaemon {
-    pub fn spawn(lines: Vec<String>) -> Self {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind fake daemon");
-        let port = listener.local_addr().expect("local addr").port();
+    pub fn spawn(lines: Vec<String>) -> Result<Self> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).context("bind fake daemon")?;
+        let port = listener.local_addr().context("local addr")?.port();
         let requests: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let requests_clone = Arc::clone(&requests);
         let handle = thread::spawn(move || {
-            if let Ok((stream, _)) = listener.accept() {
-                let mut line = String::new();
-                let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
-                if reader.read_line(&mut line).expect("read command request") > 0 {
-                    requests_clone.lock().expect("lock requests").push(line);
-                }
-                let mut writer = stream;
-                for payload in lines {
-                    writer.write_all(payload.as_bytes()).expect("write payload");
-                    writer.write_all(b"\n").expect("write newline");
-                    writer.flush().expect("flush payload");
-                }
+            if let Err(error) = Self::serve_client(listener, lines, requests_clone) {
+                panic!("fake daemon failed: {error:?}");
             }
         });
-        Self {
+        Ok(Self {
             port,
             requests,
             handle: Some(handle),
-        }
+        })
     }
 
     pub fn port(&self) -> u16 {
         self.port
     }
 
-    pub fn take_requests(&mut self) -> Vec<String> {
+    pub fn take_requests(&mut self) -> Result<Vec<String>> {
         if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+            handle
+                .join()
+                .map_err(|_| anyhow!("fake daemon thread panicked"))?;
         }
-        self.requests.lock().expect("lock requests").clone()
+        let requests = self
+            .requests
+            .lock()
+            .map_err(|error| anyhow!("lock requests: {error}"))?;
+        Ok(requests.clone())
+    }
+
+    fn serve_client(
+        listener: TcpListener,
+        lines: Vec<String>,
+        requests: Arc<Mutex<Vec<String>>>,
+    ) -> Result<()> {
+        let (stream, _) = listener.accept().context("accept connection")?;
+        Self::record_request(&stream, &requests)?;
+        Self::stream_responses(stream, &lines)
+    }
+
+    fn record_request(stream: &TcpStream, requests: &Arc<Mutex<Vec<String>>>) -> Result<()> {
+        let mut line = String::new();
+        let mut reader = BufReader::new(stream.try_clone().context("clone stream")?);
+        if reader
+            .read_line(&mut line)
+            .context("read command request")?
+            == 0
+        {
+            return Ok(());
+        }
+        let mut guard = requests
+            .lock()
+            .map_err(|error| anyhow!("lock requests: {error}"))?;
+        guard.push(line);
+        Ok(())
+    }
+
+    fn stream_responses(mut stream: TcpStream, lines: &[String]) -> Result<()> {
+        for payload in lines {
+            stream
+                .write_all(payload.as_bytes())
+                .context("write payload")?;
+            stream.write_all(b"\n").context("write newline")?;
+        }
+        stream.flush().context("flush payloads")
     }
 }
 
@@ -174,14 +234,13 @@ impl Drop for FakeDaemon {
     }
 }
 
-pub(super) fn read_fixture(name: &str) -> String {
+pub(super) fn read_fixture(name: &str) -> Result<String> {
     let normalized = name.trim().trim_matches('"');
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests");
     path.push("golden");
     path.push(normalized);
-    fs::read_to_string(&path)
-        .unwrap_or_else(|error| panic!("read fixture at {}: {error}", path.display()))
+    fs::read_to_string(&path).with_context(|| format!("read fixture at {}", path.display()))
 }
 
 pub(super) fn default_daemon_lines() -> Vec<String> {

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -2,10 +2,12 @@ use super::support::{default_daemon_lines, read_fixture};
 
 use std::cell::RefCell;
 use std::ffi::OsString;
-use std::io::{self, BufRead, Cursor, Write};
-use std::net::TcpListener;
+use std::io::{self, BufRead, BufReader, Cursor, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::process::ExitCode;
 use std::thread;
+
+use anyhow::{Context, Result, anyhow};
 
 use crate::{
     AppError, Cli, CommandDescriptor, CommandInvocation, CommandRequest, ConfigLoader,
@@ -15,7 +17,7 @@ use rstest::rstest;
 use weaver_config::{Config, SocketEndpoint};
 
 #[test]
-fn serialises_command_request_matches_golden() {
+fn serialises_command_request_matches_golden() -> Result<()> {
     let invocation = CommandInvocation {
         domain: String::from("observe"),
         operation: String::from("get-definition"),
@@ -25,10 +27,11 @@ fn serialises_command_request_matches_golden() {
     let mut buffer: Vec<u8> = Vec::new();
     request
         .write_jsonl(&mut buffer)
-        .expect("serialises request");
-    let actual = String::from_utf8(buffer).expect("request utf8");
-    let expected = read_fixture("request_observe_get_definition.jsonl");
+        .context("serialises request")?;
+    let actual = String::from_utf8(buffer).context("request utf8")?;
+    let expected = read_fixture("request_observe_get_definition.jsonl")?;
     assert_eq!(actual, expected);
+    Ok(())
 }
 
 #[rstest]
@@ -87,18 +90,19 @@ fn exit_code_from_status_out_of_range_defaults_to_failure() {
 }
 
 #[test]
-fn read_daemon_messages_errors_without_exit() {
+fn read_daemon_messages_errors_without_exit() -> Result<()> {
     let input = b"{\"kind\":\"stream\",\"stream\":\"stdout\",\"data\":\"hi\"}\n";
     let mut cursor = Cursor::new(&input[..]);
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     let error = read_daemon_messages(&mut cursor, &mut stdout, &mut stderr).unwrap_err();
     assert!(matches!(error, AppError::MissingExit));
-    assert_eq!(String::from_utf8(stdout).unwrap(), "hi");
+    assert_eq!(String::from_utf8(stdout).context("stdout utf8")?, "hi");
+    Ok(())
 }
 
 #[test]
-fn read_daemon_messages_warns_after_empty_lines() {
+fn read_daemon_messages_warns_after_empty_lines() -> Result<()> {
     let mut payload = Vec::new();
     for _ in 0..EMPTY_LINE_LIMIT {
         payload.extend_from_slice(b"\n");
@@ -108,21 +112,23 @@ fn read_daemon_messages_warns_after_empty_lines() {
     let mut stderr = Vec::new();
     let error = read_daemon_messages(&mut cursor, &mut stdout, &mut stderr).unwrap_err();
     assert!(matches!(error, AppError::MissingExit));
-    let warning = String::from_utf8(stderr).unwrap();
+    let warning = String::from_utf8(stderr).context("stderr utf8")?;
     assert!(warning.contains("Warning: received"));
+    Ok(())
 }
 
 #[test]
-fn read_daemon_messages_fails_on_malformed_json() {
+fn read_daemon_messages_fails_on_malformed_json() -> Result<()> {
     let mut cursor = Cursor::new(Vec::from("this is not json\n"));
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     let error = read_daemon_messages(&mut cursor, &mut stdout, &mut stderr).unwrap_err();
     assert!(matches!(error, AppError::ParseMessage(_)));
+    Ok(())
 }
 
 #[test]
-fn run_with_loader_reports_configuration_failures() {
+fn run_with_loader_reports_configuration_failures() -> Result<()> {
     struct FailingLoader;
 
     impl ConfigLoader for FailingLoader {
@@ -142,13 +148,14 @@ fn run_with_loader_reports_configuration_failures() {
     assert_eq!(exit, ExitCode::FAILURE);
     assert!(
         String::from_utf8(stderr)
-            .unwrap()
+            .context("stderr utf8")?
             .contains("command domain")
     );
+    Ok(())
 }
 
 #[test]
-fn run_with_loader_filters_configuration_arguments() {
+fn run_with_loader_filters_configuration_arguments() -> Result<()> {
     struct RecordingLoader {
         recorded: RefCell<Vec<OsString>>,
     }
@@ -209,18 +216,19 @@ fn run_with_loader_filters_configuration_arguments() {
 
     assert!(!stderr.is_empty());
     assert!(stdout.is_empty());
+    Ok(())
 }
 
 /// Exercises a full daemon connection cycle: connect, write JSONL request,
 /// read daemon messages, and verify exit status. The caller provides a setup
 /// closure that spawns a listener thread and returns the endpoint.
-fn test_daemon_connection<F>(setup_listener: F)
+fn test_daemon_connection<F>(setup_listener: F) -> Result<()>
 where
-    F: FnOnce() -> (SocketEndpoint, thread::JoinHandle<()>),
+    F: FnOnce() -> Result<(SocketEndpoint, thread::JoinHandle<()>)>,
 {
-    let (endpoint, handle) = setup_listener();
+    let (endpoint, handle) = setup_listener()?;
 
-    let mut connection = connect(&endpoint).expect("connect to daemon");
+    let mut connection = connect(&endpoint).context("connect to daemon")?;
     let request = CommandRequest {
         command: CommandDescriptor {
             domain: "observe".into(),
@@ -228,70 +236,120 @@ where
         },
         arguments: Vec::new(),
     };
-    request.write_jsonl(&mut connection).expect("write request");
+    request
+        .write_jsonl(&mut connection)
+        .context("write request")?;
 
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let status =
-        read_daemon_messages(&mut connection, &mut stdout, &mut stderr).expect("read responses");
+    let status = read_daemon_messages(&mut connection, &mut stdout, &mut stderr)
+        .context("read responses")?;
     assert_eq!(status, 17);
 
-    handle.join().expect("join listener thread");
+    handle
+        .join()
+        .map_err(|_| anyhow!("listener thread panicked"))?;
+    Ok(())
 }
 
 #[test]
-fn connect_successfully_establishes_tcp_connection() {
+fn connect_successfully_establishes_tcp_connection() -> Result<()> {
     test_daemon_connection(|| {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
-        let port = listener.local_addr().unwrap().port();
+        let listener = TcpListener::bind(("127.0.0.1", 0)).context("bind listener")?;
+        let port = listener.local_addr().context("listener local addr")?.port();
 
         let handle = thread::spawn(move || {
-            if let Ok((stream, _)) = listener.accept() {
-                let mut buffer = String::new();
-                let mut reader = io::BufReader::new(stream.try_clone().unwrap());
-                let _ = reader.read_line(&mut buffer);
-                let mut writer = stream;
-                for line in default_daemon_lines() {
-                    writer.write_all(line.as_bytes()).unwrap();
-                    writer.write_all(b"\n").unwrap();
-                    writer.flush().unwrap();
-                }
+            if let Err(error) = accept_tcp_connection(listener, default_daemon_lines()) {
+                panic!("tcp listener failed: {error:?}");
             }
         });
 
-        (SocketEndpoint::tcp("127.0.0.1", port), handle)
-    });
+        Ok((SocketEndpoint::tcp("127.0.0.1", port), handle))
+    })?;
+    Ok(())
 }
 
 #[cfg(unix)]
 #[test]
-fn connect_supports_unix_sockets() {
+fn connect_supports_unix_sockets() -> Result<()> {
     use std::os::unix::net::UnixListener;
 
-    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = tempfile::tempdir().context("tempdir")?;
     let socket_path = dir.path().join("daemon.sock");
     let socket_path_for_listener = socket_path.clone();
     let socket_display = socket_path
         .to_str()
-        .expect("socket path is utf8")
+        .context("socket path is utf8")?
         .to_owned();
 
     test_daemon_connection(move || {
-        let listener = UnixListener::bind(&socket_path_for_listener).expect("bind unix");
+        let listener = UnixListener::bind(&socket_path_for_listener).context("bind unix")?;
 
         let handle = thread::spawn(move || {
-            if let Ok((mut stream, _)) = listener.accept() {
-                let mut buffer = String::new();
-                let mut reader = io::BufReader::new(stream.try_clone().unwrap());
-                let _ = reader.read_line(&mut buffer);
-                for line in default_daemon_lines() {
-                    stream.write_all(line.as_bytes()).unwrap();
-                    stream.write_all(b"\n").unwrap();
-                    stream.flush().unwrap();
-                }
+            if let Err(error) = accept_unix_connection(listener, default_daemon_lines()) {
+                panic!("unix listener failed: {error:?}");
             }
         });
 
-        (SocketEndpoint::unix(socket_display), handle)
-    });
+        Ok((SocketEndpoint::unix(socket_display), handle))
+    })?;
+    Ok(())
+}
+
+fn accept_tcp_connection(listener: TcpListener, lines: Vec<String>) -> Result<()> {
+    let (stream, _) = listener.accept().context("accept tcp connection")?;
+    respond_to_request(stream, &lines)
+}
+
+#[cfg(unix)]
+fn accept_unix_connection(
+    listener: std::os::unix::net::UnixListener,
+    lines: Vec<String>,
+) -> Result<()> {
+    let (stream, _) = listener.accept().context("accept unix connection")?;
+    respond_to_request(stream, &lines)
+}
+
+fn respond_to_request<T>(mut stream: T, lines: &[String]) -> Result<()>
+where
+    T: TryCloneStream,
+{
+    let mut buffer = String::new();
+    {
+        let clone = stream.try_clone().context("clone stream")?;
+        let mut reader = BufReader::new(clone);
+        let _ = reader.read_line(&mut buffer).context("read request")?;
+    }
+    write_lines(&mut stream, lines).context("write response lines")
+}
+
+fn write_lines(stream: &mut impl Write, lines: &[String]) -> io::Result<()> {
+    for line in lines {
+        stream.write_all(line.as_bytes())?;
+        stream.write_all(b"\n")?;
+    }
+    stream.flush()
+}
+
+trait TryCloneStream: Write {
+    type Owned: Read + Write + Send + 'static;
+
+    fn try_clone(&self) -> io::Result<Self::Owned>;
+}
+
+impl TryCloneStream for TcpStream {
+    type Owned = TcpStream;
+
+    fn try_clone(&self) -> io::Result<Self::Owned> {
+        TcpStream::try_clone(self)
+    }
+}
+
+#[cfg(unix)]
+impl TryCloneStream for std::os::unix::net::UnixStream {
+    type Owned = std::os::unix::net::UnixStream;
+
+    fn try_clone(&self) -> io::Result<Self::Owned> {
+        std::os::unix::net::UnixStream::try_clone(self)
+    }
 }

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -1,3 +1,8 @@
+//! Unit tests for Weaver CLI core functionality.
+//!
+//! Exercises command serialisation, daemon message parsing, configuration
+//! loading, and socket connection establishment (TCP and Unix domain sockets).
+
 use super::support::{accept_tcp_connection, decode_utf8, default_daemon_lines, read_fixture};
 
 #[cfg(unix)]

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -1,9 +1,12 @@
-use super::support::{default_daemon_lines, read_fixture};
+use super::support::{accept_tcp_connection, decode_utf8, default_daemon_lines, read_fixture};
+
+#[cfg(unix)]
+use super::support::accept_unix_connection;
 
 use std::cell::RefCell;
 use std::ffi::OsString;
-use std::io::{self, BufRead, BufReader, Cursor, Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::io::Cursor;
+use std::net::TcpListener;
 use std::process::ExitCode;
 use std::thread;
 
@@ -28,7 +31,7 @@ fn serialises_command_request_matches_golden() -> Result<()> {
     request
         .write_jsonl(&mut buffer)
         .context("serialises request")?;
-    let actual = String::from_utf8(buffer).context("request utf8")?;
+    let actual = decode_utf8(buffer, "request")?;
     let expected = read_fixture("request_observe_get_definition.jsonl")?;
     assert_eq!(actual, expected);
     Ok(())
@@ -97,7 +100,7 @@ fn read_daemon_messages_errors_without_exit() -> Result<()> {
     let mut stderr = Vec::new();
     let error = read_daemon_messages(&mut cursor, &mut stdout, &mut stderr).unwrap_err();
     assert!(matches!(error, AppError::MissingExit));
-    assert_eq!(String::from_utf8(stdout).context("stdout utf8")?, "hi");
+    assert_eq!(decode_utf8(stdout, "stdout")?, "hi");
     Ok(())
 }
 
@@ -112,7 +115,7 @@ fn read_daemon_messages_warns_after_empty_lines() -> Result<()> {
     let mut stderr = Vec::new();
     let error = read_daemon_messages(&mut cursor, &mut stdout, &mut stderr).unwrap_err();
     assert!(matches!(error, AppError::MissingExit));
-    let warning = String::from_utf8(stderr).context("stderr utf8")?;
+    let warning = decode_utf8(stderr, "stderr")?;
     assert!(warning.contains("Warning: received"));
     Ok(())
 }
@@ -146,11 +149,7 @@ fn run_with_loader_reports_configuration_failures() -> Result<()> {
         &FailingLoader,
     );
     assert_eq!(exit, ExitCode::FAILURE);
-    assert!(
-        String::from_utf8(stderr)
-            .context("stderr utf8")?
-            .contains("command domain")
-    );
+    assert!(decode_utf8(stderr, "stderr")?.contains("command domain"));
     Ok(())
 }
 
@@ -294,62 +293,4 @@ fn connect_supports_unix_sockets() -> Result<()> {
         Ok((SocketEndpoint::unix(socket_display), handle))
     })?;
     Ok(())
-}
-
-fn accept_tcp_connection(listener: TcpListener, lines: Vec<String>) -> Result<()> {
-    let (stream, _) = listener.accept().context("accept tcp connection")?;
-    respond_to_request(stream, &lines)
-}
-
-#[cfg(unix)]
-fn accept_unix_connection(
-    listener: std::os::unix::net::UnixListener,
-    lines: Vec<String>,
-) -> Result<()> {
-    let (stream, _) = listener.accept().context("accept unix connection")?;
-    respond_to_request(stream, &lines)
-}
-
-fn respond_to_request<T>(mut stream: T, lines: &[String]) -> Result<()>
-where
-    T: TryCloneStream,
-{
-    let mut buffer = String::new();
-    {
-        let clone = stream.try_clone().context("clone stream")?;
-        let mut reader = BufReader::new(clone);
-        let _ = reader.read_line(&mut buffer).context("read request")?;
-    }
-    write_lines(&mut stream, lines).context("write response lines")
-}
-
-fn write_lines(stream: &mut impl Write, lines: &[String]) -> io::Result<()> {
-    for line in lines {
-        stream.write_all(line.as_bytes())?;
-        stream.write_all(b"\n")?;
-    }
-    stream.flush()
-}
-
-trait TryCloneStream: Write {
-    type Owned: Read + Write + Send + 'static;
-
-    fn try_clone(&self) -> io::Result<Self::Owned>;
-}
-
-impl TryCloneStream for TcpStream {
-    type Owned = TcpStream;
-
-    fn try_clone(&self) -> io::Result<Self::Owned> {
-        TcpStream::try_clone(self)
-    }
-}
-
-#[cfg(unix)]
-impl TryCloneStream for std::os::unix::net::UnixStream {
-    type Owned = std::os::unix::net::UnixStream;
-
-    fn try_clone(&self) -> io::Result<Self::Owned> {
-        std::os::unix::net::UnixStream::try_clone(self)
-    }
 }


### PR DESCRIPTION
## Summary
- align the workspace lint configuration with the stricter clippy and rust rules
- refactor the CLI test support to use anyhow-powered fallible helpers and reduce nesting
- update CLI behaviour and unit tests to propagate errors instead of panicking

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68fbfe4e32648322a04db1753cd58835

## Summary by Sourcery

Tighten linting rules across the workspace and harden the CLI test suite by refactoring tests to use fallible helpers with anyhow, extracting shared networking logic, and replacing panics with propagated errors

Enhancements:
- Align workspace and clippy lint configurations with stricter deny rules and reduced complexity thresholds
- Refactor CLI test support by extracting common daemon connection logic into fallible helpers using anyhow

Build:
- Add anyhow as a workspace and crate dependency

Tests:
- Convert unit and behaviour tests to return Result and replace unwraps/expect with error propagation and context
- Update TestWorld and FakeDaemon support methods to use anyhow-based error handling and ensure assertions return Results