### PR TITLE
Migrate weaver to ortho-config v0.6.0 and add fail-fast tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,7 @@ dependencies = [
  "clap",
  "dirs 6.0.0",
  "libc",
+ "once_cell",
  "ortho_config",
  "rstest",
  "rstest-bdd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,9 +906,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ortho_config"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b8b9c66f5679fdb6653199c56aff45307cff6da9b0b65cf15cce1e7c18693a"
+checksum = "b2e82f7058eab712537b07c5f9e8367da9ade93c42ae08286a5272ae8e5c2435"
 dependencies = [
  "camino",
  "clap",
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "ortho_config_macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a617081116c2b82c642121f241737fab8d8b8456ae4cd5a001799e7402d9f120"
+checksum = "df57a79d218bae4aa23466dc2156e8f0c2e85ceac788097839d71b38b8c0e9e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 camino = { version = "1.1", features = ["serde1"] }
 clap = { version = "4.5", features = ["derive"] }
 once_cell = "1.19"
-ortho_config = "0.5.0"
+ortho_config = "0.6.0"
 rstest = "0.23"
 rstest-bdd = "0.1.0-alpha4"
 rstest-bdd-macros = "0.1.0-alpha4"

--- a/crates/weaver-config/Cargo.toml
+++ b/crates/weaver-config/Cargo.toml
@@ -30,3 +30,4 @@ rstest.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-macros.workspace = true
 tempfile.workspace = true
+once_cell.workspace = true

--- a/crates/weaver-config/tests/configuration_failfast.rs
+++ b/crates/weaver-config/tests/configuration_failfast.rs
@@ -1,0 +1,95 @@
+#![cfg(feature = "cli")]
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+
+use ortho_config::OrthoError;
+use tempfile::TempDir;
+use weaver_config::Config;
+
+struct EnvOverride {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvOverride {
+    fn set_var(key: &'static str, value: &OsStr) -> Self {
+        let previous = std::env::var_os(key);
+        // Nightly currently marks environment mutation as unsafe while the API
+        // stabilises, so mirror the pattern used in other tests.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvOverride {
+    fn drop(&mut self) {
+        // Restore any previous value (or remove the override) so other tests
+        // inherit a clean environment.
+        match self.previous.take() {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+#[test]
+fn malformed_configs_return_aggregated_error() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cli_path = temp_dir.path().join("cli_weaver.toml");
+    let env_path = temp_dir.path().join("env_weaver.toml");
+
+    fs::write(
+        &cli_path,
+        r#"daemon_socket = { transport = "tcp" host = "127.0.0.1" }"#,
+    )
+    .expect("write malformed cli config");
+    fs::write(
+        &env_path,
+        r#"daemon_socket = { transport = "tcp", port = not_a_number }"#,
+    )
+    .expect("write malformed env config");
+
+    let _env = EnvOverride::set_var("WEAVER_CONFIG_PATH", env_path.as_os_str());
+
+    let args = vec![
+        OsString::from("weaver-cli"),
+        OsString::from("--config-path"),
+        cli_path.clone().into_os_string(),
+    ];
+
+    let error = Config::load_from_iter(args).expect_err("loading must fail");
+    let message = error.to_string();
+    assert!(
+        message.contains("multiple configuration errors"),
+        "expected aggregate message, got {message:?}"
+    );
+
+    match error.as_ref() {
+        OrthoError::Aggregate(aggregate) => {
+            let mut mentioned_paths = aggregate
+                .iter()
+                .filter_map(|err| match err {
+                    OrthoError::File { path, .. } => Some(path.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            mentioned_paths.sort();
+
+            assert_eq!(
+                mentioned_paths.len(),
+                2,
+                "expected both failing files to be reported, got {mentioned_paths:?}"
+            );
+            assert!(
+                mentioned_paths.contains(&cli_path),
+                "missing CLI path in aggregate: {mentioned_paths:?}"
+            );
+            assert!(
+                mentioned_paths.contains(&env_path),
+                "missing env path in aggregate: {mentioned_paths:?}"
+            );
+        }
+        other => panic!("expected aggregated error, got {other:?}"),
+    }
+}

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -8,10 +8,24 @@ to minimize boiler‑plate. The library uses `serde` for deserialization and
 management. This guide covers the functionality currently implemented in the
 repository.
 
+## Weaver integration
+
+The `weaver-config` crate targets `ortho-config` v0.6.0. Its `Config` struct
+declares discovery rules inline via `#[ortho_config(discovery(...))]`, listing
+the `weaver.toml` project file, `.weaver.toml` dotfile, and the
+`--config-path`/`WEAVER_CONFIG_PATH` override in one attribute. The CLI calls
+`Config::load_from_iter` while the daemon calls `Config::load`, so both
+binaries share the generated loaders with no manual builders to maintain.
+
+Because v0.6.0 returns an aggregated error whenever every discovered file
+fails, the CLI and daemon now exit immediately when a configuration file exists
+but cannot be parsed. Operators no longer see silent fallbacks to defaults; the
+`OrthoError` reported via `LoadConfiguration` pinpoints each offending file.
+
 ## Core concepts and motivation
 
 Rust projects often wire together `clap` for CLI parsing, `serde` for
-de/serialization, and ad‑hoc code for loading `*.toml` files or reading
+de/serialization, and ad-hoc code for loading `*.toml` files or reading
 environment variables. Mapping between different naming conventions (kebab‑case
 flags, `UPPER_SNAKE_CASE` environment variables, and `snake_case` struct
 fields) can be tedious. `OrthoConfig` addresses these problems by letting

--- a/docs/ortho-config-v0-6-0-migration-guide.md
+++ b/docs/ortho-config-v0-6-0-migration-guide.md
@@ -220,6 +220,23 @@ announcements.[^changelog]
 Once everything compiles and tests pass, the upgraded configuration experience
 is ready for release.
 
+## Weaver adoption status
+
+The Weaver workspace now follows this migration guide:
+
+- `Cargo.toml` pins `ortho_config = "0.6.0"`, so every crate (CLI, daemon, and
+  shared config) compiles against the new runtime and macro releases.
+- `Cargo.lock` records `ortho_config`/`ortho_config_macros` v0.6.0, ensuring
+  reproducible builds pick up the stricter discovery semantics.
+- `weaver-config::Config` relies on the `#[ortho_config(discovery(...))]`
+  attribute, so no bespoke builders remain to audit for the new declarative API.
+- Both `weaver-cli` and `weaverd` bubble the aggregated `OrthoError` returned
+  by `Config::load`/`load_from_iter`, meaning broken configuration files now
+  stop launches immediately instead of falling back to defaults.
+- Operator-facing documentation (`docs/weaver-design.md` and
+  `docs/users-guide.md`) now calls out the fail-fast behaviour so users know
+  how to remedy invalid configuration files.
+
 [^forwarded-features]: Optional parser features on `ortho_config` automatically
 enable matching flags on the macro crate, keeping generated code in sync with
 runtime capabilities.【F:ortho_config/Cargo.toml†L41-L45】

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -645,7 +645,7 @@ July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
 [^11]: Compile_fail doc test ignored in cfg(test) - help - The Rust Programming
 Language Forum, accessed on July 15, 2025,
 <https://users.rust-lang.org/t/compile-fail-doc-test-ignored-in-cfg-test/124927>
-accessed on July 15, 2025,
+ accessed on July 15, 2025,
 <https://users.rust-lang.org/t/test-setup-for-doctests/50426>
 [^12]: quote_doctest - Rust - [Docs.rs](http://Docs.rs), accessed on July 15,
 2025, <https://docs.rs/quote-doctest>

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -67,10 +67,20 @@ directive = "force"
 
 `weaver` now uses `ortho-config` v0.6.0, which treats invalid configuration
 files as fatal. When `--config-path` points at a broken file—or when discovery
-finds a malformed `weaver.toml`/`.weaver.toml`—both the CLI and daemon abort
+finds a malformed `weaver.toml`/`.weaver.toml`—, both the CLI and daemon abort
 with a `LoadConfiguration` error that lists every offending path. Remove or fix
 the reported files before retrying. If no configuration files exist at all the
 loader still falls back to the built-in defaults described below.
+
+Operators will see aggregated errors enumerated in the order discovery
+encounters them. For example:
+
+```text
+failed to load configuration: multiple configuration errors:
+1: Configuration file error in '/etc/weaver/weaver.toml': expected `}`
+2: Configuration file error in '/home/alex/.weaver.toml': invalid type:
+string "yes", expected a boolean
+```
 
 ## Defaults
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -63,6 +63,15 @@ capability = "act.rename-symbol"
 directive = "force"
 ```
 
+### Validation and error reporting
+
+`weaver` now uses `ortho-config` v0.6.0, which treats invalid configuration
+files as fatal. When `--config-path` points at a broken file—or when discovery
+finds a malformed `weaver.toml`/`.weaver.toml`—both the CLI and daemon abort
+with a `LoadConfiguration` error that lists every offending path. Remove or fix
+the reported files before retrying. If no configuration files exist at all the
+loader still falls back to the built-in defaults described below.
+
 ## Defaults
 
 - **Daemon socket:** On Unix-like targets, the daemon listens on

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -304,6 +304,17 @@ Configuration is layered with `ortho-config`, producing the precedence order
 alongside the standard XDG locations, ensuring the CLI and daemon resolve
 identical results regardless of which component loads the settings.
 
+The workspace now targets `ortho-config` v0.6.0. The switch lets
+`weaver-config::Config` declare its discovery policy inline through the
+`#[ortho_config(discovery(...))]` attribute. The app name, dotfile, project
+file, and `--config-path` flag are all defined next to the struct, so every
+consumer shares the same generated loader without bespoke builders.
+
+Version 0.6.0 also tightens error handling: if any discovered configuration
+file fails to parse, `ConfigDiscovery::load_first` returns an aggregated
+`OrthoError`. Both the CLI and daemon bubble that error to the user instead of
+quietly falling back to defaults, making misconfigurations immediately visible.
+
 The daemon transport defaults to a Unix domain socket placed under
 `$XDG_RUNTIME_DIR/weaver/weaverd.sock`. When the runtime directory is absent,
 or otherwise unavailable, the path falls back to a per-user namespace under the


### PR DESCRIPTION
## Summary
- Migrate workspace to ortho-config v0.6.0, enabling inline discovery and fail-fast error handling
- Add integration tests validating aggregated errors for misconfigured config sources
- Update all crates to consume ortho_config 0.6.0; refresh Cargo.lock accordingly
- Align Weaver docs with new behavior and discovery API, including clearer error reporting
- Add Weaver adoption notes to the migration guide for v0.6.0

## Changes
- Dependency updates
  - Cargo.toml: ortho_config = "0.6.0" (was 0.5.0)
  - Cargo.lock: updated to ortho_config 0.6.0 and ortho_config_macros 0.6.0 with new checksums
  - Rationale: build now uses the new runtime and macro releases that introduce declarative discovery

- API/Runtime behavior
  - Weave integration uses inline discovery: weaver-config Config now declares discovery rules via #[ortho_config(discovery(...))], covering weaver.toml, .weaver.toml, and --config-path/WEAVER_CONFIG_PATH override
  - CLI uses Config::load_from_iter; daemon uses Config::load; both share generated loaders with no bespoke builders
  - If any discovered config file fails to parse, ortho-config 0.6.0 returns an aggregated error and the CLI/daemon exit with LoadConfiguration, instead of silently falling back to defaults
  - This makes misconfigurations immediately visible to operators

- Tests
  - crates/weaver-config/tests/configuration_failfast.rs: new integration test to validate aggregated OrthoError when multiple config sources fail parsing (malformed CLI and environment config)
  - Verifies that the error reports both offending files in the aggregate

- Documentation updates
  - docs/ortho-config-users-guide.md: Clarifies Weaver integration, discovery rules, and fail-fast semantics; notes how LoadConfiguration reports offending files
  - docs/weaver-design.md: Notes that the workspace targets ortho-config 0.6.0, inline discovery, and fail-fast error handling across CLI/daemon
  - docs/users-guide.md: Adds a Validation and error reporting section describing fail-fast behavior and how to remediate invalid configuration files
  - docs/ortho-config-v0-6-0-migration-guide.md: Adds a Weaver adoption status section detailing the changes in the workspace and lockfile to ensure reproducible builds
  - Minor formatting fix in docs/rust-doctest-dry-guide.md (doc-edit polish)

- Rationale
- The upgrade brings a unified, declarative discovery API across weaver components and tighter error handling, reducing silent defaults when configurations are invalid.
- Updated docs ensure users/operators are aware of fail-fast behavior and how to locate offending configuration files.

- Testing plan
  - Build the workspace and run test suite to ensure no regressions: cargo build; cargo test
  - Validate configuration loading behavior with malformed weaver.toml/.weaver.toml or bad --config-path and confirm an aggregated OrthoError is produced listing offending files
  - With a valid config present, verify no silent fallback occurs and the proper config is loaded
  - Manual sanity checks: Run weaver CLI and weaverd to confirm both respect the new fail-fast semantics

## Notes for reviewers
- This PR focuses on dependency upgrades, test coverage for fail-fast behavior, and documentation alignment around ortho-config v0.6.0. No public API surface changes beyond the internal use of the new discovery semantics and the propagated errors have been introduced in this patch.
- If desired, we can add more integration tests that simulate various misconfig scenarios to lock in the fail-fast behavior.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/dc3310f6-97f9-4d19-8cca-e41282a161d5