### PR TITLE
Bump shared-actions SHAs in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
       - name: Format
         run: make check-fmt
       - name: Markdown lint
@@ -29,7 +29,7 @@ jobs:
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           output-path: lcov.info
           format: lcov
@@ -37,7 +37,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump shared-actions SHAs used in CI workflows to the latest release
- Align setup-rust, generate-coverage, and upload-codescene-coverage actions with the updated SHA

## Changes
### CI Workflows
- Update sha for setup-rust action to aebb3f5b831102e2a10ef909c83d7d50ea86c332
- Update sha for generate-coverage action to aebb3f5b831102e2a10ef909c83d7d50ea86c332
- Update sha for upload-codescene-coverage action to aebb3f5b831102e2a10ef909c83d7d50ea86c332

### Notes
- These changes are purely SHA bumps; no functional changes to CI logic.

## Test plan
- CI checks will run automatically on the PR to validate the updated SHAs
- If needed, re-run workflows to confirm they fetch the new SHAs and complete successfully
- Ensure no YAML syntax changes were introduced and that the workflow steps execute as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2e959f8b-eb60-40ec-bb1b-ff158838e70b

## Summary by Sourcery

CI:
- Bump setup-rust, generate-coverage, and upload-codescene-coverage shared actions in ci.yml to a newer shared-actions commit SHA.