### PR TITLE
Use --locked cargo install for weaver binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,5 +45,5 @@ help: ## Show available targets
 	awk 'BEGIN {FS=":"; printf "Available targets:\n"} {printf "  %-20s %s\n", $$1, $$2}'
 
 install: ## Install weaver and weaverd binaries
-	$(CARGO) install --path crates/weaver-cli
-	$(CARGO) install --path crates/weaverd
+	$(CARGO) install --locked --release --path crates/weaver-cli
+	$(CARGO) install --locked --release --path crates/weaverd

--- a/Makefile
+++ b/Makefile
@@ -45,5 +45,5 @@ help: ## Show available targets
 	awk 'BEGIN {FS=":"; printf "Available targets:\n"} {printf "  %-20s %s\n", $$1, $$2}'
 
 install: ## Install weaver and weaverd binaries
-	$(CARGO) install --locked --release --path crates/weaver-cli
-	$(CARGO) install --locked --release --path crates/weaverd
+	$(CARGO) install --locked --path crates/weaver-cli
+	$(CARGO) install --locked --path crates/weaverd


### PR DESCRIPTION
Use --locked when installing both weaver-cli and weaverd via cargo install.

Changes:
- Update Makefile install target to use `cargo install --locked --path crates/weaver-cli`
- Update Makefile install target to use `cargo install --locked --path crates/weaverd>`

Note: Binary naming and bin section modifications were implemented in earlier commits; this PR only adds the --locked flag to ensure reproducible installs.

🤖 Generated with Claude Code

## Summary by Sourcery

Enable deterministic installs by using Cargo's --locked flag for the two binaries.

New Features:
- None

Enhancements:
- Cargo install commands now lock dependencies to Cargo.lock to ensure consistent builds.

📎 **Task**: https://www.terragonlabs.com/task/ccf8b971-083b-4cd0-b965-07e9067bac50