### PR TITLE
Clarify backend failure error field format

### DIFF
--- a/crates/weaverd/src/health.rs
+++ b/crates/weaverd/src/health.rs
@@ -102,6 +102,7 @@ impl HealthReporter for StructuredHealthReporter {
     }
 }
 
+#[inline]
 fn display_error<E>(error: &E) -> tracing::field::DisplayValue<&E>
 where
     E: fmt::Display + ?Sized,

--- a/crates/weaverd/src/health.rs
+++ b/crates/weaverd/src/health.rs
@@ -102,6 +102,7 @@ impl HealthReporter for StructuredHealthReporter {
     }
 }
 
+/// Wraps an error reference so tracing records its `Display` representation.
 #[inline]
 fn display_error<E>(error: &E) -> tracing::field::DisplayValue<&E>
 where

--- a/crates/weaverd/src/health.rs
+++ b/crates/weaverd/src/health.rs
@@ -87,6 +87,8 @@ impl HealthReporter for StructuredHealthReporter {
     }
 
     fn backend_failed(&self, error: &BackendStartupError) {
+        // Emit the backend error using `Display` to match the
+        // `bootstrap_failed` schema field format.
         health_event!(
             error,
             event = "backend_failed",

--- a/crates/weaverd/src/health.rs
+++ b/crates/weaverd/src/health.rs
@@ -3,6 +3,8 @@
 use crate::backends::{BackendKind, BackendStartupError};
 use crate::bootstrap::BootstrapError;
 
+use std::fmt;
+
 use weaver_config::Config;
 
 const HEALTH_TARGET: &str = concat!(env!("CARGO_PKG_NAME"), "::health");
@@ -73,7 +75,7 @@ impl HealthReporter for StructuredHealthReporter {
         health_event!(
             error,
             event = "bootstrap_failed",
-            error = %error,
+            error = display_error(error),
             "daemon bootstrap failed"
         );
     }
@@ -86,16 +88,23 @@ impl HealthReporter for StructuredHealthReporter {
         health_event!(info, event = "backend_ready", backend = %kind, "backend ready");
     }
 
+    /// Emits the backend error using `Display` to match the
+    /// `bootstrap_failed` schema field format.
     fn backend_failed(&self, error: &BackendStartupError) {
-        // Emit the backend error using `Display` to match the
-        // `bootstrap_failed` schema field format.
         health_event!(
             error,
             event = "backend_failed",
             backend = %error.kind,
             message = %error.message(),
-            error = %error,
+            error = display_error(error),
             "backend failed to start"
         );
     }
+}
+
+fn display_error<E>(error: &E) -> tracing::field::DisplayValue<&E>
+where
+    E: fmt::Display + ?Sized,
+{
+    tracing::field::display(error)
 }


### PR DESCRIPTION
## Summary
- document that the backend failure health event emits the error via `Display` to match the schema used for bootstrap failures

## Testing
- make check-fmt

------
https://chatgpt.com/codex/tasks/task_e_6902932286c48322b49d2decf8c5cb97

## Summary by Sourcery

Documentation:
- Add comment explaining that `backend_failed` uses `Display` for its error field format