### PR TITLE
Build CLI/daemon foundation: add weaver-lsp-host with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -539,6 +545,15 @@ checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
  "memchr",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -991,7 +1006,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -1023,6 +1038,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,7 +1077,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -1061,7 +1089,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -1367,7 +1395,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1566,7 +1594,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1663,6 +1691,17 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2354,6 +2393,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "weaver-lsp-host"
+version = "0.1.0"
+dependencies = [
+ "lsp-types",
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
+ "thiserror 2.0.17",
+ "weaver-config",
+]
+
+[[package]]
 name = "weaverd"
 version = "0.1.0"
 dependencies = [
@@ -2636,7 +2687,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/weaver-cli",
     "crates/weaver-config",
     "crates/weaverd",
+    "crates/weaver-lsp-host",
 ]
 resolver = "2"
 
@@ -25,6 +26,7 @@ serde_json = "1.0"
 thiserror = "2.0"
 tempfile = "3.10"
 dirs = "6.0"
+lsp-types = "0.97"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/weaver-lsp-host/Cargo.toml
+++ b/crates/weaver-lsp-host/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "weaver-lsp-host"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+weaver-config = { path = "../weaver-config" }
+lsp-types = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+rstest-bdd = { workspace = true }
+rstest-bdd-macros = { workspace = true }

--- a/crates/weaver-lsp-host/src/capability.rs
+++ b/crates/weaver-lsp-host/src/capability.rs
@@ -1,0 +1,169 @@
+//! Capability modelling and resolution.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use weaver_config::{CapabilityMatrix, CapabilityOverride};
+
+use crate::language::Language;
+use crate::server::ServerCapabilitySet;
+
+/// LSP feature exposed through the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum CapabilityKind {
+    /// `textDocument/definition`.
+    Definition,
+    /// `textDocument/references`.
+    References,
+    /// Diagnostics for a document.
+    Diagnostics,
+}
+
+impl CapabilityKind {
+    /// Returns the capability key used for overrides.
+    #[must_use]
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::Definition => "observe.get-definition",
+            Self::References => "observe.find-references",
+            Self::Diagnostics => "verify.diagnostics",
+        }
+    }
+}
+
+/// Provenance for a capability's availability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilitySource {
+    /// Provided directly by the language server.
+    ServerAdvertised,
+    /// Enabled by a force override.
+    ForcedOverride,
+    /// Disabled by an explicit deny override.
+    DeniedOverride,
+    /// Unavailable because the server does not support it.
+    MissingOnServer,
+}
+
+impl fmt::Display for CapabilitySource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::ServerAdvertised => "advertised by server",
+            Self::ForcedOverride => "forced by override",
+            Self::DeniedOverride => "denied by override",
+            Self::MissingOnServer => "missing from server",
+        };
+        formatter.write_str(label)
+    }
+}
+
+/// Effective state for a single capability after negotiation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityState {
+    /// Capability kind being described.
+    pub kind: CapabilityKind,
+    /// Whether the capability is usable.
+    pub enabled: bool,
+    /// Why the capability is (un)available.
+    pub source: CapabilitySource,
+}
+
+impl CapabilityState {
+    /// Constructs a new capability state.
+    #[must_use]
+    pub fn new(kind: CapabilityKind, enabled: bool, source: CapabilitySource) -> Self {
+        Self {
+            kind,
+            enabled,
+            source,
+        }
+    }
+}
+
+/// Capability summary for a single language.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilitySummary {
+    language: Language,
+    states: BTreeMap<CapabilityKind, CapabilityState>,
+}
+
+impl CapabilitySummary {
+    /// Returns the language associated with this summary.
+    #[must_use]
+    pub fn language(&self) -> Language {
+        self.language
+    }
+
+    /// Returns the state for the requested capability.
+    #[must_use]
+    pub fn state(&self, capability: CapabilityKind) -> CapabilityState {
+        match self.states.get(&capability) {
+            Some(state) => *state,
+            None => CapabilityState::new(capability, false, CapabilitySource::MissingOnServer),
+        }
+    }
+
+    /// Returns an iterator over all resolved capability states.
+    pub fn states(&self) -> impl Iterator<Item = CapabilityState> + '_ {
+        self.states.values().copied()
+    }
+}
+
+/// Resolves capability availability for a language using server data and overrides.
+pub(crate) fn resolve_capabilities(
+    language: Language,
+    advertised: ServerCapabilitySet,
+    overrides: &CapabilityMatrix,
+) -> CapabilitySummary {
+    let mut states = BTreeMap::new();
+    for capability in [
+        CapabilityKind::Definition,
+        CapabilityKind::References,
+        CapabilityKind::Diagnostics,
+    ] {
+        let state = resolve_state(language, capability, advertised, overrides);
+        states.insert(capability, state);
+    }
+    CapabilitySummary { language, states }
+}
+
+fn resolve_state(
+    language: Language,
+    capability: CapabilityKind,
+    advertised: ServerCapabilitySet,
+    overrides: &CapabilityMatrix,
+) -> CapabilityState {
+    match overrides.override_for(language.as_str(), capability.key()) {
+        Some(CapabilityOverride::Force) => {
+            return CapabilityState::new(capability, true, CapabilitySource::ForcedOverride);
+        }
+        Some(CapabilityOverride::Deny) => {
+            return CapabilityState::new(capability, false, CapabilitySource::DeniedOverride);
+        }
+        None | Some(CapabilityOverride::Allow) => {}
+    }
+
+    let (available, source) = match capability {
+        CapabilityKind::Definition => (
+            advertised.supports_definition(),
+            capability_source(advertised.supports_definition()),
+        ),
+        CapabilityKind::References => (
+            advertised.supports_references(),
+            capability_source(advertised.supports_references()),
+        ),
+        CapabilityKind::Diagnostics => (
+            advertised.supports_diagnostics(),
+            capability_source(advertised.supports_diagnostics()),
+        ),
+    };
+
+    CapabilityState::new(capability, available, source)
+}
+
+fn capability_source(available: bool) -> CapabilitySource {
+    if available {
+        CapabilitySource::ServerAdvertised
+    } else {
+        CapabilitySource::MissingOnServer
+    }
+}

--- a/crates/weaver-lsp-host/src/capability.rs
+++ b/crates/weaver-lsp-host/src/capability.rs
@@ -143,18 +143,18 @@ fn resolve_state(
     }
 
     let (available, source) = match capability {
-        CapabilityKind::Definition => (
-            advertised.supports_definition(),
-            capability_source(advertised.supports_definition()),
-        ),
-        CapabilityKind::References => (
-            advertised.supports_references(),
-            capability_source(advertised.supports_references()),
-        ),
-        CapabilityKind::Diagnostics => (
-            advertised.supports_diagnostics(),
-            capability_source(advertised.supports_diagnostics()),
-        ),
+        CapabilityKind::Definition => {
+            let available = advertised.supports_definition();
+            (available, capability_source(available))
+        }
+        CapabilityKind::References => {
+            let available = advertised.supports_references();
+            (available, capability_source(available))
+        }
+        CapabilityKind::Diagnostics => {
+            let available = advertised.supports_diagnostics();
+            (available, capability_source(available))
+        }
     };
 
     CapabilityState::new(capability, available, source)

--- a/crates/weaver-lsp-host/src/errors.rs
+++ b/crates/weaver-lsp-host/src/errors.rs
@@ -1,0 +1,113 @@
+//! Error types surfaced by the LSP host facade.
+
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::capability::{CapabilityKind, CapabilitySource};
+use crate::language::Language;
+use crate::server::LanguageServerError;
+
+/// Operation being executed when an error occurred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostOperation {
+    /// Server initialisation handshake.
+    Initialise,
+    /// `textDocument/definition` handling.
+    Definition,
+    /// `textDocument/references` handling.
+    References,
+    /// Diagnostic retrieval.
+    Diagnostics,
+}
+
+impl fmt::Display for HostOperation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Initialise => "initialisation",
+            Self::Definition => "definition",
+            Self::References => "references",
+            Self::Diagnostics => "diagnostics",
+        };
+        formatter.write_str(label)
+    }
+}
+
+/// Errors returned by [`crate::LspHost`].
+#[derive(Debug, Error)]
+pub enum LspHostError {
+    /// The requested language has not been registered.
+    #[error("language '{language}' is not registered with the LSP host")]
+    UnknownLanguage {
+        /// Language requested by the caller.
+        language: Language,
+    },
+
+    /// The language has already been registered.
+    #[error("language '{language}' already has a registered server")]
+    DuplicateLanguage {
+        /// Language for which a duplicate server was registered.
+        language: Language,
+    },
+
+    /// A capability is disabled by overrides or missing server support.
+    #[error("capability {capability:?} for {language} is unavailable: {reason}")]
+    CapabilityUnavailable {
+        /// Language associated with the capability.
+        language: Language,
+        /// Capability that was requested.
+        capability: CapabilityKind,
+        /// Why the capability is not available.
+        reason: CapabilitySource,
+    },
+
+    /// Underlying language server returned an error.
+    #[error("language server for {language} failed during {operation}: {source}")]
+    Server {
+        /// Language associated with the server.
+        language: Language,
+        /// Operation that failed.
+        operation: HostOperation,
+        /// Underlying error.
+        #[source]
+        source: LanguageServerError,
+    },
+}
+
+impl LspHostError {
+    /// Builds an `UnknownLanguage` error for the supplied language.
+    pub(crate) fn unknown(language: Language) -> Self {
+        Self::UnknownLanguage { language }
+    }
+
+    /// Builds a `DuplicateLanguage` error.
+    pub(crate) fn duplicate(language: Language) -> Self {
+        Self::DuplicateLanguage { language }
+    }
+
+    /// Builds a `CapabilityUnavailable` error with the provided reason.
+    pub(crate) fn capability_unavailable(
+        language: Language,
+        capability: CapabilityKind,
+        reason: CapabilitySource,
+    ) -> Self {
+        Self::CapabilityUnavailable {
+            language,
+            capability,
+            reason,
+        }
+    }
+
+    /// Wraps an underlying language server failure.
+    pub(crate) fn server(
+        language: Language,
+        operation: HostOperation,
+        source: LanguageServerError,
+    ) -> Self {
+        Self::Server {
+            language,
+            operation,
+            source,
+        }
+    }
+}

--- a/crates/weaver-lsp-host/src/host.rs
+++ b/crates/weaver-lsp-host/src/host.rs
@@ -1,0 +1,174 @@
+//! Host facade that mediates access to per-language servers.
+
+use std::collections::HashMap;
+
+use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, ReferenceParams, Uri};
+
+use crate::capability::{CapabilityKind, CapabilitySummary, resolve_capabilities};
+use crate::errors::{HostOperation, LspHostError};
+use crate::language::Language;
+use crate::server::{LanguageServer, LanguageServerError};
+
+struct Session {
+    server: Box<dyn LanguageServer>,
+    state: SessionState,
+}
+
+struct CallContext {
+    language: Language,
+    capability: CapabilityKind,
+    operation: HostOperation,
+}
+
+enum SessionState {
+    Pending,
+    Ready { summary: CapabilitySummary },
+}
+
+/// Orchestrates multiple language servers and applies capability overrides.
+pub struct LspHost {
+    overrides: weaver_config::CapabilityMatrix,
+    sessions: HashMap<Language, Session>,
+}
+
+impl LspHost {
+    /// Builds an empty host with the supplied capability overrides.
+    #[must_use]
+    pub fn new(overrides: weaver_config::CapabilityMatrix) -> Self {
+        Self {
+            overrides,
+            sessions: HashMap::new(),
+        }
+    }
+
+    /// Registers a server for the given language.
+    pub fn register_language(
+        &mut self,
+        language: Language,
+        server: Box<dyn LanguageServer>,
+    ) -> Result<(), LspHostError> {
+        if self.sessions.contains_key(&language) {
+            return Err(LspHostError::duplicate(language));
+        }
+
+        self.sessions.insert(
+            language,
+            Session {
+                server,
+                state: SessionState::Pending,
+            },
+        );
+        Ok(())
+    }
+
+    /// Initialises the language server and returns the resolved capability summary.
+    pub fn initialise(&mut self, language: Language) -> Result<CapabilitySummary, LspHostError> {
+        let overrides = self.overrides.clone();
+        let session = self.session_mut(language)?;
+        Self::ensure_initialised(language, session, &overrides)
+    }
+
+    /// Returns the resolved capabilities when the language is already initialised.
+    #[must_use]
+    pub fn capabilities(&self, language: Language) -> Option<CapabilitySummary> {
+        self.sessions
+            .get(&language)
+            .and_then(|session| match &session.state {
+                SessionState::Ready { summary } => Some(summary.clone()),
+                SessionState::Pending => None,
+            })
+    }
+
+    /// Routes a definition request to the configured language server.
+    pub fn goto_definition(
+        &mut self,
+        language: Language,
+        params: GotoDefinitionParams,
+    ) -> Result<GotoDefinitionResponse, LspHostError> {
+        let context = CallContext {
+            language,
+            capability: CapabilityKind::Definition,
+            operation: HostOperation::Definition,
+        };
+        self.call_with_capability(context, move |server| server.goto_definition(params))
+    }
+
+    /// Routes a references request to the configured language server.
+    pub fn references(
+        &mut self,
+        language: Language,
+        params: ReferenceParams,
+    ) -> Result<Vec<lsp_types::Location>, LspHostError> {
+        let context = CallContext {
+            language,
+            capability: CapabilityKind::References,
+            operation: HostOperation::References,
+        };
+        self.call_with_capability(context, move |server| server.references(params))
+    }
+
+    /// Retrieves diagnostics for the supplied document.
+    pub fn diagnostics(
+        &mut self,
+        language: Language,
+        uri: Uri,
+    ) -> Result<Vec<lsp_types::Diagnostic>, LspHostError> {
+        let context = CallContext {
+            language,
+            capability: CapabilityKind::Diagnostics,
+            operation: HostOperation::Diagnostics,
+        };
+        self.call_with_capability(context, move |server| server.diagnostics(uri))
+    }
+
+    fn call_with_capability<F, T>(
+        &mut self,
+        context: CallContext,
+        call: F,
+    ) -> Result<T, LspHostError>
+    where
+        F: FnOnce(&mut dyn LanguageServer) -> Result<T, LanguageServerError>,
+    {
+        let overrides = self.overrides.clone();
+        let session = self.session_mut(context.language)?;
+        let summary = Self::ensure_initialised(context.language, session, &overrides)?;
+        let state = summary.state(context.capability);
+        if !state.enabled {
+            return Err(LspHostError::capability_unavailable(
+                context.language,
+                context.capability,
+                state.source,
+            ));
+        }
+
+        call(session.server.as_mut())
+            .map_err(|source| LspHostError::server(context.language, context.operation, source))
+    }
+
+    fn ensure_initialised(
+        language: Language,
+        session: &mut Session,
+        overrides: &weaver_config::CapabilityMatrix,
+    ) -> Result<CapabilitySummary, LspHostError> {
+        match &session.state {
+            SessionState::Ready { summary } => Ok(summary.clone()),
+            SessionState::Pending => {
+                let capabilities = session.server.initialise().map_err(|source| {
+                    LspHostError::server(language, HostOperation::Initialise, source)
+                })?;
+
+                let summary = resolve_capabilities(language, capabilities, overrides);
+                session.state = SessionState::Ready {
+                    summary: summary.clone(),
+                };
+                Ok(summary)
+            }
+        }
+    }
+
+    fn session_mut(&mut self, language: Language) -> Result<&mut Session, LspHostError> {
+        self.sessions
+            .get_mut(&language)
+            .ok_or_else(|| LspHostError::unknown(language))
+    }
+}

--- a/crates/weaver-lsp-host/src/host.rs
+++ b/crates/weaver-lsp-host/src/host.rs
@@ -89,7 +89,7 @@ impl LspHost {
         Ok(())
     }
 
-    /// Initialises the language server and returns the resolved capability summary.
+    /// Initializes the language server and returns the resolved capability summary.
     pub fn initialize(&mut self, language: Language) -> Result<CapabilitySummary, LspHostError> {
         let overrides = &self.overrides;
         let session = self

--- a/crates/weaver-lsp-host/src/host.rs
+++ b/crates/weaver-lsp-host/src/host.rs
@@ -99,7 +99,7 @@ impl LspHost {
         Self::ensure_initialized(language, session, overrides)
     }
 
-    /// Returns the resolved capabilities when the language is already initialised.
+    /// Returns the resolved capabilities when the language is already initialized.
     #[must_use]
     pub fn capabilities(&self, language: Language) -> Option<CapabilitySummary> {
         self.sessions

--- a/crates/weaver-lsp-host/src/host.rs
+++ b/crates/weaver-lsp-host/src/host.rs
@@ -90,13 +90,13 @@ impl LspHost {
     }
 
     /// Initialises the language server and returns the resolved capability summary.
-    pub fn initialise(&mut self, language: Language) -> Result<CapabilitySummary, LspHostError> {
+    pub fn initialize(&mut self, language: Language) -> Result<CapabilitySummary, LspHostError> {
         let overrides = &self.overrides;
         let session = self
             .sessions
             .get_mut(&language)
             .ok_or_else(|| LspHostError::unknown(language))?;
-        Self::ensure_initialised(language, session, overrides)
+        Self::ensure_initialized(language, session, overrides)
     }
 
     /// Returns the resolved capabilities when the language is already initialised.
@@ -163,7 +163,7 @@ impl LspHost {
             .sessions
             .get_mut(&language)
             .ok_or_else(|| LspHostError::unknown(language))?;
-        let summary = Self::ensure_initialised(language, session, overrides)?;
+        let summary = Self::ensure_initialized(language, session, overrides)?;
         let state = summary.state(spec.capability);
         if !state.enabled {
             return Err(LspHostError::capability_unavailable(
@@ -177,7 +177,7 @@ impl LspHost {
             .map_err(|source| LspHostError::server(language, spec.operation, source))
     }
 
-    fn ensure_initialised(
+    fn ensure_initialized(
         language: Language,
         session: &mut Session,
         overrides: &weaver_config::CapabilityMatrix,
@@ -185,7 +185,7 @@ impl LspHost {
         match &session.state {
             SessionState::Ready { summary } => Ok(summary.clone()),
             SessionState::Pending => {
-                let capabilities = session.server.initialise().map_err(|source| {
+                let capabilities = session.server.initialize().map_err(|source| {
                     LspHostError::server(language, HostOperation::Initialise, source)
                 })?;
 

--- a/crates/weaver-lsp-host/src/language.rs
+++ b/crates/weaver-lsp-host/src/language.rs
@@ -1,0 +1,62 @@
+//! Supported languages for the LSP host.
+
+use std::fmt;
+use std::str::FromStr;
+
+use thiserror::Error;
+
+/// Languages managed by the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Language {
+    /// Rust via `rust-analyzer` or compatible servers.
+    Rust,
+    /// Python via `pylsp` or compatible servers.
+    Python,
+    /// TypeScript via `typescript-language-server` or `tsserver`.
+    TypeScript,
+}
+
+impl Language {
+    /// Returns the lower-case identifier used in configuration overrides.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+            Self::Python => "python",
+            Self::TypeScript => "typescript",
+        }
+    }
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Errors raised when parsing language identifiers.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("unsupported language '{0}'")]
+pub struct LanguageParseError(String);
+
+impl LanguageParseError {
+    /// Returns the input that failed to parse.
+    #[must_use]
+    pub fn input(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl FromStr for Language {
+    type Err = LanguageParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let normalised = input.trim().to_ascii_lowercase();
+        match normalised.as_str() {
+            "rust" => Ok(Self::Rust),
+            "python" => Ok(Self::Python),
+            "typescript" | "ts" => Ok(Self::TypeScript),
+            other => Err(LanguageParseError(other.to_string())),
+        }
+    }
+}

--- a/crates/weaver-lsp-host/src/lib.rs
+++ b/crates/weaver-lsp-host/src/lib.rs
@@ -1,0 +1,21 @@
+#![deny(missing_docs)]
+//! Language Server Protocol host facade.
+//!
+//! The crate owns the lifecycle of per-language servers, merges their
+//! advertised capabilities with configuration overrides, and exposes a narrow
+//! interface for core requests (definition, references, diagnostics). It keeps
+//! server-specific details behind the [`LanguageServer`] trait so tests and
+//! higher-level crates can inject lightweight implementations without spawning
+//! real language servers.
+
+mod capability;
+mod errors;
+mod host;
+mod language;
+mod server;
+
+pub use capability::{CapabilityKind, CapabilitySource, CapabilityState, CapabilitySummary};
+pub use errors::{HostOperation, LspHostError};
+pub use host::LspHost;
+pub use language::{Language, LanguageParseError};
+pub use server::{LanguageServer, LanguageServerError, ServerCapabilitySet};

--- a/crates/weaver-lsp-host/src/lib.rs
+++ b/crates/weaver-lsp-host/src/lib.rs
@@ -1,5 +1,5 @@
-#![deny(missing_docs)]
 //! Language Server Protocol host facade.
+#![deny(missing_docs)]
 //!
 //! The crate owns the lifecycle of per-language servers, merges their
 //! advertised capabilities with configuration overrides, and exposes a narrow

--- a/crates/weaver-lsp-host/src/server.rs
+++ b/crates/weaver-lsp-host/src/server.rs
@@ -1,0 +1,110 @@
+//! Abstractions over concrete language server implementations.
+
+use std::error::Error;
+use std::fmt;
+
+use lsp_types::{Diagnostic, GotoDefinitionParams, GotoDefinitionResponse, ReferenceParams, Uri};
+use thiserror::Error;
+
+/// Minimal set of capabilities the host inspects during negotiation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerCapabilitySet {
+    definition: bool,
+    references: bool,
+    diagnostics: bool,
+}
+
+impl ServerCapabilitySet {
+    /// Builds a capability set describing the server's advertised support.
+    #[must_use]
+    pub fn new(definition: bool, references: bool, diagnostics: bool) -> Self {
+        Self {
+            definition,
+            references,
+            diagnostics,
+        }
+    }
+
+    /// Whether the server reports support for `textDocument/definition`.
+    #[must_use]
+    pub fn supports_definition(self) -> bool {
+        self.definition
+    }
+
+    /// Whether the server reports support for `textDocument/references`.
+    #[must_use]
+    pub fn supports_references(self) -> bool {
+        self.references
+    }
+
+    /// Whether the server reports support for diagnostics.
+    #[must_use]
+    pub fn supports_diagnostics(self) -> bool {
+        self.diagnostics
+    }
+}
+
+/// Errors reported by language server implementations.
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct LanguageServerError {
+    message: String,
+    #[source]
+    source: Option<Box<dyn Error + Send + Sync>>,
+}
+
+impl LanguageServerError {
+    /// Builds an error without an underlying source.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Builds an error that wraps an underlying source.
+    #[must_use]
+    pub fn with_source(
+        message: impl Into<String>,
+        source: impl Into<Box<dyn Error + Send + Sync>>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            source: Some(source.into()),
+        }
+    }
+
+    /// Human-friendly description without the optional source.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        self.message.as_str()
+    }
+}
+
+/// Behaviour required from concrete language server bindings.
+pub trait LanguageServer: Send {
+    /// Runs the server initialisation handshake and returns advertised capabilities.
+    fn initialise(&mut self) -> Result<ServerCapabilitySet, LanguageServerError>;
+
+    /// Handles a `textDocument/definition` request.
+    fn goto_definition(
+        &mut self,
+        params: GotoDefinitionParams,
+    ) -> Result<GotoDefinitionResponse, LanguageServerError>;
+
+    /// Handles a `textDocument/references` request.
+    fn references(
+        &mut self,
+        params: ReferenceParams,
+    ) -> Result<Vec<lsp_types::Location>, LanguageServerError>;
+
+    /// Returns diagnostics for the supplied URI.
+    fn diagnostics(&mut self, uri: Uri) -> Result<Vec<Diagnostic>, LanguageServerError>;
+}
+
+impl fmt::Debug for dyn LanguageServer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("LanguageServer")
+    }
+}

--- a/crates/weaver-lsp-host/src/server.rs
+++ b/crates/weaver-lsp-host/src/server.rs
@@ -84,8 +84,8 @@ impl LanguageServerError {
 
 /// Behaviour required from concrete language server bindings.
 pub trait LanguageServer: Send {
-    /// Runs the server initialisation handshake and returns advertised capabilities.
-    fn initialise(&mut self) -> Result<ServerCapabilitySet, LanguageServerError>;
+    /// Runs the server initialization handshake and returns advertised capabilities.
+    fn initialize(&mut self) -> Result<ServerCapabilitySet, LanguageServerError>;
 
     /// Handles a `textDocument/definition` request.
     fn goto_definition(

--- a/crates/weaver-lsp-host/src/tests/behaviour.rs
+++ b/crates/weaver-lsp-host/src/tests/behaviour.rs
@@ -202,8 +202,17 @@ fn then_override_succeeds(world: &RefCell<TestWorld>) {
 fn then_missing_capability(world: &RefCell<TestWorld>) {
     let borrow = world.borrow();
     match &borrow.last_error {
-        Some(LspHostError::CapabilityUnavailable { capability, .. }) => {
+        Some(LspHostError::CapabilityUnavailable {
+            capability,
+            reason,
+            ..
+        }) => {
             assert_eq!(*capability, CapabilityKind::References);
+            assert_eq!(
+                *reason,
+                CapabilitySource::MissingOnServer,
+                "unexpected capability unavailability reason for References"
+            );
         }
         other => panic!("expected capability error, got {other:?}"),
     }

--- a/crates/weaver-lsp-host/src/tests/behaviour.rs
+++ b/crates/weaver-lsp-host/src/tests/behaviour.rs
@@ -1,7 +1,6 @@
 //! Behavioural tests for the LSP host facade using `rstest-bdd`.
 
 use std::cell::RefCell;
-use std::str::FromStr;
 
 use lsp_types::{
     Diagnostic, GotoDefinitionParams, GotoDefinitionResponse, Location, PartialResultParams,
@@ -16,7 +15,7 @@ use crate::capability::{CapabilityKind, CapabilitySource};
 use crate::errors::{HostOperation, LspHostError};
 use crate::language::Language;
 use crate::server::ServerCapabilitySet;
-use crate::tests::support::{CallKind, ResponseSet, TestServerConfig, TestWorld};
+use crate::tests::support::{sample_uri, CallKind, ResponseSet, TestServerConfig, TestWorld};
 
 #[fixture]
 fn world() -> RefCell<TestWorld> {
@@ -107,12 +106,12 @@ fn given_force_override(world: &RefCell<TestWorld>) {
 
 #[when("rust is initialised")]
 fn when_rust_initialised(world: &RefCell<TestWorld>) {
-    world.borrow_mut().initialise(Language::Rust);
+    world.borrow_mut().initialize(Language::Rust);
 }
 
 #[when("python is initialised")]
 fn when_python_initialised(world: &RefCell<TestWorld>) {
-    world.borrow_mut().initialise(Language::Python);
+    world.borrow_mut().initialize(Language::Python);
 }
 
 #[when("typescript handles a diagnostics request")]
@@ -278,11 +277,6 @@ fn sample_responses() -> ResponseSet {
         }],
         diagnostics: vec![Diagnostic::default()],
     }
-}
-
-fn sample_uri() -> Uri {
-    Uri::from_str("file:///workspace/main.rs")
-        .unwrap_or_else(|error| panic!("invalid test URL: {error}"))
 }
 
 fn definition_params() -> GotoDefinitionParams {

--- a/crates/weaver-lsp-host/src/tests/behaviour.rs
+++ b/crates/weaver-lsp-host/src/tests/behaviour.rs
@@ -30,19 +30,19 @@ fn given_all_languages(world: &RefCell<TestWorld>) {
             language: Language::Rust,
             capabilities: ServerCapabilitySet::new(true, true, true),
             responses: responses.clone(),
-            initialisation_error: None,
+            initialization_error: None,
         },
         TestServerConfig {
             language: Language::Python,
             capabilities: ServerCapabilitySet::new(true, true, true),
             responses: responses.clone(),
-            initialisation_error: None,
+            initialization_error: None,
         },
         TestServerConfig {
             language: Language::TypeScript,
             capabilities: ServerCapabilitySet::new(true, true, true),
             responses,
-            initialisation_error: None,
+            initialization_error: None,
         },
     ];
 
@@ -57,7 +57,7 @@ fn given_python_missing_references(world: &RefCell<TestWorld>) {
         language: Language::Python,
         capabilities: ServerCapabilitySet::new(true, false, true),
         responses,
-        initialisation_error: None,
+        initialization_error: None,
     }];
 
     *world.borrow_mut() = TestWorld::new(configs, CapabilityMatrix::default());
@@ -71,7 +71,7 @@ fn given_typescript_missing_diagnostics(world: &RefCell<TestWorld>) {
         language: Language::TypeScript,
         capabilities: ServerCapabilitySet::new(true, true, false),
         responses,
-        initialisation_error: None,
+        initialization_error: None,
     }];
 
     *world.borrow_mut() = TestWorld::new(configs, CapabilityMatrix::default());
@@ -83,7 +83,7 @@ fn given_rust_failure(world: &RefCell<TestWorld>) {
         language: Language::Rust,
         capabilities: ServerCapabilitySet::new(true, true, true),
         responses: sample_responses(),
-        initialisation_error: Some(String::from("intentional init failure")),
+        initialization_error: Some(String::from("intentional init failure")),
     }];
 
     *world.borrow_mut() = TestWorld::new(configs, CapabilityMatrix::default());
@@ -247,7 +247,7 @@ fn assert_call_recorded(world: &RefCell<TestWorld>, language: Language, kind: Ca
     let borrow = world.borrow();
     let calls = borrow
         .calls(language)
-        .unwrap_or_else(|| panic!("missing calls for {language}"));
+        .expect("missing calls for language");
     assert!(
         calls.contains(&kind),
         "expected to record {kind:?} for {language}, got {calls:?}"

--- a/crates/weaver-lsp-host/src/tests/behaviour.rs
+++ b/crates/weaver-lsp-host/src/tests/behaviour.rs
@@ -1,0 +1,305 @@
+//! Behavioural tests for the LSP host facade using `rstest-bdd`.
+
+use std::cell::RefCell;
+use std::str::FromStr;
+
+use lsp_types::{
+    Diagnostic, GotoDefinitionParams, GotoDefinitionResponse, Location, PartialResultParams,
+    Position, ReferenceContext, ReferenceParams, TextDocumentIdentifier, TextDocumentPositionParams,
+    Uri, WorkDoneProgressParams,
+};
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use weaver_config::{CapabilityMatrix, CapabilityOverride};
+
+use crate::capability::{CapabilityKind, CapabilitySource};
+use crate::errors::{HostOperation, LspHostError};
+use crate::language::Language;
+use crate::server::ServerCapabilitySet;
+use crate::tests::support::{CallKind, ResponseSet, TestServerConfig, TestWorld};
+
+#[fixture]
+fn world() -> RefCell<TestWorld> {
+    RefCell::new(TestWorld::new(Vec::new(), CapabilityMatrix::default()))
+}
+
+#[given("stub servers for all primary languages")]
+fn given_all_languages(world: &RefCell<TestWorld>) {
+    let responses = sample_responses();
+    let configs = vec![
+        TestServerConfig {
+            language: Language::Rust,
+            capabilities: ServerCapabilitySet::new(true, true, true),
+            responses: responses.clone(),
+            initialisation_error: None,
+        },
+        TestServerConfig {
+            language: Language::Python,
+            capabilities: ServerCapabilitySet::new(true, true, true),
+            responses: responses.clone(),
+            initialisation_error: None,
+        },
+        TestServerConfig {
+            language: Language::TypeScript,
+            capabilities: ServerCapabilitySet::new(true, true, true),
+            responses,
+            initialisation_error: None,
+        },
+    ];
+
+    *world.borrow_mut() = TestWorld::new(configs, CapabilityMatrix::default());
+}
+
+#[given("a python server missing references")]
+fn given_python_missing_references(world: &RefCell<TestWorld>) {
+    let mut responses = sample_responses();
+    responses.references = Vec::new();
+    let configs = vec![TestServerConfig {
+        language: Language::Python,
+        capabilities: ServerCapabilitySet::new(true, false, true),
+        responses,
+        initialisation_error: None,
+    }];
+
+    *world.borrow_mut() = TestWorld::new(configs, CapabilityMatrix::default());
+}
+
+#[given("a typescript server missing diagnostics")]
+fn given_typescript_missing_diagnostics(world: &RefCell<TestWorld>) {
+    let mut responses = sample_responses();
+    responses.diagnostics = Vec::new();
+    let configs = vec![TestServerConfig {
+        language: Language::TypeScript,
+        capabilities: ServerCapabilitySet::new(true, true, false),
+        responses,
+        initialisation_error: None,
+    }];
+
+    *world.borrow_mut() = TestWorld::new(configs, CapabilityMatrix::default());
+}
+
+#[given("a rust server that fails during initialisation")]
+fn given_rust_failure(world: &RefCell<TestWorld>) {
+    let configs = vec![TestServerConfig {
+        language: Language::Rust,
+        capabilities: ServerCapabilitySet::new(true, true, true),
+        responses: sample_responses(),
+        initialisation_error: Some(String::from("intentional init failure")),
+    }];
+
+    *world.borrow_mut() = TestWorld::new(configs, CapabilityMatrix::default());
+}
+
+#[given("a deny override for python references")]
+fn given_deny_override(world: &RefCell<TestWorld>) {
+    apply_override(world, Language::Python, CapabilityKind::References, CapabilityOverride::Deny);
+}
+
+#[given("a force override for typescript diagnostics")]
+fn given_force_override(world: &RefCell<TestWorld>) {
+    apply_override(
+        world,
+        Language::TypeScript,
+        CapabilityKind::Diagnostics,
+        CapabilityOverride::Force,
+    );
+}
+
+#[when("rust is initialised")]
+fn when_rust_initialised(world: &RefCell<TestWorld>) {
+    world.borrow_mut().initialise(Language::Rust);
+}
+
+#[when("python is initialised")]
+fn when_python_initialised(world: &RefCell<TestWorld>) {
+    world.borrow_mut().initialise(Language::Python);
+}
+
+#[when("typescript handles a diagnostics request")]
+fn when_typescript_diagnostics(world: &RefCell<TestWorld>) {
+    let uri = sample_uri();
+    world.borrow_mut().request_diagnostics(Language::TypeScript, uri);
+}
+
+#[when("rust handles a definition request")]
+fn when_rust_definition(world: &RefCell<TestWorld>) {
+    world
+        .borrow_mut()
+        .request_definition(Language::Rust, definition_params());
+}
+
+#[when("rust handles a references request")]
+fn when_rust_references(world: &RefCell<TestWorld>) {
+    world
+        .borrow_mut()
+        .request_references(Language::Rust, reference_params());
+}
+
+#[when("rust handles a diagnostics request")]
+fn when_rust_diagnostics(world: &RefCell<TestWorld>) {
+    let uri = sample_uri();
+    world.borrow_mut().request_diagnostics(Language::Rust, uri);
+}
+
+#[when("python handles a references request")]
+fn when_python_references(world: &RefCell<TestWorld>) {
+    world
+        .borrow_mut()
+        .request_references(Language::Python, reference_params());
+}
+
+#[then("rust capabilities are available from the server")]
+fn then_rust_capabilities(world: &RefCell<TestWorld>) {
+    let borrow = world.borrow();
+    let summary = borrow
+        .last_capabilities
+        .as_ref()
+        .unwrap_or_else(|| panic!("capabilities missing"));
+
+    for state in summary.states() {
+        assert!(state.enabled, "capability {:?} should be enabled", state.kind);
+        assert_eq!(state.source, CapabilitySource::ServerAdvertised);
+    }
+}
+
+#[then("rust recorded a definition call")]
+fn then_rust_recorded_definition(world: &RefCell<TestWorld>) {
+    assert_call_recorded(world, Language::Rust, CallKind::Definition);
+}
+
+#[then("rust recorded a references call")]
+fn then_rust_recorded_references(world: &RefCell<TestWorld>) {
+    assert_call_recorded(world, Language::Rust, CallKind::References);
+}
+
+#[then("rust recorded a diagnostics call")]
+fn then_rust_recorded_diagnostics(world: &RefCell<TestWorld>) {
+    assert_call_recorded(world, Language::Rust, CallKind::Diagnostics);
+}
+
+#[then("diagnostics succeed via override")]
+fn then_override_succeeds(world: &RefCell<TestWorld>) {
+    let borrow = world.borrow();
+    assert!(borrow.last_error.is_none(), "override should allow diagnostics");
+    assert!(
+        borrow
+            .last_diagnostics
+            .as_ref()
+            .map(|set| !set.is_empty())
+            .unwrap_or(false),
+        "diagnostics should propagate"
+    );
+
+    let summary = borrow
+        .host
+        .capabilities(Language::TypeScript)
+        .unwrap_or_else(|| panic!("capability summary missing"));
+    let diagnostics = summary.state(CapabilityKind::Diagnostics);
+    assert_eq!(diagnostics.source, CapabilitySource::ForcedOverride);
+}
+
+#[then("the request fails with an unavailable capability error")]
+fn then_missing_capability(world: &RefCell<TestWorld>) {
+    let borrow = world.borrow();
+    match &borrow.last_error {
+        Some(LspHostError::CapabilityUnavailable { capability, .. }) => {
+            assert_eq!(*capability, CapabilityKind::References);
+        }
+        other => panic!("expected capability error, got {other:?}"),
+    }
+}
+
+#[then("python recorded only initialisation")]
+fn then_python_calls(world: &RefCell<TestWorld>) {
+    let calls = world
+        .borrow()
+        .calls(Language::Python)
+        .unwrap_or_else(|| panic!("calls missing"));
+    assert_eq!(calls, [CallKind::Initialise]);
+}
+
+#[then("typescript recorded a diagnostics call")]
+fn then_override_order(world: &RefCell<TestWorld>) {
+    assert_call_recorded(world, Language::TypeScript, CallKind::Diagnostics);
+}
+
+#[then("the request fails with a server error")]
+fn then_server_error(world: &RefCell<TestWorld>) {
+    let borrow = world.borrow();
+    match &borrow.last_error {
+        Some(LspHostError::Server {
+            operation: HostOperation::Initialise,
+            ..
+        }) => {}
+        other => panic!("expected server error, got {other:?}"),
+    }
+}
+
+fn assert_call_recorded(world: &RefCell<TestWorld>, language: Language, kind: CallKind) {
+    let borrow = world.borrow();
+    let calls = borrow
+        .calls(language)
+        .unwrap_or_else(|| panic!("missing calls for {language}"));
+    assert!(
+        calls.contains(&kind),
+        "expected to record {kind:?} for {language}, got {calls:?}"
+    );
+}
+
+fn apply_override(
+    world: &RefCell<TestWorld>,
+    language: Language,
+    capability: CapabilityKind,
+    directive: CapabilityOverride,
+) {
+    let mut overrides = CapabilityMatrix::default();
+    overrides.set_override(language.as_str(), capability.key(), directive);
+    world.borrow_mut().rebuild_host(overrides);
+}
+
+fn sample_responses() -> ResponseSet {
+    ResponseSet {
+        definition: GotoDefinitionResponse::Array(vec![Location {
+            uri: sample_uri(),
+            range: lsp_types::Range::default(),
+        }]),
+        references: vec![Location {
+            uri: sample_uri(),
+            range: lsp_types::Range::default(),
+        }],
+        diagnostics: vec![Diagnostic::default()],
+    }
+}
+
+fn sample_uri() -> Uri {
+    Uri::from_str("file:///workspace/main.rs")
+        .unwrap_or_else(|error| panic!("invalid test URL: {error}"))
+}
+
+fn definition_params() -> GotoDefinitionParams {
+    GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: sample_uri() },
+            position: Position::new(1, 2),
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn reference_params() -> ReferenceParams {
+    ReferenceParams {
+        text_document_position: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: sample_uri() },
+            position: Position::new(1, 2),
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+        context: ReferenceContext {
+            include_declaration: false,
+        },
+    }
+}
+
+#[scenario(path = "tests/features/lsp_host.feature")]
+fn lsp_host_behaviour(#[from(world)] _: RefCell<TestWorld>) {}

--- a/crates/weaver-lsp-host/src/tests/behaviour.rs
+++ b/crates/weaver-lsp-host/src/tests/behaviour.rs
@@ -153,7 +153,7 @@ fn then_rust_capabilities(world: &RefCell<TestWorld>) {
     let summary = borrow
         .last_capabilities
         .as_ref()
-        .unwrap_or_else(|| panic!("capabilities missing"));
+        .expect("capabilities missing");
 
     for state in summary.states() {
         assert!(state.enabled, "capability {:?} should be enabled", state.kind);
@@ -192,7 +192,7 @@ fn then_override_succeeds(world: &RefCell<TestWorld>) {
     let summary = borrow
         .host
         .capabilities(Language::TypeScript)
-        .unwrap_or_else(|| panic!("capability summary missing"));
+        .expect("capability summary missing");
     let diagnostics = summary.state(CapabilityKind::Diagnostics);
     assert_eq!(diagnostics.source, CapabilitySource::ForcedOverride);
 }
@@ -222,7 +222,7 @@ fn then_python_calls(world: &RefCell<TestWorld>) {
     let calls = world
         .borrow()
         .calls(Language::Python)
-        .unwrap_or_else(|| panic!("calls missing"));
+        .expect("calls missing");
     assert_eq!(calls, [CallKind::Initialise]);
 }
 

--- a/crates/weaver-lsp-host/src/tests/mod.rs
+++ b/crates/weaver-lsp-host/src/tests/mod.rs
@@ -1,0 +1,5 @@
+//! Test suites covering the LSP host facade.
+
+mod behaviour;
+mod support;
+mod unit;

--- a/crates/weaver-lsp-host/src/tests/support/mod.rs
+++ b/crates/weaver-lsp-host/src/tests/support/mod.rs
@@ -3,5 +3,16 @@
 mod recording_server;
 mod world;
 
+use std::str::FromStr;
+
+use lsp_types::Uri;
+use rstest::fixture;
+
 pub use recording_server::{CallKind, RecordingLanguageServer, RecordingServerHandle};
 pub use world::{TestServerConfig, TestWorld};
+
+/// Common URI used by host tests.
+#[fixture]
+pub fn sample_uri() -> Uri {
+    Uri::from_str("file:///workspace/main.rs").expect("invalid test URI")
+}

--- a/crates/weaver-lsp-host/src/tests/support/mod.rs
+++ b/crates/weaver-lsp-host/src/tests/support/mod.rs
@@ -1,0 +1,7 @@
+//! Shared fixtures and helpers for host tests.
+
+mod recording_server;
+mod world;
+
+pub use recording_server::{CallKind, RecordingLanguageServer, RecordingServerHandle};
+pub use world::{TestServerConfig, TestWorld};

--- a/crates/weaver-lsp-host/src/tests/support/recording_server.rs
+++ b/crates/weaver-lsp-host/src/tests/support/recording_server.rs
@@ -9,7 +9,7 @@ use crate::server::{LanguageServer, LanguageServerError, ServerCapabilitySet};
 /// Discriminates the kind of call recorded by the stub server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallKind {
-    /// `initialize` was invoked.
+    /// `initialise` was invoked.
     Initialise,
     /// `textDocument/definition` was invoked.
     Definition,

--- a/crates/weaver-lsp-host/src/tests/support/recording_server.rs
+++ b/crates/weaver-lsp-host/src/tests/support/recording_server.rs
@@ -38,7 +38,7 @@ impl RecordingLanguageServer {
     }
 
     /// Creates a server that fails during initialisation.
-    pub fn failing_initialise(
+    pub fn failing_initialize(
         capabilities: ServerCapabilitySet,
         message: impl Into<String>,
     ) -> Self {
@@ -77,7 +77,7 @@ impl RecordingLanguageServer {
 }
 
 impl LanguageServer for RecordingLanguageServer {
-    fn initialise(&mut self) -> Result<ServerCapabilitySet, LanguageServerError> {
+    fn initialize(&mut self) -> Result<ServerCapabilitySet, LanguageServerError> {
         with_state(&self.shared, |state| {
             state.record_call(CallKind::Initialise);
             if let Some(message) = &state.fail_initialise {

--- a/crates/weaver-lsp-host/src/tests/support/recording_server.rs
+++ b/crates/weaver-lsp-host/src/tests/support/recording_server.rs
@@ -1,0 +1,188 @@
+//! Recording language server used in tests.
+
+use std::sync::{Arc, Mutex};
+
+use lsp_types::{Diagnostic, GotoDefinitionParams, GotoDefinitionResponse, Location, ReferenceParams, Uri};
+
+use crate::server::{LanguageServer, LanguageServerError, ServerCapabilitySet};
+
+/// Discriminates the kind of call recorded by the stub server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallKind {
+    /// `initialize` was invoked.
+    Initialise,
+    /// `textDocument/definition` was invoked.
+    Definition,
+    /// `textDocument/references` was invoked.
+    References,
+    /// Diagnostics were requested.
+    Diagnostics,
+}
+
+/// Test double that records every request routed through it.
+#[derive(Clone)]
+pub struct RecordingLanguageServer {
+    shared: Arc<Mutex<RecordingState>>,
+}
+
+impl RecordingLanguageServer {
+    /// Creates a server that reports the provided capabilities and responses.
+    pub fn new(capabilities: ServerCapabilitySet, responses: ResponseSet) -> Self {
+        Self {
+            shared: Arc::new(Mutex::new(RecordingState::new(
+                capabilities,
+                responses,
+                None,
+            ))),
+        }
+    }
+
+    /// Creates a server that fails during initialisation.
+    pub fn failing_initialise(
+        capabilities: ServerCapabilitySet,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            shared: Arc::new(Mutex::new(RecordingState::new(
+                capabilities,
+                ResponseSet::default(),
+                Some(message.into()),
+            ))),
+        }
+    }
+
+    /// Returns a handle that can be used to assert recorded calls.
+    pub fn handle(&self) -> RecordingServerHandle {
+        RecordingServerHandle {
+            shared: Arc::clone(&self.shared),
+        }
+    }
+}
+
+impl LanguageServer for RecordingLanguageServer {
+    fn initialise(&mut self) -> Result<ServerCapabilitySet, LanguageServerError> {
+        with_state(&self.shared, |state| {
+            state.record_call(CallKind::Initialise);
+            if let Some(message) = &state.fail_initialise {
+                return Err(LanguageServerError::new(message.clone()));
+            }
+            state.initialised = true;
+            Ok(state.capabilities)
+        })
+    }
+
+    fn goto_definition(
+        &mut self,
+        _params: GotoDefinitionParams,
+    ) -> Result<GotoDefinitionResponse, LanguageServerError> {
+        with_state(&self.shared, |state| {
+            state.record_call(CallKind::Definition);
+            if !state.initialised {
+                return Err(LanguageServerError::new(
+                    "definition requested before initialisation",
+                ));
+            }
+            Ok(state.responses.definition.clone())
+        })
+    }
+
+    fn references(
+        &mut self,
+        _params: ReferenceParams,
+    ) -> Result<Vec<Location>, LanguageServerError> {
+        with_state(&self.shared, |state| {
+            state.record_call(CallKind::References);
+            if !state.initialised {
+                return Err(LanguageServerError::new(
+                    "references requested before initialisation",
+                ));
+            }
+            Ok(state.responses.references.clone())
+        })
+    }
+
+    fn diagnostics(&mut self, _uri: Uri) -> Result<Vec<Diagnostic>, LanguageServerError> {
+        with_state(&self.shared, |state| {
+            state.record_call(CallKind::Diagnostics);
+            if !state.initialised {
+                return Err(LanguageServerError::new(
+                    "diagnostics requested before initialisation",
+                ));
+            }
+            Ok(state.responses.diagnostics.clone())
+        })
+    }
+}
+
+/// Handle that exposes recorded state for assertions.
+#[derive(Clone)]
+pub struct RecordingServerHandle {
+    shared: Arc<Mutex<RecordingState>>,
+}
+
+impl RecordingServerHandle {
+    /// Returns the ordered list of calls the server observed.
+    pub fn calls(&self) -> Vec<CallKind> {
+        with_state(&self.shared, |state| state.calls.clone())
+    }
+}
+
+fn with_state<R, F>(shared: &Arc<Mutex<RecordingState>>, action: F) -> R
+where
+    F: FnOnce(&mut RecordingState) -> R,
+{
+    let mut guard = shared
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    action(&mut guard)
+}
+
+/// Static responses returned by the stub server.
+#[derive(Debug, Clone)]
+pub struct ResponseSet {
+    /// Response returned for definition requests.
+    pub definition: GotoDefinitionResponse,
+    /// Response returned for reference requests.
+    pub references: Vec<Location>,
+    /// Response returned for diagnostics requests.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl Default for ResponseSet {
+    fn default() -> Self {
+        Self {
+            definition: GotoDefinitionResponse::Array(Vec::new()),
+            references: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RecordingState {
+    capabilities: ServerCapabilitySet,
+    responses: ResponseSet,
+    calls: Vec<CallKind>,
+    initialised: bool,
+    fail_initialise: Option<String>,
+}
+
+impl RecordingState {
+    fn new(
+        capabilities: ServerCapabilitySet,
+        responses: ResponseSet,
+        fail_initialise: Option<String>,
+    ) -> Self {
+        Self {
+            capabilities,
+            responses,
+            calls: Vec::new(),
+            initialised: false,
+            fail_initialise,
+        }
+    }
+
+    fn record_call(&mut self, kind: CallKind) {
+        self.calls.push(kind);
+    }
+}

--- a/crates/weaver-lsp-host/src/tests/support/world.rs
+++ b/crates/weaver-lsp-host/src/tests/support/world.rs
@@ -17,11 +17,11 @@ use super::recording_server::{CallKind, RecordingLanguageServer, RecordingServer
 pub struct TestServerConfig {
     /// Language served by the stub.
     pub language: Language,
-    /// Capabilities reported during initialisation.
+    /// Capabilities reported during initialization.
     pub capabilities: ServerCapabilitySet,
     /// Responses returned for core operations.
     pub responses: ResponseSet,
-    /// Optional error to surface during initialisation.
+    /// Optional error to surface during initialization.
     pub initialisation_error: Option<String>,
 }
 

--- a/crates/weaver-lsp-host/src/tests/support/world.rs
+++ b/crates/weaver-lsp-host/src/tests/support/world.rs
@@ -22,7 +22,7 @@ pub struct TestServerConfig {
     /// Responses returned for core operations.
     pub responses: ResponseSet,
     /// Optional error to surface during initialization.
-    pub initialisation_error: Option<String>,
+    pub initialization_error: Option<String>,
 }
 
 impl TestServerConfig {
@@ -33,7 +33,7 @@ impl TestServerConfig {
             language,
             capabilities,
             responses: ResponseSet::default(),
-            initialisation_error: None,
+            initialization_error: None,
         }
     }
 }
@@ -44,7 +44,7 @@ impl Default for TestServerConfig {
             language: Language::Rust,
             capabilities: ServerCapabilitySet::new(true, true, true),
             responses: ResponseSet::default(),
-            initialisation_error: None,
+            initialization_error: None,
         }
     }
 }
@@ -113,7 +113,7 @@ impl TestWorld {
             .map(RecordingServerHandle::calls)
     }
 
-    /// Initialises the server for the language and stores the outcome.
+    /// Initializes the server for the language and stores the outcome.
     pub fn initialize(&mut self, language: Language) {
         self.last_capabilities = None;
         self.last_error = None;
@@ -162,7 +162,7 @@ impl TestWorld {
         self.last_capabilities = None;
 
         for config in &self.configs {
-            let server = match &config.initialisation_error {
+            let server = match &config.initialization_error {
                 Some(message) => RecordingLanguageServer::failing_initialize(
                     config.capabilities,
                     message.clone(),

--- a/crates/weaver-lsp-host/src/tests/support/world.rs
+++ b/crates/weaver-lsp-host/src/tests/support/world.rs
@@ -1,0 +1,177 @@
+//! BDD test world encapsulating the host and stub servers.
+
+use std::collections::HashMap;
+
+use lsp_types::{Diagnostic, GotoDefinitionResponse, Location, Uri};
+
+use crate::capability::CapabilitySummary;
+use crate::errors::LspHostError;
+use crate::language::Language;
+use crate::server::ServerCapabilitySet;
+use crate::LspHost;
+
+use super::recording_server::{CallKind, RecordingLanguageServer, RecordingServerHandle, ResponseSet};
+
+/// Configuration used to seed a stub server for a language.
+#[derive(Debug, Clone)]
+pub struct TestServerConfig {
+    /// Language served by the stub.
+    pub language: Language,
+    /// Capabilities reported during initialisation.
+    pub capabilities: ServerCapabilitySet,
+    /// Responses returned for core operations.
+    pub responses: ResponseSet,
+    /// Optional error to surface during initialisation.
+    pub initialisation_error: Option<String>,
+}
+
+impl TestServerConfig {
+    /// Builds a config with the supplied capabilities and default responses.
+    #[must_use]
+    pub fn with_defaults(language: Language, capabilities: ServerCapabilitySet) -> Self {
+        Self {
+            language,
+            capabilities,
+            responses: ResponseSet::default(),
+            initialisation_error: None,
+        }
+    }
+}
+
+impl Default for TestServerConfig {
+    fn default() -> Self {
+        Self {
+            language: Language::Rust,
+            capabilities: ServerCapabilitySet::new(true, true, true),
+            responses: ResponseSet::default(),
+            initialisation_error: None,
+        }
+    }
+}
+
+/// Shared state exercised by BDD step implementations.
+pub struct TestWorld {
+    /// Configurations used to rebuild the host between steps.
+    configs: Vec<TestServerConfig>,
+    /// Host instance under test.
+    pub host: LspHost,
+    handles: HashMap<Language, RecordingServerHandle>,
+    /// Last error observed while exercising the host.
+    pub last_error: Option<LspHostError>,
+    /// Last definition response observed.
+    pub last_definition: Option<GotoDefinitionResponse>,
+    /// Last references response observed.
+    pub last_references: Option<Vec<Location>>,
+    /// Last diagnostics response observed.
+    pub last_diagnostics: Option<Vec<Diagnostic>>,
+    /// Last capability summary observed.
+    pub last_capabilities: Option<CapabilitySummary>,
+}
+
+impl TestWorld {
+    /// Builds a world populated with the supplied stub servers.
+    #[must_use]
+    pub fn new(configs: Vec<TestServerConfig>, overrides: weaver_config::CapabilityMatrix) -> Self {
+        let mut world = Self {
+            configs,
+            host: LspHost::new(overrides.clone()),
+            handles: HashMap::new(),
+            last_error: None,
+            last_definition: None,
+            last_references: None,
+            last_diagnostics: None,
+            last_capabilities: None,
+        };
+        world.rebuild_host(overrides);
+        world
+    }
+
+    /// Returns the recorded call sequence for the specified language.
+    pub fn calls(&self, language: Language) -> Option<Vec<CallKind>> {
+        self.handles
+            .get(&language)
+            .map(RecordingServerHandle::calls)
+    }
+
+    /// Initialises the server for the language and stores the outcome.
+    pub fn initialise(&mut self, language: Language) {
+        self.last_capabilities = None;
+        self.last_error = None;
+        match self.host.initialise(language) {
+            Ok(summary) => self.last_capabilities = Some(summary),
+            Err(error) => self.last_error = Some(error),
+        }
+    }
+
+    /// Issues a definition request.
+    pub fn request_definition(
+        &mut self,
+        language: Language,
+        params: lsp_types::GotoDefinitionParams,
+    ) {
+        self.last_definition = None;
+        self.last_error = None;
+        match self.host.goto_definition(language, params) {
+            Ok(response) => self.last_definition = Some(response),
+            Err(error) => self.last_error = Some(error),
+        }
+    }
+
+    /// Issues a references request.
+    pub fn request_references(
+        &mut self,
+        language: Language,
+        params: lsp_types::ReferenceParams,
+    ) {
+        self.last_references = None;
+        self.last_error = None;
+        match self.host.references(language, params) {
+            Ok(response) => self.last_references = Some(response),
+            Err(error) => self.last_error = Some(error),
+        }
+    }
+
+    /// Issues a diagnostics request.
+    pub fn request_diagnostics(&mut self, language: Language, uri: Uri) {
+        self.last_diagnostics = None;
+        self.last_error = None;
+        match self.host.diagnostics(language, uri) {
+            Ok(response) => self.last_diagnostics = Some(response),
+            Err(error) => self.last_error = Some(error),
+        }
+    }
+
+    /// Rebuilds the host using the stored server configs and supplied overrides.
+    pub fn rebuild_host(&mut self, overrides: weaver_config::CapabilityMatrix) {
+        self.host = LspHost::new(overrides);
+        self.handles.clear();
+        self.last_error = None;
+        self.last_definition = None;
+        self.last_references = None;
+        self.last_diagnostics = None;
+        self.last_capabilities = None;
+
+        for config in &self.configs {
+            let server = match &config.initialisation_error {
+                Some(message) => RecordingLanguageServer::failing_initialise(
+                    config.capabilities,
+                    message.clone(),
+                ),
+                None => RecordingLanguageServer::new(
+                    config.capabilities,
+                    config.responses.clone(),
+                ),
+            };
+
+            let handle = server.handle();
+            if let Err(error) = self.host.register_language(config.language, Box::new(server)) {
+                panic!(
+                    "failed to register stub server for {language}: {error}",
+                    language = config.language,
+                    error = error
+                );
+            }
+            self.handles.insert(config.language, handle);
+        }
+    }
+}

--- a/crates/weaver-lsp-host/src/tests/support/world.rs
+++ b/crates/weaver-lsp-host/src/tests/support/world.rs
@@ -114,10 +114,10 @@ impl TestWorld {
     }
 
     /// Initialises the server for the language and stores the outcome.
-    pub fn initialise(&mut self, language: Language) {
+    pub fn initialize(&mut self, language: Language) {
         self.last_capabilities = None;
         self.last_error = None;
-        match self.host.initialise(language) {
+        match self.host.initialize(language) {
             Ok(summary) => self.last_capabilities = Some(summary),
             Err(error) => self.last_error = Some(error),
         }
@@ -163,7 +163,7 @@ impl TestWorld {
 
         for config in &self.configs {
             let server = match &config.initialisation_error {
-                Some(message) => RecordingLanguageServer::failing_initialise(
+                Some(message) => RecordingLanguageServer::failing_initialize(
                     config.capabilities,
                     message.clone(),
                 ),
@@ -176,9 +176,8 @@ impl TestWorld {
             let handle = server.handle();
             if let Err(error) = self.host.register_language(config.language, Box::new(server)) {
                 panic!(
-                    "failed to register stub server for {language}: {error}",
-                    language = config.language,
-                    error = error
+                    "failed to register stub server for {}: {}",
+                    config.language, error
                 );
             }
             self.handles.insert(config.language, handle);

--- a/crates/weaver-lsp-host/src/tests/unit.rs
+++ b/crates/weaver-lsp-host/src/tests/unit.rs
@@ -1,0 +1,115 @@
+//! Unit tests for small host behaviours.
+
+use std::cell::RefCell;
+use std::str::FromStr;
+
+use rstest::rstest;
+use weaver_config::{CapabilityMatrix, CapabilityOverride};
+
+use crate::capability::{CapabilityKind, CapabilitySource};
+use crate::errors::LspHostError;
+use crate::language::Language;
+use crate::server::ServerCapabilitySet;
+use crate::tests::support::{CallKind, RecordingLanguageServer, ResponseSet, TestWorld};
+
+#[rstest]
+fn applies_force_and_deny_overrides() {
+    let mut overrides = CapabilityMatrix::default();
+    overrides.set_override(
+        Language::Rust.as_str(),
+        CapabilityKind::Diagnostics.key(),
+        CapabilityOverride::Deny,
+    );
+    overrides.set_override(
+        Language::Rust.as_str(),
+        CapabilityKind::References.key(),
+        CapabilityOverride::Force,
+    );
+
+    let config = vec![crate::tests::support::TestServerConfig {
+        language: Language::Rust,
+        capabilities: ServerCapabilitySet::new(true, false, false),
+        responses: ResponseSet::default(),
+        initialisation_error: None,
+    }];
+    let mut world = TestWorld::new(config, overrides);
+
+    world.initialise(Language::Rust);
+    let summary = world
+        .last_capabilities
+        .take()
+        .unwrap_or_else(|| panic!("missing capabilities"));
+
+    let references = summary.state(CapabilityKind::References);
+    assert!(references.enabled);
+    assert_eq!(references.source, CapabilitySource::ForcedOverride);
+
+    let diagnostics = summary.state(CapabilityKind::Diagnostics);
+    assert!(!diagnostics.enabled);
+    assert_eq!(diagnostics.source, CapabilitySource::DeniedOverride);
+}
+
+#[rstest]
+fn rejects_duplicate_language_registration() {
+    let server = RecordingLanguageServer::new(
+        ServerCapabilitySet::new(true, true, true),
+        ResponseSet::default(),
+    );
+    let mut host = crate::LspHost::new(CapabilityMatrix::default());
+
+    assert!(host
+        .register_language(Language::Rust, Box::new(server.clone()))
+        .is_ok());
+    match host.register_language(Language::Rust, Box::new(server)) {
+        Err(LspHostError::DuplicateLanguage { .. }) => {}
+        other => panic!("expected duplicate language error, got {other:?}"),
+    }
+}
+
+#[rstest]
+fn reports_unknown_language_on_request() {
+    let mut host = crate::LspHost::new(CapabilityMatrix::default());
+    match host.goto_definition(Language::Rust, definition_params()) {
+        Err(LspHostError::UnknownLanguage { .. }) => {}
+        other => panic!("expected unknown language error, got {other:?}"),
+    }
+}
+
+#[rstest]
+fn calls_initialise_before_requests() {
+    let responses = ResponseSet::default();
+    let server = RecordingLanguageServer::new(
+        ServerCapabilitySet::new(true, true, true),
+        responses,
+    );
+    let handle = server.handle();
+    let mut host = crate::LspHost::new(CapabilityMatrix::default());
+    assert!(host
+        .register_language(Language::Rust, Box::new(server))
+        .is_ok());
+
+    let uri = sample_uri();
+    let _ = host.diagnostics(Language::Rust, uri);
+
+    let calls = handle.calls();
+    assert!(
+        calls.starts_with(&[CallKind::Initialise]),
+        "initialise should precede requests: {calls:?}"
+    );
+}
+
+fn definition_params() -> lsp_types::GotoDefinitionParams {
+    lsp_types::GotoDefinitionParams {
+        text_document_position_params: lsp_types::TextDocumentPositionParams {
+            text_document: lsp_types::TextDocumentIdentifier { uri: sample_uri() },
+            position: lsp_types::Position::new(1, 2),
+        },
+        work_done_progress_params: lsp_types::WorkDoneProgressParams::default(),
+        partial_result_params: lsp_types::PartialResultParams::default(),
+    }
+}
+
+fn sample_uri() -> lsp_types::Uri {
+    lsp_types::Uri::from_str("file:///workspace/main.rs")
+        .unwrap_or_else(|error| panic!("invalid test URL: {error}"))
+}

--- a/crates/weaver-lsp-host/src/tests/unit.rs
+++ b/crates/weaver-lsp-host/src/tests/unit.rs
@@ -38,7 +38,7 @@ fn applies_force_and_deny_overrides() {
     let summary = world
         .last_capabilities
         .take()
-        .unwrap_or_else(|| panic!("missing capabilities"));
+        .expect("missing capabilities");
 
     let references = summary.state(CapabilityKind::References);
     assert!(references.enabled);
@@ -51,20 +51,35 @@ fn applies_force_and_deny_overrides() {
 
 #[rstest]
 fn parses_known_languages() {
-    assert_eq!(Language::from_str("rust").unwrap(), Language::Rust);
-    assert_eq!(Language::from_str("python").unwrap(), Language::Python);
-    assert_eq!(Language::from_str("typescript").unwrap(), Language::TypeScript);
+    assert_eq!(Language::from_str("rust").expect("rust should parse"), Language::Rust);
+    assert_eq!(
+        Language::from_str("python").expect("python should parse"),
+        Language::Python
+    );
+    assert_eq!(
+        Language::from_str("typescript").expect("typescript should parse"),
+        Language::TypeScript
+    );
 }
 
 #[rstest]
 fn parses_typescript_alias_ts() {
-    assert_eq!(Language::from_str("ts").unwrap(), Language::TypeScript);
+    assert_eq!(
+        Language::from_str("ts").expect("ts alias should parse"),
+        Language::TypeScript
+    );
 }
 
 #[rstest]
 fn trims_whitespace_in_language_parse() {
-    assert_eq!(Language::from_str(" rust ").unwrap(), Language::Rust);
-    assert_eq!(Language::from_str("\tpython\n").unwrap(), Language::Python);
+    assert_eq!(
+        Language::from_str(" rust ").expect("padded rust should parse"),
+        Language::Rust
+    );
+    assert_eq!(
+        Language::from_str("\tpython\n").expect("padded python should parse"),
+        Language::Python
+    );
 }
 
 #[rstest]

--- a/crates/weaver-lsp-host/src/tests/unit.rs
+++ b/crates/weaver-lsp-host/src/tests/unit.rs
@@ -30,7 +30,7 @@ fn applies_force_and_deny_overrides() {
         language: Language::Rust,
         capabilities: ServerCapabilitySet::new(true, false, false),
         responses: ResponseSet::default(),
-        initialisation_error: None,
+        initialization_error: None,
     }];
     let mut world = TestWorld::new(config, overrides);
 
@@ -164,11 +164,11 @@ fn propagates_server_error_from_definition() {
 }
 
 #[rstest]
-    fn calls_initialise_before_requests() {
-        let responses = ResponseSet::default();
-        let server = RecordingLanguageServer::new(
-            ServerCapabilitySet::new(true, true, true),
-            responses,
+fn calls_initialise_before_requests() {
+    let responses = ResponseSet::default();
+    let server = RecordingLanguageServer::new(
+        ServerCapabilitySet::new(true, true, true),
+        responses,
     );
     let handle = server.handle();
     let mut host = crate::LspHost::new(CapabilityMatrix::default());

--- a/crates/weaver-lsp-host/src/tests/unit.rs
+++ b/crates/weaver-lsp-host/src/tests/unit.rs
@@ -1,7 +1,6 @@
 //! Unit tests for small host behaviours.
 
 use std::cell::RefCell;
-use std::str::FromStr;
 
 use rstest::rstest;
 use weaver_config::{CapabilityMatrix, CapabilityOverride};
@@ -11,7 +10,7 @@ use crate::capability::{CapabilityKind, CapabilitySource};
 use crate::errors::LspHostError;
 use crate::language::{Language, LanguageParseError};
 use crate::server::ServerCapabilitySet;
-use crate::tests::support::{CallKind, RecordingLanguageServer, ResponseSet, TestWorld};
+use crate::tests::support::{sample_uri, CallKind, RecordingLanguageServer, ResponseSet, TestWorld};
 
 #[rstest]
 fn applies_force_and_deny_overrides() {
@@ -35,7 +34,7 @@ fn applies_force_and_deny_overrides() {
     }];
     let mut world = TestWorld::new(config, overrides);
 
-    world.initialise(Language::Rust);
+    world.initialize(Language::Rust);
     let summary = world
         .last_capabilities
         .take()
@@ -105,7 +104,7 @@ fn reports_unknown_language_on_request() {
 fn propagates_server_error_from_definition() {
     struct FailingServer;
     impl crate::server::LanguageServer for FailingServer {
-        fn initialise(&mut self) -> Result<ServerCapabilitySet, crate::server::LanguageServerError> {
+        fn initialize(&mut self) -> Result<ServerCapabilitySet, crate::server::LanguageServerError> {
             Ok(ServerCapabilitySet::new(true, true, true))
         }
 
@@ -150,11 +149,11 @@ fn propagates_server_error_from_definition() {
 }
 
 #[rstest]
-fn calls_initialise_before_requests() {
-    let responses = ResponseSet::default();
-    let server = RecordingLanguageServer::new(
-        ServerCapabilitySet::new(true, true, true),
-        responses,
+    fn calls_initialise_before_requests() {
+        let responses = ResponseSet::default();
+        let server = RecordingLanguageServer::new(
+            ServerCapabilitySet::new(true, true, true),
+            responses,
     );
     let handle = server.handle();
     let mut host = crate::LspHost::new(CapabilityMatrix::default());
@@ -181,9 +180,4 @@ fn definition_params() -> lsp_types::GotoDefinitionParams {
         work_done_progress_params: lsp_types::WorkDoneProgressParams::default(),
         partial_result_params: lsp_types::PartialResultParams::default(),
     }
-}
-
-fn sample_uri() -> lsp_types::Uri {
-    lsp_types::Uri::from_str("file:///workspace/main.rs")
-        .unwrap_or_else(|error| panic!("invalid test URL: {error}"))
 }

--- a/crates/weaver-lsp-host/tests/features/lsp_host.feature
+++ b/crates/weaver-lsp-host/tests/features/lsp_host.feature
@@ -1,0 +1,32 @@
+Feature: LSP host core routing
+
+  Scenario: Initialises Rust server and routes core requests
+    Given stub servers for all primary languages
+    When rust is initialised
+    And rust handles a definition request
+    And rust handles a references request
+    And rust handles a diagnostics request
+    Then rust capabilities are available from the server
+    And rust recorded a definition call
+    And rust recorded a references call
+    And rust recorded a diagnostics call
+
+  Scenario: Deny override blocks unsupported capability
+    Given a python server missing references
+    And a deny override for python references
+    When python is initialised
+    And python handles a references request
+    Then the request fails with an unavailable capability error
+    And python recorded only initialisation
+
+  Scenario: Force override enables diagnostics
+    Given a typescript server missing diagnostics
+    And a force override for typescript diagnostics
+    When typescript handles a diagnostics request
+    Then diagnostics succeed via override
+    And typescript recorded a diagnostics call
+
+  Scenario: Server initialisation failures surface errors
+    Given a rust server that fails during initialisation
+    When rust is initialised
+    Then the request fails with a server error

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,7 +49,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
         refuse to start when sockets are bound, and emit recovery guidance for
         the operator.
 
-- [ ] Build the `weaver-lsp-host` crate with support for initialisation,
+- [x] Build the `weaver-lsp-host` crate with support for initialisation,
     capability detection, and core LSP features (definition, references,
     diagnostics) for Rust, Python, and TypeScript.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
         demonstrate precedence order (file < env < CLI), and default sockets
         align with the design doc.
 - [x] Implement the `weaver-cli` executable as the thin JSONL client that
-      initialises configuration via `ortho-config`, exposes the
+      initializes configuration via `ortho-config`, exposes the
       `--capabilities` probe, and streams requests to a running daemon over
       standard IO.
       - Acceptance criteria: CLI command surface mirrors the design table,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,7 +49,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
         refuse to start when sockets are bound, and emit recovery guidance for
         the operator.
 
-- [x] Build the `weaver-lsp-host` crate with support for initialisation,
+- [x] Build the `weaver-lsp-host` crate with support for initialization,
     capability detection, and core LSP features (definition, references,
     diagnostics) for Rust, Python, and TypeScript.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -199,6 +199,19 @@ unless an exit status was already observed. Any session that ends without an
 explicit exit message is treated as an error, so callers do not misinterpret a
 partial response as success.
 
+## Language server capability detection
+
+The new `weaver-lsp-host` crate initialises the LSP servers for Rust, Python,
+and TypeScript and records which core requests each server advertises:
+`textDocument/definition`, `textDocument/references`, and diagnostics. These
+advertised capabilities are merged with any overrides provided via
+`capability_overrides` in `weaver-config`. `force` directives allow a request
+even when the server claims not to support it, while `deny` directives block
+the request regardless of the server report. When a request is rejected, the
+error explains whether the feature was disabled by configuration or simply
+absent from the server so operators and agents can adjust their plans without
+guesswork.
+
 ### Capability probe
 
 The capability matrix negotiated through configuration overrides can be

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1106,3 +1106,17 @@ additional serde/serde_json surface when it is not required, which partially
 offsets the build bloat introduced by the new localization stack (i18n-embed,
 fluent, unic-langid). Upstream now ships `rstest-bdd-patterns` 0.1.0 via the
 same pin, so the entire stack aligns on stable releases.
+
+#### 2025-11-27: Introduce `weaver-lsp-host` with capability-aware routing
+
+The new `weaver-lsp-host` crate owns the lifecycle of language servers for
+Rust, Python, and TypeScript. Initialisation now records the capabilities the
+server advertises for `textDocument/definition`, `textDocument/references`, and
+diagnostics, and then folds in operator overrides from `weaver-config`.
+Explicit `force` directives enable missing features, while `deny` directives
+block requests even when the server reports support. Core observe/verify calls
+are routed through a small trait so higher layers can inject sandboxed or
+recording implementations without spawning real servers during tests. Requests
+fail fast with structured errors that surface both the language and the reason
+(server missing, override deny, or server error) to callers, keeping the
+capability matrix honest before the daemon adds sandboxing and transport.

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -160,6 +160,169 @@ It separates the high-cost initialization of language analysis tools from the
 rapid execution of commands, and it fuses multiple data sources to build a
 comprehensive model of the codebase.
 
+### LSP host structure
+
+The following class diagram captures the structure of the `weaver-lsp-host`
+module, showing how capability negotiation, session state, and language server
+adaptors fit together:
+
+```mermaid
+classDiagram
+    class LspHost {
+        -CapabilityMatrix overrides
+        -HashMap~Language, Session~ sessions
+        +new(overrides: CapabilityMatrix) LspHost
+        +register_language(language: Language, server: Box~LanguageServer~) Result~(), LspHostError~
+        +initialise(language: Language) Result~CapabilitySummary, LspHostError~
+        +capabilities(language: Language) Option~CapabilitySummary~
+        +goto_definition(language: Language, params: GotoDefinitionParams) Result~GotoDefinitionResponse, LspHostError~
+        +references(language: Language, params: ReferenceParams) Result~Vec~Location~, LspHostError~
+        +diagnostics(language: Language, uri: Uri) Result~Vec~Diagnostic~, LspHostError~
+        -call_with_capability(context: CallContext, call: FnOnce) Result~T, LspHostError~
+        -ensure_initialised(language: Language, session: Session, overrides: CapabilityMatrix)
+          Result~CapabilitySummary, LspHostError~
+        -session_mut(language: Language) Result~Session, LspHostError~
+    }
+
+    class Session {
+        -Box~LanguageServer~ server
+        -SessionState state
+    }
+
+    class SessionState {
+        <<enum>>
+        Pending
+        Ready(summary: CapabilitySummary)
+    }
+
+    class CallContext {
+        -Language language
+        -CapabilityKind capability
+        -HostOperation operation
+    }
+
+    class LanguageServer {
+        <<interface>>
+        +initialise() Result~ServerCapabilitySet, LanguageServerError~
+        +goto_definition(params: GotoDefinitionParams) Result~GotoDefinitionResponse, LanguageServerError~
+        +references(params: ReferenceParams) Result~Vec~Location~, LanguageServerError~
+        +diagnostics(uri: Uri) Result~Vec~Diagnostic~, LanguageServerError~
+    }
+
+    class ServerCapabilitySet {
+        -bool definition
+        -bool references
+        -bool diagnostics
+        +new(definition: bool, references: bool, diagnostics: bool) ServerCapabilitySet
+        +supports_definition() bool
+        +supports_references() bool
+        +supports_diagnostics() bool
+    }
+
+    class LanguageServerError {
+        -String message
+        -Option~Error~ source
+        +new(message: String) LanguageServerError
+        +with_source(message: String, source: Error) LanguageServerError
+        +message() &str
+    }
+
+    class CapabilityKind {
+        <<enum>>
+        Definition
+        References
+        Diagnostics
+        +key() &str
+    }
+
+    class CapabilitySource {
+        <<enum>>
+        ServerAdvertised
+        ForcedOverride
+        DeniedOverride
+        MissingOnServer
+    }
+
+    class CapabilityState {
+        +CapabilityKind kind
+        +bool enabled
+        +CapabilitySource source
+        +new(kind: CapabilityKind, enabled: bool, source: CapabilitySource) CapabilityState
+    }
+
+    class CapabilitySummary {
+        -Language language
+        -BTreeMap~CapabilityKind, CapabilityState~ states
+        +language() Language
+        +state(capability: CapabilityKind) CapabilityState
+        +states() Iterator~CapabilityState~
+    }
+
+    class Language {
+        <<enum>>
+        Rust
+        Python
+        TypeScript
+        +as_str() &str
+        +from_str(input: &str) Result~Language, LanguageParseError~
+    }
+
+    class LanguageParseError {
+        -String input
+        +input() &str
+    }
+
+    class HostOperation {
+        <<enum>>
+        Initialise
+        Definition
+        References
+        Diagnostics
+    }
+
+    class LspHostError {
+        <<enum>>
+        UnknownLanguage(language: Language)
+        DuplicateLanguage(language: Language)
+        CapabilityUnavailable(language: Language, capability: CapabilityKind, reason: CapabilitySource)
+        Server(language: Language, operation: HostOperation, source: LanguageServerError)
+        +unknown(language: Language) LspHostError
+        +duplicate(language: Language) LspHostError
+        +capability_unavailable(language: Language, capability: CapabilityKind, reason: CapabilitySource) LspHostError
+        +server(language: Language, operation: HostOperation, source: LanguageServerError) LspHostError
+    }
+
+    class CapabilityMatrix {
+    }
+
+    %% Relationships
+    LspHost --> Session : manages
+    LspHost --> CapabilityMatrix : uses overrides
+    LspHost --> CapabilitySummary : returns
+    LspHost --> LspHostError : returns
+    Session --> SessionState : has
+    Session --> LanguageServer : owns
+    CapabilitySummary --> CapabilityState : aggregates
+    CapabilitySummary --> CapabilityKind : keyed by
+    CapabilityState --> CapabilityKind : describes
+    CapabilityState --> CapabilitySource : describes
+    LspHostError --> Language : references
+    LspHostError --> CapabilityKind : references
+    LspHostError --> CapabilitySource : references
+    LspHostError --> HostOperation : references
+    LspHostError --> LanguageServerError : wraps
+    LanguageServerError --> ServerCapabilitySet : produced by initialise
+    ServerCapabilitySet --> CapabilityKind : describes support for
+    Language --> LanguageParseError : parse failure
+    CapabilityMatrix ..> Language : keyed by
+    CapabilityMatrix ..> CapabilityKind : keyed by
+    LanguageServer <|.. RecordingLanguageServer
+
+    class RecordingLanguageServer {
+        <<test double>>
+    }
+```
+
 ### 2.1. Client-Daemon Interaction: The UNIX Way with JSONL
 
 The system is split into two primary components: `weaver`, a lightweight


### PR DESCRIPTION
## Summary
- Build CLI/daemon foundation by introducing the weaver-lsp-host crate, a capability-aware LSP host facade.
- The crate manages per-language LSP server lifecycles, negotiates advertised capabilities against configuration overrides, and routes core LSP requests (definition, references, diagnostics) through a small, test-friendly interface.
- This lays the foundation for the CLI/daemon to integrate with language servers in a controlled, observable manner.

Key outcomes:
- Per-language LSP server lifecycle management with capability negotiation
- Override semantics (force/deny) to control routing of core requests
- Lightweight, test-friendly abstraction over LanguageServer bindings
- Behavioral and unit tests with a mock recording server to validate routing and errors
- Feature-file driven tests covering initialization, routing, and error paths

## Changes
- Added new workspace crate: crates/weaver-lsp-host
  - capability.rs
    - Defines CapabilityKind (Definition, References, Diagnostics)
    - CapabilitySource (ServerAdvertised, ForcedOverride, DeniedOverride, MissingOnServer)
    - CapabilityState and CapabilitySummary with resolution logic
    - resolve_capabilities to merge server capabilities with overrides
  - errors.rs
    - LspHostError with variants for UnknownLanguage, DuplicateLanguage, CapabilityUnavailable, Server
    - HostOperation enum and Display impl for human-friendly messages
  - host.rs
    - LspHost: orchestrates multiple language servers and applies capability overrides
    - register_language, initialise, capabilities, goto_definition, references, diagnostics
    - call_with_capability and ensure_initialised helpers
  - language.rs
    - Language enum (Rust, Python, TypeScript) with parsing from strings
  - server.rs
    - LanguageServer trait: initialise, goto_definition, references, diagnostics
    - ServerCapabilitySet as a minimal capability descriptor
  - lib.rs
    - Public exports for CapabilityKind, CapabilitySource, CapabilityState, CapabilitySummary, LspHostError, LspHost, Language, LanguageParseError
  - tests (BDD and unit tests)
    - tests/behaviour.rs: Behavioural tests for the LSP host facade using rstest-bdd
    - tests/mod.rs, tests/unit.rs: Unit tests for host behaviours and override semantics
    - tests/support/mod.rs, tests/support/world.rs, tests/support/recording_server.rs
    - tests/features/lsp_host.feature: LSP host feature scenarios
    - docs and test support infrastructure updates to seed hosts, servers, and track calls
- Documentation and examples
  - Documentation and usage notes updated to reflect the new host facade and capability negotiation model
  - Workspace wiring updated to include the new crate for CLI/daemon integration

## Why this matters
This work provides a robust foundation for integrating language server capabilities into the CLI/daemon flow. It offers:
- Clear separation of concerns between capability negotiation and request routing
- Deterministic behavior under overrides (force/deny)
- Safe fallbacks and structured errors that expose both language and reason for failures
- A testable abstraction enabling future extensions without spinning real servers during tests

## How to test locally
- Build and run tests for the workspace: cargo test
- Specifically verify tests under crates/weaver-lsp-host, including:
  - unit tests for capability resolution and error handling
  - behaviour tests covering initialization, routing, and override semantics
  - feature file scenarios in tests/features/lsp_host.feature

## CI and downstream impact
- No changes required to existing crates beyond adding the new crate to the workspace (Cargo.toml updated accordingly).
- The new crate is designed to be consumed by the CLI/daemon foundation, providing a predictable, observable LSP host layer for Rust, Python, and TypeScript.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/411a0372-8035-48a3-bf5d-630cfc998100