### PR TITLE
Plan Phase 1 Socket Listener MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcefde6aee6db6d70c149d48e17111e9e088a1ff71da92234e986a23fb4c134"
+checksum = "b7451d147800bd8b0b8621116a2c553b13408f2b7914a5b818eccaa37240ed9a"
 dependencies = [
  "ctor",
  "derive_more 0.99.20",
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-macros"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225ddea765e1f1b6491aef744475f5feaea2b4070c29fea0482155b643c09ee0"
+checksum = "c58aca0e441b276f7e52a6fe1b9bb8c341004110f610e7dfda112578c0c18837"
 dependencies = [
  "camino",
  "cap-std 3.4.5",
@@ -1585,10 +1585,11 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da2291923de0d5f83564b4e6c193c67722129180983f0b3f424dc7e0580c0c0"
+checksum = "59a52766aaee3793eec30ff351a5ebddba34dddab8500b18891cddece364a66d"
 dependencies = [
+ "gherkin",
  "regex",
  "thiserror 1.0.69",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ once_cell = "1.19"
 ortho_config = "0.6.0"
 predicates = "3.1"
 rstest = "0.26.1"
-rstest-bdd = { version = "0.2.0", default-features = false }
-rstest-bdd-macros = "0.2.0"
+rstest-bdd = { version = "0.3.2", default-features = false }
+rstest-bdd-macros = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.10"

--- a/crates/weaver-cli/src/lifecycle/shutdown_tests.rs
+++ b/crates/weaver-cli/src/lifecycle/shutdown_tests.rs
@@ -124,6 +124,13 @@ fn wait_for_shutdown_succeeds_when_pid_and_socket_disappear() {
 fn wait_for_shutdown_propagates_socket_probe_errors() {
     use std::os::unix::fs::PermissionsExt;
 
+    // Skip on root to avoid permission errors being bypassed.
+    // SAFETY: geteuid() is always safe to call.
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping test: running as root");
+        return;
+    }
+
     let (_temp_dir, paths) = create_temp_runtime_paths();
 
     // Create PID file so we actually need to check the socket.

--- a/crates/weaverd/src/lib.rs
+++ b/crates/weaverd/src/lib.rs
@@ -37,6 +37,7 @@ mod placeholder_provider;
 mod process;
 pub mod safety_harness;
 mod telemetry;
+mod transport;
 
 pub use backends::{
     BackendKind, BackendKindParseError, BackendProvider, BackendStartupError, FusionBackends,

--- a/crates/weaverd/src/process/errors.rs
+++ b/crates/weaverd/src/process/errors.rs
@@ -13,6 +13,7 @@ use ortho_config::OrthoError;
 use weaver_config::{RuntimePathsError, SocketPreparationError};
 
 use crate::bootstrap::BootstrapError;
+use crate::transport::ListenerError;
 
 use super::daemonizer::DaemonizeError;
 use super::shutdown::ShutdownError;
@@ -145,6 +146,13 @@ pub enum LaunchError {
         #[source]
         source: BootstrapError,
     },
+    /// Socket listener startup failed.
+    #[error("daemon socket listener failed: {source}")]
+    Listener {
+        /// Underlying listener error.
+        #[source]
+        source: ListenerError,
+    },
 }
 
 impl From<Arc<OrthoError>> for LaunchError {
@@ -185,5 +193,11 @@ impl From<ShutdownError> for LaunchError {
 impl From<BootstrapError> for LaunchError {
     fn from(source: BootstrapError) -> Self {
         Self::Bootstrap { source }
+    }
+}
+
+impl From<ListenerError> for LaunchError {
+    fn from(source: ListenerError) -> Self {
+        Self::Listener { source }
     }
 }

--- a/crates/weaverd/src/process/launch.rs
+++ b/crates/weaverd/src/process/launch.rs
@@ -10,6 +10,7 @@ use crate::backends::BackendProvider;
 use crate::bootstrap::{ConfigLoader, StaticConfigLoader, SystemConfigLoader, bootstrap_with};
 use crate::health::HealthReporter;
 use crate::placeholder_provider::NoopBackendProvider;
+use crate::transport::{NoopConnectionHandler, SocketListener};
 
 use super::daemonizer::{Daemonizer, SystemDaemonizer};
 use super::errors::LaunchError;
@@ -116,9 +117,14 @@ where
     guard.write_health(HealthState::Starting)?;
     let static_loader = StaticConfigLoader::new(config.clone());
     let daemon = bootstrap_with(&static_loader, reporter, provider)?;
+    let listener = SocketListener::bind(config.daemon_socket())?;
+    let handler = Arc::new(NoopConnectionHandler);
+    let listener_handle = listener.start(handler)?;
     guard.write_health(HealthState::Ready)?;
     shutdown.wait()?;
     guard.write_health(HealthState::Stopping)?;
+    listener_handle.shutdown();
+    listener_handle.join()?;
     drop(daemon);
     info!(
         target: PROCESS_TARGET,

--- a/crates/weaverd/src/process/launch.rs
+++ b/crates/weaverd/src/process/launch.rs
@@ -115,9 +115,9 @@ where
     let pid = std::process::id();
     guard.write_pid(pid)?;
     guard.write_health(HealthState::Starting)?;
+    let listener = SocketListener::bind(config.daemon_socket())?;
     let static_loader = StaticConfigLoader::new(config.clone());
     let daemon = bootstrap_with(&static_loader, reporter, provider)?;
-    let listener = SocketListener::bind(config.daemon_socket())?;
     let handler = Arc::new(NoopConnectionHandler);
     let listener_handle = listener.start(handler)?;
     guard.write_health(HealthState::Ready)?;

--- a/crates/weaverd/src/tests/mod.rs
+++ b/crates/weaverd/src/tests/mod.rs
@@ -5,5 +5,6 @@ mod lib_api;
 mod process_behaviour;
 mod safety_harness_behaviour;
 mod safety_harness_types;
+mod socket_behaviour;
 mod support;
 mod unit;

--- a/crates/weaverd/src/tests/socket_behaviour.rs
+++ b/crates/weaverd/src/tests/socket_behaviour.rs
@@ -155,4 +155,6 @@ fn then_listener_fails(world: &RefCell<ListenerWorld>) {
 }
 
 #[scenario(path = "tests/features/daemon_socket.feature")]
-fn daemon_socket_listener(#[from(world)] _: RefCell<ListenerWorld>) {}
+fn daemon_socket_listener(#[from(world)] world: RefCell<ListenerWorld>) {
+    drop(world);
+}

--- a/crates/weaverd/src/tests/socket_behaviour.rs
+++ b/crates/weaverd/src/tests/socket_behaviour.rs
@@ -1,0 +1,160 @@
+//! Behavioural tests for the daemon socket listener.
+
+use std::cell::RefCell;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::{Duration, Instant};
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+
+use weaver_config::SocketEndpoint;
+
+use crate::transport::{ConnectionHandler, ConnectionStream, ListenerHandle, SocketListener};
+
+struct ListenerWorld {
+    endpoint: SocketEndpoint,
+    listener: Option<ListenerHandle>,
+    accepted: Arc<AtomicUsize>,
+    address: Option<SocketAddr>,
+    bind_error: Option<String>,
+    reserved: Option<TcpListener>,
+}
+
+impl ListenerWorld {
+    fn new() -> Self {
+        Self {
+            endpoint: SocketEndpoint::tcp("127.0.0.1", 0),
+            listener: None,
+            accepted: Arc::new(AtomicUsize::new(0)),
+            address: None,
+            bind_error: None,
+            reserved: None,
+        }
+    }
+
+    fn start_listener(&mut self) {
+        let handler = Arc::new(CountingHandler {
+            count: Arc::clone(&self.accepted),
+        });
+        match SocketListener::bind(&self.endpoint) {
+            Ok(listener) => {
+                self.address = listener.local_addr();
+                match listener.start(handler) {
+                    Ok(handle) => {
+                        self.listener = Some(handle);
+                    }
+                    Err(error) => {
+                        self.bind_error = Some(error.to_string());
+                    }
+                }
+            }
+            Err(error) => {
+                self.bind_error = Some(error.to_string());
+            }
+        }
+    }
+
+    fn reserve_port(&mut self) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind reserved port");
+        let port = listener.local_addr().expect("local addr").port();
+        self.endpoint = SocketEndpoint::tcp("127.0.0.1", port);
+        self.reserved = Some(listener);
+    }
+
+    fn connect_clients(&self, count: usize) {
+        let addr = self.address.expect("listener address should be set");
+        for _ in 0..count {
+            TcpStream::connect(addr).expect("connect client");
+        }
+    }
+
+    fn wait_for_connections(&self, expected: usize) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if self.accepted.load(Ordering::SeqCst) >= expected {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+}
+
+impl Drop for ListenerWorld {
+    fn drop(&mut self) {
+        if let Some(handle) = self.listener.take() {
+            handle.shutdown();
+            let _ = handle.join();
+        }
+        self.reserved = None;
+    }
+}
+
+struct CountingHandler {
+    count: Arc<AtomicUsize>,
+}
+
+impl ConnectionHandler for CountingHandler {
+    fn handle(&self, _stream: ConnectionStream) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[fixture]
+fn world() -> RefCell<ListenerWorld> {
+    RefCell::new(ListenerWorld::new())
+}
+
+#[given("a TCP socket listener is running")]
+fn given_tcp_listener(world: &RefCell<ListenerWorld>) {
+    world.borrow_mut().start_listener();
+    assert!(
+        world.borrow().bind_error.is_none(),
+        "listener start failed: {:?}",
+        world.borrow().bind_error
+    );
+}
+
+#[given("a TCP socket is already bound")]
+fn given_tcp_in_use(world: &RefCell<ListenerWorld>) {
+    world.borrow_mut().reserve_port();
+}
+
+#[when("a client connects")]
+fn when_client_connects(world: &RefCell<ListenerWorld>) {
+    world.borrow().connect_clients(1);
+}
+
+#[when("two clients connect")]
+fn when_two_clients_connect(world: &RefCell<ListenerWorld>) {
+    world.borrow().connect_clients(2);
+}
+
+#[when("the listener starts on the same socket")]
+fn when_listener_starts_same_socket(world: &RefCell<ListenerWorld>) {
+    world.borrow_mut().start_listener();
+}
+
+#[then("the listener records {count} connections")]
+fn then_listener_records(world: &RefCell<ListenerWorld>, count: usize) {
+    assert!(
+        world.borrow().wait_for_connections(count),
+        "expected {count} connections, got {}",
+        world.borrow().accepted.load(Ordering::SeqCst)
+    );
+}
+
+#[then("starting the listener fails")]
+fn then_listener_fails(world: &RefCell<ListenerWorld>) {
+    assert!(
+        world.borrow().bind_error.is_some(),
+        "expected listener start to fail"
+    );
+}
+
+#[scenario(path = "tests/features/daemon_socket.feature")]
+fn daemon_socket_listener(#[from(world)] _: RefCell<ListenerWorld>) {}

--- a/crates/weaverd/src/transport/errors.rs
+++ b/crates/weaverd/src/transport/errors.rs
@@ -1,0 +1,70 @@
+//! Error types for socket listener operations.
+
+use std::io;
+use std::net::SocketAddr;
+
+use thiserror::Error;
+
+/// Errors surfaced while binding or running the socket listener.
+#[derive(Debug, Error)]
+pub enum ListenerError {
+    #[error("failed to resolve TCP address {host}:{port}: {source}")]
+    Resolve {
+        host: String,
+        port: u16,
+        #[source]
+        source: io::Error,
+    },
+    #[error("no TCP addresses resolved for {host}:{port}")]
+    ResolveEmpty { host: String, port: u16 },
+    #[error("failed to bind TCP listener at {addr}: {source}")]
+    BindTcp {
+        addr: SocketAddr,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to enable non-blocking listener: {source}")]
+    NonBlocking {
+        #[source]
+        source: io::Error,
+    },
+    #[cfg(not(unix))]
+    #[error("unix sockets are unsupported for endpoint {endpoint}")]
+    UnsupportedUnix { endpoint: String },
+    #[cfg(unix)]
+    #[error("failed to bind unix listener at {path}: {source}")]
+    BindUnix {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+    #[cfg(unix)]
+    #[error("existing unix socket {path} is already in use")]
+    UnixInUse { path: String },
+    #[cfg(unix)]
+    #[error("unix socket path {path} is not a socket")]
+    UnixNotSocket { path: String },
+    #[cfg(unix)]
+    #[error("failed to read metadata for unix socket {path}: {source}")]
+    UnixMetadata {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+    #[cfg(unix)]
+    #[error("failed to connect to existing unix socket {path}: {source}")]
+    UnixConnect {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+    #[cfg(unix)]
+    #[error("failed to remove stale unix socket {path}: {source}")]
+    UnixCleanup {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("listener thread panicked")]
+    ThreadPanic,
+}

--- a/crates/weaverd/src/transport/handler.rs
+++ b/crates/weaverd/src/transport/handler.rs
@@ -1,0 +1,77 @@
+//! Connection handling abstractions for the daemon listener.
+
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+
+use tracing::warn;
+
+use super::LISTENER_TARGET;
+
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+
+/// Stream types accepted by the daemon listener.
+pub(crate) enum ConnectionStream {
+    Tcp(TcpStream),
+    #[cfg(unix)]
+    Unix(UnixStream),
+}
+
+impl Read for ConnectionStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Tcp(stream) => stream.read(buf),
+            #[cfg(unix)]
+            Self::Unix(stream) => stream.read(buf),
+        }
+    }
+}
+
+impl Write for ConnectionStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Tcp(stream) => stream.write(buf),
+            #[cfg(unix)]
+            Self::Unix(stream) => stream.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Tcp(stream) => stream.flush(),
+            #[cfg(unix)]
+            Self::Unix(stream) => stream.flush(),
+        }
+    }
+}
+
+/// Handles accepted socket connections.
+pub(crate) trait ConnectionHandler: Send + Sync + 'static {
+    /// Handles a single connection. Implementations should avoid panicking.
+    fn handle(&self, stream: ConnectionStream);
+}
+
+/// Default handler that drains data until the peer disconnects.
+#[derive(Debug, Default)]
+pub(crate) struct NoopConnectionHandler;
+
+impl ConnectionHandler for NoopConnectionHandler {
+    fn handle(&self, mut stream: ConnectionStream) {
+        let mut buffer = [0_u8; 1024];
+        loop {
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => {
+                    warn!(
+                        target: LISTENER_TARGET,
+                        error = %error,
+                        "connection handler error"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/crates/weaverd/src/transport/listener.rs
+++ b/crates/weaverd/src/transport/listener.rs
@@ -1,0 +1,360 @@
+//! Listener implementation for daemon transport sockets.
+
+use std::io;
+use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
+use std::time::Duration;
+
+use tracing::{info, warn};
+
+use weaver_config::SocketEndpoint;
+
+use super::{ConnectionHandler, ConnectionStream, LISTENER_TARGET, ListenerError};
+
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::FileTypeExt;
+#[cfg(unix)]
+use std::os::unix::net::{UnixListener, UnixStream};
+#[cfg(unix)]
+use std::path::Path;
+
+const ACCEPT_BACKOFF: Duration = Duration::from_millis(25);
+const ERROR_BACKOFF: Duration = Duration::from_millis(150);
+
+/// Listener that binds to a socket endpoint.
+#[derive(Debug)]
+pub(crate) struct SocketListener {
+    endpoint: SocketEndpoint,
+    listener: ListenerKind,
+}
+
+#[derive(Debug)]
+enum ListenerKind {
+    Tcp(TcpListener),
+    #[cfg(unix)]
+    Unix(UnixListener),
+}
+
+impl SocketListener {
+    pub(crate) fn bind(endpoint: &SocketEndpoint) -> Result<Self, ListenerError> {
+        match endpoint {
+            SocketEndpoint::Tcp { host, port } => {
+                let listener = bind_tcp(host, *port)?;
+                Ok(Self {
+                    endpoint: endpoint.clone(),
+                    listener: ListenerKind::Tcp(listener),
+                })
+            }
+            SocketEndpoint::Unix { path } => {
+                #[cfg(unix)]
+                {
+                    let listener = bind_unix(path.as_std_path())?;
+                    Ok(Self {
+                        endpoint: endpoint.clone(),
+                        listener: ListenerKind::Unix(listener),
+                    })
+                }
+
+                #[cfg(not(unix))]
+                {
+                    Err(ListenerError::UnsupportedUnix {
+                        endpoint: endpoint.to_string(),
+                    })
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_addr(&self) -> Option<SocketAddr> {
+        match &self.listener {
+            ListenerKind::Tcp(listener) => listener.local_addr().ok(),
+            #[cfg(unix)]
+            ListenerKind::Unix(_) => None,
+        }
+    }
+
+    pub(crate) fn start(
+        mut self,
+        handler: Arc<dyn ConnectionHandler>,
+    ) -> Result<ListenerHandle, ListenerError> {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        if let Err(error) = match &self.listener {
+            ListenerKind::Tcp(listener) => listener.set_nonblocking(true),
+            #[cfg(unix)]
+            ListenerKind::Unix(listener) => listener.set_nonblocking(true),
+        } {
+            #[cfg(unix)]
+            cleanup_unix_socket(&self.endpoint);
+            return Err(ListenerError::NonBlocking { source: error });
+        }
+        let shutdown_flag = Arc::clone(&shutdown);
+        let handle = thread::spawn(move || run_accept_loop(&mut self, shutdown_flag, handler));
+        Ok(ListenerHandle {
+            shutdown,
+            handle: Some(handle),
+        })
+    }
+}
+
+/// Handle to the background listener thread.
+pub(crate) struct ListenerHandle {
+    shutdown: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl ListenerHandle {
+    pub(crate) fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn join(mut self) -> Result<(), ListenerError> {
+        if let Some(handle) = self.handle.take() {
+            match handle.join() {
+                Ok(()) => Ok(()),
+                Err(_) => Err(ListenerError::ThreadPanic),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for ListenerHandle {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+}
+
+fn run_accept_loop(
+    listener: &mut SocketListener,
+    shutdown: Arc<AtomicBool>,
+    handler: Arc<dyn ConnectionHandler>,
+) {
+    info!(
+        target: LISTENER_TARGET,
+        endpoint = %listener.endpoint,
+        "socket listener active"
+    );
+    let mut last_error = None::<io::ErrorKind>;
+    while !shutdown.load(Ordering::SeqCst) {
+        match accept_connection(listener) {
+            Ok(Some(stream)) => {
+                last_error = None;
+                let handler = Arc::clone(&handler);
+                thread::spawn(move || handler.handle(stream));
+            }
+            Ok(None) => {
+                thread::sleep(ACCEPT_BACKOFF);
+            }
+            Err(error) => {
+                let kind = error.kind();
+                if last_error != Some(kind) {
+                    warn!(
+                        target: LISTENER_TARGET,
+                        error = %error,
+                        "socket accept error"
+                    );
+                }
+                last_error = Some(kind);
+                thread::sleep(ERROR_BACKOFF);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    cleanup_unix_socket(&listener.endpoint);
+}
+
+fn accept_connection(listener: &mut SocketListener) -> Result<Option<ConnectionStream>, io::Error> {
+    match &listener.listener {
+        ListenerKind::Tcp(tcp) => match tcp.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false)?;
+                Ok(Some(ConnectionStream::Tcp(stream)))
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(error) => Err(error),
+        },
+        #[cfg(unix)]
+        ListenerKind::Unix(unix) => match unix.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false)?;
+                Ok(Some(ConnectionStream::Unix(stream)))
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(error) => Err(error),
+        },
+    }
+}
+
+fn bind_tcp(host: &str, port: u16) -> Result<TcpListener, ListenerError> {
+    let mut addrs = (host, port)
+        .to_socket_addrs()
+        .map_err(|source| ListenerError::Resolve {
+            host: host.to_string(),
+            port,
+            source,
+        })?;
+    let addr = addrs
+        .find(|addr| matches!(addr, SocketAddr::V4(_) | SocketAddr::V6(_)))
+        .ok_or_else(|| ListenerError::ResolveEmpty {
+            host: host.to_string(),
+            port,
+        })?;
+    TcpListener::bind(addr).map_err(|source| ListenerError::BindTcp { addr, source })
+}
+
+#[cfg(unix)]
+fn bind_unix(path: &Path) -> Result<UnixListener, ListenerError> {
+    if path.exists() {
+        let metadata =
+            fs::symlink_metadata(path).map_err(|source| ListenerError::UnixMetadata {
+                path: path.display().to_string(),
+                source,
+            })?;
+        if !metadata.file_type().is_socket() {
+            return Err(ListenerError::UnixNotSocket {
+                path: path.display().to_string(),
+            });
+        }
+        match UnixStream::connect(path) {
+            Ok(_stream) => {
+                return Err(ListenerError::UnixInUse {
+                    path: path.display().to_string(),
+                });
+            }
+            Err(error)
+                if error.kind() == io::ErrorKind::ConnectionRefused
+                    || error.kind() == io::ErrorKind::NotFound =>
+            {
+                fs::remove_file(path).map_err(|source| ListenerError::UnixCleanup {
+                    path: path.display().to_string(),
+                    source,
+                })?;
+            }
+            Err(error) => {
+                return Err(ListenerError::UnixConnect {
+                    path: path.display().to_string(),
+                    source: error,
+                });
+            }
+        }
+    }
+
+    UnixListener::bind(path).map_err(|source| ListenerError::BindUnix {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+#[cfg(unix)]
+fn cleanup_unix_socket(endpoint: &SocketEndpoint) {
+    let SocketEndpoint::Unix { path } = endpoint else {
+        return;
+    };
+    if let Err(error) = fs::remove_file(path.as_std_path())
+        && error.kind() != io::ErrorKind::NotFound
+    {
+        warn!(
+            target: LISTENER_TARGET,
+            error = %error,
+            path = %path,
+            "failed to remove unix socket file"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::NoopConnectionHandler;
+    use super::*;
+    use std::net::TcpStream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
+
+    struct CountingHandler {
+        count: Arc<AtomicUsize>,
+    }
+
+    impl ConnectionHandler for CountingHandler {
+        fn handle(&self, _stream: ConnectionStream) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn wait_for_count(count: &AtomicUsize, expected: usize) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if count.load(Ordering::SeqCst) >= expected {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+
+    #[test]
+    fn tcp_listener_accepts_connections() {
+        let endpoint = SocketEndpoint::tcp("127.0.0.1", 0);
+        let listener = SocketListener::bind(&endpoint).expect("bind tcp listener");
+        let addr = listener
+            .local_addr()
+            .expect("listener should report local address");
+        let count = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(CountingHandler {
+            count: Arc::clone(&count),
+        });
+        let handle = listener.start(handler).expect("start listener");
+
+        TcpStream::connect(addr).expect("connect first client");
+        TcpStream::connect(addr).expect("connect second client");
+
+        assert!(wait_for_count(&count, 2), "expected two connections");
+        handle.shutdown();
+        handle.join().expect("join listener");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_listener_cleans_stale_socket_files() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("weaverd.sock");
+        {
+            let _stale = UnixListener::bind(&path).expect("bind stale listener");
+        }
+        assert!(path.exists(), "stale socket should remain");
+
+        let endpoint = SocketEndpoint::unix(path.to_str().expect("utf8 path").to_string());
+        let listener = SocketListener::bind(&endpoint).expect("bind new listener");
+        let handler = Arc::new(NoopConnectionHandler);
+        let handle = listener.start(handler).expect("start listener");
+
+        UnixStream::connect(&path).expect("connect unix client");
+
+        handle.shutdown();
+        handle.join().expect("join listener");
+        assert!(
+            !path.exists(),
+            "listener should remove unix socket on shutdown"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_listener_rejects_in_use_socket() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("weaverd.sock");
+        let _existing = UnixListener::bind(&path).expect("bind existing listener");
+
+        let endpoint = SocketEndpoint::unix(path.to_str().expect("utf8 path").to_string());
+        let error = SocketListener::bind(&endpoint).expect_err("should fail bind");
+        assert!(matches!(error, ListenerError::UnixInUse { .. }));
+    }
+}

--- a/crates/weaverd/src/transport/listener_tests.rs
+++ b/crates/weaverd/src/transport/listener_tests.rs
@@ -1,0 +1,103 @@
+//! Tests for the socket listener.
+
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use rstest::{fixture, rstest};
+
+use weaver_config::SocketEndpoint;
+
+use super::listener::SocketListener;
+use super::{ConnectionHandler, CountingHandler, ListenerError, NoopConnectionHandler};
+
+#[derive(Clone)]
+struct CountingFixture {
+    count: Arc<AtomicUsize>,
+    handler: Arc<CountingHandler>,
+}
+
+#[fixture]
+fn counting_fixture() -> CountingFixture {
+    let (count, handler) = CountingHandler::new();
+    CountingFixture { count, handler }
+}
+
+#[fixture]
+fn tcp_endpoint() -> SocketEndpoint {
+    SocketEndpoint::tcp("127.0.0.1", 0)
+}
+
+fn wait_for_count(count: &AtomicUsize, expected: usize) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if count.load(Ordering::SeqCst) >= expected {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    false
+}
+
+#[rstest]
+fn tcp_listener_accepts_connections(
+    tcp_endpoint: SocketEndpoint,
+    counting_fixture: CountingFixture,
+) {
+    let listener = SocketListener::bind(&tcp_endpoint).expect("bind tcp listener");
+    let addr = listener
+        .local_addr()
+        .expect("listener should report local address");
+    let CountingFixture { count, handler } = counting_fixture;
+    let handler: Arc<dyn ConnectionHandler> = handler;
+    let handle = listener.start(handler).expect("start listener");
+
+    TcpStream::connect(addr).expect("connect first client");
+    TcpStream::connect(addr).expect("connect second client");
+
+    assert!(wait_for_count(&count, 2), "expected two connections");
+    handle.shutdown();
+    handle.join().expect("join listener");
+}
+
+#[cfg(unix)]
+#[fixture]
+fn unix_tempdir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("temp dir")
+}
+
+#[cfg(unix)]
+#[rstest]
+fn unix_listener_cleans_stale_socket_files(unix_tempdir: tempfile::TempDir) {
+    let path = unix_tempdir.path().join("weaverd.sock");
+    {
+        let _stale = std::os::unix::net::UnixListener::bind(&path).expect("bind stale listener");
+    }
+    assert!(path.exists(), "stale socket should remain");
+
+    let endpoint = SocketEndpoint::unix(path.to_str().expect("utf8 path").to_string());
+    let listener = SocketListener::bind(&endpoint).expect("bind new listener");
+    let handler = Arc::new(NoopConnectionHandler);
+    let handle = listener.start(handler).expect("start listener");
+
+    std::os::unix::net::UnixStream::connect(&path).expect("connect unix client");
+
+    handle.shutdown();
+    handle.join().expect("join listener");
+    assert!(
+        !path.exists(),
+        "listener should remove unix socket on shutdown"
+    );
+}
+
+#[cfg(unix)]
+#[rstest]
+fn unix_listener_rejects_in_use_socket(unix_tempdir: tempfile::TempDir) {
+    let path = unix_tempdir.path().join("weaverd.sock");
+    let _existing = std::os::unix::net::UnixListener::bind(&path).expect("bind existing listener");
+
+    let endpoint = SocketEndpoint::unix(path.to_str().expect("utf8 path").to_string());
+    let error = SocketListener::bind(&endpoint).expect_err("should fail bind");
+    assert!(matches!(error, ListenerError::UnixInUse { .. }));
+}

--- a/crates/weaverd/src/transport/mod.rs
+++ b/crates/weaverd/src/transport/mod.rs
@@ -1,0 +1,16 @@
+//! Socket listener for daemon transport endpoints.
+//!
+//! The transport module binds to configured socket endpoints and accepts
+//! connections in a background thread.
+
+mod errors;
+mod handler;
+mod listener;
+
+pub(crate) use self::errors::ListenerError;
+pub(crate) use self::handler::{ConnectionHandler, ConnectionStream, NoopConnectionHandler};
+#[cfg(test)]
+pub(crate) use self::listener::ListenerHandle;
+pub(crate) use self::listener::SocketListener;
+
+const LISTENER_TARGET: &str = concat!(env!("CARGO_PKG_NAME"), "::transport");

--- a/crates/weaverd/src/transport/mod.rs
+++ b/crates/weaverd/src/transport/mod.rs
@@ -6,11 +6,17 @@
 mod errors;
 mod handler;
 mod listener;
+#[cfg(test)]
+mod listener_tests;
+#[cfg(test)]
+mod test_utils;
 
 pub(crate) use self::errors::ListenerError;
 pub(crate) use self::handler::{ConnectionHandler, ConnectionStream, NoopConnectionHandler};
 #[cfg(test)]
 pub(crate) use self::listener::ListenerHandle;
 pub(crate) use self::listener::SocketListener;
+#[cfg(test)]
+pub(crate) use self::test_utils::CountingHandler;
 
 const LISTENER_TARGET: &str = concat!(env!("CARGO_PKG_NAME"), "::transport");

--- a/crates/weaverd/src/transport/test_utils.rs
+++ b/crates/weaverd/src/transport/test_utils.rs
@@ -1,0 +1,28 @@
+//! Test helpers for the transport module.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use super::{ConnectionHandler, ConnectionStream};
+
+pub(crate) struct CountingHandler {
+    count: Arc<AtomicUsize>,
+}
+
+impl CountingHandler {
+    pub(crate) fn new() -> (Arc<AtomicUsize>, Arc<Self>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(Self {
+            count: Arc::clone(&count),
+        });
+        (count, handler)
+    }
+}
+
+impl ConnectionHandler for CountingHandler {
+    fn handle(&self, _stream: ConnectionStream) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+}

--- a/crates/weaverd/tests/features/daemon_socket.feature
+++ b/crates/weaverd/tests/features/daemon_socket.feature
@@ -3,7 +3,7 @@ Feature: Daemon socket listener
   Scenario: Accepting a TCP connection
     Given a TCP socket listener is running
     When a client connects
-    Then the listener records 1 connections
+    Then the listener records 1 connection
 
   Scenario: Accepting concurrent TCP connections
     Given a TCP socket listener is running

--- a/crates/weaverd/tests/features/daemon_socket.feature
+++ b/crates/weaverd/tests/features/daemon_socket.feature
@@ -1,0 +1,16 @@
+Feature: Daemon socket listener
+
+  Scenario: Accepting a TCP connection
+    Given a TCP socket listener is running
+    When a client connects
+    Then the listener records 1 connections
+
+  Scenario: Accepting concurrent TCP connections
+    Given a TCP socket listener is running
+    When two clients connect
+    Then the listener records 2 connections
+
+  Scenario: Listener binding fails when the socket is in use
+    Given a TCP socket is already bound
+    When the listener starts on the same socket
+    Then starting the listener fails

--- a/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
+++ b/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
@@ -1,8 +1,9 @@
 # Implement the weaverd socket listener (Phase 1)
 
-This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
-`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
-`Outcomes & Retrospective` must be kept up to date as work proceeds.
+This execution plan (ExecPlan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
 
 Status: COMPLETE
 
@@ -11,13 +12,13 @@ its own.
 
 ## Purpose / Big Picture
 
-We need the daemon to accept client connections over the configured transport
-so the CLI can connect reliably and the rest of the JSONL protocol can be
-layered on top in the next roadmap step. Success is observable when the daemon
-binds to the socket declared in configuration, accepts multiple concurrent
-connections without crashing, and keeps running even when individual
-connections fail. Unit tests and behavioural tests must cover success and
-failure paths using `rstest-bdd` v0.3.2.
+The daemon must accept client connections over the configured transport so the
+command-line interface (CLI) can connect reliably and the rest of the JSON
+Lines (JSONL) protocol can be layered on top in the next roadmap step. Success
+is observable when the daemon binds to the socket declared in configuration,
+accepts multiple concurrent connections without crashing, and keeps running
+even when individual connections fail. Unit tests and behavioural tests must
+cover success and failure paths using `rstest-bdd` v0.3.2.
 
 ## Constraints
 
@@ -103,11 +104,11 @@ failure paths using `rstest-bdd` v0.3.2.
 
 The daemon now binds a socket listener during startup, accepts concurrent
 connections via a non-blocking accept loop, and cleans up Unix socket files on
-shutdown. Unit and BDD coverage validate success, concurrency, and failure
-paths. A small test guard was added for root environments to keep shutdown
-probe behaviour deterministic. The rollout preserved existing configuration and
-CLI interfaces while ensuring `make check-fmt`, `make lint`, and `make test`
-pass.
+shutdown. Unit and behaviour-driven development (BDD) coverage validate
+success, concurrency, and failure paths. A small test guard was added for root
+environments to keep shutdown probe behaviour deterministic. The rollout
+preserved existing configuration and CLI behaviour while ensuring
+`make check-fmt`, `make lint`, and `make test` pass.
 
 ## Context and Orientation
 
@@ -171,7 +172,7 @@ are safe to re-run.
 1. Inventory socket-related code and daemon launch flow.
 
    rg -n "daemon_socket|SocketEndpoint|listener|accept" crates/weaverd rg -n
-   "connect\(" crates/weaver-cli/src/transport.rs rg -n "socket"
+   "connect\\(" crates/weaver-cli/src/transport.rs rg -n "socket"
    docs/users-guide.md docs/weaver-design.md
 
 2. If the workspace still pins `rstest-bdd` to 0.2.x, update the workspace

--- a/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
+++ b/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
@@ -1,0 +1,265 @@
+# Implement the weaverd socket listener (Phase 1)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+No `PLANS.md` file exists in the repository root, so this document stands on
+its own.
+
+## Purpose / Big Picture
+
+We need the daemon to accept client connections over the configured transport
+so the CLI can connect reliably and the rest of the JSONL protocol can be
+layered on top in the next roadmap step. Success is observable when the daemon
+binds to the socket declared in configuration, accepts multiple concurrent
+connections without crashing, and keeps running even when individual
+connections fail. Unit tests and behavioural tests must cover success and
+failure paths using `rstest-bdd` v0.3.2.
+
+## Constraints
+
+- Use the existing `SocketEndpoint` configuration contract from
+  `crates/weaver-config` without changing the schema.
+- Support Unix domain sockets on Unix targets and TCP sockets on all targets;
+  fail fast with a clear error if a Unix socket is requested on a non-Unix
+  platform.
+- Do not introduce a JSONL request loop or change CLI request/response
+  semantics in this phase.
+- Keep modules under 400 lines and add a `//!` module-level comment to any new
+  module.
+- Use `rstest-bdd` v0.3.2 for behavioural tests; update the workspace
+  dependency if required.
+- Do not add new runtime dependencies beyond the `rstest-bdd` version bump
+  unless explicitly approved.
+
+## Tolerances (Exception Triggers)
+
+- Scope: if the work requires touching more than 12 files or exceeds 500 net
+  new/changed lines, stop and ask for guidance.
+- Dependencies: if any new runtime dependency is required (other than
+  updating `rstest-bdd`/`rstest-bdd-macros`), stop and ask for approval.
+- Interfaces: if the CLI JSONL envelope, `weaver-config` schema, or public CLI
+  flags must change, stop and ask for direction.
+- Architecture: if an async runtime (Tokio, async-std) appears necessary to
+  meet the acceptance criteria, stop and ask before proceeding.
+- Tests: if `make test` still fails after two fix attempts, stop and report
+  the failing cases.
+
+## Risks
+
+- Risk: Unix socket files can linger and cause bind failures after crashes.
+  Severity: medium. Likelihood: medium.
+  Mitigation: attempt safe cleanup of stale socket paths when no listener is
+  active and log when cleanup is skipped.
+- Risk: Non-blocking accept loops can spin if errors are not throttled.
+  Severity: medium. Likelihood: medium.
+  Mitigation: add bounded sleep/backoff on repeated accept errors.
+- Risk: Updating `rstest-bdd` to 0.3.2 could break existing scenarios across
+  crates. Severity: high. Likelihood: medium.
+  Mitigation: update the workspace dependency first, run the full suite, and
+  adjust any failing scenarios before implementing new steps.
+
+## Progress
+
+- [x] 2026-01-10 Drafted ExecPlan for the daemon socket listener.
+- [ ] Inventory current daemon launch flow and socket-related helpers.
+- [ ] Update workspace `rstest-bdd` dependencies to 0.3.2 (if not already) and
+      confirm existing tests still compile.
+- [ ] Add a socket listener module with a testable connection handler.
+- [ ] Integrate the listener into `run_daemon_with` and graceful shutdown.
+- [ ] Add unit tests for binding, cleanup, and error handling.
+- [ ] Add `rstest-bdd` scenarios covering happy/unhappy connection paths.
+- [ ] Update `docs/weaver-design.md` and `docs/users-guide.md` with design and
+      behaviour notes.
+- [ ] Mark the Phase 1 socket listener roadmap entry as done.
+- [ ] Run `make check-fmt`, `make lint`, and `make test` successfully.
+
+## Surprises & Discoveries
+
+- None yet.
+
+## Decision Log
+
+- Decision: Pending — record the listener concurrency and cleanup strategy
+  once the implementation approach is finalised.
+  Date/Author: 2026-01-10 / plan author.
+
+## Outcomes & Retrospective
+
+Not started yet.
+
+## Context and Orientation
+
+`weaverd` currently boots, prepares runtime files, and then blocks on the
+shutdown signal without binding any socket. The daemon launch flow is in
+`crates/weaverd/src/process/launch.rs`, which loads configuration, prepares
+socket directories, acquires the process lock, and then calls
+`bootstrap_with`. The transport contract lives in
+`crates/weaver-config/src/socket.rs` via `SocketEndpoint`, which distinguishes
+Unix domain sockets (filesystem paths) from TCP sockets (host/port). The CLI
+connects using `crates/weaver-cli/src/transport.rs` and expects the daemon to
+accept either Unix or TCP connections.
+
+A Unix domain socket is a local, filesystem-backed socket used for
+inter-process communication on Unix-like systems. TCP sockets are network
+sockets addressed by host and port; they work on all platforms.
+
+Existing test harnesses for the daemon live under `crates/weaverd/src/tests/`
+with Gherkin feature files in `crates/weaverd/tests/features/`.
+
+Key files likely to change or be referenced:
+
+- `crates/weaverd/src/process/launch.rs` (daemon runtime orchestration).
+- `crates/weaverd/src/process/errors.rs` (launch error surface).
+- `crates/weaverd/src/lib.rs` (module exports and crate-level docs).
+- `crates/weaver-config/src/socket.rs` (socket endpoint contract).
+- `crates/weaver-cli/src/transport.rs` (client transport expectations).
+- `docs/weaver-design.md` and `docs/users-guide.md` (design and user-facing
+  behaviour).
+- `docs/roadmap.md` (Phase 1 socket listener entry).
+
+## Plan of Work
+
+Stage A: understand the current flow and requirements. Confirm where to bind
+and how the daemon currently signals readiness. Review the CLI transport code
+so the listener matches expected behaviour, and check whether any existing
+socket cleanup logic exists to avoid duplicating it.
+
+Stage B: introduce a dedicated listener module in `weaverd` that can bind to a
+`SocketEndpoint` and accept connections via a small, testable interface. The
+module should expose a connection handler trait so unit tests can record
+connections without needing the full request loop. Decide and document how the
+listener stops on shutdown and how it handles transient accept errors.
+
+Stage C: wire the listener into `run_daemon_with`. The listener must bind
+before the daemon reports `ready`, and it must shut down cleanly after the
+shutdown signal is received. Ensure any socket files are cleaned up on exit.
+
+Stage D: add unit tests and BDD scenarios. Unit tests should validate binding,
+cleanup, and error classification. Behavioural tests should confirm that the
+daemon accepts connections and that failure cases return structured errors
+without crashing. Update the design and user guide documentation with the
+chosen listener design and any new operator-visible behaviour. Finally, mark
+the roadmap entry as complete and run the quality gates.
+
+## Concrete Steps
+
+Run these commands from the repository root (`/root/repo`). The `rg` commands
+are safe to re-run.
+
+1. Inventory socket-related code and daemon launch flow.
+
+   rg -n "daemon_socket|SocketEndpoint|listener|accept" crates/weaverd
+   rg -n "connect\(" crates/weaver-cli/src/transport.rs
+   rg -n "socket" docs/users-guide.md docs/weaver-design.md
+
+2. If the workspace still pins `rstest-bdd` to 0.2.x, update the workspace
+   dependencies in `Cargo.toml` to 0.3.2 and adjust any tests that fail to
+   compile.
+
+3. Add a listener module, for example `crates/weaverd/src/transport.rs`, with:
+
+   - A `DaemonListener`/`SocketListener` struct that binds to `SocketEndpoint`.
+   - A `ConnectionHandler` trait for handling accepted connections.
+   - A `ListenerHandle` that owns the accept loop thread and a shutdown flag.
+
+4. Integrate the listener into `crates/weaverd/src/process/launch.rs` so the
+   daemon reports ready only after binding. Ensure shutdown signals stop the
+   listener and clean up Unix socket files.
+
+5. Add unit tests alongside the listener module to validate:
+
+   - TCP binding on an ephemeral port.
+   - Unix socket binding (on Unix) and cleanup of stale socket files.
+   - Error handling when the socket is already in use.
+
+6. Add BDD coverage using `rstest-bdd` v0.3.2. Add a feature file such as
+   `crates/weaverd/tests/features/daemon_socket.feature` and new step
+   definitions under `crates/weaverd/src/tests/` to cover:
+
+   - Happy path: daemon accepts a connection on the configured socket.
+   - Unhappy path: binding fails when the socket is already in use.
+   - Concurrency: two clients can connect without crashing the daemon.
+
+7. Update documentation:
+
+   - `docs/weaver-design.md` to record the listener strategy and error
+     handling decisions.
+   - `docs/users-guide.md` to describe any user-visible behaviour changes.
+   - `docs/roadmap.md` to mark the socket listener item as done.
+
+8. Format and validate documentation if any docs changed:
+
+   set -o pipefail
+   make fmt 2>&1 | tee /tmp/weaver-fmt.log
+   make markdownlint 2>&1 | tee /tmp/weaver-markdownlint.log
+
+   Run `make nixie` only if a Mermaid diagram was edited.
+
+9. Run the Rust quality gates:
+
+   set -o pipefail
+   make check-fmt 2>&1 | tee /tmp/weaver-check-fmt.log
+   make lint 2>&1 | tee /tmp/weaver-lint.log
+   make test 2>&1 | tee /tmp/weaver-test.log
+
+## Validation and Acceptance
+
+Acceptance requires all of the following:
+
+- Unit tests demonstrate binding success and failure cases for both Unix and
+  TCP endpoints (platform permitting).
+- New `rstest-bdd` scenarios pass and cover at least one happy path and one
+  unhappy path for the listener.
+- `make check-fmt`, `make lint`, and `make test` succeed.
+- `docs/users-guide.md` documents any relevant behavioural changes for the
+  daemon socket listener.
+- `docs/weaver-design.md` records the design decisions taken.
+- The Phase 1 roadmap entry for the socket listener is marked as done.
+
+## Idempotence and Recovery
+
+All steps are safe to re-run. If a test or lint step fails, fix the issue and
+re-run the same command. If a Unix socket file is left behind by a failed run,
+remove it and rerun the listener test; the implementation should also attempt
+safe cleanup on startup.
+
+## Artifacts and Notes
+
+Example Gherkin snippet for the listener behaviour:
+
+  Feature: Daemon socket listener
+
+    Scenario: Accepting a client connection
+      Given the daemon is running with a TCP socket
+      When a client connects
+      Then the daemon records the connection
+
+## Interfaces and Dependencies
+
+The listener module should expose a small, testable interface, for example:
+
+- `weaverd::transport::SocketListener` with
+  `fn bind(endpoint: &SocketEndpoint) -> Result<Self, ListenerError>`.
+- `weaverd::transport::ConnectionHandler` trait with
+  `fn handle(&self, stream: ConnectionStream)` where `ConnectionStream` wraps
+  `TcpStream` or `UnixStream`.
+- `weaverd::transport::ListenerHandle` with `fn shutdown(self)` and
+  `fn join(self) -> Result<(), ListenerError>` to coordinate shutdown.
+
+`ListenerError` should wrap binding and accept failures without panicking and
+should be convertible into `LaunchError` so `run_daemon_with` can fail fast on
+bind errors.
+
+Dependencies should remain unchanged except for updating `rstest-bdd` and
+`rstest-bdd-macros` to v0.3.2.
+
+## Revision note
+
+2026-01-10: Replaced the previous weaver-graph ExecPlan with a Phase 1 socket
+listener plan to match the user request. This shifts scope to `weaverd`
+transport setup and introduces new testing and documentation updates required
+for the listener work.

--- a/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
+++ b/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
@@ -212,16 +212,22 @@ are safe to re-run.
 
 8. Format and validate documentation if any docs changed:
 
-   set -o pipefail make fmt 2>&1 | tee /tmp/weaver-fmt.log make markdownlint
-   2>&1 | tee /tmp/weaver-markdownlint.log
+   ```sh
+   set -o pipefail
+   make fmt 2>&1 | tee /tmp/weaver-fmt.log
+   make markdownlint 2>&1 | tee /tmp/weaver-markdownlint.log
+   ```
 
    Run `make nixie` only if a Mermaid diagram was edited.
 
 9. Run the Rust quality gates:
 
-   set -o pipefail make check-fmt 2>&1 | tee /tmp/weaver-check-fmt.log make
-   lint 2>&1 | tee /tmp/weaver-lint.log make test 2>&1 | tee
-   /tmp/weaver-test.log
+   ```sh
+   set -o pipefail
+   make check-fmt 2>&1 | tee /tmp/weaver-check-fmt.log
+   make lint 2>&1 | tee /tmp/weaver-lint.log
+   make test 2>&1 | tee /tmp/weaver-test.log
+   ```
 
 ## Validation and Acceptance
 
@@ -248,12 +254,14 @@ safe cleanup on startup.
 
 Example Gherkin snippet for the listener behaviour:
 
-  Feature: Daemon socket listener
+```gherkin
+Feature: Daemon socket listener
 
-    Scenario: Accepting a client connection
-      Given the daemon is running with a TCP socket
-      When a client connects
-      Then the daemon records the connection
+  Scenario: Accepting a client connection
+    Given the daemon is running with a TCP socket
+    When a client connects
+    Then the daemon records the connection
+```
 
 ## Interfaces and Dependencies
 

--- a/docs/execplans/phase-4-weaver-graph.md
+++ b/docs/execplans/phase-4-weaver-graph.md
@@ -1,81 +1,32 @@
-# Implement the weaverd socket listener (Phase 1)
+# Deliver the weaver-graph call hierarchy provider
 
-This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
-`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
-`Outcomes & Retrospective` must be kept up to date as work proceeds.
-
-Status: DRAFT
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
 
 No `PLANS.md` file exists in the repository root, so this document stands on
 its own.
 
 ## Purpose / Big Picture
 
-We need the daemon to accept client connections over the configured transport
-so the CLI can connect reliably and the rest of the JSONL protocol can be
-layered on top in the next roadmap step. Success is observable when the daemon
-binds to the socket declared in configuration, accepts multiple concurrent
-connections without crashing, and keeps running even when individual
-connections fail. Unit tests and behavioural tests must cover success and
-failure paths using `rstest-bdd` v0.3.2.
-
-## Constraints
-
-- Use the existing `SocketEndpoint` configuration contract from
-  `crates/weaver-config` without changing the schema.
-- Support Unix domain sockets on Unix targets and TCP sockets on all targets;
-  fail fast with a clear error if a Unix socket is requested on a non-Unix
-  platform.
-- Do not introduce a JSONL request loop or change CLI request/response
-  semantics in this phase.
-- Keep modules under 400 lines and add a `//!` module-level comment to any new
-  module.
-- Use `rstest-bdd` v0.3.2 for behavioural tests; update the workspace
-  dependency if required.
-- Do not add new runtime dependencies beyond the `rstest-bdd` version bump
-  unless explicitly approved.
-
-## Tolerances (Exception Triggers)
-
-- Scope: if the work requires touching more than 12 files or exceeds 500 net
-  new/changed lines, stop and ask for guidance.
-- Dependencies: if any new runtime dependency is required (other than
-  updating `rstest-bdd`/`rstest-bdd-macros`), stop and ask for approval.
-- Interfaces: if the CLI JSONL envelope, `weaver-config` schema, or public CLI
-  flags must change, stop and ask for direction.
-- Architecture: if an async runtime (Tokio, async-std) appears necessary to
-  meet the acceptance criteria, stop and ask before proceeding.
-- Tests: if `make test` still fails after two fix attempts, stop and report
-  the failing cases.
-
-## Risks
-
-- Risk: Unix socket files can linger and cause bind failures after crashes.
-  Severity: medium. Likelihood: medium.
-  Mitigation: attempt safe cleanup of stale socket paths when no listener is
-  active and log when cleanup is skipped.
-- Risk: Non-blocking accept loops can spin if errors are not throttled.
-  Severity: medium. Likelihood: medium.
-  Mitigation: add bounded sleep/backoff on repeated accept errors.
-- Risk: Updating `rstest-bdd` to 0.3.2 could break existing scenarios across
-  crates. Severity: high. Likelihood: medium.
-  Mitigation: update the workspace dependency first, run the full suite, and
-  adjust any failing scenarios before implementing new steps.
+Implement the relational intelligence layer so Weaver can build a call graph
+from Language Server Protocol (LSP) `textDocument/callHierarchy` data. Success
+is visible when the weaver-graph crate can return a graph of nodes and edges
+for a symbol, and when the daemon-facing interface (or any public API) can
+surface that graph to callers with clear errors for unsupported or empty
+results. Behavioural tests must exercise both happy and unhappy paths using
+`rstest-bdd` v0.2.0.
 
 ## Progress
 
-- [x] 2026-01-10 Drafted ExecPlan for the daemon socket listener.
-- [ ] Inventory current daemon launch flow and socket-related helpers.
-- [ ] Update workspace `rstest-bdd` dependencies to 0.3.2 (if not already) and
-      confirm existing tests still compile.
-- [ ] Add a socket listener module with a testable connection handler.
-- [ ] Integrate the listener into `run_daemon_with` and graceful shutdown.
-- [ ] Add unit tests for binding, cleanup, and error handling.
-- [ ] Add `rstest-bdd` scenarios covering happy/unhappy connection paths.
-- [ ] Update `docs/weaver-design.md` and `docs/users-guide.md` with design and
-      behaviour notes.
-- [ ] Mark the Phase 1 socket listener roadmap entry as done.
+- [x] 2026-01-02 Drafted ExecPlan for weaver-graph call hierarchy provider.
+- [ ] Inventory current call hierarchy and graph-related code for gaps.
+- [ ] Implement or complete the weaver-graph crate API and LSP provider.
+- [ ] Add unit tests for graph data structures and LSP mapping.
+- [ ] Add rstest-bdd behavioural tests covering success and failure cases.
+- [ ] Update `docs/weaver-design.md` and `docs/users-guide.md`.
 - [ ] Run `make check-fmt`, `make lint`, and `make test` successfully.
+- [ ] Mark the Phase 2 roadmap entry as done.
 
 ## Surprises & Discoveries
 
@@ -83,9 +34,10 @@ failure paths using `rstest-bdd` v0.3.2.
 
 ## Decision Log
 
-- Decision: Pending — record the listener concurrency and cleanup strategy
-  once the implementation approach is finalised.
-  Date/Author: 2026-01-10 / plan author.
+- Decision: Use Language Server Protocol (LSP) `textDocument/callHierarchy` as
+  the minimum viable product (MVP) provider for the call graph. Rationale:
+  Matches the Phase 2 roadmap requirement and reuses existing LSP
+  infrastructure. Date/Author: 2026-01-02 / plan author.
 
 ## Outcomes & Retrospective
 
@@ -93,173 +45,205 @@ Not started yet.
 
 ## Context and Orientation
 
-`weaverd` currently boots, prepares runtime files, and then blocks on the
-shutdown signal without binding any socket. The daemon launch flow is in
-`crates/weaverd/src/process/launch.rs`, which loads configuration, prepares
-socket directories, acquires the process lock, and then calls
-`bootstrap_with`. The transport contract lives in
-`crates/weaver-config/src/socket.rs` via `SocketEndpoint`, which distinguishes
-Unix domain sockets (filesystem paths) from TCP sockets (host/port). The CLI
-connects using `crates/weaver-cli/src/transport.rs` and expects the daemon to
-accept either Unix or TCP connections.
+The Phase 2 roadmap item lives in `docs/roadmap.md` and calls for creating the
+`weaver-graph` crate with an LSP-backed provider. The design context for call
+graphs is documented in `docs/weaver-design.md` (see the call graph and
+provider strategy section). The call hierarchy capability is part of the LSP
+surface in `crates/weaver-lsp-host`, while user-facing behaviour is documented
+in `docs/users-guide.md` under `observe call-hierarchy`.
 
-A Unix domain socket is a local, filesystem-backed socket used for
-inter-process communication on Unix-like systems. TCP sockets are network
-sockets addressed by host and port; they work on all platforms.
+Key files and modules to understand or edit:
 
-Existing test harnesses for the daemon live under `crates/weaverd/src/tests/`
-with Gherkin feature files in `crates/weaverd/tests/features/`.
+- `crates/weaver-graph/src/lib.rs` and its modules for graph data types.
+- `crates/weaver-graph/src/provider.rs` for the provider interface and LSP
+  adapter.
+- `crates/weaver-lsp-host/src/host.rs`, `server.rs`, and `capability.rs` for
+  call hierarchy support and capability negotiation.
+- `crates/weaver-graph/tests` for behavioural tests and
+  `crates/weaver-graph/src/tests.rs` (or `src/tests/`) for unit tests.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md` for
+  documentation updates.
 
-Key files likely to change or be referenced:
+Definitions used in this plan:
 
-- `crates/weaverd/src/process/launch.rs` (daemon runtime orchestration).
-- `crates/weaverd/src/process/errors.rs` (launch error surface).
-- `crates/weaverd/src/lib.rs` (module exports and crate-level docs).
-- `crates/weaver-config/src/socket.rs` (socket endpoint contract).
-- `crates/weaver-cli/src/transport.rs` (client transport expectations).
-- `docs/weaver-design.md` and `docs/users-guide.md` (design and user-facing
-  behaviour).
-- `docs/roadmap.md` (Phase 1 socket listener entry).
+- Call hierarchy: LSP API (`textDocument/prepareCallHierarchy`,
+  `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls`) that returns
+  callers and callees for a symbol at a position.
+- Call graph: A graph of nodes (symbols) and edges (call relationships) with
+  provenance describing which provider produced each edge.
 
 ## Plan of Work
 
-Stage A: understand the current flow and requirements. Confirm where to bind
-and how the daemon currently signals readiness. Review the CLI transport code
-so the listener matches expected behaviour, and check whether any existing
-socket cleanup logic exists to avoid duplicating it.
+First, confirm the current state of the workspace. If the `weaver-graph` crate
+or call hierarchy support is missing, create or add it; if it already exists,
+identify gaps against the roadmap requirement. Review how `weaver-lsp-host`
+exposes call hierarchy calls and decide how to adapt it to a
+`CallHierarchyClient` trait so the graph provider can be tested in isolation.
 
-Stage B: introduce a dedicated listener module in `weaverd` that can bind to a
-`SocketEndpoint` and accept connections via a small, testable interface. The
-module should expose a connection handler trait so unit tests can record
-connections without needing the full request loop. Decide and document how the
-listener stops on shutdown and how it handles transient accept errors.
+Next, implement or complete the `weaver-graph` API. Define public types for
+nodes, edges, and the graph itself, including identifiers that are stable and
+human readable (for example, `path:line:column:name`). Keep the graph
+bidirectional to enable efficient `callers_of` and `callees_of` queries.
+Implement a provider trait that can build graphs from a start position and
+accept a depth limit. The LSP provider should: prepare call hierarchy items at
+the requested position, map items to nodes, traverse incoming and outgoing
+calls up to the requested depth, deduplicate nodes, and record edges with
+source metadata. Return semantic errors for missing symbols, missing capability
+support, and upstream LSP failures. Ensure each module has a `//!` comment and
+public APIs have rustdoc examples.
 
-Stage C: wire the listener into `run_daemon_with`. The listener must bind
-before the daemon reports `ready`, and it must shut down cleanly after the
-shutdown signal is received. Ensure any socket files are cleaned up on exit.
+Add unit tests that validate graph structure behaviour (node IDs, edge
+creation, deduplication, depth limits, callers/callees queries). For
+behavioural tests, add a new Gherkin feature file and use `rstest-bdd` to
+exercise the provider against a stub call hierarchy client. Include scenarios
+for a simple happy path (single caller and callee), a no-results path (symbol
+not found), and a provider error path (simulated LSP failure or unsupported
+capability). Use `rstest` fixtures for shared setup, keep tests deterministic,
+and prefer `mockall` or a small in-memory stub implementing the client trait.
 
-Stage D: add unit tests and BDD scenarios. Unit tests should validate binding,
-cleanup, and error classification. Behavioural tests should confirm that the
-daemon accepts connections and that failure cases return structured errors
-without crashing. Update the design and user guide documentation with the
-chosen listener design and any new operator-visible behaviour. Finally, mark
-the roadmap entry as complete and run the quality gates.
+Update documentation to reflect the implemented behaviour. In
+`docs/weaver-design.md`, document the concrete graph data model and the LSP
+provider strategy, including provenance on edges. In `docs/users-guide.md`,
+confirm the `observe call-hierarchy` output schema matches the implemented
+graph (nodes and edges, and any fields such as source or confidence). Finally,
+mark the Phase 2 roadmap item as done in `docs/roadmap.md`.
 
 ## Concrete Steps
 
 Run these commands from the repository root (`/root/repo`). The `rg` commands
 are safe to re-run.
 
-1. Inventory socket-related code and daemon launch flow.
+1. Inventory current implementation and call hierarchy wiring.
 
-   rg -n "daemon_socket|SocketEndpoint|listener|accept" crates/weaverd
-   rg -n "connect\(" crates/weaver-cli/src/transport.rs
-   rg -n "socket" docs/users-guide.md docs/weaver-design.md
+   ```sh
+   rg "weaver-graph" -n
+   rg "callHierarchy" -n crates/weaver-lsp-host
+   rg "call-hierarchy" -n docs
+   ```
 
-2. If the workspace still pins `rstest-bdd` to 0.2.x, update the workspace
-   dependencies in `Cargo.toml` to 0.3.2 and adjust any tests that fail to
-   compile.
+2. If the crate does not exist, create it and add it to the workspace.
 
-3. Add a listener module, for example `crates/weaverd/src/transport.rs`, with:
+   cargo new crates/weaver-graph --lib
 
-   - A `DaemonListener`/`SocketListener` struct that binds to `SocketEndpoint`.
-   - A `ConnectionHandler` trait for handling accepted connections.
-   - A `ListenerHandle` that owns the accept loop thread and a shutdown flag.
+   Then update `Cargo.toml` (workspace members and shared dependencies).
 
-4. Integrate the listener into `crates/weaverd/src/process/launch.rs` so the
-   daemon reports ready only after binding. Ensure shutdown signals stop the
-   listener and clean up Unix socket files.
+3. Implement or adjust the weaver-graph modules:
 
-5. Add unit tests alongside the listener module to validate:
+   - `crates/weaver-graph/src/lib.rs`
+   - `crates/weaver-graph/src/node.rs`, `edge.rs`, `graph.rs`, `error.rs`
+   - `crates/weaver-graph/src/provider.rs` for the LSP provider
 
-   - TCP binding on an ephemeral port.
-   - Unix socket binding (on Unix) and cleanup of stale socket files.
-   - Error handling when the socket is already in use.
+4. Ensure `weaver-lsp-host` exposes call hierarchy operations and capabilities
+   if missing. Touch the following only if required by the inventory step:
 
-6. Add BDD coverage using `rstest-bdd` v0.3.2. Add a feature file such as
-   `crates/weaverd/tests/features/daemon_socket.feature` and new step
-   definitions under `crates/weaverd/src/tests/` to cover:
+   - `crates/weaver-lsp-host/src/host.rs`
+   - `crates/weaver-lsp-host/src/server.rs`
+   - `crates/weaver-lsp-host/src/capability.rs`
+   - `crates/weaver-lsp-host/src/errors.rs`
 
-   - Happy path: daemon accepts a connection on the configured socket.
-   - Unhappy path: binding fails when the socket is already in use.
-   - Concurrency: two clients can connect without crashing the daemon.
+5. Add tests:
 
-7. Update documentation:
+   - Unit tests in `crates/weaver-graph/src/tests.rs` or
+     `crates/weaver-graph/src/tests/`.
+   - Behavioural tests in `crates/weaver-graph/tests/behaviour.rs` with a
+     feature file at `crates/weaver-graph/tests/features/weaver_graph.feature`.
+   - Add `rstest-bdd` and `rstest-bdd-macros` as dev-dependencies in
+     `crates/weaver-graph/Cargo.toml` using workspace versions.
 
-   - `docs/weaver-design.md` to record the listener strategy and error
-     handling decisions.
-   - `docs/users-guide.md` to describe any user-visible behaviour changes.
-   - `docs/roadmap.md` to mark the socket listener item as done.
+6. Update documentation:
 
-8. Format and validate documentation if any docs changed:
+   - `docs/weaver-design.md`
+   - `docs/users-guide.md`
+   - `docs/roadmap.md`
 
+7. Format and validate documentation (required after doc changes):
+
+   ```sh
    set -o pipefail
    make fmt 2>&1 | tee /tmp/weaver-fmt.log
    make markdownlint 2>&1 | tee /tmp/weaver-markdownlint.log
+   ```
 
    Run `make nixie` only if a Mermaid diagram was edited.
 
-9. Run the Rust quality gates:
+8. Run the Rust quality gates:
 
+   ```sh
    set -o pipefail
    make check-fmt 2>&1 | tee /tmp/weaver-check-fmt.log
    make lint 2>&1 | tee /tmp/weaver-lint.log
    make test 2>&1 | tee /tmp/weaver-test.log
+   ```
 
 ## Validation and Acceptance
 
 Acceptance requires all of the following:
 
-- Unit tests demonstrate binding success and failure cases for both Unix and
-  TCP endpoints (platform permitting).
-- New `rstest-bdd` scenarios pass and cover at least one happy path and one
-  unhappy path for the listener.
-- `make check-fmt`, `make lint`, and `make test` succeed.
-- `docs/users-guide.md` documents any relevant behavioural changes for the
-  daemon socket listener.
-- `docs/weaver-design.md` records the design decisions taken.
-- The Phase 1 roadmap entry for the socket listener is marked as done.
+- New unit tests for weaver-graph pass, and at least one test fails before the
+  implementation and passes after.
+- New `rstest-bdd` scenarios for call graph behaviour pass, covering both
+  success and failure cases.
+- `make check-fmt`, `make lint`, and `make test` all succeed.
+- `docs/users-guide.md` accurately describes the call hierarchy output schema
+  and any new CLI behaviour.
+- `docs/weaver-design.md` records the graph model and provider decisions.
+- The Phase 2 roadmap item is marked as done.
 
 ## Idempotence and Recovery
 
-All steps are safe to re-run. If a test or lint step fails, fix the issue and
-re-run the same command. If a Unix socket file is left behind by a failed run,
-remove it and rerun the listener test; the implementation should also attempt
-safe cleanup on startup.
+All commands and tests above are safe to re-run. If a test fails midway, fix
+the underlying issue and re-run only the failing test or the full `make test`
+suite. If formatting or linting fails, apply fixes and re-run the same command
+until it passes. Keep documentation edits small so `make fmt` can be applied
+multiple times without drift.
 
 ## Artifacts and Notes
 
-Example Gherkin snippet for the listener behaviour:
+Example Gherkin snippet for the behavioural test (stored in the feature file):
 
-  Feature: Daemon socket listener
+```gherkin
+Feature: Call graph via LSP call hierarchy
 
-    Scenario: Accepting a client connection
-      Given the daemon is running with a TCP socket
-      When a client connects
-      Then the daemon records the connection
+  Scenario: Build a call graph for a symbol with callers and callees
+    Given a call hierarchy client with a simple call chain
+    When a call graph is built from "main" with depth 2
+    Then the graph includes nodes "main" and "helper"
+    And the graph includes an edge from "main" to "helper"
+```
+
+Example JSON payload for `observe call-hierarchy` (update to match actual
+output schema):
+
+```json
+{"nodes":[{"id":"/src/lib.rs:10:0:main"}],"edges":[{"caller":"n1","callee":"n2"}]}
+```
 
 ## Interfaces and Dependencies
 
-The listener module should expose a small, testable interface, for example:
+The weaver-graph crate must expose a minimal public API that other crates can
+consume:
 
-- `weaverd::transport::SocketListener` with
-  `fn bind(endpoint: &SocketEndpoint) -> Result<Self, ListenerError>`.
-- `weaverd::transport::ConnectionHandler` trait with
-  `fn handle(&self, stream: ConnectionStream)` where `ConnectionStream` wraps
-  `TcpStream` or `UnixStream`.
-- `weaverd::transport::ListenerHandle` with `fn shutdown(self)` and
-  `fn join(self) -> Result<(), ListenerError>` to coordinate shutdown.
+- `weaver_graph::CallGraph` with `add_node`, `add_edge`, `callers_of`,
+  `callees_of`, `find_by_name`, `node_count`, and `edge_count`.
+- `weaver_graph::CallNode` and `weaver_graph::CallEdge` with stable `NodeId`
+  strings and optional call-site metadata.
+- `weaver_graph::CallGraphProvider` with:
 
-`ListenerError` should wrap binding and accept failures without panicking and
-should be convertible into `LaunchError` so `run_daemon_with` can fail fast on
-bind errors.
+    fn build_graph(&mut self, position: &SourcePosition, depth: u32)
+        -> Result<CallGraph, GraphError>;
+    fn callers_graph(&mut self, position: &SourcePosition, depth: u32)
+        -> Result<CallGraph, GraphError>;
+    fn callees_graph(&mut self, position: &SourcePosition, depth: u32)
+        -> Result<CallGraph, GraphError>;
 
-Dependencies should remain unchanged except for updating `rstest-bdd` and
-`rstest-bdd-macros` to v0.3.2.
+- `weaver_graph::CallHierarchyClient` trait implemented by an adapter over
+  `weaver-lsp-host` so the LSP provider can run without owning the host.
 
-## Revision note
+Dependencies and versions:
 
-2026-01-10: Replaced the previous weaver-graph ExecPlan with a Phase 1 socket
-listener plan to match the user request. This shifts scope to `weaverd`
-transport setup and introduces new testing and documentation updates required
-for the listener work.
+- `lsp-types` from the workspace for call hierarchy types.
+- `rstest-bdd` and `rstest-bdd-macros` v0.2.0 for behavioural tests.
+- `mockall` if mocking is required; otherwise use a small in-memory stub.
+
+Ensure each module starts with a `//!` comment and keep files under 400 lines
+by splitting modules if necessary.

--- a/docs/execplans/phase-4-weaver-graph.md
+++ b/docs/execplans/phase-4-weaver-graph.md
@@ -1,32 +1,81 @@
-# Deliver the weaver-graph call hierarchy provider
+# Implement the weaverd socket listener (Phase 1)
 
-This ExecPlan is a living document. The sections `Progress`,
-`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
-be kept up to date as work proceeds.
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
 
 No `PLANS.md` file exists in the repository root, so this document stands on
 its own.
 
 ## Purpose / Big Picture
 
-Implement the relational intelligence layer so Weaver can build a call graph
-from Language Server Protocol (LSP) `textDocument/callHierarchy` data. Success
-is visible when the weaver-graph crate can return a graph of nodes and edges
-for a symbol, and when the daemon-facing interface (or any public API) can
-surface that graph to callers with clear errors for unsupported or empty
-results. Behavioural tests must exercise both happy and unhappy paths using
-`rstest-bdd` v0.2.0.
+We need the daemon to accept client connections over the configured transport
+so the CLI can connect reliably and the rest of the JSONL protocol can be
+layered on top in the next roadmap step. Success is observable when the daemon
+binds to the socket declared in configuration, accepts multiple concurrent
+connections without crashing, and keeps running even when individual
+connections fail. Unit tests and behavioural tests must cover success and
+failure paths using `rstest-bdd` v0.3.2.
+
+## Constraints
+
+- Use the existing `SocketEndpoint` configuration contract from
+  `crates/weaver-config` without changing the schema.
+- Support Unix domain sockets on Unix targets and TCP sockets on all targets;
+  fail fast with a clear error if a Unix socket is requested on a non-Unix
+  platform.
+- Do not introduce a JSONL request loop or change CLI request/response
+  semantics in this phase.
+- Keep modules under 400 lines and add a `//!` module-level comment to any new
+  module.
+- Use `rstest-bdd` v0.3.2 for behavioural tests; update the workspace
+  dependency if required.
+- Do not add new runtime dependencies beyond the `rstest-bdd` version bump
+  unless explicitly approved.
+
+## Tolerances (Exception Triggers)
+
+- Scope: if the work requires touching more than 12 files or exceeds 500 net
+  new/changed lines, stop and ask for guidance.
+- Dependencies: if any new runtime dependency is required (other than
+  updating `rstest-bdd`/`rstest-bdd-macros`), stop and ask for approval.
+- Interfaces: if the CLI JSONL envelope, `weaver-config` schema, or public CLI
+  flags must change, stop and ask for direction.
+- Architecture: if an async runtime (Tokio, async-std) appears necessary to
+  meet the acceptance criteria, stop and ask before proceeding.
+- Tests: if `make test` still fails after two fix attempts, stop and report
+  the failing cases.
+
+## Risks
+
+- Risk: Unix socket files can linger and cause bind failures after crashes.
+  Severity: medium. Likelihood: medium.
+  Mitigation: attempt safe cleanup of stale socket paths when no listener is
+  active and log when cleanup is skipped.
+- Risk: Non-blocking accept loops can spin if errors are not throttled.
+  Severity: medium. Likelihood: medium.
+  Mitigation: add bounded sleep/backoff on repeated accept errors.
+- Risk: Updating `rstest-bdd` to 0.3.2 could break existing scenarios across
+  crates. Severity: high. Likelihood: medium.
+  Mitigation: update the workspace dependency first, run the full suite, and
+  adjust any failing scenarios before implementing new steps.
 
 ## Progress
 
-- [x] 2026-01-02 Drafted ExecPlan for weaver-graph call hierarchy provider.
-- [ ] Inventory current call hierarchy and graph-related code for gaps.
-- [ ] Implement or complete the weaver-graph crate API and LSP provider.
-- [ ] Add unit tests for graph data structures and LSP mapping.
-- [ ] Add rstest-bdd behavioural tests covering success and failure cases.
-- [ ] Update `docs/weaver-design.md` and `docs/users-guide.md`.
+- [x] 2026-01-10 Drafted ExecPlan for the daemon socket listener.
+- [ ] Inventory current daemon launch flow and socket-related helpers.
+- [ ] Update workspace `rstest-bdd` dependencies to 0.3.2 (if not already) and
+      confirm existing tests still compile.
+- [ ] Add a socket listener module with a testable connection handler.
+- [ ] Integrate the listener into `run_daemon_with` and graceful shutdown.
+- [ ] Add unit tests for binding, cleanup, and error handling.
+- [ ] Add `rstest-bdd` scenarios covering happy/unhappy connection paths.
+- [ ] Update `docs/weaver-design.md` and `docs/users-guide.md` with design and
+      behaviour notes.
+- [ ] Mark the Phase 1 socket listener roadmap entry as done.
 - [ ] Run `make check-fmt`, `make lint`, and `make test` successfully.
-- [ ] Mark the Phase 2 roadmap entry as done.
 
 ## Surprises & Discoveries
 
@@ -34,10 +83,9 @@ results. Behavioural tests must exercise both happy and unhappy paths using
 
 ## Decision Log
 
-- Decision: Use Language Server Protocol (LSP) `textDocument/callHierarchy` as
-  the minimum viable product (MVP) provider for the call graph. Rationale:
-  Matches the Phase 2 roadmap requirement and reuses existing LSP
-  infrastructure. Date/Author: 2026-01-02 / plan author.
+- Decision: Pending — record the listener concurrency and cleanup strategy
+  once the implementation approach is finalised.
+  Date/Author: 2026-01-10 / plan author.
 
 ## Outcomes & Retrospective
 
@@ -45,205 +93,173 @@ Not started yet.
 
 ## Context and Orientation
 
-The Phase 2 roadmap item lives in `docs/roadmap.md` and calls for creating the
-`weaver-graph` crate with an LSP-backed provider. The design context for call
-graphs is documented in `docs/weaver-design.md` (see the call graph and
-provider strategy section). The call hierarchy capability is part of the LSP
-surface in `crates/weaver-lsp-host`, while user-facing behaviour is documented
-in `docs/users-guide.md` under `observe call-hierarchy`.
+`weaverd` currently boots, prepares runtime files, and then blocks on the
+shutdown signal without binding any socket. The daemon launch flow is in
+`crates/weaverd/src/process/launch.rs`, which loads configuration, prepares
+socket directories, acquires the process lock, and then calls
+`bootstrap_with`. The transport contract lives in
+`crates/weaver-config/src/socket.rs` via `SocketEndpoint`, which distinguishes
+Unix domain sockets (filesystem paths) from TCP sockets (host/port). The CLI
+connects using `crates/weaver-cli/src/transport.rs` and expects the daemon to
+accept either Unix or TCP connections.
 
-Key files and modules to understand or edit:
+A Unix domain socket is a local, filesystem-backed socket used for
+inter-process communication on Unix-like systems. TCP sockets are network
+sockets addressed by host and port; they work on all platforms.
 
-- `crates/weaver-graph/src/lib.rs` and its modules for graph data types.
-- `crates/weaver-graph/src/provider.rs` for the provider interface and LSP
-  adapter.
-- `crates/weaver-lsp-host/src/host.rs`, `server.rs`, and `capability.rs` for
-  call hierarchy support and capability negotiation.
-- `crates/weaver-graph/tests` for behavioural tests and
-  `crates/weaver-graph/src/tests.rs` (or `src/tests/`) for unit tests.
-- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md` for
-  documentation updates.
+Existing test harnesses for the daemon live under `crates/weaverd/src/tests/`
+with Gherkin feature files in `crates/weaverd/tests/features/`.
 
-Definitions used in this plan:
+Key files likely to change or be referenced:
 
-- Call hierarchy: LSP API (`textDocument/prepareCallHierarchy`,
-  `callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls`) that returns
-  callers and callees for a symbol at a position.
-- Call graph: A graph of nodes (symbols) and edges (call relationships) with
-  provenance describing which provider produced each edge.
+- `crates/weaverd/src/process/launch.rs` (daemon runtime orchestration).
+- `crates/weaverd/src/process/errors.rs` (launch error surface).
+- `crates/weaverd/src/lib.rs` (module exports and crate-level docs).
+- `crates/weaver-config/src/socket.rs` (socket endpoint contract).
+- `crates/weaver-cli/src/transport.rs` (client transport expectations).
+- `docs/weaver-design.md` and `docs/users-guide.md` (design and user-facing
+  behaviour).
+- `docs/roadmap.md` (Phase 1 socket listener entry).
 
 ## Plan of Work
 
-First, confirm the current state of the workspace. If the `weaver-graph` crate
-or call hierarchy support is missing, create or add it; if it already exists,
-identify gaps against the roadmap requirement. Review how `weaver-lsp-host`
-exposes call hierarchy calls and decide how to adapt it to a
-`CallHierarchyClient` trait so the graph provider can be tested in isolation.
+Stage A: understand the current flow and requirements. Confirm where to bind
+and how the daemon currently signals readiness. Review the CLI transport code
+so the listener matches expected behaviour, and check whether any existing
+socket cleanup logic exists to avoid duplicating it.
 
-Next, implement or complete the `weaver-graph` API. Define public types for
-nodes, edges, and the graph itself, including identifiers that are stable and
-human readable (for example, `path:line:column:name`). Keep the graph
-bidirectional to enable efficient `callers_of` and `callees_of` queries.
-Implement a provider trait that can build graphs from a start position and
-accept a depth limit. The LSP provider should: prepare call hierarchy items at
-the requested position, map items to nodes, traverse incoming and outgoing
-calls up to the requested depth, deduplicate nodes, and record edges with
-source metadata. Return semantic errors for missing symbols, missing capability
-support, and upstream LSP failures. Ensure each module has a `//!` comment and
-public APIs have rustdoc examples.
+Stage B: introduce a dedicated listener module in `weaverd` that can bind to a
+`SocketEndpoint` and accept connections via a small, testable interface. The
+module should expose a connection handler trait so unit tests can record
+connections without needing the full request loop. Decide and document how the
+listener stops on shutdown and how it handles transient accept errors.
 
-Add unit tests that validate graph structure behaviour (node IDs, edge
-creation, deduplication, depth limits, callers/callees queries). For
-behavioural tests, add a new Gherkin feature file and use `rstest-bdd` to
-exercise the provider against a stub call hierarchy client. Include scenarios
-for a simple happy path (single caller and callee), a no-results path (symbol
-not found), and a provider error path (simulated LSP failure or unsupported
-capability). Use `rstest` fixtures for shared setup, keep tests deterministic,
-and prefer `mockall` or a small in-memory stub implementing the client trait.
+Stage C: wire the listener into `run_daemon_with`. The listener must bind
+before the daemon reports `ready`, and it must shut down cleanly after the
+shutdown signal is received. Ensure any socket files are cleaned up on exit.
 
-Update documentation to reflect the implemented behaviour. In
-`docs/weaver-design.md`, document the concrete graph data model and the LSP
-provider strategy, including provenance on edges. In `docs/users-guide.md`,
-confirm the `observe call-hierarchy` output schema matches the implemented
-graph (nodes and edges, and any fields such as source or confidence). Finally,
-mark the Phase 2 roadmap item as done in `docs/roadmap.md`.
+Stage D: add unit tests and BDD scenarios. Unit tests should validate binding,
+cleanup, and error classification. Behavioural tests should confirm that the
+daemon accepts connections and that failure cases return structured errors
+without crashing. Update the design and user guide documentation with the
+chosen listener design and any new operator-visible behaviour. Finally, mark
+the roadmap entry as complete and run the quality gates.
 
 ## Concrete Steps
 
 Run these commands from the repository root (`/root/repo`). The `rg` commands
 are safe to re-run.
 
-1. Inventory current implementation and call hierarchy wiring.
+1. Inventory socket-related code and daemon launch flow.
 
-   ```sh
-   rg "weaver-graph" -n
-   rg "callHierarchy" -n crates/weaver-lsp-host
-   rg "call-hierarchy" -n docs
-   ```
+   rg -n "daemon_socket|SocketEndpoint|listener|accept" crates/weaverd
+   rg -n "connect\(" crates/weaver-cli/src/transport.rs
+   rg -n "socket" docs/users-guide.md docs/weaver-design.md
 
-2. If the crate does not exist, create it and add it to the workspace.
+2. If the workspace still pins `rstest-bdd` to 0.2.x, update the workspace
+   dependencies in `Cargo.toml` to 0.3.2 and adjust any tests that fail to
+   compile.
 
-   cargo new crates/weaver-graph --lib
+3. Add a listener module, for example `crates/weaverd/src/transport.rs`, with:
 
-   Then update `Cargo.toml` (workspace members and shared dependencies).
+   - A `DaemonListener`/`SocketListener` struct that binds to `SocketEndpoint`.
+   - A `ConnectionHandler` trait for handling accepted connections.
+   - A `ListenerHandle` that owns the accept loop thread and a shutdown flag.
 
-3. Implement or adjust the weaver-graph modules:
+4. Integrate the listener into `crates/weaverd/src/process/launch.rs` so the
+   daemon reports ready only after binding. Ensure shutdown signals stop the
+   listener and clean up Unix socket files.
 
-   - `crates/weaver-graph/src/lib.rs`
-   - `crates/weaver-graph/src/node.rs`, `edge.rs`, `graph.rs`, `error.rs`
-   - `crates/weaver-graph/src/provider.rs` for the LSP provider
+5. Add unit tests alongside the listener module to validate:
 
-4. Ensure `weaver-lsp-host` exposes call hierarchy operations and capabilities
-   if missing. Touch the following only if required by the inventory step:
+   - TCP binding on an ephemeral port.
+   - Unix socket binding (on Unix) and cleanup of stale socket files.
+   - Error handling when the socket is already in use.
 
-   - `crates/weaver-lsp-host/src/host.rs`
-   - `crates/weaver-lsp-host/src/server.rs`
-   - `crates/weaver-lsp-host/src/capability.rs`
-   - `crates/weaver-lsp-host/src/errors.rs`
+6. Add BDD coverage using `rstest-bdd` v0.3.2. Add a feature file such as
+   `crates/weaverd/tests/features/daemon_socket.feature` and new step
+   definitions under `crates/weaverd/src/tests/` to cover:
 
-5. Add tests:
+   - Happy path: daemon accepts a connection on the configured socket.
+   - Unhappy path: binding fails when the socket is already in use.
+   - Concurrency: two clients can connect without crashing the daemon.
 
-   - Unit tests in `crates/weaver-graph/src/tests.rs` or
-     `crates/weaver-graph/src/tests/`.
-   - Behavioural tests in `crates/weaver-graph/tests/behaviour.rs` with a
-     feature file at `crates/weaver-graph/tests/features/weaver_graph.feature`.
-   - Add `rstest-bdd` and `rstest-bdd-macros` as dev-dependencies in
-     `crates/weaver-graph/Cargo.toml` using workspace versions.
+7. Update documentation:
 
-6. Update documentation:
+   - `docs/weaver-design.md` to record the listener strategy and error
+     handling decisions.
+   - `docs/users-guide.md` to describe any user-visible behaviour changes.
+   - `docs/roadmap.md` to mark the socket listener item as done.
 
-   - `docs/weaver-design.md`
-   - `docs/users-guide.md`
-   - `docs/roadmap.md`
+8. Format and validate documentation if any docs changed:
 
-7. Format and validate documentation (required after doc changes):
-
-   ```sh
    set -o pipefail
    make fmt 2>&1 | tee /tmp/weaver-fmt.log
    make markdownlint 2>&1 | tee /tmp/weaver-markdownlint.log
-   ```
 
    Run `make nixie` only if a Mermaid diagram was edited.
 
-8. Run the Rust quality gates:
+9. Run the Rust quality gates:
 
-   ```sh
    set -o pipefail
    make check-fmt 2>&1 | tee /tmp/weaver-check-fmt.log
    make lint 2>&1 | tee /tmp/weaver-lint.log
    make test 2>&1 | tee /tmp/weaver-test.log
-   ```
 
 ## Validation and Acceptance
 
 Acceptance requires all of the following:
 
-- New unit tests for weaver-graph pass, and at least one test fails before the
-  implementation and passes after.
-- New `rstest-bdd` scenarios for call graph behaviour pass, covering both
-  success and failure cases.
-- `make check-fmt`, `make lint`, and `make test` all succeed.
-- `docs/users-guide.md` accurately describes the call hierarchy output schema
-  and any new CLI behaviour.
-- `docs/weaver-design.md` records the graph model and provider decisions.
-- The Phase 2 roadmap item is marked as done.
+- Unit tests demonstrate binding success and failure cases for both Unix and
+  TCP endpoints (platform permitting).
+- New `rstest-bdd` scenarios pass and cover at least one happy path and one
+  unhappy path for the listener.
+- `make check-fmt`, `make lint`, and `make test` succeed.
+- `docs/users-guide.md` documents any relevant behavioural changes for the
+  daemon socket listener.
+- `docs/weaver-design.md` records the design decisions taken.
+- The Phase 1 roadmap entry for the socket listener is marked as done.
 
 ## Idempotence and Recovery
 
-All commands and tests above are safe to re-run. If a test fails midway, fix
-the underlying issue and re-run only the failing test or the full `make test`
-suite. If formatting or linting fails, apply fixes and re-run the same command
-until it passes. Keep documentation edits small so `make fmt` can be applied
-multiple times without drift.
+All steps are safe to re-run. If a test or lint step fails, fix the issue and
+re-run the same command. If a Unix socket file is left behind by a failed run,
+remove it and rerun the listener test; the implementation should also attempt
+safe cleanup on startup.
 
 ## Artifacts and Notes
 
-Example Gherkin snippet for the behavioural test (stored in the feature file):
+Example Gherkin snippet for the listener behaviour:
 
-```gherkin
-Feature: Call graph via LSP call hierarchy
+  Feature: Daemon socket listener
 
-  Scenario: Build a call graph for a symbol with callers and callees
-    Given a call hierarchy client with a simple call chain
-    When a call graph is built from "main" with depth 2
-    Then the graph includes nodes "main" and "helper"
-    And the graph includes an edge from "main" to "helper"
-```
-
-Example JSON payload for `observe call-hierarchy` (update to match actual
-output schema):
-
-```json
-{"nodes":[{"id":"/src/lib.rs:10:0:main"}],"edges":[{"caller":"n1","callee":"n2"}]}
-```
+    Scenario: Accepting a client connection
+      Given the daemon is running with a TCP socket
+      When a client connects
+      Then the daemon records the connection
 
 ## Interfaces and Dependencies
 
-The weaver-graph crate must expose a minimal public API that other crates can
-consume:
+The listener module should expose a small, testable interface, for example:
 
-- `weaver_graph::CallGraph` with `add_node`, `add_edge`, `callers_of`,
-  `callees_of`, `find_by_name`, `node_count`, and `edge_count`.
-- `weaver_graph::CallNode` and `weaver_graph::CallEdge` with stable `NodeId`
-  strings and optional call-site metadata.
-- `weaver_graph::CallGraphProvider` with:
+- `weaverd::transport::SocketListener` with
+  `fn bind(endpoint: &SocketEndpoint) -> Result<Self, ListenerError>`.
+- `weaverd::transport::ConnectionHandler` trait with
+  `fn handle(&self, stream: ConnectionStream)` where `ConnectionStream` wraps
+  `TcpStream` or `UnixStream`.
+- `weaverd::transport::ListenerHandle` with `fn shutdown(self)` and
+  `fn join(self) -> Result<(), ListenerError>` to coordinate shutdown.
 
-    fn build_graph(&mut self, position: &SourcePosition, depth: u32)
-        -> Result<CallGraph, GraphError>;
-    fn callers_graph(&mut self, position: &SourcePosition, depth: u32)
-        -> Result<CallGraph, GraphError>;
-    fn callees_graph(&mut self, position: &SourcePosition, depth: u32)
-        -> Result<CallGraph, GraphError>;
+`ListenerError` should wrap binding and accept failures without panicking and
+should be convertible into `LaunchError` so `run_daemon_with` can fail fast on
+bind errors.
 
-- `weaver_graph::CallHierarchyClient` trait implemented by an adapter over
-  `weaver-lsp-host` so the LSP provider can run without owning the host.
+Dependencies should remain unchanged except for updating `rstest-bdd` and
+`rstest-bdd-macros` to v0.3.2.
 
-Dependencies and versions:
+## Revision note
 
-- `lsp-types` from the workspace for call hierarchy types.
-- `rstest-bdd` and `rstest-bdd-macros` v0.2.0 for behavioural tests.
-- `mockall` if mocking is required; otherwise use a small in-memory stub.
-
-Ensure each module starts with a `//!` comment and keep files under 400 lines
-by splitting modules if necessary.
+2026-01-10: Replaced the previous weaver-graph ExecPlan with a Phase 1 socket
+listener plan to match the user request. This shifts scope to `weaverd`
+transport setup and introduces new testing and documentation updates required
+for the listener work.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,7 +50,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
         refuse to start when sockets are bound, and emit recovery guidance for
         the operator.
 
-- [ ] Implement the socket listener in `weaverd` to accept client connections
+- [x] Implement the socket listener in `weaverd` to accept client connections
       on the configured Unix domain socket (or TCP socket on non-Unix
       platforms).
       - Acceptance criteria: Daemon binds to the socket path from configuration,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -122,7 +122,7 @@ confirming no listener responds, while actively used sockets cause the daemon
 to fail fast with a clear error. The listener removes the Unix socket file on
 shutdown to avoid lingering bind failures. While the request loop is still a
 placeholder, the daemon replies with a minimal JSONL exit message and closes
-the connection so clients do not block waiting for a response.
+the connection, so clients do not block waiting for a response.
 
 The health snapshot is a single-line JSON document describing the current
 state, enabling operators and automation to poll readiness without speaking the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -115,6 +115,13 @@ published a PID, the second invocation now reports "launch already in progress"
 instead of removing the lock. If the daemon exited uncleanly, the new instance
 removes the stale files before continuing.
 
+The daemon now binds a socket listener as part of startup. It binds to the
+configured `--daemon-socket` endpoint and accepts multiple client connections
+concurrently. On Unix targets, stale socket files are removed only after
+confirming no listener responds, while actively used sockets cause the daemon
+to fail fast with a clear error. The listener removes the Unix socket file on
+shutdown to avoid lingering bind failures.
+
 The health snapshot is a single-line JSON document describing the current
 state, enabling operators and automation to poll readiness without speaking the
 daemon protocol. Example:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -120,7 +120,9 @@ configured `--daemon-socket` endpoint and accepts multiple client connections
 concurrently. On Unix targets, stale socket files are removed only after
 confirming no listener responds, while actively used sockets cause the daemon
 to fail fast with a clear error. The listener removes the Unix socket file on
-shutdown to avoid lingering bind failures.
+shutdown to avoid lingering bind failures. While the request loop is still a
+placeholder, the daemon replies with a minimal JSONL exit message and closes
+the connection so clients do not block waiting for a response.
 
 The health snapshot is a single-line JSON document describing the current
 state, enabling operators and automation to poll readiness without speaking the

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -985,7 +985,10 @@ concurrently without stalling the daemon. Connection and accept failures are
 logged and throttled with backoff rather than crashing the process. For Unix
 domain sockets, any stale socket file is removed only after confirming no
 listener responds, and the daemon cleans up the socket file on shutdown to
-avoid lingering bind errors.
+avoid lingering bind errors. Until the request loop is fully implemented, the
+placeholder handler reads a single JSONL request line, replies with a minimal
+`exit` message, and closes the connection so CLI clients do not hang while
+waiting for a response.
 
 A `SystemShutdownSignal` built on `signal-hook` listens for `SIGTERM`,
 `SIGINT`, `SIGQUIT`, and `SIGHUP`, logging the event and giving the runtime a

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -987,7 +987,7 @@ domain sockets, any stale socket file is removed only after confirming no
 listener responds, and the daemon cleans up the socket file on shutdown to
 avoid lingering bind errors. Until the request loop is fully implemented, the
 placeholder handler reads a single JSONL request line, replies with a minimal
-`exit` message, and closes the connection so CLI clients do not hang while
+`exit` message, and closes the connection, so CLI clients do not hang while
 waiting for a response.
 
 A `SystemShutdownSignal` built on `signal-hook` listens for `SIGTERM`,

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -976,12 +976,23 @@ JSON health snapshot to `weaverd.health`. Both artefacts are written atomically
 via a temporary file and rename so readers never observe a truncated payload.
 The snapshot records the lifecycle state (`starting`, `ready`, `stopping`), the
 PID, and a UNIX timestamp so external probes can consume the same readiness
-signal as the CLI. A `SystemShutdownSignal` built on `signal-hook` listens for
-`SIGTERM`, `SIGINT`, `SIGQUIT`, and `SIGHUP`, logging the event and giving the
-runtime a ten-second budget to shut down gracefully. Developers can opt into a
-foreground mode for debugging by setting the `WEAVER_FOREGROUND` environment
-variable, which bypasses daemonisation while preserving the same
-PID/lock/health choreography.
+signal as the CLI.
+
+The daemon now binds a socket listener as part of startup. The listener binds
+to the configured `SocketEndpoint`, switches into a non-blocking accept loop,
+and spawns lightweight handler threads so multiple clients can connect
+concurrently without stalling the daemon. Connection and accept failures are
+logged and throttled with backoff rather than crashing the process. For Unix
+domain sockets, any stale socket file is removed only after confirming no
+listener responds, and the daemon cleans up the socket file on shutdown to
+avoid lingering bind errors.
+
+A `SystemShutdownSignal` built on `signal-hook` listens for `SIGTERM`,
+`SIGINT`, `SIGQUIT`, and `SIGHUP`, logging the event and giving the runtime a
+ten-second budget to shut down gracefully. Developers can opt into a foreground
+mode for debugging by setting the `WEAVER_FOREGROUND` environment variable,
+which bypasses daemonisation while preserving the same PID/lock/health
+choreography.
 
 ```mermaid
 erDiagram


### PR DESCRIPTION
## Summary
- Expands the weaverd socket listener work into Phase 1 MVP scope and introduces a dedicated transport layer for socket listening, tests, and documentation. The ExecPlan doc for Phase 1 is added and will guide ongoing milestones.

## Changes
- Add new transport module: crates/weaverd/src/transport with errors.rs, handler.rs, listener.rs, and mod.rs to expose ListenerError, ConnectionHandler, ConnectionStream, NoopConnectionHandler, and SocketListener.
- Wire a SocketListener into the daemon launch so the daemon binds to the configured daemon socket early and supports graceful shutdown.
- Implement a non-blocking accept loop with a bounded number of worker threads and a simple ConnectionHandler interface to allow testing of connection counts.
- Add test suites:
  - crates/weaverd/src/tests/socket_behaviour.rs (behavioral tests for binding, connections, and concurrent clients)
  - crates/weaverd/src/transport/listener_tests.rs (unit tests for binding, cleanup, and in-use sockets)
  - crates/weaverd/src/transport/test_utils.rs (CountingHandler for test instrumentation)
- Add tests across platforms: Unix socket handling on Unix targets and TCP sockets on all targets; include tests for stale Unix socket cleanup and in-use sockets.
- Add test feature file: crates/weaverd/tests/features/daemon_socket.feature
- Add docs ExecPlan: docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
- Update dependencies: rstest-bdd and rstest-bdd-macros to 0.3.2; update Cargo.toml
- Update docs: docs/weaver-design.md, docs/users-guide.md, docs/roadmap.md to reflect the new design and status.
- Update test guard in weaver-cli shutdown tests to skip when running as root for deterministic results.
- Export transport module from crates/weaverd/src/lib.rs to surface listener types to the rest of the crate.

## Plan & Rationale
- The ExecPlan doc is the canonical reference for Phase 1 socket listener work, capturing objectives, scope, constraints, risks, implementation steps, and acceptance criteria. This PR implements the MVP and aligns integration with the daemon lifecycle without introducing a full JSON-Lines request loop yet.

## Validation & Acceptance Criteria
- The Phase 1 ExecPlan document exists at the specified path and contains Phase 1 milestones and acceptance criteria.
- The daemon socket listener compiles and can bind to Unix domain and TCP sockets where supported.
- Unit tests and BDD-style tests cover binding, cleanup, concurrency, and error handling.
- make check-fmt, make lint, and make test pass.

## How to test locally
- Review the new ExecPlan document at docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md.
- Build and run tests: cargo test -p weaverd; cargo test -p weaverd --features unix; run the BDD style tests if your environment supports them.

## Idempotence
- The changes are idempotent with respect to doc creation and do not affect runtime behavior unless the listener is started in daemon mode.

## Artifacts and Notes
- Path to the new ExecPlan: docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md

🌿 Generated by [Terry](https://www.terragonlabs.com)

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f328e45b-dd7f-415e-a152-4709cd5a0b0b