### PR TITLE
Document act apply-patch CLI with Tree-sitter safety integration

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,8 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
       - Acceptance criteria: Schema documented in crate docs, integration tests
         demonstrate precedence order (file < env < CLI), and default sockets
         align with the design doc.
-- [x] Implement the `weaver-cli` executable as the thin JSONL client that
+- [x] Implement the `weaver-cli` executable as the thin JSON Lines (JSONL)
+      client that
       initializes configuration via `ortho-config`, exposes the
       `--capabilities` probe, and streams requests to a running daemon over
       standard IO.
@@ -63,8 +64,8 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
     filesystem.
   - Acceptance criteria: Edit transactions pass through syntactic and semantic
     lock validation before commit, failures leave the filesystem untouched,
-    and BDD scenarios cover success, syntactic failure, semantic failure, and
-    backend unavailable error paths.
+    and behaviour-driven development (BDD) scenarios cover success, syntactic
+    failure, semantic failure, and backend unavailable error paths.
 
 - [x] Implement atomic edits to ensure that multi-file changes either succeed
     or fail as a single transaction.
@@ -98,9 +99,9 @@ and relational understanding of code.*
 *Outcome: Provide a safety-locked patch application path that mirrors the
 `apply_patch` semantics for agents and integrates with the Double-Lock harness.*
 
-- [ ] Add JSON Lines (JSONL) request/response types and a
-    `weaver act apply-patch` command that reads the patch stream from standard
-    input (STDIN) and forwards it to the daemon.
+- [ ] Add JSONL request/response types and a `weaver act apply-patch` command
+    that reads the patch stream from standard input (STDIN) and forwards it to
+    the daemon.
   - Acceptance criteria: CLI streams raw patch input, returns non-zero exit
     codes on failure, and surfaces structured errors.
 - [ ] Implement the patch parser and matcher in `weaverd` to support modify,
@@ -113,9 +114,8 @@ and relational understanding of code.*
   - Acceptance criteria: Tree-sitter validates modified/new files, LSP
     diagnostics are compared against the pre-edit baseline, and failures
     leave the filesystem untouched.
-- [ ] Add unit, behaviour-driven development (BDD), and end-to-end tests
-    covering create/modify/delete and failure paths (missing hunk, invalid
-    header, traversal attempt).
+- [ ] Add unit, BDD, and end-to-end tests covering create/modify/delete and
+    failure paths (missing hunk, invalid header, traversal attempt).
   - Acceptance criteria: tests pass under `make test` and error messaging is
     asserted for each failure mode.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,13 +98,14 @@ and relational understanding of code.*
 *Outcome: Provide a safety-locked patch application path that mirrors the
 `apply_patch` semantics for agents and integrates with the Double-Lock harness.*
 
-- [ ] Add JSONL request/response types and a `weaver act apply-patch` command
-    that reads the patch stream from STDIN and forwards it to the daemon.
+- [ ] Add JSON Lines (JSONL) request/response types and a
+    `weaver act apply-patch` command that reads the patch stream from standard
+    input (STDIN) and forwards it to the daemon.
   - Acceptance criteria: CLI streams raw patch input, returns non-zero exit
     codes on failure, and surfaces structured errors.
 - [ ] Implement the patch parser and matcher in `weaverd` to support modify,
     create, and delete operations, including fuzzy matching, line-ending
-    normalisation, and path traversal checks.
+    normalization, and path traversal checks.
   - Acceptance criteria: patch application is atomic per command, missing
     hunks are rejected, and parent directories are created for new files.
 - [ ] Integrate apply-patch with the safety harness using syntactic and
@@ -112,8 +113,9 @@ and relational understanding of code.*
   - Acceptance criteria: Tree-sitter validates modified/new files, LSP
     diagnostics are compared against the pre-edit baseline, and failures
     leave the filesystem untouched.
-- [ ] Add unit, BDD, and end-to-end tests covering create/modify/delete and
-    failure paths (missing hunk, invalid header, traversal attempt).
+- [ ] Add unit, behaviour-driven development (BDD), and end-to-end tests
+    covering create/modify/delete and failure paths (missing hunk, invalid
+    header, traversal attempt).
   - Acceptance criteria: tests pass under `make test` and error messaging is
     asserted for each failure mode.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,6 +93,30 @@ and relational understanding of code.*
     graph generation, using the `textDocument/callHierarchy` request as the
     initial data source.
 
+### Step: Deliver `act apply-patch` command
+
+*Outcome: Provide a safety-locked patch application path that mirrors the
+`apply_patch` semantics for agents and integrates with the Double-Lock harness.*
+
+- [ ] Add JSONL request/response types and a `weaver act apply-patch` command
+    that reads the patch stream from STDIN and forwards it to the daemon.
+  - Acceptance criteria: CLI streams raw patch input, returns non-zero exit
+    codes on failure, and surfaces structured errors.
+- [ ] Implement the patch parser and matcher in `weaverd` to support modify,
+    create, and delete operations, including fuzzy matching, line-ending
+    normalisation, and path traversal checks.
+  - Acceptance criteria: patch application is atomic per command, missing
+    hunks are rejected, and parent directories are created for new files.
+- [ ] Integrate apply-patch with the safety harness using syntactic and
+    semantic locks, ensuring no on-disk writes on lock failure.
+  - Acceptance criteria: Tree-sitter validates modified/new files, LSP
+    diagnostics are compared against the pre-edit baseline, and failures
+    leave the filesystem untouched.
+- [ ] Add unit, BDD, and end-to-end tests covering create/modify/delete and
+    failure paths (missing hunk, invalid header, traversal attempt).
+  - Acceptance criteria: tests pass under `make test` and error messaging is
+    asserted for each failure mode.
+
 ## Phase 3: Plugin Ecosystem & Specialist Tools
 
 *Goal: Build the plugin architecture to enable orchestration of best-in-class,

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1508,6 +1508,11 @@ other `act` commands. The parsed patch is applied to in-memory buffers, then:
   backend is unavailable or times out, the command fails fast without falling
   back to a weaker validation mode.
 
+Lock evaluation is single-shot: `act apply-patch` does not retry or fall back
+when Tree-sitter or LSP validation is unavailable or exceeds the timeout.
+Instead, it returns a structured backend-unavailable error and exits with a
+non-zero status after leaving the filesystem untouched.
+
 Only if both locks pass does the daemon commit the changes atomically. Paths
 are normalised and rejected if they escape the workspace root (for example,
 `../..` traversal or absolute paths), preventing patch-based directory


### PR DESCRIPTION
## Summary
- Documents the new `act apply-patch` command, its patch format, and safety-harness integration; aligns the Roadmap and Weaver design docs with the CLI-first workflow, patch semantics, and safety guarantees.

## Changes

### Roadmap updates
- Step: Deliver `act apply-patch` command
  - Outcome: Provide a safety-locked patch application path that mirrors the `apply_patch` semantics for agents and integrates with the Double-Lock harness.
  - Acceptance criteria:
    - Add JSONL request/response types and a `weaver act apply-patch` command that reads the patch stream from STDIN and forwards it to the daemon.
    - CLI streams raw patch input, returns non-zero exit codes on failure, and surfaces structured errors.
    - Implement the patch parser and matcher in the daemon to support modify, create, and delete operations, including fuzzy matching, line-ending normalisation, and path traversal checks.
    - Patch application is atomic per command; missing hunks are rejected; parent directories are created for new files.
    - Integrate apply-patch with the safety harness using syntactic and semantic locks; no on-disk writes on lock failure.
    - Tree-sitter validates modified/new files, LSP diagnostics are compared against the pre-edit baseline, and failures leave the filesystem untouched.
    - Add unit, BDD, and end-to-end tests covering create/modify/delete and failure paths.
    - Acceptance: tests pass under `make test` and error messaging is asserted for each failure mode.

### Weaver design updates
- 4.3. The `act apply-patch` command: safety-locked patch application
  - `act apply-patch` provides a deterministic, CLI-first way to apply structured patches while benefiting from Weaver's Double-Lock safety harness. The command re-implements the `apply_patch` semantics used by AI agent tooling, favouring resilient search-and-replace blocks over line-numbered diffs. Every operation is validated through the Tree-sitter syntactic lock and the LSP semantic lock before any file is written to disk.

- 4.3.1. Patch format and operations
  - `act apply-patch` reads a stream of Git-style file operations from standard input (STDIN). Each operation starts with a `diff --git a/... b/...` header; the tool targets the `b/` path relative to the workspace root and supports quoted filenames. The operation type is inferred from the metadata lines that follow:
  - Modify: Uses one or more `SEARCH`/`REPLACE` blocks.
  - Create: Uses `new file mode <permissions>` and a standard diff hunk.
  - Delete: Uses `deleted file mode <permissions>` and an empty body.
  - `act apply-patch` accepts text-only patches. Binary diffs (for example, Git binary patch blocks or hunks containing NUL bytes) are rejected with a structured error; callers must supply text representations instead.
  
  Example blocks are provided in the design notes; actual tooling should reject non-text content.

- 4.3.2. Modification semantics
  - The modify operation uses an ordered, cursor-based search to apply multiple blocks within a single file:
  - The file is loaded into memory and a `cursor` starts at byte offset 0.
  - Each `SEARCH` block is matched against the remaining content from `cursor`.
  - Matching tries an exact match first, then a fuzzy match that trims leading and trailing whitespace and normalizes line endings (`\r\n` vs `\n`).
  - If a block fails to match, the entire command fails and no files are modified.
  - When a match succeeds, the matched span is replaced with the `REPLACE` block and the cursor advances to the end of the replacement.
  
  This strategy avoids false positives while remaining resilient to unrelated line shifts and indentation changes. The replacement content preserves the existing file's dominant line ending style; new files follow the line endings present in the patch hunk, defaulting to `\n` when no style is implied.

- 4.3.3. Apply-patch end-to-end flow
  - (Flow diagram overview included in the design docs; see the 4.3 section for the full sequence.)

- 4.3.4. Apply-patch lock interaction sequence
  - (Sequence diagram overview included in the design docs; see the 4.3 section for the full sequence.)

- 4.3.5. Creation and deletion semantics
  - For `new file mode` operations, the tool extracts the added (`+`) lines from the first diff hunk, creates any parent directories, and writes the new file content. For `deleted file mode` operations, the target file is removed; any additional body content is ignored.

- 4.3.6. Safety harness integration and path validation
  - `act apply-patch` is governed by the same Double-Lock verification pipeline as other `act` commands. The parsed patch is applied to in-memory buffers, then:
  - Syntactic Lock (Tree-sitter): All modified or created files are parsed to ensure they remain syntactically valid. If the parser is unavailable or a timeout elapses, the command fails fast with a structured backend-unavailable error.
  - Semantic Lock (LSP): The modified content is synchronised to the LSP server and diagnostics are checked for newly introduced errors. If the LSP backend is unavailable or times out, the command fails fast without falling back to a weaker validation mode.
  - Only if both locks pass does the daemon commit the changes atomically. Paths are normalised and rejected if they escape the workspace root (for example, `../..` traversal or absolute paths), preventing patch-based directory traversal attacks.

## Design notes
- The docs reflect the CLI-first workflow and parity with existing `act` commands, while emphasising safety guarantees and atomicity.
- The new sections align with the existing design language for commands, patches, and safety harness integration.

## Tests and validation (documentation-level)
- The roadmap now includes acceptance criteria for behavior, patch format, safety checks, and test coverage. Reviewers should ensure the documentation matches the intended implementation and the expected test plan.

## How to review
- Confirm that the Roadmap section accurately captures the acceptance criteria for `act apply-patch`.
- Confirm that Weaver design includes a complete description of 4.3 (patch format, semantics, safety harness integration).
- Ensure references to the new command appear consistently in the act command catalog.

## Additional context
- This change is purely documentation updates to reflect upcoming work and design decisions for the `act apply-patch` tool.

## Test plan
- [ ] Validate that Roadmap acceptance criteria cover CLI streaming input, patch parsing, atomic application, and safety checks.
- [ ] Verify patch format and operation examples in the design doc sections (4.3.1–4.3.4) are coherent and match the described behavior.
- [ ] Ensure `act apply-patch` is listed in the act command catalog within weaver-design.md.
- [ ] Cross-check consistency between roadmap and design docs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ec2082ed-3704-4f06-8bed-0a0c88a479de

## Summary by Sourcery

Document the new `act apply-patch` command, including its patch format, semantics, and safety-harness integration, and align the roadmap and design docs with its planned behavior and acceptance criteria.

Documentation:
- Describe the `act apply-patch` command in the Weaver design doc, covering patch format, semantics, and Double-Lock (Tree-sitter and LSP) safety validation.
- Update the act command catalog to include `act apply-patch` alongside existing act commands.
- Extend the roadmap with a new step for delivering `act apply-patch`, outlining CLI behavior, daemon-side patch handling, safety guarantees, and required test coverage.
