### PR TITLE
Extend design doc with human-readable code context blocks

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,6 +53,15 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
     capability detection, and core LSP features (definition, references,
     diagnostics) for Rust, Python, and TypeScript.
 
+- [ ] Add human-readable output rendering for commands that return code
+    locations or diagnostics, using `miette` or a compatible renderer to
+    show context blocks.
+  - Acceptance criteria: Definition, reference, diagnostics, and safety
+    harness failure outputs include file headers, line-numbered source
+    context, and caret spans in human-readable mode; JSONL output remains
+    unchanged; missing source content falls back to path-and-range with a
+    clear explanation.
+
 - [x] Implement the initial version of the `weaver-sandbox` crate, using
     `birdcage` for its focused scope and production usage, prioritising robust
     Linux support via namespaces and seccomp-bpf.

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -429,6 +429,42 @@ Because lifecycle commands operate exclusively on shared filesystem artefacts
 they remain side-effect free with respect to the JSONL transport and can be
 used safely from automation tooling.
 
+#### 2.1.3. Human-readable output and code context blocks
+
+Weaver continues to treat JSONL as the canonical, machine-readable transport,
+but the CLI may emit human-readable output when the daemon streams plain text
+payloads. Whenever a command returns code locations or diagnostics, the
+human-readable output must include code context blocks rendered using `miette`
+or a renderer modelled on its output. This applies to any response containing
+`Location`, `Range`, or `Diagnostic` data, including definition lookups,
+reference searches, call hierarchy edges, structural matches, rewrite results,
+and verification failures surfaced by the safety harness.
+
+Context blocks are required because line-and-column tuples alone are
+insufficient for fast triage. The renderer should show a labelled header with
+the path and coordinate, a small window of surrounding source (defaulting to
+two lines of context before and after), and a caret span highlighting the exact
+range. Multi-line ranges should render a distinct marker on each line. When
+multiple results point into the same file, the output should group them under a
+single file header to avoid repetition while still emitting a separate context
+block for each location.
+
+If the renderer cannot access the file contents (for example, the file is
+missing or was generated in-memory), the output should fall back to the
+path-and-range header plus a short explanation describing why the context could
+not be rendered. JSONL payloads remain unchanged; the context blocks are an
+additive, human-facing presentation layer.
+
+Example (ASCII-only, modelled on `miette`):
+
+```text
+error: Undefined variable `new_function_name`
+  --> src/main.py:42:5
+   |
+42 |     print(new_function_name)
+   |           ^^^^^^^^^^^^^^^^^ not found in this scope
+```
+
 ### 2.2. Semantic, Syntactic, and Relational Fusion
 
 A core premise of `Weaver` is that a truly robust understanding of a codebase

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -435,10 +435,11 @@ Weaver continues to treat JSONL as the canonical, machine-readable transport,
 but the CLI may emit human-readable output when the daemon streams plain text
 payloads. Whenever a command returns code locations or diagnostics, the
 human-readable output must include code context blocks rendered using `miette`
-or a renderer modelled on its output. This applies to any response containing
-`Location`, `Range`, or `Diagnostic` data, including definition lookups,
-reference searches, call hierarchy edges, structural matches, rewrite results,
-and verification failures surfaced by the safety harness.
+(a user-friendly diagnostic rendering library) or a renderer modelled on its
+output. This applies to any response containing `Location`, `Range`, or
+`Diagnostic` data, including definition lookups, reference searches, call
+hierarchy edges, structural matches, rewrite results, and verification failures
+surfaced by the safety harness.
 
 Context blocks are required because line-and-column tuples alone are
 insufficient for fast triage. The renderer should show a labelled header with


### PR DESCRIPTION
## Summary
- Extends Weaver design docs to define human-readable output blocks for code context rendering (2.1.3).
- Updates the roadmap to include a task for adding human-readable code context rendering for commands that return code locations or diagnostics.

## Changes
- docs/weaver-design.md
  - Added section 2.1.3: "Human-readable output and code context blocks" describing how the CLI should render human-readable context blocks when commands return Location, Range, or Diagnostic data (including Definition, References, Call Graphs, and related results).
  - Specifies rendering details: per-file headers, labelled path and coordinates, two-line context windows before/after, caret spans for exact ranges, support for multi-line ranges, and grouping multiple results by file. If file content is unavailable, fall back to a path-and-range header with an explanation. JSONL payloads remain unchanged.
  - Provides an ASCII example illustrating a typical context block.
- docs/roadmap.md
  - Added a task to implement human-readable output rendering for commands that return code locations or diagnostics, using a renderer modeled on miette (or compatible).
  - Includes acceptance criteria describing headers, context blocks, grouping behavior, fallback behavior for missing content, and JSONL immutability.

## Rationale
- JSONL remains the canonical machine-readable transport. The new human-readable blocks are additive presentation enhancements for faster triage and debugging when interacting with the CLI.
- Context blocks address the insufficiency of raw line/column data by providing headers, surrounding source context, and precise caret highlighting.

## Design details
- Target data: any response containing Location, Range, or Diagnostic data (including definitions, references, relationships, rewrites, and safety-verification results).
- Rendering rules:
  - Show a labelled file header with path and coordinates.
  - Render a small window of surrounding source (default: two lines before and after).
  - Display a caret span highlighting the exact range; multi-line ranges render markers on each line.
  - If multiple results point into the same file, group under a single header but emit separate context blocks per location.
  - If the file content cannot be read (missing, in-memory generation), fall back to path-and-range header plus a brief explanation.
  - JSONL payloads remain unchanged.
- Example (ASCII, inspired by miette):

```text
error: Undefined variable `new_function_name`
  --> src/main.py:42:5
   |
42 |     print(new_function_name)
   |           ^^^^^^^^^^^^^^^^^ not found in this scope
```

## Acceptance criteria
- For responses containing Location, Range, or Diagnostic data, the human-readable output includes code context blocks as described.
- JSONL payloads are unchanged.
- If file content is unavailable, output falls back to a path-and-range header with an explanatory note.
- When multiple results target the same file, outputs are grouped under a single file header with individual context blocks.

## Testing plan
- Peer review of the design additions.
- Manual validation by comparing a sample Location/Range/Diagnostic payload against the described ASCII example and fallback behavior.
- Ensure no changes to existing JSONL transport are required.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3cbe81fc-6b7c-413e-9094-d97a12203d69

## Summary by Sourcery

Extend the Weaver design and roadmap to define human-readable CLI code context blocks for location and diagnostic outputs while keeping JSONL as the canonical transport.

Documentation:
- Document human-readable CLI code context blocks for responses containing locations, ranges, and diagnostics, including headers, context windows, caret highlighting, grouping, and fallbacks for missing content.
- Update the roadmap with a task and acceptance criteria for implementing miette-style human-readable context rendering alongside unchanged JSONL output.