### PR TITLE
Preserve IO error sources in SafetyHarnessError via Arc

### DIFF
--- a/crates/weaverd/src/safety_harness/transaction.rs
+++ b/crates/weaverd/src/safety_harness/transaction.rs
@@ -181,12 +181,9 @@ fn commit_changes(
     let mut prepared: Vec<(PathBuf, tempfile::NamedTempFile, String, bool)> = Vec::new();
 
     for path in paths {
-        let content = context.modified(path).ok_or_else(|| {
-            SafetyHarnessError::file_write(
-                path.clone(),
-                std::io::Error::other("modified content missing from context"),
-            )
-        })?;
+        let content = context
+            .modified(path)
+            .ok_or_else(|| SafetyHarnessError::ModifiedContentMissing { path: path.clone() })?;
 
         let original = context.original(path).cloned().unwrap_or_default();
         let existed = path.exists();

--- a/crates/weaverd/src/safety_harness/transaction.rs
+++ b/crates/weaverd/src/safety_harness/transaction.rs
@@ -181,12 +181,12 @@ fn commit_changes(
     let mut prepared: Vec<(PathBuf, tempfile::NamedTempFile, String, bool)> = Vec::new();
 
     for path in paths {
-        let content = context
-            .modified(path)
-            .ok_or_else(|| SafetyHarnessError::FileWriteError {
-                path: path.clone(),
-                message: "modified content missing from context".to_string(),
-            })?;
+        let content = context.modified(path).ok_or_else(|| {
+            SafetyHarnessError::file_write(
+                path.clone(),
+                std::io::Error::other("modified content missing from context"),
+            )
+        })?;
 
         let original = context.original(path).cloned().unwrap_or_default();
         let existed = path.exists();


### PR DESCRIPTION
## Summary
- Preserve error source chain for SafetyHarnessError by wrapping IO errors in Arc and propagating as the source
- Add capability to access the underlying IO error via an io_source accessor
- Update error display to reflect the underlying source error
- Rework error constructors to use a shared Arc<std::io::Error> for file read/write
- Introduce ModifiedContentMissing variant for missing modified content during commit
- Add tests to verify source chaining and display of underlying IO errors

## Changes
- crates/weaverd/src/safety_harness/error.rs
  - Import Arc and derive Clone for SafetyHarnessError
  - FileReadError and FileWriteError now hold a source: Arc<std::io::Error> instead of a message string
  - Mark the source field with #[source] to preserve the error chain
  - Add ModifiedContentMissing variant to represent missing modified content for a path
  - Display implementations updated to reference the source error
  - Constructors updated: file_read and file_write now wrap std::io::Error in Arc
  - Add io_source() accessor to retrieve the underlying std::io::Error when present
  - SafetyHarnessError derives Clone
- crates/weaverd/src/safety_harness/transaction.rs
  - In commit_changes, when a path has no modified content in context, return SafetyHarnessError::ModifiedContentMissing { path }
- tests
  - Added io_errors_preserve_source_chain test to verify the IO error source chain is preserved and included in the display output
  - Added io_source_accessor_exposes_underlying_error test to verify io_source() returns the underlying error

## Why
- Improves debuggability by preserving the full error chain across SafetyHarnessError boundaries, especially for I/O operations. This enables better diagnostics and more informative error reporting.

## Test Plan
- Run cargo test for the weaverd crate
- Verify: io_errors_preserve_source_chain passes
- Verify: io_source_accessor_exposes_underlying_error passes
- Ensure existing tests continue to pass and error formatting reflects the underlying source

## Notes
- Public API surface remains compatible; internal representations now preserve the original IO error as the source, enabling proper error chaining and reporting.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---
ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d26cb60c-9609-4670-ba70-1856545eb022