### PR TITLE
docs: update users-guide with weaver sub-commands and LSP capabilities

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -261,39 +261,129 @@ the exact payload schema.
 
 #### observe get-definition
 
-Syntax: `weaver observe get-definition --uri <URI> --position <LINE:COL>` Human
-output: `definition: <URI>:<LINE>:<COL>` JSON payload:
-`{"uri":"<URI>","line":42,"column":17}`
+Syntax:
+
+```sh
+weaver observe get-definition --uri <URI> --position <LINE:COL>
+```
+
+Human output:
+
+```text
+definition: <URI>:<LINE>:<COL>
+```
+
+JSON payload:
+
+```json
+{"uri":"<URI>","line":42,"column":17}
+```
 
 #### observe find-references
 
-Syntax: `weaver observe find-references --uri <URI> --position <LINE:COL>`
-Human output: `reference: <URI>:<LINE>:<COL>` JSON payload:
-`{"references":[{"uri":"<URI>","line":12,"column":3}]}`
+Syntax:
+
+```sh
+weaver observe find-references --uri <URI> --position <LINE:COL>
+```
+
+Human output:
+
+```text
+reference: <URI>:<LINE>:<COL>
+```
+
+JSON payload:
+
+```json
+{"references":[{"uri":"<URI>","line":12,"column":3}]}
+```
 
 #### observe call-hierarchy
 
-Syntax: `weaver observe call-hierarchy --uri <URI> --position <LINE:COL>` Human
-output: `call-hierarchy: <SYMBOL> (direction outgoing, depth 2)` JSON payload:
-`{"nodes":[{"id":"n1"}],"edges":[{"caller":"n1","callee":"n2"}]}`
+Syntax:
+
+```sh
+weaver observe call-hierarchy --uri <URI> --position <LINE:COL>
+```
+
+Human output:
+
+```text
+call hierarchy: <SYMBOL> (direction outgoing, depth 2)
+```
+
+JSON payload:
+
+```json
+{"nodes":[{"id":"n1"}],"edges":[{"caller":"n1","callee":"n2"}]}
+```
 
 #### observe grep
 
-Syntax: `weaver observe grep --pattern <PATTERN> --path <PATH>` Optional:
-`--language <LANG>` Human output: `match: <PATH>:<LINE>:<COL> "$NAME"` JSON
-payload: `{"matches":[{"start":[1,1],"captures":{"NAME":"foo"}}]}`
+Syntax:
+
+```sh
+weaver observe grep --pattern <PATTERN> --path <PATH>
+```
+
+Optional flags:
+
+```text
+--language <LANG>
+```
+
+Human output:
+
+```text
+match: <PATH>:<LINE>:<COL> "$NAME"
+```
+
+JSON payload:
+
+```json
+{"matches":[{"start":[1,1],"captures":{"NAME":"foo"}}]}
+```
 
 #### verify diagnostics
 
-Syntax: `weaver verify diagnostics --uri <URI>` Human output:
-`diagnostic: <URI>:<LINE>:<COL> <MESSAGE>` JSON payload:
-`{"diagnostics":[{"line":12,"column":5,"message":"..."}]}`
+Syntax:
+
+```sh
+weaver verify diagnostics --uri <URI>
+```
+
+Human output:
+
+```text
+diagnostic: <URI>:<LINE>:<COL> <MESSAGE>
+```
+
+JSON payload:
+
+```json
+{"diagnostics":[{"line":12,"column":5,"message":"..."}]}
+```
 
 #### act apply-rewrite
 
-Syntax: `weaver act apply-rewrite --pattern <PATTERN> --replacement <REPL>`
-Target: `--path <PATH>` Human output: `rewrite: <PATH> (replacements 2)` JSON
-payload: `{"path":"<PATH>","replacements":2,"changed":true}`
+Syntax:
+
+```sh
+weaver act apply-rewrite --pattern <PATTERN> --replacement <REPL> --path <PATH>
+```
+
+Human output:
+
+```text
+rewrite: <PATH> (replacements 2)
+```
+
+JSON payload:
+
+```json
+{"path":"<PATH>","replacements":2,"changed":true}
+```
 
 ## Language server capability detection
 


### PR DESCRIPTION
## Summary
- Updates to docs/users-guide.md to document the new weaver sub-commands and the LSP-backed capabilities.
- Adds a dedicated command reference with syntax, output formats, and examples for daemon lifecycle and domain operations.
- Introduces domain-specific commands (observe, act, verify) and their supported operations, including call hierarchy support.
- Clarifies capability overrides and safety semantics when using weaver-config.
- Refactors and updates related CLI flag explanations and daemon-client interaction details.

## Changes
- Added a new command reference section to the user guide detailing:
  - Output formats: how daemon responses are structured (JSONL envelopes) and how the CLI handles streams and exit statuses.
  - Daemon lifecycle commands: how to start/stop/check status of the daemon and what to expect from health snapshots.
  - Domain commands: usage for observe, act, and verify with explicit syntax examples.
- Documented specific domain operations and payloads:
  - observe get-definition
  - observe find-references
  - observe call-hierarchy
  - observe grep
  - verify diagnostics
  - act apply-rewrite
- Described how capability detection works for LSP-backed operations and how overrides are applied via weaver-config:
  - TextDocument/definition, textDocument/references, diagnostics, and call hierarchy (
    textDocument/prepareCallHierarchy and related calls).
  - Overriding capabilities with force/deny directives and the merged capability matrix.
- Clarified that the CLI and daemon share the same runtime layout and how daemon socket overrides affect that layout.
- Mentioned timeouts and safety constraints for daemon connections and sessions (e.g., five-second daemon connection timeout).
- Updated terminology and examples to reflect the latest behavior and capabilities (e.g., call hierarchy support and updated JSON payload structures).

## Why
- Aligns the documentation with the updated users-guide that introduces weaver sub-commands and LSP-backed capabilities.
- Improves discoverability of domain operations and their expected inputs/outputs.
- Provides operators and contributors with a clear reference for how the CLI interacts with the daemon and how capability overrides are applied.

## How to test
- Read the updated docs/users-guide.md to verify the new sections appear under:
  - Command reference
  - Output formats
  - Daemon lifecycle commands
  - Domain commands (observe, act, verify) with the listed sub-commands
- Example checks:
  - Validate that the capability keys list includes observe.call-hierarchy and is documented alongside textDocument/definition and textDocument/references.
  - Confirm the documented payload shapes for the JSONL envelope and the sample capability probe output.
  - Ensure wording around daemon socket overrides, shared runtime layout, and timeouts matches the latest behavior described in the patch.

## Notes
- This is a documentation-only change; no code changes were made.
- If further sections are added (e.g., more examples for other languages or newer capabilities), consider extending the command reference with additional domain operations and payload samples.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e3b80e77-abab-4d0e-be0c-fba39ddd82f7

## Summary by Sourcery

Update the user guide to document weaver CLI command families, daemon lifecycle interactions, domain operations, and LSP-backed capabilities.

Documentation:
- Add a command reference section describing weaver command families, output formats, and daemon lifecycle commands with examples.
- Document domain commands (observe, act, verify) including concrete sub-commands, expected human-readable output, and JSON payload shapes.
- Explain capability probing, LSP capability detection (including call hierarchy), and how configuration overrides affect the effective capability matrix.
- Clarify shared runtime layout, daemon socket overrides, connection timeouts, and daemon session failure semantics in the CLI documentation.