### PR TITLE
Address code review comments for testing updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,8 +1457,6 @@ dependencies = [
  "regex",
  "rstest-bdd-patterns",
  "rust-embed",
- "serde",
- "serde_json",
  "thiserror 1.0.69",
  "unic-langid",
 ]
@@ -1487,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.1.0-alpha4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e86cae3abdbeecef13e120bdedaa6d96e9d3fee9b83efa58b86fc250fdf32f"
+checksum = "dee8d9e47e63602b9061a3d73e48c0248f49d5bc730d64a8b27750f09342f81b"
 dependencies = [
  "regex",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.5", features = ["derive"] }
 once_cell = "1.19"
 ortho_config = "0.5.0"
 rstest = "0.23"
-rstest-bdd = "0.1.0"
+rstest-bdd = { version = "0.1.0", default-features = false }
 rstest-bdd-macros = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/weaver-cli/src/tests/behaviour.rs
+++ b/crates/weaver-cli/src/tests/behaviour.rs
@@ -8,12 +8,14 @@ use crate::EMPTY_LINE_LIMIT;
 
 use std::cell::RefCell;
 
-use anyhow::Result;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 #[given("a running fake daemon")]
-fn given_running_daemon(world: &RefCell<TestWorld>) -> Result<()> {
-    world.borrow_mut().start_daemon()
+fn given_running_daemon(world: &RefCell<TestWorld>) {
+    world
+        .borrow_mut()
+        .start_daemon()
+        .expect("failed to start fake daemon");
 }
 
 #[given("capability overrides force python rename")]
@@ -22,58 +24,71 @@ fn given_capability_override(world: &RefCell<TestWorld>) {
 }
 
 #[given("a running fake daemon sending malformed json")]
-fn given_malformed_daemon(world: &RefCell<TestWorld>) -> Result<()> {
+fn given_malformed_daemon(world: &RefCell<TestWorld>) {
     world
         .borrow_mut()
         .start_daemon_with_lines(vec![String::from("not valid json")])
+        .expect("failed to start malformed daemon");
 }
 
 #[given("a running fake daemon that closes without exit")]
-fn given_daemon_missing_exit(world: &RefCell<TestWorld>) -> Result<()> {
-    world.borrow_mut().start_daemon_with_lines(vec![
-        "{\"kind\":\"stream\",\"stream\":\"stdout\",\"data\":\"partial\"}".to_string(),
-    ])
+fn given_daemon_missing_exit(world: &RefCell<TestWorld>) {
+    world
+        .borrow_mut()
+        .start_daemon_with_lines(vec![
+            "{\"kind\":\"stream\",\"stream\":\"stdout\",\"data\":\"partial\"}".to_string(),
+        ])
+        .expect("failed to start daemon missing exit event");
 }
 
 #[given("a running fake daemon that emits empty lines")]
-fn given_daemon_with_empty_lines(world: &RefCell<TestWorld>) -> Result<()> {
+fn given_daemon_with_empty_lines(world: &RefCell<TestWorld>) {
     let mut lines = Vec::new();
     for _ in 0..EMPTY_LINE_LIMIT {
         lines.push(String::new());
     }
-    world.borrow_mut().start_daemon_with_lines(lines)
+    world
+        .borrow_mut()
+        .start_daemon_with_lines(lines)
+        .expect("failed to start daemon with empty lines");
 }
 
 #[when("the operator runs {command}")]
-fn when_operator_runs(world: &RefCell<TestWorld>, command: String) -> Result<()> {
-    world.borrow_mut().run(&command)
+fn when_operator_runs(world: &RefCell<TestWorld>, command: String) {
+    world
+        .borrow_mut()
+        .run(&command)
+        .expect("failed to run CLI command");
 }
 
 #[then("the daemon receives {fixture}")]
-fn then_daemon_receives(world: &RefCell<TestWorld>, fixture: String) -> Result<()> {
-    world.borrow().assert_golden_request(&fixture)
+fn then_daemon_receives(world: &RefCell<TestWorld>, fixture: String) {
+    world
+        .borrow()
+        .assert_golden_request(&fixture)
+        .expect("daemon did not receive expected fixture");
 }
 
 #[then("stdout is {expected}")]
-fn then_stdout_is(world: &RefCell<TestWorld>, expected: String) -> Result<()> {
+fn then_stdout_is(world: &RefCell<TestWorld>, expected: String) {
     let world = world.borrow();
     let expected = expected.trim_matches('"');
-    assert_eq!(world.stdout_text()?, expected);
-    Ok(())
+    let actual = world.stdout_text().expect("stdout text missing");
+    assert_eq!(actual, expected);
 }
 
 #[then("stderr is {expected}")]
-fn then_stderr_is(world: &RefCell<TestWorld>, expected: String) -> Result<()> {
+fn then_stderr_is(world: &RefCell<TestWorld>, expected: String) {
     let world = world.borrow();
     let expected = expected.trim_matches('"');
-    assert_eq!(world.stderr_text()?, expected);
-    Ok(())
+    let actual = world.stderr_text().expect("stderr text missing");
+    assert_eq!(actual, expected);
 }
 
 #[then("stderr contains {snippet}")]
-fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) -> Result<()> {
+fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) {
     let world = world.borrow();
-    let stderr = world.stderr_text()?;
+    let stderr = world.stderr_text().expect("stderr text missing");
     let snippet = snippet.trim_matches('"');
     assert!(
         stderr.contains(snippet),
@@ -81,22 +96,30 @@ fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) -> Result<(
         stderr,
         snippet
     );
-    Ok(())
 }
 
 #[then("the CLI exits with code {status}")]
-fn then_exit_code(world: &RefCell<TestWorld>, status: u8) -> Result<()> {
-    world.borrow().assert_exit_code(status)
+fn then_exit_code(world: &RefCell<TestWorld>, status: u8) {
+    world
+        .borrow()
+        .assert_exit_code(status)
+        .expect("exit code assertion failed");
 }
 
 #[then("the CLI fails")]
-fn then_exit_failure(world: &RefCell<TestWorld>) -> Result<()> {
-    world.borrow().assert_failure()
+fn then_exit_failure(world: &RefCell<TestWorld>) {
+    world
+        .borrow()
+        .assert_failure()
+        .expect("CLI did not fail as expected");
 }
 
 #[then("capabilities output is {fixture}")]
-fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) -> Result<()> {
-    world.borrow().assert_capabilities_output(&fixture)
+fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) {
+    world
+        .borrow()
+        .assert_capabilities_output(&fixture)
+        .expect("capabilities output mismatch");
 }
 
 #[scenario(path = "tests/features/weaver_cli.feature")]

--- a/crates/weaverd/src/tests/behaviour.rs
+++ b/crates/weaverd/src/tests/behaviour.rs
@@ -9,8 +9,6 @@ use crate::backends::BackendKind;
 
 use super::support::{self, HealthEvent, TestWorld};
 
-type StepResult = Result<(), String>;
-
 #[fixture]
 fn world() -> RefCell<TestWorld> {
     support::world()
@@ -27,13 +25,12 @@ fn given_failing_loader(world: &RefCell<TestWorld>) {
 }
 
 #[given("a backend provider that fails for {backend}")]
-fn given_backend_failure(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn given_backend_failure(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     world
         .borrow()
         .provider
         .fail_on(kind, "intentional test failure");
-    Ok(())
 }
 
 #[when("the daemon bootstrap runs")]
@@ -42,17 +39,15 @@ fn when_bootstrap_runs(world: &RefCell<TestWorld>) {
 }
 
 #[when("the {backend} backend is requested")]
-fn when_backend_requested(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn when_backend_requested(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     world.borrow_mut().request_backend(kind);
-    Ok(())
 }
 
 #[when("the {backend} backend is requested again")]
-fn when_backend_requested_again(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn when_backend_requested_again(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     world.borrow_mut().request_backend(kind);
-    Ok(())
 }
 
 #[then("bootstrap succeeds")]
@@ -122,18 +117,12 @@ fn assert_event_recorded(world: &RefCell<TestWorld>, event: HealthEvent, message
 }
 
 /// Parses the backend identifier and asserts the reporter observed the event.
-fn assert_backend_event<F>(
-    world: &RefCell<TestWorld>,
-    backend: String,
-    event: F,
-    message: &str,
-) -> StepResult
+fn assert_backend_event<F>(world: &RefCell<TestWorld>, backend: String, event: F, message: &str)
 where
     F: FnOnce(BackendKind) -> HealthEvent,
 {
-    let kind = parse_backend(&backend)?;
+    let kind = parse_backend(&backend);
     assert_event_recorded(world, event(kind), message);
-    Ok(())
 }
 
 #[then("the reporter recorded bootstrap start")]
@@ -155,7 +144,7 @@ fn then_reporter_success(world: &RefCell<TestWorld>) {
 }
 
 #[then("the reporter recorded backend start for {backend}")]
-fn then_reporter_backend_start(world: &RefCell<TestWorld>, backend: String) -> StepResult {
+fn then_reporter_backend_start(world: &RefCell<TestWorld>, backend: String) {
     assert_backend_event(
         world,
         backend,
@@ -165,7 +154,7 @@ fn then_reporter_backend_start(world: &RefCell<TestWorld>, backend: String) -> S
 }
 
 #[then("the reporter recorded backend ready for {backend}")]
-fn then_reporter_backend_ready(world: &RefCell<TestWorld>, backend: String) -> StepResult {
+fn then_reporter_backend_ready(world: &RefCell<TestWorld>, backend: String) {
     assert_backend_event(
         world,
         backend,
@@ -184,8 +173,8 @@ fn then_reporter_failure(world: &RefCell<TestWorld>) {
 }
 
 #[then("the reporter recorded backend failure for {backend}")]
-fn then_reporter_backend_failure(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn then_reporter_backend_failure(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     let events = world.borrow().reporter.events();
     let failed = events.iter().any(|event| {
         matches!(
@@ -196,32 +185,26 @@ fn then_reporter_backend_failure(world: &RefCell<TestWorld>, backend: String) ->
             } if *recorded == kind
         )
     });
-    if failed {
-        Ok(())
-    } else {
-        Err(format!(
-            "backend failure event missing for {kind:?}: {events:?}"
-        ))
-    }
+    assert!(
+        failed,
+        "backend failure event missing for {kind:?}: {events:?}"
+    );
 }
 
 #[then("the backend was started exactly once for {backend}")]
-fn then_backend_started_once(world: &RefCell<TestWorld>, backend: String) -> StepResult {
-    let kind = parse_backend(&backend)?;
+fn then_backend_started_once(world: &RefCell<TestWorld>, backend: String) {
+    let kind = parse_backend(&backend);
     let starts = world.borrow().backend_starts();
-    if starts.as_slice() == [kind] {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected single start for {kind:?}, got {starts:?}"
-        ))
-    }
+    assert!(
+        starts.as_slice() == [kind],
+        "expected single start for {kind:?}, got {starts:?}"
+    );
 }
 
 #[scenario(path = "tests/features/daemon_bootstrap.feature")]
 fn daemon_bootstrap(#[from(world)] _: RefCell<TestWorld>) {}
 
-fn parse_backend(name: &str) -> Result<BackendKind, String> {
+fn parse_backend(name: &str) -> BackendKind {
     name.parse::<BackendKind>()
-        .map_err(|error| format!("invalid backend '{name}': {error}"))
+        .unwrap_or_else(|error| panic!("invalid backend '{name}': {error}"))
 }

--- a/crates/weaverd/src/tests/process_behaviour.rs
+++ b/crates/weaverd/src/tests/process_behaviour.rs
@@ -7,7 +7,7 @@ use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 use crate::process::{LaunchError, LaunchMode};
-use crate::tests::support::{ProcessTestWorld, StepResult, snapshot_status};
+use crate::tests::support::{ProcessTestWorld, snapshot_status};
 
 #[fixture]
 fn world() -> RefCell<ProcessTestWorld> {
@@ -20,20 +20,27 @@ fn given_world(world: &RefCell<ProcessTestWorld>) {
 }
 
 #[when("the daemon starts in background mode")]
-fn when_daemon_starts_background(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow_mut().start_background()
+fn when_daemon_starts_background(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow_mut()
+        .start_background()
+        .unwrap_or_else(|error| panic!("daemon background start failed: {error}"));
 }
 
 #[when("the daemon starts in foreground mode")]
-fn when_daemon_starts_foreground(world: &RefCell<ProcessTestWorld>) -> StepResult {
+fn when_daemon_starts_foreground(world: &RefCell<ProcessTestWorld>) {
     world
         .borrow_mut()
         .start_foreground(LaunchMode::Foreground, true)
+        .unwrap_or_else(|error| panic!("daemon foreground start failed: {error}"));
 }
 
 #[when("the daemon starts in foreground mode with invalid configuration")]
-fn when_daemon_starts_invalid(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow_mut().start_foreground_with_invalid_config()
+fn when_daemon_starts_invalid(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow_mut()
+        .start_foreground_with_invalid_config()
+        .unwrap_or_else(|error| panic!("invalid foreground start should fail: {error}"));
 }
 
 #[when("shutdown is triggered")]
@@ -42,30 +49,41 @@ fn when_shutdown_triggered(world: &RefCell<ProcessTestWorld>) {
 }
 
 #[when("we wait for the daemon to become ready")]
-fn when_wait_for_ready(world: &RefCell<ProcessTestWorld>) -> StepResult {
+fn when_wait_for_ready(world: &RefCell<ProcessTestWorld>) {
     world.borrow_mut().record_wait_for_status("ready");
-    Ok(())
 }
 
 #[when("the daemon run completes")]
 #[then("the daemon run completes")]
-fn daemon_run_completes(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow_mut().join_background()
+fn daemon_run_completes(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow_mut()
+        .join_background()
+        .unwrap_or_else(|error| panic!("daemon run should complete: {error}"));
 }
 
 #[given("stale runtime artefacts exist")]
-fn given_stale_runtime(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow().write_stale_runtime()
+fn given_stale_runtime(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow()
+        .write_stale_runtime()
+        .unwrap_or_else(|error| panic!("failed to write stale runtime: {error}"));
 }
 
 #[given("stale runtime artefacts with invalid pid exist")]
-fn given_stale_runtime_invalid(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow().write_stale_runtime_with_invalid_pid(99999)
+fn given_stale_runtime_invalid(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow()
+        .write_stale_runtime_with_invalid_pid(99999)
+        .unwrap_or_else(|error| panic!("failed to write invalid stale runtime: {error}"));
 }
 
 #[given("a lock without a pid file exists")]
-fn given_lock_without_pid(world: &RefCell<ProcessTestWorld>) -> StepResult {
-    world.borrow().write_lock_without_pid()
+fn given_lock_without_pid(world: &RefCell<ProcessTestWorld>) {
+    world
+        .borrow()
+        .write_lock_without_pid()
+        .unwrap_or_else(|error| panic!("failed to write lock without pid: {error}"));
 }
 
 #[then("daemonisation was requested")]

--- a/crates/weaverd/src/tests/support/mod.rs
+++ b/crates/weaverd/src/tests/support/mod.rs
@@ -8,6 +8,6 @@ mod world;
 
 pub use backend_provider::RecordingBackendProvider;
 pub use config_loader::{FailingConfigLoader, TestConfigLoader};
-pub use process_world::{ProcessTestWorld, StepResult, snapshot_status};
+pub use process_world::{ProcessTestWorld, snapshot_status};
 pub use reporter::{HealthEvent, RecordingHealthReporter};
 pub use world::{TestWorld, world};

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1057,14 +1057,16 @@ a logical, incremental progression.
 
 #### 2025-11-12: Adopt `rstest-bdd` 0.1.0 for scenario tests
 
-We moved the workspace dependency on `rstest-bdd`/`rstest-bdd-macros` from
+The workspace dependency on `rstest-bdd`/`rstest-bdd-macros` moved from
 `0.1.0-alpha4` to the `0.1.0` stable release to reduce reliance on pre-release
 behavioural testing tooling. The upgrade keeps the ergonomics of
 `compile-time-validation` and `strict-compile-time-validation` features intact
-while benefiting from upstream fixes (notably improved localisation support and
+while benefiting from upstream fixes (notably improved localization support and
 step registration diagnostics) that shipped with the stable tag. All crates
 consuming the workspace dependency continue to share the same version through
 `workspace.dependencies`, ensuring scenarios and supporting macros evolve in
-lockstep. Upstream still ships the internal `rstest-bdd-patterns` crate as an
-`alpha4` build, but it remains a purely transitive dependency bundled with the
-stable API surface, so no additional action is required on our side.
+lockstep. The default `diagnostics` feature is now disabled to avoid the
+additional serde/serde_json surface when it is not required, which partially
+offsets the build bloat introduced by the new localization stack (i18n-embed,
+fluent, unic-langid). Upstream now ships `rstest-bdd-patterns` 0.1.0 via the
+same pin, so the entire stack aligns on stable releases.


### PR DESCRIPTION
## Summary

- Align tests with updated testing harness (rstest-bdd 0.1.0) by removing Result-based step returns and using explicit panics/unwraps, improving error messages and readability.
- Update various test suites (CLI, Weaverd) to reflect interface changes and better failure reporting.
- Fix documentation wording related to localization and update dependency configuration.

## Changes

### Testing framework updates
- Update weaver-cli and weaverd tests to drop Result return types in step definitions; return unit type and use expect/unwrap with clear messages.
- Replace previous error propagation (context/?). with explicit panics and descriptive messages for failed steps.
- Adjust assertions to work with new helper APIs (stdout/stderr/text assertions now use expect/unwrap-based paths).
- Remove StepResult alias from weaverd support and adapt test code accordingly.

### CLI and Weaverd tests
- Adjust daemon start helpers (start_daemon, start_daemon_with_lines) to panic with clear messages on failure.
- Update command execution and daemon I/O assertions to use expect/unwrapped results.
- Refactor test helpers and assertions to align with updated BackendKind parsing (panic on invalid input paths).

### Support and infrastructure
- Refactor support modules to remove StepResult exposure and simplify world/test harness interfaces.
- Update test world wiring to reflect direct returns and panics rather than Result-based control flow.

### Documentation
- Fix localisation wording to localization in docs/weaver-design.md to align with US English standards.

### Dependencies
- Bump workspace-wide rstest-bdd to 0.1.0 and disable default-features for tighter surface area.
- Adjust Cargo.lock/Cargo.toml to reflect the new dependency configuration.

### Build artifacts
- Update Cargo.lock and related dependency footprints to reflect the testing-harness changes.

## Test plan
- Run cargo test across all crates (weaver-cli, weaverd) to ensure compilation and test execution succeed.
- Specifically verify that all updated steps panic with informative messages on failure and that stdout/stderr assertions behave as expected.
- Confirm documentation renders correctly after localisation wording fix.
- Ensure dependency changes build cleanly with no regressions in test harness behavior.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6743f21f-abdb-421f-97d9-84d070abd9ab

## Summary by Sourcery

Align tests with the stable rstest-bdd 0.1.0 harness by replacing Result-based step returns with explicit panics and unwraps for clearer failure messages, update CLI and weaverd test suites and support modules accordingly, correct localization wording in documentation, and bump the testing dependency without default features.

Enhancements:
- Replace Result-based step definitions in weaver-cli and weaverd tests with explicit expect/unwrap calls for improved error diagnostics
- Refactor CLI and daemon test helpers to panic on failures and align assertions with new helper APIs
- Simplify test support modules by removing StepResult alias and adapting world/harness interfaces

Build:
- Upgrade rstest-bdd to version 0.1.0 with default-features disabled and update Cargo.toml and Cargo.lock

Documentation:
- Fix wording from localisation to localization in design documentation