### PR TITLE
Foundation: introduce weaver-sandbox for CLI/daemon isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,6 @@ name = "weaver-sandbox"
 version = "0.1.0"
 dependencies = [
  "birdcage",
- "once_cell",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "birdcage"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
+dependencies = [
+ "bitflags 2.9.4",
+ "libc",
+ "log",
+ "rustix 0.38.44",
+ "seccompiler",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +197,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 1.1.2",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
@@ -200,7 +213,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -578,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1009,6 +1022,12 @@ dependencies = [
  "bitflags 2.9.4",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1590,6 +1609,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -1597,7 +1629,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1608,7 +1640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -1637,6 +1669,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seccompiler"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6575e3c2b3a0fe2ef3e53855b6a8dead7c29f783da5e123d378c8c6a89017e"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "self_cell"
@@ -1873,7 +1914,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2402,6 +2443,18 @@ dependencies = [
  "rstest-bdd-macros",
  "thiserror 2.0.17",
  "weaver-config",
+]
+
+[[package]]
+name = "weaver-sandbox"
+version = "0.1.0"
+dependencies = [
+ "birdcage",
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
+ "tempfile",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,6 +2450,7 @@ name = "weaver-sandbox"
 version = "0.1.0"
 dependencies = [
  "birdcage",
+ "once_cell",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/weaver-config",
     "crates/weaverd",
     "crates/weaver-lsp-host",
+    "crates/weaver-sandbox",
 ]
 resolver = "2"
 
@@ -27,6 +28,7 @@ thiserror = "2.0"
 tempfile = "3.10"
 dirs = "6.0"
 lsp-types = "0.97"
+birdcage = "0.8.1"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean: ## Remove build artifacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
-	RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" $(CARGO) test $(BUILD_JOBS) --workspace --all-targets --all-features
+	RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" RUST_TEST_THREADS=1 $(CARGO) test $(BUILD_JOBS) --workspace --all-targets --all-features
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ clean: ## Remove build artifacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
-	RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" RUST_TEST_THREADS=1 $(CARGO) test $(BUILD_JOBS) --workspace --all-targets --all-features
+	RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" RUST_TEST_THREADS=1 $(CARGO) test $(BUILD_JOBS) --all-targets --all-features -p weaver-sandbox
+	RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" $(CARGO) test $(BUILD_JOBS) --workspace --all-targets --all-features --exclude weaver-sandbox
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/crates/weaver-sandbox/Cargo.toml
+++ b/crates/weaver-sandbox/Cargo.toml
@@ -12,4 +12,3 @@ rstest.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-macros.workspace = true
 tempfile.workspace = true
-once_cell.workspace = true

--- a/crates/weaver-sandbox/Cargo.toml
+++ b/crates/weaver-sandbox/Cargo.toml
@@ -12,3 +12,4 @@ rstest.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-macros.workspace = true
 tempfile.workspace = true
+once_cell.workspace = true

--- a/crates/weaver-sandbox/Cargo.toml
+++ b/crates/weaver-sandbox/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 
 [dependencies]
 birdcage.workspace = true
+once_cell.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/weaver-sandbox/Cargo.toml
+++ b/crates/weaver-sandbox/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "weaver-sandbox"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+birdcage.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+rstest-bdd.workspace = true
+rstest-bdd-macros.workspace = true
+tempfile.workspace = true

--- a/crates/weaver-sandbox/src/env_guard.rs
+++ b/crates/weaver-sandbox/src/env_guard.rs
@@ -1,0 +1,52 @@
+//! Restores the parent process environment after sandbox activation.
+
+use std::collections::BTreeSet;
+use std::env;
+use std::ffi::OsString;
+
+/// Restores the parent process environment after `birdcage` strips variables.
+#[derive(Debug)]
+pub struct EnvGuard {
+    original: Vec<(OsString, OsString)>,
+}
+
+impl EnvGuard {
+    /// Captures the current environment for later restoration.
+    #[must_use]
+    pub fn capture() -> Self {
+        Self {
+            original: env::vars_os().collect(),
+        }
+    }
+
+    fn original_keys(&self) -> BTreeSet<OsString> {
+        self.original.iter().map(|(key, _)| key.clone()).collect()
+    }
+
+    fn restore(&self) {
+        let expected_keys = self.original_keys();
+
+        // Remove variables introduced while the guard was active.
+        for (key, _) in env::vars_os() {
+            if !expected_keys.contains(&key) {
+                // SAFETY: keys originate from the host OS and were previously
+                // present in the environment, so removal cannot violate
+                // invariants expected by `std::env`.
+                unsafe { env::remove_var(&key) };
+            }
+        }
+
+        for (key, value) in &self.original {
+            // SAFETY: keys and values were captured from the process
+            // environment before sandboxing mutated it, so restoring them
+            // preserves the prior state without introducing invalid data.
+            unsafe { env::set_var(key, value) };
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}

--- a/crates/weaver-sandbox/src/env_guard.rs
+++ b/crates/weaver-sandbox/src/env_guard.rs
@@ -26,13 +26,15 @@ impl EnvGuard {
         // Remove variables introduced while the guard was active.
         for key in current.keys() {
             if !expected_keys.contains(key) {
-                // Nightly marks environment mutation as unsafe while the API
-                // stabilises; perform the operation within an unsafe block.
+                // Safety: project policy requires env mutation to be wrapped in
+                // `unsafe` until the std APIs settle for Rust 2024. We mutate
+                // only after snapshotting to avoid iterator invalidation.
                 unsafe { env::remove_var(key) };
             }
         }
 
         for (key, value) in &self.original {
+            // Safety: see note above regarding env mutation policy.
             unsafe { env::set_var(key, value) };
         }
     }

--- a/crates/weaver-sandbox/src/env_guard.rs
+++ b/crates/weaver-sandbox/src/env_guard.rs
@@ -1,4 +1,10 @@
 //! Restores the parent process environment after sandbox activation.
+//!
+//! Note: Project testing policy requires environment mutations (`set_var`,
+//! `remove_var`) to remain inside `unsafe` blocks on Rust 2024 toolchains.
+//! Although these std APIs are normally safe, wrapping them acknowledges the
+//! upstream marker while still containing all mutations behind the guard's
+//! snapshot-and-restore discipline.
 
 use std::collections::{HashMap, HashSet};
 use std::env;

--- a/crates/weaver-sandbox/src/error.rs
+++ b/crates/weaver-sandbox/src/error.rs
@@ -1,0 +1,39 @@
+//! Domain errors raised by the sandbox wrapper.
+
+use std::io;
+use std::path::PathBuf;
+
+use birdcage::error::Error as BirdcageError;
+use thiserror::Error;
+
+/// Errors raised while preparing or launching a sandboxed process.
+#[derive(Debug, Error)]
+pub enum SandboxError {
+    /// The supplied program path was not absolute.
+    #[error("sandboxed commands require absolute program paths, got {0}")]
+    ProgramNotAbsolute(PathBuf),
+
+    /// The program was not whitelisted in the profile.
+    #[error("executable {program} is not authorised by the sandbox profile")]
+    ExecutableNotAuthorised { program: PathBuf },
+
+    /// The supplied path does not exist and therefore cannot be whitelisted.
+    #[error("path {path} does not exist on the host filesystem")]
+    MissingPath { path: PathBuf },
+
+    /// Canonicalisation of a path failed.
+    #[error("failed to canonicalise {path}: {source}")]
+    CanonicalisationFailed { path: PathBuf, source: io::Error },
+
+    /// The current process hosts more than one thread.
+    #[error("sandboxing must occur in a single-threaded context (observed {thread_count} threads)")]
+    MultiThreaded { thread_count: usize },
+
+    /// Thread count could not be determined from `/proc`.
+    #[error("failed to determine thread count: {source}")]
+    ThreadCountUnavailable { source: io::Error },
+
+    /// The underlying sandbox library rejected activation.
+    #[error("birdcage activation failed: {0}")]
+    Activation(#[from] BirdcageError),
+}

--- a/crates/weaver-sandbox/src/lib.rs
+++ b/crates/weaver-sandbox/src/lib.rs
@@ -39,7 +39,7 @@
 //! [`SandboxError::MultiThreaded`] rather than panicking on the internal
 //! assertion used by `birdcage`.
 
-mod env_guard;
+pub(crate) mod env_guard;
 mod error;
 mod profile;
 mod runtime;

--- a/crates/weaver-sandbox/src/lib.rs
+++ b/crates/weaver-sandbox/src/lib.rs
@@ -1,0 +1,51 @@
+//! Sandboxing utilities for Weaver processes.
+//!
+//! The `weaver-sandbox` crate wraps the [`birdcage`] library with policy
+//! defaults aligned to Weaver's zero-trust design. Callers describe the
+//! resources a subprocess is permitted to access using a [`SandboxProfile`],
+//! then launch that subprocess through a [`Sandbox`]. Linux namespaces and
+//! `seccomp-bpf` filters are applied automatically via `birdcage`.
+//!
+//! The sandbox is intentionally restrictive:
+//! - Networking is disabled unless explicitly enabled.
+//! - Environment variables are stripped unless whitelisted.
+//! - Executables must be whitelisted and provided as absolute paths.
+//! - Standard library locations on Linux are whitelisted by default to keep
+//!   dynamically linked binaries functional without exposing the wider
+//!   filesystem.
+//!
+//! ```rust,no_run
+//! use weaver_sandbox::{
+//!     Sandbox, SandboxCommand, SandboxProfile, error::SandboxError, process::Stdio,
+//! };
+//!
+//! # fn main() -> Result<(), SandboxError> {
+//! let profile = SandboxProfile::new()
+//!     .allow_executable("/bin/echo")
+//!     .allow_networking();
+//!
+//! let mut command = SandboxCommand::new("/bin/echo");
+//! command.arg("hello from the cage").stdout(Stdio::piped());
+//!
+//! let sandbox = Sandbox::new(profile);
+//! let mut child = sandbox.spawn(command)?;
+//! let output = child.wait_with_output()?;
+//! assert_eq!(String::from_utf8_lossy(&output.stdout), "hello from the cage\n");
+//! # Ok(()) }
+//! ```
+//!
+//! Callers should invoke [`Sandbox::spawn`] from a single-threaded context.
+//! When multiple threads are active the sandbox returns a
+//! [`SandboxError::MultiThreaded`] rather than panicking on the internal
+//! assertion used by `birdcage`.
+
+mod env_guard;
+mod error;
+mod profile;
+mod runtime;
+mod sandbox;
+
+pub use birdcage::process;
+pub use error::SandboxError;
+pub use profile::{EnvironmentPolicy, NetworkPolicy, SandboxProfile};
+pub use sandbox::{Sandbox, SandboxChild, SandboxCommand, SandboxOutput};

--- a/crates/weaver-sandbox/src/profile.rs
+++ b/crates/weaver-sandbox/src/profile.rs
@@ -38,9 +38,9 @@ pub struct SandboxProfile {
     read_only_paths: Vec<PathBuf>,
     read_write_paths: Vec<PathBuf>,
     executable_paths: Vec<PathBuf>,
-    read_only_paths_canon: std::sync::OnceLock<std::collections::BTreeSet<PathBuf>>,
-    read_write_paths_canon: std::sync::OnceLock<std::collections::BTreeSet<PathBuf>>,
-    executable_paths_canon: std::sync::OnceLock<std::collections::BTreeSet<PathBuf>>,
+    read_only_paths_canon: std::sync::OnceLock<Vec<PathBuf>>,
+    read_write_paths_canon: std::sync::OnceLock<Vec<PathBuf>>,
+    executable_paths_canon: std::sync::OnceLock<Vec<PathBuf>>,
     environment: EnvironmentPolicy,
     network: NetworkPolicy,
 }
@@ -118,7 +118,7 @@ impl SandboxProfile {
 
     pub(crate) fn read_only_paths_canonicalised(
         &self,
-    ) -> Result<&std::collections::BTreeSet<PathBuf>, crate::SandboxError> {
+    ) -> Result<&Vec<PathBuf>, crate::SandboxError> {
         if let Some(set) = self.read_only_paths_canon.get() {
             return Ok(set);
         }
@@ -133,7 +133,7 @@ impl SandboxProfile {
 
     pub(crate) fn read_write_paths_canonicalised(
         &self,
-    ) -> Result<&std::collections::BTreeSet<PathBuf>, crate::SandboxError> {
+    ) -> Result<&Vec<PathBuf>, crate::SandboxError> {
         if let Some(set) = self.read_write_paths_canon.get() {
             return Ok(set);
         }
@@ -147,7 +147,7 @@ impl SandboxProfile {
 
     pub(crate) fn executable_paths_canonicalised(
         &self,
-    ) -> Result<&std::collections::BTreeSet<PathBuf>, crate::SandboxError> {
+    ) -> Result<&Vec<PathBuf>, crate::SandboxError> {
         if let Some(set) = self.executable_paths_canon.get() {
             return Ok(set);
         }

--- a/crates/weaver-sandbox/src/profile.rs
+++ b/crates/weaver-sandbox/src/profile.rs
@@ -1,0 +1,159 @@
+//! Sandbox policy definition and builder helpers.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use crate::runtime::linux_runtime_roots;
+
+/// Environment inheritance strategy applied to sandboxed processes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum EnvironmentPolicy {
+    /// Remove all environment variables before launching the child.
+    #[default]
+    Isolated,
+    /// Allow only the named environment variables to be inherited.
+    AllowList(BTreeSet<String>),
+    /// Inherit the full environment unchanged.
+    InheritAll,
+}
+
+/// Network access policy applied to sandboxed processes.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum NetworkPolicy {
+    /// Block networking by entering a separate network namespace.
+    #[default]
+    Deny,
+    /// Permit networking in the sandboxed process.
+    Allow,
+}
+
+/// Declarative description of the resources a sandboxed process may access.
+///
+/// The profile defaults to a restrictive configuration: networking and the
+/// environment are disabled, and only standard Linux runtime library roots are
+/// whitelisted for read access. Callers must explicitly list the executables
+/// and data paths a sandboxed process requires.
+#[derive(Debug, Clone)]
+pub struct SandboxProfile {
+    read_only_paths: Vec<PathBuf>,
+    read_write_paths: Vec<PathBuf>,
+    executable_paths: Vec<PathBuf>,
+    environment: EnvironmentPolicy,
+    network: NetworkPolicy,
+}
+
+impl SandboxProfile {
+    /// Creates a profile with Linux runtime library paths whitelisted for
+    /// read-only access.
+    ///
+    /// ```
+    /// use weaver_sandbox::SandboxProfile;
+    ///
+    /// let profile = SandboxProfile::new()
+    ///     .allow_executable("/bin/echo")
+    ///     .allow_read_write_path("/tmp/weaver-sandbox");
+    /// assert!(profile.network_policy().is_denied());
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            read_only_paths: linux_runtime_roots(),
+            read_write_paths: Vec::new(),
+            executable_paths: Vec::new(),
+            environment: EnvironmentPolicy::default(),
+            network: NetworkPolicy::default(),
+        }
+    }
+
+    /// Grants execute and read access to the provided path.
+    #[must_use]
+    pub fn allow_executable(mut self, path: impl Into<PathBuf>) -> Self {
+        self.executable_paths.push(path.into());
+        self
+    }
+
+    /// Grants read-only access to the provided path.
+    #[must_use]
+    pub fn allow_read_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.read_only_paths.push(path.into());
+        self
+    }
+
+    /// Grants read-write access to the provided path.
+    #[must_use]
+    pub fn allow_read_write_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.read_write_paths.push(path.into());
+        self
+    }
+
+    /// Whitelists an environment variable for inheritance.
+    #[must_use]
+    pub fn allow_environment_variable(mut self, key: impl Into<String>) -> Self {
+        match &mut self.environment {
+            EnvironmentPolicy::Isolated => {
+                let mut allow = BTreeSet::new();
+                allow.insert(key.into());
+                self.environment = EnvironmentPolicy::AllowList(allow);
+            }
+            EnvironmentPolicy::AllowList(keys) => {
+                let _ = keys.insert(key.into());
+            }
+            EnvironmentPolicy::InheritAll => {}
+        }
+        self
+    }
+
+    /// Inherit all environment variables from the parent process.
+    #[must_use]
+    pub fn allow_full_environment(mut self) -> Self {
+        self.environment = EnvironmentPolicy::InheritAll;
+        self
+    }
+
+    /// Allows the sandboxed process to use the host network namespace.
+    #[must_use]
+    pub fn allow_networking(mut self) -> Self {
+        self.network = NetworkPolicy::Allow;
+        self
+    }
+
+    /// Returns read-only paths configured on the profile.
+    pub(crate) fn read_only_paths(&self) -> &[PathBuf] {
+        &self.read_only_paths
+    }
+
+    /// Returns read-write paths configured on the profile.
+    pub(crate) fn read_write_paths(&self) -> &[PathBuf] {
+        &self.read_write_paths
+    }
+
+    /// Returns executable paths configured on the profile.
+    pub(crate) fn executable_paths(&self) -> &[PathBuf] {
+        &self.executable_paths
+    }
+
+    /// Returns the configured environment policy.
+    pub(crate) fn environment_policy(&self) -> &EnvironmentPolicy {
+        &self.environment
+    }
+
+    /// Returns the network policy.
+    #[must_use]
+    pub fn network_policy(&self) -> NetworkPolicy {
+        self.network
+    }
+}
+
+impl Default for SandboxProfile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NetworkPolicy {
+    /// Returns true when networking is denied.
+    #[must_use]
+    pub fn is_denied(self) -> bool {
+        matches!(self, Self::Deny)
+    }
+}

--- a/crates/weaver-sandbox/src/runtime.rs
+++ b/crates/weaver-sandbox/src/runtime.rs
@@ -1,0 +1,60 @@
+//! Platform helpers for sandbox defaults and preflight checks.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Returns standard Linux library paths that should be readable by default.
+#[must_use]
+pub fn linux_runtime_roots() -> Vec<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let candidates = [
+            "/lib",
+            "/lib64",
+            "/usr/lib",
+            "/usr/lib64",
+            "/lib/x86_64-linux-gnu",
+            "/usr/lib/x86_64-linux-gnu",
+        ];
+        candidates
+            .iter()
+            .filter_map(|path| {
+                let candidate = Path::new(path);
+                if candidate.exists() {
+                    fs::canonicalize(candidate).ok()
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Vec::new()
+    }
+}
+
+/// Returns the number of threads in the current process.
+pub fn thread_count() -> io::Result<usize> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = fs::read_to_string("/proc/self/status")?;
+        let (_, tail) = status
+            .split_once("Threads:")
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing thread count"))?;
+        let count = tail
+            .split_whitespace()
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "malformed thread count"))?;
+        count
+            .parse::<usize>()
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(1)
+    }
+}

--- a/crates/weaver-sandbox/src/runtime.rs
+++ b/crates/weaver-sandbox/src/runtime.rs
@@ -16,6 +16,8 @@ pub fn linux_runtime_roots() -> Vec<PathBuf> {
             "/usr/lib64",
             "/lib/x86_64-linux-gnu",
             "/usr/lib/x86_64-linux-gnu",
+            "/lib/aarch64-linux-gnu",
+            "/usr/lib/aarch64-linux-gnu",
         ];
         candidates
             .iter()

--- a/crates/weaver-sandbox/src/sandbox.rs
+++ b/crates/weaver-sandbox/src/sandbox.rs
@@ -1,0 +1,144 @@
+//! Sandbox orchestration built on top of `birdcage`.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use birdcage::process::{Child, Command, Output};
+use birdcage::{Birdcage, Exception, Sandbox as BirdcageTrait};
+
+use crate::env_guard::EnvGuard;
+use crate::error::SandboxError;
+use crate::profile::{EnvironmentPolicy, NetworkPolicy, SandboxProfile};
+use crate::runtime::thread_count;
+
+/// Builder for sandboxed commands.
+pub type SandboxCommand = Command;
+/// Handle to a running sandboxed process.
+pub type SandboxChild = Child;
+/// Captured output from a sandboxed process.
+pub type SandboxOutput = Output;
+
+/// Launches commands inside a restrictive sandbox.
+#[derive(Debug)]
+pub struct Sandbox {
+    profile: SandboxProfile,
+}
+
+impl Sandbox {
+    /// Creates a sandbox with the supplied profile.
+    #[must_use]
+    pub fn new(profile: SandboxProfile) -> Self {
+        Self { profile }
+    }
+
+    /// Spawns the provided command inside the configured sandbox.
+    ///
+    /// The command's program path must be absolute and whitelisted on the
+    /// profile. When more than one thread exists in the current process the
+    /// function returns [`SandboxError::MultiThreaded`] to avoid triggering the
+    /// single-thread assertion enforced by `birdcage`.
+    pub fn spawn(&self, command: SandboxCommand) -> Result<SandboxChild, SandboxError> {
+        self.ensure_single_threaded()?;
+        let program = Self::canonical_program(Path::new(command.get_program()))?;
+        self.ensure_program_whitelisted(&program)?;
+
+        let env_guard = EnvGuard::capture();
+        let exceptions = self.collect_exceptions(&program)?;
+
+        let mut sandbox = Birdcage::new();
+        for exception in exceptions {
+            sandbox.add_exception(exception)?;
+        }
+
+        let child = sandbox.spawn(command)?;
+        drop(env_guard);
+        Ok(child)
+    }
+
+    fn ensure_single_threaded(&self) -> Result<(), SandboxError> {
+        let threads =
+            thread_count().map_err(|source| SandboxError::ThreadCountUnavailable { source })?;
+        if threads > 1 {
+            return Err(SandboxError::MultiThreaded {
+                thread_count: threads,
+            });
+        }
+        Ok(())
+    }
+
+    fn ensure_program_whitelisted(&self, program: &Path) -> Result<(), SandboxError> {
+        let authorised = canonicalised_set(self.profile.executable_paths())?;
+        if authorised.contains(program) {
+            return Ok(());
+        }
+        Err(SandboxError::ExecutableNotAuthorised {
+            program: program.to_path_buf(),
+        })
+    }
+
+    fn collect_exceptions(&self, program: &Path) -> Result<Vec<Exception>, SandboxError> {
+        let mut exceptions = Vec::new();
+        let read_only = canonicalised_set(self.profile.read_only_paths())?;
+        let read_write = canonicalised_set(self.profile.read_write_paths())?;
+        let executables = canonicalised_set(self.profile.executable_paths())?;
+
+        for path in read_only {
+            exceptions.push(Exception::Read(path));
+        }
+        for path in read_write {
+            exceptions.push(Exception::WriteAndRead(path));
+        }
+        for path in executables {
+            exceptions.push(Exception::ExecuteAndRead(path));
+        }
+
+        exceptions.push(Exception::ExecuteAndRead(program.to_path_buf()));
+
+        match self.profile.environment_policy() {
+            EnvironmentPolicy::Isolated => {}
+            EnvironmentPolicy::AllowList(keys) => {
+                for key in keys {
+                    exceptions.push(Exception::Environment(key.clone()));
+                }
+            }
+            EnvironmentPolicy::InheritAll => exceptions.push(Exception::FullEnvironment),
+        }
+
+        if matches!(self.profile.network_policy(), NetworkPolicy::Allow) {
+            exceptions.push(Exception::Networking);
+        }
+
+        Ok(exceptions)
+    }
+
+    fn canonical_program(program: &Path) -> Result<PathBuf, SandboxError> {
+        if !program.is_absolute() {
+            return Err(SandboxError::ProgramNotAbsolute(program.to_path_buf()));
+        }
+
+        canonicalise(program)
+    }
+}
+
+fn canonicalised_set(paths: &[PathBuf]) -> Result<BTreeSet<PathBuf>, SandboxError> {
+    let mut set = BTreeSet::new();
+    for path in paths {
+        let canonical = canonicalise(path)?;
+        let _ = set.insert(canonical);
+    }
+    Ok(set)
+}
+
+fn canonicalise(path: &Path) -> Result<PathBuf, SandboxError> {
+    if !path.exists() {
+        return Err(SandboxError::MissingPath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    fs::canonicalize(path).map_err(|source| SandboxError::CanonicalisationFailed {
+        path: path.to_path_buf(),
+        source,
+    })
+}

--- a/crates/weaver-sandbox/src/sandbox.rs
+++ b/crates/weaver-sandbox/src/sandbox.rs
@@ -174,6 +174,9 @@ fn rebuild_from_existing_ancestor(path: &Path) -> Result<PathBuf, SandboxError> 
             source,
         })?;
 
+    // `existing` comes from `path.ancestors()`, so this prefix relationship
+    // should always hold. Mapping the failure to `MissingPath` preserves total
+    // behaviour while signalling an unexpected invariant break.
     let tail = path
         .strip_prefix(existing)
         .map_err(|_| SandboxError::MissingPath {

--- a/crates/weaver-sandbox/src/sandbox.rs
+++ b/crates/weaver-sandbox/src/sandbox.rs
@@ -125,7 +125,9 @@ fn canonicalised_set(paths: &[PathBuf]) -> Result<BTreeSet<PathBuf>, SandboxErro
 fn canonicalise(path: &Path) -> Result<PathBuf, SandboxError> {
     match fs::canonicalize(path) {
         Ok(resolved) => Ok(resolved),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => rebuild_from_existing_ancestor(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            rebuild_from_existing_ancestor(path)
+        }
         Err(source) => Err(SandboxError::CanonicalisationFailed {
             path: path.to_path_buf(),
             source,

--- a/crates/weaver-sandbox/src/tests/behaviour.rs
+++ b/crates/weaver-sandbox/src/tests/behaviour.rs
@@ -1,7 +1,6 @@
 //! Behavioural tests for sandbox spawning using `rstest-bdd`.
 
 use std::cell::RefCell;
-use std::env;
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
@@ -40,8 +39,12 @@ fn given_profile_allows_fixture(world: &RefCell<TestWorld>) {
 
 #[given("environment variables KEEP_ME and DROP_ME are set")]
 fn given_environment_variables(_world: &RefCell<TestWorld>) {
-    env::set_var("KEEP_ME", "present");
-    env::set_var("DROP_ME", "remove-me");
+    _world
+        .borrow_mut()
+        .set_env_var("KEEP_ME", "present");
+    _world
+        .borrow_mut()
+        .set_env_var("DROP_ME", "remove-me");
 }
 
 #[given("the sandbox allows only KEEP_ME to be inherited")]
@@ -111,9 +114,12 @@ fn then_stdout_absent(world: &RefCell<TestWorld>, text: String) {
 }
 
 #[then("environment markers are cleaned up")]
-fn then_environment_cleaned(_world: &RefCell<TestWorld>) {
-    env::remove_var("KEEP_ME");
-    env::remove_var("DROP_ME");
+fn then_environment_cleaned(world: &RefCell<TestWorld>) {
+    {
+        world.borrow_mut().clear_env();
+    }
+    assert!(std::env::var_os("KEEP_ME").is_none());
+    assert!(std::env::var_os("DROP_ME").is_none());
 }
 
 #[scenario(path = "tests/features/sandbox.feature")]

--- a/crates/weaver-sandbox/src/tests/behaviour.rs
+++ b/crates/weaver-sandbox/src/tests/behaviour.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! Behavioural tests for sandbox spawning using `rstest-bdd`.
 
 use std::cell::RefCell;

--- a/crates/weaver-sandbox/src/tests/behaviour.rs
+++ b/crates/weaver-sandbox/src/tests/behaviour.rs
@@ -57,6 +57,19 @@ fn given_environment_allowlist(world: &RefCell<TestWorld>) {
         .allow_environment_variable("KEEP_ME");
 }
 
+#[given("the sandbox uses the default environment isolation")]
+fn given_environment_default_isolation(world: &RefCell<TestWorld>) {
+    let mut world = world.borrow_mut();
+    world.configure_env_reader();
+}
+
+#[given("the sandbox inherits the full environment")]
+fn given_environment_full_inheritance(world: &RefCell<TestWorld>) {
+    let mut world = world.borrow_mut();
+    world.configure_env_reader();
+    world.profile = world.profile.clone().allow_full_environment();
+}
+
 #[when("the sandbox launches the command")]
 fn when_launch(world: &RefCell<TestWorld>) {
     world.borrow_mut().launch();

--- a/crates/weaver-sandbox/src/tests/behaviour.rs
+++ b/crates/weaver-sandbox/src/tests/behaviour.rs
@@ -115,9 +115,7 @@ fn then_stdout_absent(world: &RefCell<TestWorld>, text: String) {
 
 #[then("environment markers are cleaned up")]
 fn then_environment_cleaned(world: &RefCell<TestWorld>) {
-    {
-        world.borrow_mut().clear_env();
-    }
+    world.borrow_mut().restore_env();
     assert!(std::env::var_os("KEEP_ME").is_none());
     assert!(std::env::var_os("DROP_ME").is_none());
 }

--- a/crates/weaver-sandbox/src/tests/behaviour.rs
+++ b/crates/weaver-sandbox/src/tests/behaviour.rs
@@ -1,0 +1,122 @@
+//! Behavioural tests for sandbox spawning using `rstest-bdd`.
+
+use std::cell::RefCell;
+use std::env;
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+
+use crate::tests::support::TestWorld;
+
+#[fixture]
+fn world() -> RefCell<TestWorld> {
+    RefCell::new(TestWorld::new())
+}
+
+#[given("a sandbox world with fixture files")]
+fn given_world(_world: &RefCell<TestWorld>) {}
+
+#[given("the command cats the allowed file")]
+fn given_allowed_cat(world: &RefCell<TestWorld>) {
+    let mut world = world.borrow_mut();
+    world.configure_cat(&world.allowed_file);
+}
+
+#[given("the command cats the forbidden file")]
+fn given_forbidden_cat(world: &RefCell<TestWorld>) {
+    let mut world = world.borrow_mut();
+    world.configure_cat(&world.forbidden_file);
+}
+
+#[given("the sandbox allows the command and fixture file")]
+fn given_profile_allows_fixture(world: &RefCell<TestWorld>) {
+    let mut world = world.borrow_mut();
+    world.profile = world
+        .profile
+        .clone()
+        .allow_executable(world.command.as_ref().unwrap().get_program())
+        .allow_read_path(&world.allowed_file);
+}
+
+#[given("environment variables KEEP_ME and DROP_ME are set")]
+fn given_environment_variables(_world: &RefCell<TestWorld>) {
+    env::set_var("KEEP_ME", "present");
+    env::set_var("DROP_ME", "remove-me");
+}
+
+#[given("the sandbox allows only KEEP_ME to be inherited")]
+fn given_environment_allowlist(world: &RefCell<TestWorld>) {
+    let mut world = world.borrow_mut();
+    world.configure_env_reader();
+    world.profile = world
+        .profile
+        .clone()
+        .allow_environment_variable("KEEP_ME");
+}
+
+#[when("the sandbox launches the command")]
+fn when_launch(world: &RefCell<TestWorld>) {
+    world.borrow_mut().launch();
+}
+
+#[then("the sandboxed process succeeds")]
+fn then_process_succeeds(world: &RefCell<TestWorld>) {
+    let world = world.borrow();
+    let output = world.output.as_ref().expect("process output missing");
+    assert!(
+        output.status.success(),
+        "sandboxed process should succeed: {:?}",
+        output.status
+    );
+    assert!(
+        world.launch_error.is_none(),
+        "unexpected launch error: {:?}",
+        world.launch_error
+    );
+}
+
+#[then("the sandboxed process fails")]
+fn then_process_fails(world: &RefCell<TestWorld>) {
+    let world = world.borrow();
+    if let Some(error) = &world.launch_error {
+        panic!("sandbox failed before execution: {error}");
+    }
+    let output = world.output.as_ref().expect("process output missing");
+    assert!(
+        !output.status.success(),
+        "sandboxed process should fail when access is blocked"
+    );
+}
+
+#[then("stdout contains {text}")]
+fn then_stdout_contains(world: &RefCell<TestWorld>, text: String) {
+    let world = world.borrow();
+    let output = world.output.as_ref().expect("process output missing");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(text.trim_matches('"')),
+        "stdout did not contain expected text. stdout={stdout:?}"
+    );
+}
+
+#[then("stdout does not contain {text}")]
+fn then_stdout_absent(world: &RefCell<TestWorld>, text: String) {
+    let world = world.borrow();
+    let output = world.output.as_ref().expect("process output missing");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains(text.trim_matches('"')),
+        "stdout unexpectedly contained {text}"
+    );
+}
+
+#[then("environment markers are cleaned up")]
+fn then_environment_cleaned(_world: &RefCell<TestWorld>) {
+    env::remove_var("KEEP_ME");
+    env::remove_var("DROP_ME");
+}
+
+#[scenario(path = "tests/features/sandbox.feature")]
+fn sandbox_behaviour(world: RefCell<TestWorld>) {
+    let _ = world;
+}

--- a/crates/weaver-sandbox/src/tests/behaviour.rs
+++ b/crates/weaver-sandbox/src/tests/behaviour.rs
@@ -38,13 +38,10 @@ fn given_profile_allows_fixture(world: &RefCell<TestWorld>) {
 }
 
 #[given("environment variables KEEP_ME and DROP_ME are set")]
-fn given_environment_variables(_world: &RefCell<TestWorld>) {
-    _world
-        .borrow_mut()
-        .set_env_var("KEEP_ME", "present");
-    _world
-        .borrow_mut()
-        .set_env_var("DROP_ME", "remove-me");
+fn given_environment_variables(world: &RefCell<TestWorld>) {
+    let mut world = world.borrow_mut();
+    world.set_env_var("KEEP_ME", "present");
+    world.set_env_var("DROP_ME", "remove-me");
 }
 
 #[given("the sandbox allows only KEEP_ME to be inherited")]
@@ -129,8 +126,16 @@ fn then_stdout_absent(world: &RefCell<TestWorld>, text: String) {
 #[then("environment markers are cleaned up")]
 fn then_environment_cleaned(world: &RefCell<TestWorld>) {
     world.borrow_mut().restore_env();
-    assert!(std::env::var_os("KEEP_ME").is_none());
-    assert!(std::env::var_os("DROP_ME").is_none());
+    assert_ne!(
+        std::env::var_os("KEEP_ME"),
+        Some(std::ffi::OsString::from("present")),
+        "KEEP_ME still holds the scenario value after restoration"
+    );
+    assert_ne!(
+        std::env::var_os("DROP_ME"),
+        Some(std::ffi::OsString::from("remove-me")),
+        "DROP_ME still holds the scenario value after restoration"
+    );
 }
 
 #[scenario(path = "tests/features/sandbox.feature")]

--- a/crates/weaver-sandbox/src/tests/behaviour.rs
+++ b/crates/weaver-sandbox/src/tests/behaviour.rs
@@ -18,24 +18,33 @@ fn given_world(_world: &RefCell<TestWorld>) {}
 
 #[given("the command cats the allowed file")]
 fn given_allowed_cat(world: &RefCell<TestWorld>) {
-    let mut world = world.borrow_mut();
-    world.configure_cat(&world.allowed_file);
+    let mut w = world.borrow_mut();
+    let target = w.allowed_file.clone();
+    w.configure_cat(&target);
 }
 
 #[given("the command cats the forbidden file")]
 fn given_forbidden_cat(world: &RefCell<TestWorld>) {
-    let mut world = world.borrow_mut();
-    world.configure_cat(&world.forbidden_file);
+    let mut w = world.borrow_mut();
+    let target = w.forbidden_file.clone();
+    w.configure_cat(&target);
 }
 
 #[given("the sandbox allows the command and fixture file")]
 fn given_profile_allows_fixture(world: &RefCell<TestWorld>) {
-    let mut world = world.borrow_mut();
-    world.profile = world
+    let mut w = world.borrow_mut();
+    let program = w
+        .command
+        .as_ref()
+        .expect("command not configured")
+        .get_program()
+        .to_path_buf();
+    let allowed = w.allowed_file.clone();
+    w.profile = w
         .profile
         .clone()
-        .allow_executable(world.command.as_ref().unwrap().get_program())
-        .allow_read_path(&world.allowed_file);
+        .allow_executable(&program)
+        .allow_read_path(&allowed);
 }
 
 #[given("environment variables KEEP_ME and DROP_ME are set")]

--- a/crates/weaver-sandbox/src/tests/env_guard.rs
+++ b/crates/weaver-sandbox/src/tests/env_guard.rs
@@ -1,0 +1,65 @@
+//! Unit tests for environment snapshot and restoration.
+
+use std::env;
+use std::sync::{Mutex, MutexGuard};
+
+use once_cell::sync::Lazy;
+
+use crate::env_guard::EnvGuard;
+
+static ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_MUTEX.lock().expect("env mutex poisoned")
+}
+
+#[test]
+fn restores_modified_and_removed_environment_variables() {
+    const EXISTING: &str = "WEAVER_ENV_GUARD_EXISTING";
+    const ANOTHER: &str = "WEAVER_ENV_GUARD_ANOTHER";
+    const EPHEMERAL: &str = "WEAVER_ENV_GUARD_EPHEMERAL";
+
+    let _guard = lock_env();
+
+    unsafe { env::set_var(EXISTING, "original") };
+    unsafe { env::set_var(ANOTHER, "keep") };
+
+    let snapshot = EnvGuard::capture();
+
+    unsafe { env::set_var(EXISTING, "changed") };
+    unsafe { env::remove_var(ANOTHER) };
+    unsafe { env::set_var(EPHEMERAL, "ephemeral") };
+
+    snapshot.restore();
+
+    assert_eq!(env::var(EXISTING).as_deref(), Ok("original"));
+    assert_eq!(env::var(ANOTHER).as_deref(), Ok("keep"));
+    assert!(env::var(EPHEMERAL).is_err());
+
+    unsafe { env::remove_var(EXISTING) };
+    unsafe { env::remove_var(ANOTHER) };
+}
+
+#[test]
+fn removes_variables_created_during_guard_lifetime() {
+    const PRE_EXISTING: &str = "WEAVER_ENV_GUARD_PRE_EXISTING";
+    const CREATED: &str = "WEAVER_ENV_GUARD_CREATED";
+
+    let _guard = lock_env();
+
+    unsafe { env::set_var(PRE_EXISTING, "value") };
+
+    let snapshot = EnvGuard::capture();
+
+    unsafe { env::set_var(CREATED, "temporary") };
+
+    assert_eq!(env::var(PRE_EXISTING).as_deref(), Ok("value"));
+    assert_eq!(env::var(CREATED).as_deref(), Ok("temporary"));
+
+    snapshot.restore();
+
+    assert_eq!(env::var(PRE_EXISTING).as_deref(), Ok("value"));
+    assert!(env::var(CREATED).is_err());
+
+    unsafe { env::remove_var(PRE_EXISTING) };
+}

--- a/crates/weaver-sandbox/src/tests/env_guard.rs
+++ b/crates/weaver-sandbox/src/tests/env_guard.rs
@@ -1,18 +1,9 @@
 //! Unit tests for environment snapshot and restoration.
 
 use std::env;
-use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use crate::env_guard::EnvGuard;
-
-static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-
-fn lock_env() -> MutexGuard<'static, ()> {
-    ENV_MUTEX
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env mutex poisoned")
-}
+use crate::tests::support::lock_env;
 
 #[test]
 fn restores_modified_and_removed_environment_variables() {

--- a/crates/weaver-sandbox/src/tests/env_guard.rs
+++ b/crates/weaver-sandbox/src/tests/env_guard.rs
@@ -1,16 +1,17 @@
 //! Unit tests for environment snapshot and restoration.
 
 use std::env;
-use std::sync::{Mutex, MutexGuard};
-
-use once_cell::sync::Lazy;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use crate::env_guard::EnvGuard;
 
-static ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn lock_env() -> MutexGuard<'static, ()> {
-    ENV_MUTEX.lock().expect("env mutex poisoned")
+    ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex poisoned")
 }
 
 #[test]

--- a/crates/weaver-sandbox/src/tests/mod.rs
+++ b/crates/weaver-sandbox/src/tests/mod.rs
@@ -1,0 +1,5 @@
+//! Test suites for the sandbox wrapper.
+
+mod behaviour;
+mod support;
+mod unit;

--- a/crates/weaver-sandbox/src/tests/mod.rs
+++ b/crates/weaver-sandbox/src/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Test suites for the sandbox wrapper.
 
 mod behaviour;
+mod env_guard;
 mod support;
 mod unit;

--- a/crates/weaver-sandbox/src/tests/sandbox_unit.rs
+++ b/crates/weaver-sandbox/src/tests/sandbox_unit.rs
@@ -1,0 +1,51 @@
+//! Unit tests covering sandbox spawn preflight errors.
+
+use std::path::PathBuf;
+
+use crate::sandbox::{Sandbox, SandboxCommand};
+use crate::{SandboxError, SandboxProfile};
+
+fn sandbox_with_profile(profile: SandboxProfile) -> Sandbox {
+    Sandbox::new(profile)
+}
+
+#[test]
+fn rejects_relative_program_paths() {
+    let sandbox = sandbox_with_profile(SandboxProfile::new());
+    let command = SandboxCommand::new("relative/bin");
+
+    let err = sandbox.spawn(command).expect_err("spawn should fail");
+    match err {
+        SandboxError::ProgramNotAbsolute(path) => {
+            assert_eq!(path, PathBuf::from("relative/bin"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_missing_program_paths() {
+    let missing = PathBuf::from("/definitely/missing/tool");
+    let sandbox = sandbox_with_profile(SandboxProfile::new());
+    let command = SandboxCommand::new(&missing);
+
+    let err = sandbox.spawn(command).expect_err("spawn should fail");
+    match err {
+        SandboxError::MissingPath { path } => assert_eq!(path, missing),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_unwhitelisted_programs() {
+    let program = PathBuf::from("/bin/echo");
+    let sandbox = sandbox_with_profile(SandboxProfile::new());
+    let mut command = SandboxCommand::new(&program);
+    command.arg("hello");
+
+    let err = sandbox.spawn(command).expect_err("spawn should fail");
+    match err {
+        SandboxError::ExecutableNotAuthorised { program: p } => assert_eq!(p, program),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/crates/weaver-sandbox/src/tests/support/env.rs
+++ b/crates/weaver-sandbox/src/tests/support/env.rs
@@ -1,0 +1,10 @@
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+pub(crate) fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex poisoned")
+}

--- a/crates/weaver-sandbox/src/tests/support/mod.rs
+++ b/crates/weaver-sandbox/src/tests/support/mod.rs
@@ -1,0 +1,104 @@
+//! Shared fixtures for sandbox behavioural tests.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use crate::error::SandboxError;
+use crate::profile::SandboxProfile;
+use crate::sandbox::{Sandbox, SandboxChild, SandboxCommand, SandboxOutput};
+use crate::process::Stdio;
+
+/// Shared state for behavioural sandbox tests.
+pub struct TestWorld {
+    pub profile: SandboxProfile,
+    pub command: Option<SandboxCommand>,
+    pub output: Option<SandboxOutput>,
+    pub launch_error: Option<SandboxError>,
+    pub temp_dir: TempDir,
+    pub allowed_file: PathBuf,
+    pub forbidden_file: PathBuf,
+}
+
+impl TestWorld {
+    pub fn new() -> Self {
+        let temp_dir = TempDir::new().expect("failed to allocate temporary directory");
+        let allowed_file = temp_dir.path().join("allowed.txt");
+        let forbidden_file = temp_dir.path().join("forbidden.txt");
+
+        write_fixture(&allowed_file, "allowed file content");
+        write_fixture(&forbidden_file, "forbidden file content");
+
+        Self {
+            profile: SandboxProfile::new(),
+            command: None,
+            output: None,
+            launch_error: None,
+            temp_dir,
+            allowed_file,
+            forbidden_file,
+        }
+    }
+
+    pub fn configure_cat(&mut self, target: &Path) {
+        let mut command = SandboxCommand::new(resolve_binary(&["/bin/cat", "/usr/bin/cat"]));
+        command.arg(target);
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        self.profile = self.profile.clone().allow_executable(command.get_program());
+
+        self.command = Some(command);
+    }
+
+    pub fn configure_env_reader(&mut self) {
+        let mut command = SandboxCommand::new(resolve_binary(&["/usr/bin/env", "/bin/env"]));
+        command.stdout(Stdio::piped());
+
+        self.profile = self
+            .profile
+            .clone()
+            .allow_executable(command.get_program());
+
+        self.command = Some(command);
+    }
+
+    pub fn launch(&mut self) {
+        let profile = self.profile.clone();
+        let Some(command) = self.command.take() else {
+            panic!("command not configured");
+        };
+
+        let sandbox = Sandbox::new(profile);
+        match sandbox.spawn(command) {
+            Ok(child) => self.capture_output(child),
+            Err(error) => self.launch_error = Some(error),
+        }
+    }
+
+    pub fn capture_output(&mut self, mut child: SandboxChild) {
+        let output = child
+            .wait_with_output()
+            .unwrap_or_else(|error| panic!("failed to read child output: {error}"));
+        self.output = Some(output);
+    }
+}
+
+pub fn resolve_binary(candidates: &[&str]) -> PathBuf {
+    for candidate in candidates {
+        let path = Path::new(candidate);
+        if path.exists() {
+            return path.to_path_buf();
+        }
+    }
+    panic!("no candidate binary found in {candidates:?}");
+}
+
+fn write_fixture(path: &Path, contents: &str) {
+    let mut file = fs::File::create(path)
+        .unwrap_or_else(|error| panic!("failed to create fixture {path:?}: {error}"));
+    file.write_all(contents.as_bytes())
+        .unwrap_or_else(|error| panic!("failed to write fixture {path:?}: {error}"));
+}

--- a/crates/weaver-sandbox/src/tests/support/mod.rs
+++ b/crates/weaver-sandbox/src/tests/support/mod.rs
@@ -115,7 +115,7 @@ impl TestWorld {
             .set_var(key, value);
     }
 
-    pub fn clear_env(&mut self) {
+    pub fn restore_env(&mut self) {
         self.env = None;
     }
 
@@ -137,6 +137,12 @@ impl TestWorld {
             .wait_with_output()
             .unwrap_or_else(|error| panic!("failed to read child output: {error}"));
         self.output = Some(output);
+    }
+}
+
+impl Drop for TestWorld {
+    fn drop(&mut self) {
+        self.restore_env();
     }
 }
 

--- a/crates/weaver-sandbox/src/tests/support/mod.rs
+++ b/crates/weaver-sandbox/src/tests/support/mod.rs
@@ -30,6 +30,9 @@ impl EnvHandle {
     }
 
     fn set_var(&mut self, key: &'static str, value: &str) {
+        // SAFETY: Environment mutation is guarded by `ENV_MUTEX`, ensuring
+        // serialised access across tests. The accompanying `EnvGuard`
+        // restores the snapshot on drop so mutations cannot leak.
         unsafe { std::env::set_var(key, value) };
     }
 }
@@ -39,7 +42,6 @@ impl Drop for EnvHandle {
         // Restore the snapshot before releasing the mutex to avoid races with
         // other tests mutating the environment.
         self.snapshot.restore();
-        drop(&self.guard);
     }
 }
 

--- a/crates/weaver-sandbox/src/tests/unit.rs
+++ b/crates/weaver-sandbox/src/tests/unit.rs
@@ -83,7 +83,7 @@ fn read_write_paths_are_recorded() {
 }
 
 #[test]
-fn canonicalises_nonexistent_child_when_parent_exists() {
+fn records_nonexistent_future_path() {
     let base = tempfile::tempdir().expect("tempdir");
     let target = base.path().join("future_dir").join("file.txt");
 

--- a/crates/weaver-sandbox/src/tests/unit.rs
+++ b/crates/weaver-sandbox/src/tests/unit.rs
@@ -1,0 +1,55 @@
+//! Unit tests for sandbox configuration helpers.
+
+use std::path::PathBuf;
+
+use crate::profile::{EnvironmentPolicy, NetworkPolicy, SandboxProfile};
+
+#[test]
+fn profile_whitelists_linux_runtime_roots() {
+    let profile = SandboxProfile::new();
+    if cfg!(target_os = "linux") {
+        assert!(
+            !profile.read_only_paths().is_empty(),
+            "linux runtime roots should be whitelisted by default"
+        );
+    } else {
+        assert!(profile.read_only_paths().is_empty());
+    }
+}
+
+#[test]
+fn environment_allowlist_deduplicates_entries() {
+    let profile = SandboxProfile::new()
+        .allow_environment_variable("KEEP_ME")
+        .allow_environment_variable("KEEP_ME");
+
+    match profile.environment_policy() {
+        EnvironmentPolicy::AllowList(keys) => {
+            assert_eq!(keys.len(), 1);
+            assert!(keys.contains("KEEP_ME"));
+        },
+        other => panic!("unexpected environment policy: {other:?}"),
+    }
+}
+
+#[test]
+fn network_is_denied_by_default() {
+    let profile = SandboxProfile::new();
+    assert_eq!(profile.network_policy(), NetworkPolicy::Deny);
+}
+
+#[test]
+fn read_write_paths_are_recorded() {
+    let profile = SandboxProfile::new()
+        .allow_read_path(PathBuf::from("/tmp"))
+        .allow_read_write_path(PathBuf::from("/var/tmp"));
+
+    assert!(profile
+        .read_only_paths()
+        .iter()
+        .any(|path| path.ends_with("tmp")));
+    assert!(profile
+        .read_write_paths()
+        .iter()
+        .any(|path| path.ends_with("tmp")));
+}

--- a/crates/weaver-sandbox/tests/features/sandbox.feature
+++ b/crates/weaver-sandbox/tests/features/sandbox.feature
@@ -1,0 +1,25 @@
+Feature: Sandbox process isolation
+
+  Scenario: Allowed file is readable
+    Given a sandbox world with fixture files
+    And the command cats the allowed file
+    And the sandbox allows the command and fixture file
+    When the sandbox launches the command
+    Then the sandboxed process succeeds
+    And stdout contains "allowed file content"
+
+  Scenario: Disallowed file access is blocked
+    Given a sandbox world with fixture files
+    And the command cats the forbidden file
+    When the sandbox launches the command
+    Then the sandboxed process fails
+
+  Scenario: Environment inheritance is restricted by default
+    Given a sandbox world with fixture files
+    And environment variables KEEP_ME and DROP_ME are set
+    And the sandbox allows only KEEP_ME to be inherited
+    When the sandbox launches the command
+    Then the sandboxed process succeeds
+    And stdout contains "KEEP_ME=present"
+    And stdout does not contain "DROP_ME"
+    And environment markers are cleaned up

--- a/crates/weaver-sandbox/tests/features/sandbox.feature
+++ b/crates/weaver-sandbox/tests/features/sandbox.feature
@@ -23,3 +23,23 @@ Feature: Sandbox process isolation
     And stdout contains "KEEP_ME=present"
     And stdout does not contain "DROP_ME"
     And environment markers are cleaned up
+
+  Scenario: Environment variables are isolated by default
+    Given a sandbox world with fixture files
+    And environment variables KEEP_ME and DROP_ME are set
+    And the sandbox uses the default environment isolation
+    When the sandbox launches the command
+    Then the sandboxed process succeeds
+    And stdout does not contain "KEEP_ME"
+    And stdout does not contain "DROP_ME"
+    And environment markers are cleaned up
+
+  Scenario: Environment variables are fully inherited when enabled
+    Given a sandbox world with fixture files
+    And environment variables KEEP_ME and DROP_ME are set
+    And the sandbox inherits the full environment
+    When the sandbox launches the command
+    Then the sandboxed process succeeds
+    And stdout contains "KEEP_ME=present"
+    And stdout contains "DROP_ME=remove-me"
+    And environment markers are cleaned up

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
     capability detection, and core LSP features (definition, references,
     diagnostics) for Rust, Python, and TypeScript.
 
-- [ ] Implement the initial version of the `weaver-sandbox` crate, using
+- [x] Implement the initial version of the `weaver-sandbox` crate, using
     `birdcage` for its focused scope and production usage, prioritising robust
     Linux support via namespaces and seccomp-bpf.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -143,7 +143,7 @@ preserving the same lock, PID, and health semantics.
 
 External tools launched by the daemon now run inside the `weaver-sandbox`
 wrapper around `birdcage` 0.8.1. Linux namespaces and `seccomp-bpf` filters are
-applied automatically, networking is disabled by default, and only a small set
+applied automatically; networking is disabled by default; and only a small set
 of standard library directories are readable to keep dynamically linked
 executables functioning. Commands must be provided as absolute paths and added
 to the sandbox allowlist before launch; requests made from multi-threaded

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -139,6 +139,19 @@ sequence within a ten-second budget. For interactive debugging or CI jobs, set
 `WEAVER_FOREGROUND=1` to keep the daemon attached to the terminal while
 preserving the same lock, PID, and health semantics.
 
+## Sandbox defaults
+
+External tools launched by the daemon now run inside the `weaver-sandbox`
+wrapper around `birdcage` 0.8.1. Linux namespaces and `seccomp-bpf` filters are
+applied automatically, networking is disabled by default, and only a small set
+of standard library directories are readable to keep dynamically linked
+executables functioning. Commands must be provided as absolute paths and added
+to the sandbox allowlist before launch; requests made from multi-threaded
+contexts return a `MultiThreaded` error rather than panicking the process. The
+sandbox strips the environment unless specific variables are explicitly
+whitelisted, so callers should pass configuration via the broker rather than
+relying on inherited host state.
+
 ### Lifecycle commands
 
 `weaver` now exposes explicit lifecycle commands so operators do not need to

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -146,7 +146,7 @@ wrapper around `birdcage` 0.8.1. Linux namespaces and `seccomp-bpf` filters are
 applied automatically; networking is disabled by default; and only a small set
 of standard library directories are readable to keep dynamically linked
 executables functioning. Commands must be provided as absolute paths and added
-to the sandbox allowlist before launch; requests made from multi-threaded
+to the sandbox allowlist before launch; requests made from multithreaded
 contexts return a `MultiThreaded` error rather than panicking the process. The
 sandbox strips the environment unless specific variables are explicitly
 whitelisted, so callers should pass configuration via the broker rather than

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -980,6 +980,23 @@ descriptor, but its `seccomp-bpf` filter will block any attempt to make its own
 surface and ensures that sandboxing is not just a library call, but a core
 principle of the system's design.
 
+### 5.3 Initial `weaver-sandbox` implementation
+
+The first cut of the dedicated `weaver-sandbox` crate now wraps `birdcage`
+v0.8.1 with Weaver defaults. Executables must be supplied as absolute paths and
+whitelisted explicitly; the wrapper canonicalises the whitelist before launch
+to prevent symlink escapes. Standard Linux library roots (`/lib`, `/lib64`,
+`/usr/lib`, and their architecture-specific variants) are whitelisted for
+read-only access by default so dynamically linked binaries remain functional
+without exposing the wider filesystem. Network access remains disabled unless
+requested, and the environment is isolated by default with an allowlist for
+specific variables when needed.
+
+`birdcage` enforces a single-threaded caller; the wrapper performs a preflight
+check and reports a `MultiThreaded` error instead of panicking when multiple
+threads are active. The test harness runs with `RUST_TEST_THREADS=1` to cover
+the happy path until a dedicated single-threaded launcher process lands.
+
 ## 6. Advanced Capabilities for AI Agents
 
 Beyond core observation and action primitives, `Weaver` is designed with

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -984,7 +984,7 @@ principle of the system's design.
 
 The first cut of the dedicated `weaver-sandbox` crate now wraps `birdcage`
 v0.8.1 with Weaver defaults. Executables must be supplied as absolute paths and
-whitelisted explicitly; the wrapper canonicalises the whitelist before launch
+whitelisted explicitly; the wrapper canonicalizes the whitelist before launch
 to prevent symlink escapes. Standard Linux library roots (`/lib`, `/lib64`,
 `/usr/lib`, and their architecture-specific variants) are whitelisted for
 read-only access by default so dynamically linked binaries remain functional

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -997,6 +997,123 @@ check and reports a `MultiThreaded` error instead of panicking when multiple
 threads are active. The test harness runs with `RUST_TEST_THREADS=1` to cover
 the happy path until a dedicated single-threaded launcher process lands.
 
+Figure 5.1 illustrates the sandbox crate structure and its integration points.
+
+```mermaid
+classDiagram
+    class Sandbox {
+        - SandboxProfile profile
+        + new(profile: SandboxProfile) Sandbox
+        + spawn(command: SandboxCommand) Result~SandboxChild, SandboxError~
+        - ensure_single_threaded() Result~(), SandboxError~
+        - ensure_program_whitelisted(program: Path) Result~(), SandboxError~
+        - collect_exceptions(program: Path) Result~Vec~Exception~, SandboxError~
+        - canonical_program(program: Path) Result~PathBuf, SandboxError~
+    }
+
+    class SandboxProfile {
+        - Vec~PathBuf~ read_only_paths
+        - Vec~PathBuf~ read_write_paths
+        - Vec~PathBuf~ executable_paths
+        - EnvironmentPolicy environment
+        - NetworkPolicy network
+        + new() SandboxProfile
+        + allow_executable(path: PathBuf) SandboxProfile
+        + allow_read_path(path: PathBuf) SandboxProfile
+        + allow_read_write_path(path: PathBuf) SandboxProfile
+        + allow_environment_variable(key: String) SandboxProfile
+        + allow_full_environment() SandboxProfile
+        + allow_networking() SandboxProfile
+        + read_only_paths() &[PathBuf]
+        + read_write_paths() &[PathBuf]
+        + executable_paths() &[PathBuf]
+        + environment_policy() &EnvironmentPolicy
+        + network_policy() NetworkPolicy
+    }
+
+    class EnvironmentPolicy {
+        <<enum>>
+        Isolated
+        AllowList(keys: BTreeSet~String~)
+        InheritAll
+        + with_allowed(key: String) EnvironmentPolicy
+        + to_exceptions() Vec~Exception~
+    }
+
+    class NetworkPolicy {
+        <<enum>>
+        Deny
+        Allow
+        + is_denied() bool
+    }
+
+    class EnvGuard {
+        - HashMap~OsString, OsString~ original
+        + capture() EnvGuard
+        + restore() void
+        - drop() void
+    }
+
+    class SandboxError {
+        <<enum>>
+        ProgramNotAbsolute(path: PathBuf)
+        ExecutableNotAuthorised(program: PathBuf)
+        MissingPath(path: PathBuf)
+        CanonicalisationFailed(path: PathBuf, source: io::Error)
+        MultiThreaded(thread_count: usize)
+        ThreadCountUnavailable(source: io::Error)
+        Activation(source: BirdcageError)
+    }
+
+    class RuntimeHelpers {
+        + linux_runtime_roots() Vec~PathBuf~
+        + thread_count() Result~usize, io::Error~
+    }
+
+    class BirdcageSandbox {
+        <<external>>
+        + new() BirdcageSandbox
+        + add_exception(exception: Exception) Result~(), BirdcageError~
+        + spawn(command: SandboxCommand) Result~SandboxChild, BirdcageError~
+    }
+
+    class BirdcageProcessTypes {
+        <<external>>
+        SandboxCommand
+        SandboxChild
+        SandboxOutput
+    }
+
+    class BirdcageException {
+        <<external enum>>
+        Read(path: PathBuf)
+        WriteAndRead(path: PathBuf)
+        ExecuteAndRead(path: PathBuf)
+        Environment(key: String)
+        FullEnvironment
+        Networking
+    }
+
+    Sandbox --> SandboxProfile : uses
+    Sandbox --> EnvGuard : uses
+    Sandbox --> BirdcageSandbox : wraps
+    Sandbox --> BirdcageException : builds
+    Sandbox --> SandboxError : returns
+    Sandbox --> RuntimeHelpers : uses
+
+    SandboxProfile --> EnvironmentPolicy : has
+    SandboxProfile --> NetworkPolicy : has
+    SandboxProfile --> RuntimeHelpers : uses linux_runtime_roots
+
+    EnvironmentPolicy --> BirdcageException : to_exceptions builds
+
+    SandboxError --> BirdcageSandbox : wraps BirdcageError
+
+    BirdcageSandbox --> BirdcageProcessTypes : spawns
+
+    RuntimeHelpers --> BirdcageSandbox : preflight for spawn
+```
+
 ## 6. Advanced Capabilities for AI Agents
 
 Beyond core observation and action primitives, `Weaver` is designed with


### PR DESCRIPTION
## Summary
- Adds a new weaver-sandbox crate that provides Foundation-level sandboxing for Weaver CLI/daemon subprocesses. It wraps birdcage to enforce Linux namespaces, seccomp filters, and strict resource isolation by default.
- Exposes a safe, high-level API to configure whitelists (executables, paths), environment and network policies, and to spawn sandboxed commands.
- Includes environment guard, error handling, runtime helpers, and a test harness with unit and behavioural tests.
- Updates to the workspace, docs, and test tooling to reflect the new sandbox foundation.

## Changes
- New crate: weaver-sandbox
  - Modules: env_guard, error, profile, runtime, sandbox, plus a compact lib.rs that exposes the public API.
  - SandboxPolicy and Builders
    - SandboxProfile: configure read-only/read-write executable paths, environment policy, and networking policy.
    - EnvironmentPolicy: Isolated, AllowList, InheritAll (default Isolated).
    - NetworkPolicy: Deny (default), Allow.
  - Runtime helpers
    - linux_runtime_roots(): canonical list of standard Linux library roots for read-only access by default.
    - thread_count(): determine active thread count (Linux: reads /proc/self/status).
  - Sandbox orchestration
    - Sandbox, SandboxCommand, SandboxChild, SandboxOutput, SandboxError (exported types)
    - spawn() enforces single-threaded context, canonicalises program path, validates whitelist, and applies preflight exceptions via birdcage.
    - EnvGuard captures/restores the parent environment to keep host state clean when sandboxing.
    - collect_exceptions() builds a list of path, environment, and network restrictions to apply in the sandbox.
- Integration and build
  - workspace Cargo.toml updated to include crates/weaver-sandbox and wire in birdcage as a dependency.
  - Makefile adjusted to run tests with RUST_TEST_THREADS=1 to align with single-threaded launcher expectations.
- Tests
  - New test suites under crates/weaver-sandbox: unit.rs, tests, and behavioural tests in tests/{behaviour, support} mirroring a BDD style.
  - Features-based sandbox scenarios added (fixtures, whitelist checks, environment inheritance).
- Documentation and roadmap
  - docs/users-guide.md updated to describe Sandbox defaults and behaviours (isolation, read-only roots, absolute path whitelisting).
  - docs/weaver-design.md includes a section on the initial weaver-sandbox implementation and its expectations.
  - docs/roadmap.md marks the sandbox feature as implemented (x).

## Why
- Provides a secure, predictable foundation for CLI/daemon workflows by isolating subprocesses, controlling inherited environment, restricting filesystem access, and blocking network access by default. This is essential for a zero-trust style of operation in Weaver's CLI/daemon components.

## How to test
- Run workspace tests:
  - cargo test --workspace --all-targets --all-features
- Focused sandbox tests:
  - cargo test -p weaver-sandbox --tests
- Behavioural tests verify:
  - Allowed executable access is honoured
  - Forbidden files cannot be read
  - Environment inheritance is restricted by default and can be whitelisted
  - Multi-threaded processes are rejected with a MultiThreaded error
- Validate documentation updates by reading the new Sandbox defaults section in the user guide.

## Migration / Notes
- This is the foundation for CLI/daemon isolation and is Linux-centric (thread_count and /proc-based checks are Linux-specific). Non-Linux hosts will have restricted defaults (e.g., empty linux_runtime_roots and thread_count returning 1).
- The new weaver-sandbox crate is added as a workspace member and is designed to be extended with additional policies and policy-driven exceptions in future iterations.

## Risk & rollback
- Minimal risk as this is a new crate with guarded public API surface. If needed, we can toggle sandbox defaults or disable Linux-specific preflights behind feature flags.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e978d32d-903a-4ae9-b14d-f0f7a4f21136

## Summary by Sourcery

Introduce a new weaver-sandbox crate that wraps the birdcage library to provide opinionated sandboxing for Weaver subprocesses, update workspace configuration and docs, and add focused tests for the new sandbox behaviour.

New Features:
- Add the weaver-sandbox crate exposing Sandbox, SandboxProfile, and related types to launch subprocesses inside a restrictive birdcage-based sandbox.
- Provide configurable environment, networking, and filesystem access policies for sandboxed commands with safe builder-style APIs.
- Include runtime helpers to detect Linux runtime library roots and current thread count for sandbox defaults and preflight checks.

Enhancements:
- Guard and restore the parent process environment around sandbox activation to avoid leaking environment changes from birdcage.
- Add detailed error types for sandbox preflight and activation failures, including non-absolute paths, missing paths, and multi-threaded callers.

Build:
- Register weaver-sandbox as a workspace member and add birdcage as a shared workspace dependency.
- Adjust the Makefile test target to run weaver-sandbox tests single-threaded and then run the remaining workspace tests separately.

Documentation:
- Document sandbox defaults and behaviour in the user guide and design docs, including environment, networking, and path-whitelisting expectations.
- Update the project roadmap to mark the initial weaver-sandbox implementation as complete.

Tests:
- Add unit and BDD-style behavioural tests for sandbox profiles, environment guarding, preflight validation, and end-to-end sandbox behaviour using fixtures.