### PR TITLE
Upgrade rstest-bdd to v0.1.0 and align tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,10 +117,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -250,6 +274,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,10 +338,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "directories"
@@ -398,12 +479,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash",
+ "self_cell",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -528,6 +663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +740,53 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "sys-locale",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "icu_collections"
@@ -718,6 +910,25 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
 
 [[package]]
 name = "inventory"
@@ -1108,6 +1319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,32 +1441,40 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd"
-version = "0.1.0-alpha4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ba71895dfbfa7c211f93d2e0a5303b6c16ce3df3493caa8259381521d7e59b"
+checksum = "c0c58a595280bc9d8386a1888aac2264838ce90f29450dfa50d4b9a00cbbcc63"
 dependencies = [
  "ctor",
+ "derive_more",
+ "fluent",
  "gherkin",
  "hashbrown",
+ "i18n-embed",
  "inventory",
  "log",
+ "once_cell",
  "regex",
  "rstest-bdd-patterns",
+ "rust-embed",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "unic-langid",
 ]
 
 [[package]]
 name = "rstest-bdd-macros"
-version = "0.1.0-alpha4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55203268dc22a1120a17e6c3abd746876da92bd00a2cd2db4e0125d5e32a293"
+checksum = "7db2930cac8d70e8a7d4aab1e0b6782b6aadfef3b68d6acf91179e8433ec44df"
 dependencies = [
  "camino",
  "cap-std",
  "cfg-if",
+ "convert_case 0.6.0",
  "gherkin",
+ "once_cell",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
@@ -1287,6 +1512,46 @@ dependencies = [
  "syn 2.0.106",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.106",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1346,6 +1611,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2f82143577edb4921b71ede051dac62ca3c16084e918bf7b40c96ae10eb33"
 
 [[package]]
 name = "semver"
@@ -1412,6 +1683,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1537,6 +1819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1945,15 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1824,6 +2124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,12 +2153,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+ "unic-langid-macros",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn 2.0.106",
+ "unic-langid-impl",
 ]
 
 [[package]]
@@ -1863,6 +2222,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,8 +1457,6 @@ dependencies = [
  "regex",
  "rstest-bdd-patterns",
  "rust-embed",
- "serde",
- "serde_json",
  "thiserror 1.0.69",
  "unic-langid",
 ]
@@ -1487,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.1.0-alpha4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e86cae3abdbeecef13e120bdedaa6d96e9d3fee9b83efa58b86fc250fdf32f"
+checksum = "dee8d9e47e63602b9061a3d73e48c0248f49d5bc730d64a8b27750f09342f81b"
 dependencies = [
  "regex",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ clap = { version = "4.5", features = ["derive"] }
 once_cell = "1.19"
 ortho_config = "0.5.0"
 rstest = "0.23"
-rstest-bdd = "0.1.0-alpha4"
-rstest-bdd-macros = "0.1.0-alpha4"
+rstest-bdd = "0.1.0"
+rstest-bdd-macros = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.5", features = ["derive"] }
 once_cell = "1.19"
 ortho_config = "0.5.0"
 rstest = "0.23"
-rstest-bdd = "0.1.0"
+rstest-bdd = { version = "0.1.0", default-features = false }
 rstest-bdd-macros = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/weaver-cli/src/tests/behaviour.rs
+++ b/crates/weaver-cli/src/tests/behaviour.rs
@@ -8,12 +8,14 @@ use crate::EMPTY_LINE_LIMIT;
 
 use std::cell::RefCell;
 
-use anyhow::Result;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 #[given("a running fake daemon")]
-fn given_running_daemon(world: &RefCell<TestWorld>) -> Result<()> {
-    world.borrow_mut().start_daemon()
+fn given_running_daemon(world: &RefCell<TestWorld>) {
+    world
+        .borrow_mut()
+        .start_daemon()
+        .expect("failed to start fake daemon");
 }
 
 #[given("capability overrides force python rename")]
@@ -22,58 +24,71 @@ fn given_capability_override(world: &RefCell<TestWorld>) {
 }
 
 #[given("a running fake daemon sending malformed json")]
-fn given_malformed_daemon(world: &RefCell<TestWorld>) -> Result<()> {
+fn given_malformed_daemon(world: &RefCell<TestWorld>) {
     world
         .borrow_mut()
         .start_daemon_with_lines(vec![String::from("not valid json")])
+        .expect("failed to start malformed daemon");
 }
 
 #[given("a running fake daemon that closes without exit")]
-fn given_daemon_missing_exit(world: &RefCell<TestWorld>) -> Result<()> {
-    world.borrow_mut().start_daemon_with_lines(vec![
-        "{\"kind\":\"stream\",\"stream\":\"stdout\",\"data\":\"partial\"}".to_string(),
-    ])
+fn given_daemon_missing_exit(world: &RefCell<TestWorld>) {
+    world
+        .borrow_mut()
+        .start_daemon_with_lines(vec![
+            "{\"kind\":\"stream\",\"stream\":\"stdout\",\"data\":\"partial\"}".to_string(),
+        ])
+        .expect("failed to start daemon missing exit event");
 }
 
 #[given("a running fake daemon that emits empty lines")]
-fn given_daemon_with_empty_lines(world: &RefCell<TestWorld>) -> Result<()> {
+fn given_daemon_with_empty_lines(world: &RefCell<TestWorld>) {
     let mut lines = Vec::new();
     for _ in 0..EMPTY_LINE_LIMIT {
         lines.push(String::new());
     }
-    world.borrow_mut().start_daemon_with_lines(lines)
+    world
+        .borrow_mut()
+        .start_daemon_with_lines(lines)
+        .expect("failed to start daemon with empty lines");
 }
 
 #[when("the operator runs {command}")]
-fn when_operator_runs(world: &RefCell<TestWorld>, command: String) -> Result<()> {
-    world.borrow_mut().run(&command)
+fn when_operator_runs(world: &RefCell<TestWorld>, command: String) {
+    world
+        .borrow_mut()
+        .run(&command)
+        .expect("failed to run CLI command");
 }
 
 #[then("the daemon receives {fixture}")]
-fn then_daemon_receives(world: &RefCell<TestWorld>, fixture: String) -> Result<()> {
-    world.borrow().assert_golden_request(&fixture)
+fn then_daemon_receives(world: &RefCell<TestWorld>, fixture: String) {
+    world
+        .borrow()
+        .assert_golden_request(&fixture)
+        .expect("daemon did not receive expected fixture");
 }
 
 #[then("stdout is {expected}")]
-fn then_stdout_is(world: &RefCell<TestWorld>, expected: String) -> Result<()> {
+fn then_stdout_is(world: &RefCell<TestWorld>, expected: String) {
     let world = world.borrow();
     let expected = expected.trim_matches('"');
-    assert_eq!(world.stdout_text()?, expected);
-    Ok(())
+    let actual = world.stdout_text().expect("stdout text missing");
+    assert_eq!(actual, expected);
 }
 
 #[then("stderr is {expected}")]
-fn then_stderr_is(world: &RefCell<TestWorld>, expected: String) -> Result<()> {
+fn then_stderr_is(world: &RefCell<TestWorld>, expected: String) {
     let world = world.borrow();
     let expected = expected.trim_matches('"');
-    assert_eq!(world.stderr_text()?, expected);
-    Ok(())
+    let actual = world.stderr_text().expect("stderr text missing");
+    assert_eq!(actual, expected);
 }
 
 #[then("stderr contains {snippet}")]
-fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) -> Result<()> {
+fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) {
     let world = world.borrow();
-    let stderr = world.stderr_text()?;
+    let stderr = world.stderr_text().expect("stderr text missing");
     let snippet = snippet.trim_matches('"');
     assert!(
         stderr.contains(snippet),
@@ -81,22 +96,30 @@ fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) -> Result<(
         stderr,
         snippet
     );
-    Ok(())
 }
 
 #[then("the CLI exits with code {status}")]
-fn then_exit_code(world: &RefCell<TestWorld>, status: u8) -> Result<()> {
-    world.borrow().assert_exit_code(status)
+fn then_exit_code(world: &RefCell<TestWorld>, status: u8) {
+    world
+        .borrow()
+        .assert_exit_code(status)
+        .expect("exit code assertion failed");
 }
 
 #[then("the CLI fails")]
-fn then_exit_failure(world: &RefCell<TestWorld>) -> Result<()> {
-    world.borrow().assert_failure()
+fn then_exit_failure(world: &RefCell<TestWorld>) {
+    world
+        .borrow()
+        .assert_failure()
+        .expect("CLI did not fail as expected");
 }
 
 #[then("capabilities output is {fixture}")]
-fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) -> Result<()> {
-    world.borrow().assert_capabilities_output(&fixture)
+fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) {
+    world
+        .borrow()
+        .assert_capabilities_output(&fixture)
+        .expect("capabilities output mismatch");
 }
 
 #[scenario(path = "tests/features/weaver_cli.feature")]

--- a/crates/weaver-cli/src/tests/behaviour.rs
+++ b/crates/weaver-cli/src/tests/behaviour.rs
@@ -100,7 +100,6 @@ fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) -> Result<()> 
 }
 
 #[scenario(path = "tests/features/weaver_cli.feature")]
-fn weaver_cli_behaviour(world: RefCell<TestWorld>) -> Result<()> {
+fn weaver_cli_behaviour(world: RefCell<TestWorld>) {
     let _ = world;
-    Ok(())
 }

--- a/crates/weaverd/src/tests/behaviour.rs
+++ b/crates/weaverd/src/tests/behaviour.rs
@@ -219,9 +219,7 @@ fn then_backend_started_once(world: &RefCell<TestWorld>, backend: String) -> Ste
 }
 
 #[scenario(path = "tests/features/daemon_bootstrap.feature")]
-fn daemon_bootstrap(#[from(world)] _: RefCell<TestWorld>) -> StepResult {
-    Ok(())
-}
+fn daemon_bootstrap(#[from(world)] _: RefCell<TestWorld>) {}
 
 fn parse_backend(name: &str) -> Result<BackendKind, String> {
     name.parse::<BackendKind>()

--- a/crates/weaverd/src/tests/behaviour.rs
+++ b/crates/weaverd/src/tests/behaviour.rs
@@ -9,8 +9,6 @@ use crate::backends::BackendKind;
 
 use super::support::{self, HealthEvent, TestWorld};
 
-type StepResult = Result<(), String>;
-
 #[fixture]
 fn world() -> RefCell<TestWorld> {
     support::world()
@@ -27,13 +25,12 @@ fn given_failing_loader(world: &RefCell<TestWorld>) {
 }
 
 #[given("a backend provider that fails for {backend}")]
-fn given_backend_failure(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn given_backend_failure(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     world
         .borrow()
         .provider
         .fail_on(kind, "intentional test failure");
-    Ok(())
 }
 
 #[when("the daemon bootstrap runs")]
@@ -42,17 +39,15 @@ fn when_bootstrap_runs(world: &RefCell<TestWorld>) {
 }
 
 #[when("the {backend} backend is requested")]
-fn when_backend_requested(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn when_backend_requested(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     world.borrow_mut().request_backend(kind);
-    Ok(())
 }
 
 #[when("the {backend} backend is requested again")]
-fn when_backend_requested_again(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn when_backend_requested_again(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     world.borrow_mut().request_backend(kind);
-    Ok(())
 }
 
 #[then("bootstrap succeeds")]
@@ -122,18 +117,12 @@ fn assert_event_recorded(world: &RefCell<TestWorld>, event: HealthEvent, message
 }
 
 /// Parses the backend identifier and asserts the reporter observed the event.
-fn assert_backend_event<F>(
-    world: &RefCell<TestWorld>,
-    backend: String,
-    event: F,
-    message: &str,
-) -> StepResult
+fn assert_backend_event<F>(world: &RefCell<TestWorld>, backend: String, event: F, message: &str)
 where
     F: FnOnce(BackendKind) -> HealthEvent,
 {
-    let kind = parse_backend(&backend)?;
+    let kind = parse_backend(&backend);
     assert_event_recorded(world, event(kind), message);
-    Ok(())
 }
 
 #[then("the reporter recorded bootstrap start")]
@@ -155,7 +144,7 @@ fn then_reporter_success(world: &RefCell<TestWorld>) {
 }
 
 #[then("the reporter recorded backend start for {backend}")]
-fn then_reporter_backend_start(world: &RefCell<TestWorld>, backend: String) -> StepResult {
+fn then_reporter_backend_start(world: &RefCell<TestWorld>, backend: String) {
     assert_backend_event(
         world,
         backend,
@@ -165,7 +154,7 @@ fn then_reporter_backend_start(world: &RefCell<TestWorld>, backend: String) -> S
 }
 
 #[then("the reporter recorded backend ready for {backend}")]
-fn then_reporter_backend_ready(world: &RefCell<TestWorld>, backend: String) -> StepResult {
+fn then_reporter_backend_ready(world: &RefCell<TestWorld>, backend: String) {
     assert_backend_event(
         world,
         backend,
@@ -184,8 +173,8 @@ fn then_reporter_failure(world: &RefCell<TestWorld>) {
 }
 
 #[then("the reporter recorded backend failure for {backend}")]
-fn then_reporter_backend_failure(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn then_reporter_backend_failure(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     let events = world.borrow().reporter.events();
     let failed = events.iter().any(|event| {
         matches!(
@@ -196,32 +185,26 @@ fn then_reporter_backend_failure(world: &RefCell<TestWorld>, backend: String) ->
             } if *recorded == kind
         )
     });
-    if failed {
-        Ok(())
-    } else {
-        Err(format!(
-            "backend failure event missing for {kind:?}: {events:?}"
-        ))
-    }
+    assert!(
+        failed,
+        "backend failure event missing for {kind:?}: {events:?}"
+    );
 }
 
 #[then("the backend was started exactly once for {backend}")]
-fn then_backend_started_once(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn then_backend_started_once(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     let starts = world.borrow().backend_starts();
-    if starts.as_slice() == [kind] {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected single start for {kind:?}, got {starts:?}"
-        ))
-    }
+    assert!(
+        starts.as_slice() == [kind],
+        "expected single start for {kind:?}, got {starts:?}"
+    );
 }
 
 #[scenario(path = "tests/features/daemon_bootstrap.feature")]
 fn daemon_bootstrap(#[from(world)] _: RefCell<TestWorld>) {}
 
-fn parse_backend(name: &str) -> Result<BackendKind, String> {
+fn parse_backend(name: &str) -> BackendKind {
     name.parse::<BackendKind>()
-        .map_err(|error| format!("invalid backend '{name}': {error}"))
+        .unwrap_or_else(|error| panic!("invalid backend '{name}': {error}"))
 }

--- a/crates/weaverd/src/tests/process_behaviour.rs
+++ b/crates/weaverd/src/tests/process_behaviour.rs
@@ -254,6 +254,4 @@ fn assert_daemon_error_contains(world: &RefCell<ProcessTestWorld>, needle: &str)
 }
 
 #[scenario(path = "tests/features/daemon_process.feature")]
-fn daemon_process(#[from(world)] _: RefCell<ProcessTestWorld>) -> StepResult {
-    Ok(())
-}
+fn daemon_process(#[from(world)] _: RefCell<ProcessTestWorld>) {}

--- a/crates/weaverd/src/tests/process_behaviour.rs
+++ b/crates/weaverd/src/tests/process_behaviour.rs
@@ -7,7 +7,7 @@ use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 use crate::process::{LaunchError, LaunchMode};
-use crate::tests::support::{ProcessTestWorld, StepResult, snapshot_status};
+use crate::tests::support::{ProcessTestWorld, snapshot_status};
 
 #[fixture]
 fn world() -> RefCell<ProcessTestWorld> {
@@ -20,20 +20,27 @@ fn given_world(world: &RefCell<ProcessTestWorld>) {
 }
 
 #[when("the daemon starts in background mode")]
-fn when_daemon_starts_background(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow_mut().start_background()
+fn when_daemon_starts_background(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow_mut()
+        .start_background()
+        .unwrap_or_else(|error| panic!("daemon background start failed: {error}"));
 }
 
 #[when("the daemon starts in foreground mode")]
-fn when_daemon_starts_foreground(world: &RefCell<ProcessTestWorld>) -> StepResult {
+fn when_daemon_starts_foreground(world: &RefCell<ProcessTestWorld>) {
     world
         .borrow_mut()
         .start_foreground(LaunchMode::Foreground, true)
+        .unwrap_or_else(|error| panic!("daemon foreground start failed: {error}"));
 }
 
 #[when("the daemon starts in foreground mode with invalid configuration")]
-fn when_daemon_starts_invalid(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow_mut().start_foreground_with_invalid_config()
+fn when_daemon_starts_invalid(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow_mut()
+        .start_foreground_with_invalid_config()
+        .unwrap_or_else(|error| panic!("invalid foreground start should fail: {error}"));
 }
 
 #[when("shutdown is triggered")]
@@ -42,30 +49,41 @@ fn when_shutdown_triggered(world: &RefCell<ProcessTestWorld>) {
 }
 
 #[when("we wait for the daemon to become ready")]
-fn when_wait_for_ready(world: &RefCell<ProcessTestWorld>) -> StepResult {
+fn when_wait_for_ready(world: &RefCell<ProcessTestWorld>) {
     world.borrow_mut().record_wait_for_status("ready");
-    Ok(())
 }
 
 #[when("the daemon run completes")]
 #[then("the daemon run completes")]
-fn daemon_run_completes(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow_mut().join_background()
+fn daemon_run_completes(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow_mut()
+        .join_background()
+        .unwrap_or_else(|error| panic!("daemon run should complete: {error}"));
 }
 
 #[given("stale runtime artefacts exist")]
-fn given_stale_runtime(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow().write_stale_runtime()
+fn given_stale_runtime(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow()
+        .write_stale_runtime()
+        .unwrap_or_else(|error| panic!("failed to write stale runtime: {error}"));
 }
 
 #[given("stale runtime artefacts with invalid pid exist")]
-fn given_stale_runtime_invalid(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow().write_stale_runtime_with_invalid_pid(99999)
+fn given_stale_runtime_invalid(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow()
+        .write_stale_runtime_with_invalid_pid(99999)
+        .unwrap_or_else(|error| panic!("failed to write invalid stale runtime: {error}"));
 }
 
 #[given("a lock without a pid file exists")]
-fn given_lock_without_pid(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow().write_lock_without_pid()
+fn given_lock_without_pid(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow()
+        .write_lock_without_pid()
+        .unwrap_or_else(|error| panic!("failed to write lock without pid: {error}"));
 }
 
 #[then("daemonisation was requested")]

--- a/crates/weaverd/src/tests/support/mod.rs
+++ b/crates/weaverd/src/tests/support/mod.rs
@@ -8,6 +8,6 @@ mod world;
 
 pub use backend_provider::RecordingBackendProvider;
 pub use config_loader::{FailingConfigLoader, TestConfigLoader};
-pub use process_world::{ProcessTestWorld, StepResult, snapshot_status};
+pub use process_world::{ProcessTestWorld, snapshot_status};
 pub use reporter::{HealthEvent, RecordingHealthReporter};
 pub use world::{TestWorld, world};

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -284,14 +284,14 @@ To enable validation pin a feature in your `dev-dependencies`:
 
 ```toml
 [dev-dependencies]
-rstest-bdd-macros = { version = "0.1.0-alpha4", features = ["compile-time-validation"] }
+rstest-bdd-macros = { version = "0.1.0", features = ["compile-time-validation"] }
 ```
 
 For strict checking use:
 
 ```toml
 [dev-dependencies]
-rstest-bdd-macros = { version = "0.1.0-alpha4", features = ["strict-compile-time-validation"] }
+rstest-bdd-macros = { version = "0.1.0", features = ["strict-compile-time-validation"] }
 ```
 
 Steps are only validated when one of these features is enabled.

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -645,7 +645,7 @@ July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
 [^11]: Compile_fail doc test ignored in cfg(test) - help - The Rust Programming
 Language Forum, accessed on July 15, 2025,
 <https://users.rust-lang.org/t/compile-fail-doc-test-ignored-in-cfg-test/124927>
-accessed on July 15, 2025,
+ accessed on July 15, 2025,
 <https://users.rust-lang.org/t/test-setup-for-doctests/50426>
 [^12]: quote_doctest - Rust - [Docs.rs](http://Docs.rs), accessed on July 15,
 2025, <https://docs.rs/quote-doctest>

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1057,14 +1057,16 @@ a logical, incremental progression.
 
 #### 2025-11-12: Adopt `rstest-bdd` 0.1.0 for scenario tests
 
-We moved the workspace dependency on `rstest-bdd`/`rstest-bdd-macros` from
+The workspace dependency on `rstest-bdd`/`rstest-bdd-macros` moved from
 `0.1.0-alpha4` to the `0.1.0` stable release to reduce reliance on pre-release
 behavioural testing tooling. The upgrade keeps the ergonomics of
 `compile-time-validation` and `strict-compile-time-validation` features intact
-while benefiting from upstream fixes (notably improved localisation support and
+while benefiting from upstream fixes (notably improved localization support and
 step registration diagnostics) that shipped with the stable tag. All crates
 consuming the workspace dependency continue to share the same version through
 `workspace.dependencies`, ensuring scenarios and supporting macros evolve in
-lockstep. Upstream still ships the internal `rstest-bdd-patterns` crate as an
-`alpha4` build, but it remains a purely transitive dependency bundled with the
-stable API surface, so no additional action is required on our side.
+lockstep. The default `diagnostics` feature is now disabled to avoid the
+additional serde/serde_json surface when it is not required, which partially
+offsets the build bloat introduced by the new localization stack (i18n-embed,
+fluent, unic-langid). Upstream now ships `rstest-bdd-patterns` 0.1.0 via the
+same pin, so the entire stack aligns on stable releases.

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1052,3 +1052,19 @@ a logical, incremental progression.
 - Zig Project. (n.d.). `zig/language-server`: Issue #398.
 
 - C# Project. (n.d.). `csharp/language-server`: Issue #2612.
+
+### C. Design Decision Log
+
+#### 2025-11-12: Adopt `rstest-bdd` 0.1.0 for scenario tests
+
+We moved the workspace dependency on `rstest-bdd`/`rstest-bdd-macros` from
+`0.1.0-alpha4` to the `0.1.0` stable release to reduce reliance on pre-release
+behavioural testing tooling. The upgrade keeps the ergonomics of
+`compile-time-validation` and `strict-compile-time-validation` features intact
+while benefiting from upstream fixes (notably improved localisation support and
+step registration diagnostics) that shipped with the stable tag. All crates
+consuming the workspace dependency continue to share the same version through
+`workspace.dependencies`, ensuring scenarios and supporting macros evolve in
+lockstep. Upstream still ships the internal `rstest-bdd-patterns` crate as an
+`alpha4` build, but it remains a purely transitive dependency bundled with the
+stable API surface, so no additional action is required on our side.


### PR DESCRIPTION
## Summary
- Upgrade workspace dependencies rstest-bdd and rstest-bdd-macros from alpha4 to the stable 0.1.0 release. 
- Align tests and documentation with the new stable API, including signature changes in test harnesses and updated version references.

## Changes
- Cargo.toml
  - Bump dependencies: rstest-bdd = "0.1.0" and rstest-bdd-macros = "0.1.0" (was alpha4).
- Cargo.lock
  - Refresh lockfile to reflect new dependency graph (includes new crates such as i18n-embed, fluent, rust-embed, unic-langid, etc.).
- Tests
  - weaver-cli: test function signatures updated to non-Result form (removed explicit Ok(()) returns).
  - weaverd: several tests updated to use empty bodies instead of returning Ok(()).
  - Overall test harness adjusted to accommodate the stable rstest-bdd APIs.
- Documentation
  - docs/rstest-bdd-users-guide.md: version references updated from alpha4 to 0.1.0 for both rstest-bdd and rstest-bdd-macros.
  - docs/weaver-design.md: added a Design Decision Log entry documenting the upgrade to rstest-bdd 0.1.0 and rationale.
- Design and tooling
  - Minor test harness and compile-time validation wiring adjusted to work with the stable 0.1.0 crates. No public API changes beyond the test harness.

## Testing plan
- Run cargo test at the workspace root to ensure all crates compile and tests pass with the new stable rstest-bdd APIs.
- Specifically verify that scenario tests initialize and register steps correctly, and that localisation/diagnostics improvements from the stable release are exercised by tests where applicable.

## Why this change
- Move from pre-release alpha4 to stable 0.1.0 to reduce reliance on pre-release tooling while preserving existing features (compile-time validation and strict-compile-time-validation). This also aligns workspace dependencies and keeps test macros in lockstep with the stable API.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f7c0cbd5-729e-4268-884f-372e2e56b163

## Summary by Sourcery

Upgrade rstest-bdd and rstest-bdd-macros from pre-release to v0.1.0, adapt the test harness and documentation to the stable API, and refresh the workspace lockfile.

Enhancements:
- Upgrade workspace dependencies rstest-bdd and rstest-bdd-macros to v0.1.0 and update Cargo.lock to reflect the new versions

Documentation:
- Update rstest-bdd user guide version references and add a design decision log entry for the v0.1.0 upgrade

Tests:
- Align scenario test functions with the stable API by removing Result returns and updating signatures