### PR TITLE
Add human-readable weaver-cli output with auto-resolve (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7451d147800bd8b0b8621116a2c553b13408f2b7914a5b818eccaa37240ed9a"
+checksum = "5e741d97bce6ea0a7d0f074716041e0d0eebe6ab9edcd243e7d12f9fd2b5e8b6"
 dependencies = [
  "ctor",
  "derive_more 0.99.20",
@@ -1552,9 +1552,9 @@ dependencies = [
  "i18n-embed",
  "inventory",
  "log",
- "once_cell",
  "regex",
  "rstest-bdd-patterns",
+ "rstest-bdd-policy",
  "rust-embed",
  "thiserror 1.0.69",
  "unic-langid",
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-macros"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58aca0e441b276f7e52a6fe1b9bb8c341004110f610e7dfda112578c0c18837"
+checksum = "a7e3b51c032a6174f82d87843a5e62cfd08ce4606005eafde07ed12561d73196"
 dependencies = [
  "camino",
  "cap-std 3.4.5",
@@ -1572,27 +1572,34 @@ dependencies = [
  "convert_case 0.6.0",
  "gherkin",
  "newt-hype",
- "once_cell",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
  "rstest-bdd-patterns",
+ "rstest-bdd-policy",
  "syn 2.0.111",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a52766aaee3793eec30ff351a5ebddba34dddab8500b18891cddece364a66d"
+checksum = "75d730afd8727e5b18bd276ebf5ea4c881760138762d0cd7d415dc6b6662c6c6"
 dependencies = [
  "gherkin",
  "regex",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "rstest-bdd-policy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d256efeb01f08e281cef9cd1e54dab33d8778e871090f5fa49b7a9a70f0caf81"
 
 [[package]]
 name = "rstest_macros"
@@ -2526,6 +2533,7 @@ dependencies = [
  "socket2",
  "tempfile",
  "thiserror 2.0.17",
+ "url",
  "weaver-config",
 ]
 
@@ -2562,6 +2570,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "url",
+ "weaver-cli",
  "weaver-graph",
  "weaver-lsp-host",
  "weaver-syntax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,6 +2533,7 @@ dependencies = [
  "socket2",
  "tempfile",
  "thiserror 2.0.17",
+ "unicode-width",
  "url",
  "weaver-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ once_cell = "1.19"
 ortho_config = "0.6.0"
 predicates = "3.1"
 rstest = "0.26.1"
-rstest-bdd = { version = "0.3.2", default-features = false }
-rstest-bdd-macros = "0.3.2"
+rstest-bdd = { version = "0.4.0", default-features = false }
+rstest-bdd-macros = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tree-sitter-python = "0.25.0"
 tree-sitter-rust = "0.24.0"
 tree-sitter-typescript = "0.23.2"
 url = "2.5"
+unicode-width = "0.2.2"
 birdcage = "0.8.1"
 cap-std = "4.0"
 

--- a/crates/weaver-cli/Cargo.toml
+++ b/crates/weaver-cli/Cargo.toml
@@ -16,6 +16,7 @@ ortho_config = { workspace = true }
 thiserror = { workspace = true }
 cap-std = { workspace = true }
 url = { workspace = true }
+unicode-width = "0.2.2"
 
 [target.'cfg(unix)'.dependencies]
 socket2 = { version = "0.5" }

--- a/crates/weaver-cli/Cargo.toml
+++ b/crates/weaver-cli/Cargo.toml
@@ -16,7 +16,7 @@ ortho_config = { workspace = true }
 thiserror = { workspace = true }
 cap-std = { workspace = true }
 url = { workspace = true }
-unicode-width = "0.2.2"
+unicode-width = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 socket2 = { version = "0.5" }

--- a/crates/weaver-cli/Cargo.toml
+++ b/crates/weaver-cli/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true }
 ortho_config = { workspace = true }
 thiserror = { workspace = true }
 cap-std = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 socket2 = { version = "0.5" }

--- a/crates/weaver-cli/src/daemon_output.rs
+++ b/crates/weaver-cli/src/daemon_output.rs
@@ -1,0 +1,93 @@
+//! Daemon response handling and output rendering.
+//!
+//! Owns parsing daemon messages and forwarding rendered output to the CLI
+//! streams.
+
+use std::io::{self, Write};
+
+use serde::Deserialize;
+
+use crate::{
+    AppError, EMPTY_LINE_LIMIT, IoStreams, OutputContext, ResolvedOutputFormat, render_human_output,
+};
+
+/// Settings for rendering daemon output.
+pub(crate) struct OutputSettings<'a> {
+    pub(crate) format: ResolvedOutputFormat,
+    pub(crate) context: &'a OutputContext,
+}
+
+pub(crate) fn read_daemon_messages<R, W, E>(
+    connection: &mut R,
+    io: &mut IoStreams<'_, W, E>,
+    settings: OutputSettings<'_>,
+) -> Result<i32, AppError>
+where
+    R: io::Read,
+    W: Write,
+    E: Write,
+{
+    use std::io::BufRead;
+
+    let mut reader = io::BufReader::new(connection);
+    let mut line = String::new();
+    let mut exit_status: Option<i32> = None;
+    let mut consecutive_empty_lines = 0;
+
+    while reader
+        .read_line(&mut line)
+        .map_err(AppError::ReadResponse)?
+        != 0
+    {
+        if line.trim().is_empty() {
+            consecutive_empty_lines += 1;
+            if consecutive_empty_lines >= EMPTY_LINE_LIMIT {
+                writeln!(
+                    io.stderr,
+                    "Warning: received {EMPTY_LINE_LIMIT} consecutive empty lines from daemon; aborting."
+                )
+                .map_err(AppError::ForwardResponse)?;
+                break;
+            }
+            line.clear();
+            continue;
+        }
+        consecutive_empty_lines = 0;
+        let message: DaemonMessage = serde_json::from_str(&line).map_err(AppError::ParseMessage)?;
+        match message {
+            DaemonMessage::Stream { stream, data } => {
+                let rendered = match settings.format {
+                    ResolvedOutputFormat::Human => render_human_output(settings.context, &data),
+                    ResolvedOutputFormat::Json => None,
+                };
+                let payload = rendered.as_deref().unwrap_or(&data);
+                match stream {
+                    StreamTarget::Stdout => io.stdout.write_all(payload.as_bytes()),
+                    StreamTarget::Stderr => io.stderr.write_all(payload.as_bytes()),
+                }
+                .map_err(AppError::ForwardResponse)?;
+            }
+            DaemonMessage::Exit { status } => exit_status = Some(status),
+        }
+        line.clear();
+    }
+
+    io.stdout.flush().map_err(AppError::ForwardResponse)?;
+    io.stderr.flush().map_err(AppError::ForwardResponse)?;
+
+    exit_status.ok_or(AppError::MissingExit)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum DaemonMessage {
+    Stream { stream: StreamTarget, data: String },
+    Exit { status: i32 },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StreamTarget {
+    Stdout,
+    Stderr,
+}

--- a/crates/weaver-cli/src/errors.rs
+++ b/crates/weaver-cli/src/errors.rs
@@ -1,0 +1,61 @@
+//! Error types and diagnostics helpers for the CLI runtime.
+
+use std::io;
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use crate::lifecycle::LifecycleError;
+
+#[derive(Debug, Error)]
+pub(crate) enum AppError {
+    #[error("failed to load configuration: {0}")]
+    LoadConfiguration(Arc<ortho_config::OrthoError>),
+    #[error("{0}")]
+    CliUsage(clap::Error),
+    #[error("the command domain must be provided")]
+    MissingDomain,
+    #[error("the command operation must be provided")]
+    MissingOperation,
+    #[error("failed to resolve daemon address {endpoint}: {source}")]
+    Resolve { endpoint: String, source: io::Error },
+    #[error("failed to connect to daemon at {endpoint}: {source}")]
+    Connect { endpoint: String, source: io::Error },
+    #[cfg(not(unix))]
+    #[error("platform does not support Unix sockets: {0}")]
+    UnsupportedUnixTransport(String),
+    #[error("failed to serialise command request: {0}")]
+    SerialiseRequest(serde_json::Error),
+    #[error("failed to send request to daemon: {0}")]
+    SendRequest(io::Error),
+    #[error("failed to read response from daemon: {0}")]
+    ReadResponse(io::Error),
+    #[error("failed to parse daemon message: {0}")]
+    ParseMessage(serde_json::Error),
+    #[error("failed to forward daemon output: {0}")]
+    ForwardResponse(io::Error),
+    #[error("daemon closed the stream without sending an exit status")]
+    MissingExit,
+    #[error("failed to serialise capability matrix: {0}")]
+    SerialiseCapabilities(serde_json::Error),
+    #[error("failed to emit capabilities: {0}")]
+    EmitCapabilities(io::Error),
+    #[error("daemon lifecycle command failed: {0}")]
+    Lifecycle(#[from] LifecycleError),
+}
+
+/// Determines whether an error indicates the daemon is not running.
+///
+/// Returns true for connection-refused, socket-not-found, and address-unavailable
+/// errors, which typically indicate the daemon process is not listening.
+pub(crate) fn is_daemon_not_running(error: &AppError) -> bool {
+    match error {
+        AppError::Connect { source, .. } => matches!(
+            source.kind(),
+            io::ErrorKind::ConnectionRefused
+                | io::ErrorKind::NotFound
+                | io::ErrorKind::AddrNotAvailable
+        ),
+        _ => false,
+    }
+}

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -70,19 +70,6 @@ impl<'a, W: Write, E: Write> IoStreams<'a, W, E> {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn with_terminal_status(
-        stdout: &'a mut W,
-        stderr: &'a mut E,
-        stdout_is_terminal: bool,
-    ) -> Self {
-        Self {
-            stdout,
-            stderr,
-            stdout_is_terminal,
-        }
-    }
-
     pub(crate) const fn stdout_is_terminal(&self) -> bool {
         self.stdout_is_terminal
     }

--- a/crates/weaver-cli/src/main.rs
+++ b/crates/weaver-cli/src/main.rs
@@ -4,11 +4,17 @@
 //! processes command-line arguments, negotiates capability output, and streams
 //! JSONL requests to the configured daemon transport.
 
-use std::io::{self, StderrLock, StdoutLock};
+use std::io::{self, IsTerminal, StderrLock, StdoutLock};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    let stdout_is_terminal = io::stdout().is_terminal();
     let mut stdout: StdoutLock<'_> = io::stdout().lock();
     let mut stderr: StderrLock<'_> = io::stderr().lock();
-    weaver_cli::run(std::env::args_os(), &mut stdout, &mut stderr)
+    weaver_cli::run(
+        std::env::args_os(),
+        &mut stdout,
+        &mut stderr,
+        stdout_is_terminal,
+    )
 }

--- a/crates/weaver-cli/src/output/mod.rs
+++ b/crates/weaver-cli/src/output/mod.rs
@@ -41,7 +41,7 @@ pub enum ResolvedOutputFormat {
 impl OutputFormat {
     /// Resolves the output format based on whether stdout is a terminal.
     #[must_use]
-    pub fn resolve(self, stdout_is_terminal: bool) -> ResolvedOutputFormat {
+    pub const fn resolve(self, stdout_is_terminal: bool) -> ResolvedOutputFormat {
         match self {
             Self::Auto => {
                 if stdout_is_terminal {
@@ -239,15 +239,20 @@ fn verification_failure_to_location(failure: VerificationFailure) -> SourceLocat
 mod tests {
     use super::*;
 
-    #[test]
-    fn resolves_auto_output_format() {
-        assert_eq!(
-            OutputFormat::Auto.resolve(true),
-            ResolvedOutputFormat::Human
-        );
-        assert_eq!(
-            OutputFormat::Auto.resolve(false),
-            ResolvedOutputFormat::Json
-        );
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(OutputFormat::Auto, true, ResolvedOutputFormat::Human)]
+    #[case(OutputFormat::Auto, false, ResolvedOutputFormat::Json)]
+    #[case(OutputFormat::Human, true, ResolvedOutputFormat::Human)]
+    #[case(OutputFormat::Human, false, ResolvedOutputFormat::Human)]
+    #[case(OutputFormat::Json, true, ResolvedOutputFormat::Json)]
+    #[case(OutputFormat::Json, false, ResolvedOutputFormat::Json)]
+    fn resolves_output_format(
+        #[case] format: OutputFormat,
+        #[case] stdout_is_terminal: bool,
+        #[case] expected: ResolvedOutputFormat,
+    ) {
+        assert_eq!(format.resolve(stdout_is_terminal), expected);
     }
 }

--- a/crates/weaver-cli/src/output/mod.rs
+++ b/crates/weaver-cli/src/output/mod.rs
@@ -1,0 +1,229 @@
+//! Human-readable output rendering for daemon responses.
+//!
+//! This module parses JSON payloads for location- and diagnostic-bearing
+//! responses and renders them with source context for humans. JSON payloads
+//! remain unchanged when JSON output is requested.
+
+mod models;
+mod render;
+mod source;
+
+use clap::ValueEnum;
+
+use crate::output::models::{
+    DiagnosticItem, DiagnosticsResponse, ReferenceResponse, VerificationFailure, parse_definitions,
+    parse_verification_failures,
+};
+use crate::output::source::{
+    SourceLocation, SourcePosition, extract_uri_argument, from_path_or_uri, from_uri,
+};
+
+/// Output format selection for domain command responses.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum OutputFormat {
+    /// Selects `human` for terminal output and `json` for redirected output.
+    Auto,
+    /// Always render human-readable output.
+    Human,
+    /// Always emit raw JSON payloads from the daemon.
+    Json,
+}
+
+/// Output format after resolving `auto` based on TTY detection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResolvedOutputFormat {
+    /// Human-readable output with source context.
+    Human,
+    /// Raw JSON payloads.
+    Json,
+}
+
+impl OutputFormat {
+    /// Resolves the output format based on whether stdout is a terminal.
+    #[must_use]
+    pub fn resolve(self, stdout_is_terminal: bool) -> ResolvedOutputFormat {
+        match self {
+            Self::Auto => {
+                if stdout_is_terminal {
+                    ResolvedOutputFormat::Human
+                } else {
+                    ResolvedOutputFormat::Json
+                }
+            }
+            Self::Human => ResolvedOutputFormat::Human,
+            Self::Json => ResolvedOutputFormat::Json,
+        }
+    }
+}
+
+/// Context about the command whose output is being rendered.
+#[derive(Clone, Debug)]
+pub struct OutputContext {
+    /// The command domain (for example `observe`).
+    pub domain: String,
+    /// The operation within the domain.
+    pub operation: String,
+    /// Raw CLI arguments supplied to the command.
+    pub arguments: Vec<String>,
+}
+
+impl OutputContext {
+    /// Creates a new output context from command metadata.
+    #[must_use]
+    pub fn new(
+        domain: impl Into<String>,
+        operation: impl Into<String>,
+        arguments: Vec<String>,
+    ) -> Self {
+        Self {
+            domain: domain.into(),
+            operation: operation.into(),
+            arguments,
+        }
+    }
+}
+
+/// Attempts to render human-readable output for known response payloads.
+///
+/// Returns `Some(rendered)` when the payload matches a known schema, otherwise
+/// returns `None` to indicate the raw payload should be forwarded.
+#[must_use]
+pub fn render_human_output(context: &OutputContext, data: &str) -> Option<String> {
+    let trimmed = data.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let domain = context.domain.to_ascii_lowercase();
+    let operation = context.operation.to_ascii_lowercase();
+
+    match (domain.as_str(), operation.as_str()) {
+        ("observe", "get-definition") => render_definitions(trimmed),
+        ("observe", "find-references") => render_references(trimmed),
+        ("verify", "diagnostics") => render_diagnostics(trimmed, context),
+        ("act", _) => render_verification_failures(trimmed),
+        _ => None,
+    }
+}
+
+fn render_definitions(payload: &str) -> Option<String> {
+    let definitions = parse_definitions(payload)?;
+    if definitions.is_empty() {
+        return Some(String::from("no definitions found\n"));
+    }
+    let locations: Vec<SourceLocation> = definitions
+        .into_iter()
+        .map(|definition| {
+            from_uri(
+                &definition.uri,
+                Some(definition.line),
+                Some(definition.column),
+                "definition",
+            )
+        })
+        .collect();
+    Some(render::render_locations(&locations))
+}
+
+fn render_references(payload: &str) -> Option<String> {
+    let response: ReferenceResponse = serde_json::from_str(payload).ok()?;
+    if response.references.is_empty() {
+        return Some(String::from("no references found\n"));
+    }
+    let locations: Vec<SourceLocation> = response
+        .references
+        .into_iter()
+        .map(|reference| {
+            from_uri(
+                &reference.uri,
+                Some(reference.line),
+                Some(reference.column),
+                "reference",
+            )
+        })
+        .collect();
+    Some(render::render_locations(&locations))
+}
+
+fn render_diagnostics(payload: &str, context: &OutputContext) -> Option<String> {
+    let response: DiagnosticsResponse = serde_json::from_str(payload).ok()?;
+    if response.diagnostics.is_empty() {
+        return Some(String::from("no diagnostics reported\n"));
+    }
+    let fallback_uri = extract_uri_argument(&context.arguments);
+    let locations: Vec<SourceLocation> = response
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| diagnostic_to_location(diagnostic, fallback_uri.as_deref()))
+        .collect();
+    Some(render::render_locations(&locations))
+}
+
+fn render_verification_failures(payload: &str) -> Option<String> {
+    let failures = parse_verification_failures(payload)?;
+    if failures.is_empty() {
+        return None;
+    }
+    let locations: Vec<SourceLocation> = failures
+        .into_iter()
+        .map(verification_failure_to_location)
+        .collect();
+    Some(render::render_locations(&locations))
+}
+
+fn diagnostic_to_location(
+    diagnostic: DiagnosticItem,
+    fallback_uri: Option<&str>,
+) -> SourceLocation {
+    let label = if diagnostic.message.is_empty() {
+        String::from("diagnostic")
+    } else {
+        diagnostic.message
+    };
+
+    if let Some(uri) = diagnostic.uri.as_deref().or(fallback_uri) {
+        from_uri(uri, Some(diagnostic.line), Some(diagnostic.column), label)
+    } else {
+        SourceLocation::unresolved(
+            String::from("<unknown source>"),
+            SourcePosition::new(Some(diagnostic.line), Some(diagnostic.column)),
+            label,
+            String::from("missing URI for diagnostic"),
+        )
+    }
+}
+
+fn verification_failure_to_location(failure: VerificationFailure) -> SourceLocation {
+    let label = if let Some(phase) = failure.phase.as_deref() {
+        format!("{phase}: {}", failure.message)
+    } else {
+        failure.message
+    };
+
+    match failure.location {
+        Some(location) => from_path_or_uri(&location, failure.line, failure.column, label),
+        None => SourceLocation::unresolved(
+            String::from("<unknown source>"),
+            SourcePosition::new(failure.line, failure.column),
+            label,
+            String::from("missing file path for verification failure"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_auto_output_format() {
+        assert_eq!(
+            OutputFormat::Auto.resolve(true),
+            ResolvedOutputFormat::Human
+        );
+        assert_eq!(
+            OutputFormat::Auto.resolve(false),
+            ResolvedOutputFormat::Json
+        );
+    }
+}

--- a/crates/weaver-cli/src/output/mod.rs
+++ b/crates/weaver-cli/src/output/mod.rs
@@ -186,7 +186,7 @@ fn render_diagnostics(payload: &str, context: &OutputContext) -> Option<String> 
 fn render_verification_failures(payload: &str) -> Option<String> {
     let failures = parse_verification_failures(payload)?;
     if failures.is_empty() {
-        return None;
+        return Some(String::from("no verification failures reported\n"));
     }
     let locations: Vec<SourceLocation> = failures
         .into_iter()

--- a/crates/weaver-cli/src/output/models.rs
+++ b/crates/weaver-cli/src/output/models.rs
@@ -1,0 +1,176 @@
+//! Data models for parsing JSON payloads into renderable locations.
+
+use serde::Deserialize;
+
+/// A definition or reference location in the daemon response.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DefinitionLocation {
+    /// The document URI containing the location.
+    pub(crate) uri: String,
+    /// Line number (1-indexed).
+    pub(crate) line: u32,
+    /// Column number (1-indexed).
+    pub(crate) column: u32,
+}
+
+/// Response wrapper for reference results.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ReferenceResponse {
+    /// Locations where the symbol is referenced.
+    pub(crate) references: Vec<DefinitionLocation>,
+}
+
+/// Response wrapper for diagnostics.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DiagnosticsResponse {
+    /// Diagnostics reported for a document.
+    pub(crate) diagnostics: Vec<DiagnosticItem>,
+}
+
+/// A diagnostic entry in the daemon response.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DiagnosticItem {
+    /// Optional document URI. May be omitted when the command already targets a URI.
+    #[serde(default)]
+    pub(crate) uri: Option<String>,
+    /// Line number (1-indexed).
+    pub(crate) line: u32,
+    /// Column number (1-indexed).
+    pub(crate) column: u32,
+    /// Human-readable diagnostic message.
+    #[serde(default)]
+    pub(crate) message: String,
+}
+
+/// Parsed verification failure used for rendering safety harness output.
+#[derive(Debug, Clone)]
+pub(crate) struct VerificationFailure {
+    /// Optional phase label (for example "SemanticLock").
+    pub(crate) phase: Option<String>,
+    /// Optional file path or URI string.
+    pub(crate) location: Option<String>,
+    /// Optional line number (1-indexed).
+    pub(crate) line: Option<u32>,
+    /// Optional column number (1-indexed).
+    pub(crate) column: Option<u32>,
+    /// Human-readable failure message.
+    pub(crate) message: String,
+}
+
+/// Parses definition locations from a JSON payload.
+#[must_use]
+pub(crate) fn parse_definitions(payload: &str) -> Option<Vec<DefinitionLocation>> {
+    serde_json::from_str::<Vec<DefinitionLocation>>(payload).ok()
+}
+
+/// Parses verification failures from a safety harness error payload.
+#[must_use]
+pub(crate) fn parse_verification_failures(payload: &str) -> Option<Vec<VerificationFailure>> {
+    let parsed: VerificationErrorEnvelope = serde_json::from_str(payload).ok()?;
+    let details = parsed.details?;
+    if let Some(kind) = parsed.kind.as_deref()
+        && kind != "VerificationError"
+    {
+        return None;
+    }
+
+    let mut failures = Vec::new();
+    for diagnostic in details.diagnostics.iter().chain(details.failures.iter()) {
+        let message = diagnostic
+            .message
+            .clone()
+            .unwrap_or_else(|| String::from("verification failure"));
+        failures.push(VerificationFailure {
+            phase: details.phase.clone(),
+            location: diagnostic.location(),
+            line: diagnostic.line,
+            column: diagnostic.column,
+            message,
+        });
+    }
+
+    Some(failures)
+}
+
+#[derive(Debug, Deserialize)]
+struct VerificationErrorEnvelope {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    details: Option<VerificationErrorDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VerificationErrorDetails {
+    phase: Option<String>,
+    #[serde(default)]
+    diagnostics: Vec<VerificationDiagnostic>,
+    #[serde(default)]
+    failures: Vec<VerificationDiagnostic>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VerificationDiagnostic {
+    file: Option<String>,
+    path: Option<String>,
+    uri: Option<String>,
+    line: Option<u32>,
+    column: Option<u32>,
+    message: Option<String>,
+}
+
+impl VerificationDiagnostic {
+    fn location(&self) -> Option<String> {
+        self.file
+            .clone()
+            .or_else(|| self.path.clone())
+            .or_else(|| self.uri.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_definition_locations() {
+        let payload = r#"[{"uri":"file:///tmp/test.rs","line":3,"column":5}]"#;
+        let locations = parse_definitions(payload).expect("definitions");
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].line, 3);
+        assert_eq!(locations[0].column, 5);
+    }
+
+    #[test]
+    fn parses_reference_response() {
+        let payload = r#"{"references":[{"uri":"file:///tmp/test.rs","line":1,"column":2}]}"#;
+        let response: ReferenceResponse = serde_json::from_str(payload).expect("references");
+        assert_eq!(response.references.len(), 1);
+        assert_eq!(response.references[0].column, 2);
+    }
+
+    #[test]
+    fn parses_diagnostics_response() {
+        let payload = r#"{"diagnostics":[{"line":10,"column":4,"message":"boom"}]}"#;
+        let response: DiagnosticsResponse = serde_json::from_str(payload).expect("diagnostics");
+        assert_eq!(response.diagnostics.len(), 1);
+        assert_eq!(response.diagnostics[0].message, "boom");
+    }
+
+    #[test]
+    fn parses_verification_failure_payload() {
+        let payload = r#"{
+  "status": "error",
+  "type": "VerificationError",
+  "details": {
+    "phase": "SemanticLock",
+    "diagnostics": [
+      {"file": "src/main.py", "line": 42, "message": "Undefined variable"}
+    ]
+  }
+}"#;
+        let failures = parse_verification_failures(payload).expect("verification");
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].phase.as_deref(), Some("SemanticLock"));
+        assert_eq!(failures[0].line, Some(42));
+    }
+}

--- a/crates/weaver-cli/src/output/render.rs
+++ b/crates/weaver-cli/src/output/render.rs
@@ -1,0 +1,221 @@
+//! Human-readable rendering of source locations.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::fs;
+
+use super::source::SourceLocation;
+
+const CONTEXT_LINES: u32 = 2;
+
+/// Renders a list of source locations into a human-readable string.
+#[must_use]
+pub(crate) fn render_locations(locations: &[SourceLocation]) -> String {
+    if locations.is_empty() {
+        return String::new();
+    }
+
+    let mut output = String::new();
+    let mut order: Vec<String> = Vec::new();
+    let mut grouped: HashMap<String, Vec<&SourceLocation>> = HashMap::new();
+
+    for location in locations {
+        let key = location.source.display();
+        if !grouped.contains_key(&key) {
+            order.push(key.clone());
+        }
+        grouped.entry(key).or_default().push(location);
+    }
+
+    for (group_index, key) in order.iter().enumerate() {
+        if group_index > 0 {
+            output.push('\n');
+        }
+        let Some(group) = grouped.get(key) else {
+            continue;
+        };
+        let source = &group[0].source;
+        writeln!(output, "{key}").expect("write header");
+
+        let content_result = source
+            .as_path()
+            .map(|path| fs::read_to_string(path).map_err(|err| err.to_string()));
+
+        for (index, location) in group.iter().enumerate() {
+            if index > 0 {
+                output.push('\n');
+            }
+            match content_result.as_ref() {
+                Some(Ok(content)) => render_location_block(&mut output, location, Some(content)),
+                Some(Err(error)) => {
+                    render_unresolved(
+                        &mut output,
+                        location,
+                        format!("source unavailable: {error}"),
+                    );
+                }
+                None => render_location_block(&mut output, location, None),
+            }
+        }
+    }
+
+    output
+}
+
+fn render_location_block(output: &mut String, location: &SourceLocation, content: Option<&str>) {
+    let line = location.position.line;
+    let column = location.position.column;
+
+    if let Some(reason) = location.source.reason() {
+        render_unresolved(output, location, reason);
+        return;
+    }
+
+    let Some(content) = content else {
+        render_unresolved(output, location, String::from("source unavailable"));
+        return;
+    };
+
+    let Some(line) = line else {
+        render_unresolved(output, location, String::from("missing line information"));
+        return;
+    };
+
+    let column = column.unwrap_or(1);
+    render_context(output, location, content, LineColumn { line, column });
+}
+
+fn render_unresolved(output: &mut String, location: &SourceLocation, reason: impl Into<String>) {
+    let reason = reason.into();
+    match (location.position.line, location.position.column) {
+        (Some(line), Some(column)) => {
+            writeln!(output, "  --> {line}:{column}").expect("write location");
+        }
+        (Some(line), None) => {
+            writeln!(output, "  --> {line}").expect("write location");
+        }
+        _ => {
+            writeln!(output, "  --> (location unavailable)").expect("write location");
+        }
+    }
+    writeln!(output, "  note: {reason}").expect("write reason");
+}
+
+fn render_context(
+    output: &mut String,
+    location: &SourceLocation,
+    content: &str,
+    point: LineColumn,
+) {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        render_unresolved(output, location, String::from("source is empty"));
+        return;
+    }
+
+    let total_lines = lines.len() as u32;
+    if point.line == 0 || point.line > total_lines {
+        render_unresolved(output, location, String::from("line out of range"));
+        return;
+    }
+
+    let start_line = point.line.saturating_sub(CONTEXT_LINES).max(1);
+    let end_line = (point.line + CONTEXT_LINES).min(total_lines);
+    let line_width = num_digits(end_line);
+
+    writeln!(output, "  --> {}:{}", point.line, point.column).expect("write location");
+    writeln!(output, "   |").expect("write gutter");
+
+    for current in start_line..=end_line {
+        let text = lines[(current - 1) as usize];
+        writeln!(output, "{current:>line_width$} | {text}").expect("write line");
+
+        if current == point.line {
+            render_caret_line(
+                output,
+                CaretContext {
+                    line_width,
+                    text,
+                    column: point.column,
+                    label: &location.label,
+                },
+            );
+        }
+    }
+}
+
+fn render_caret_line(output: &mut String, context: CaretContext<'_>) {
+    let line_len = context.text.chars().count();
+    let column_index = context.column.saturating_sub(1) as usize;
+    let caret_pos = column_index.min(line_len);
+    let mut caret_line = String::new();
+    caret_line.extend(std::iter::repeat_n(' ', caret_pos));
+    caret_line.push('^');
+    if !context.label.is_empty() {
+        caret_line.push(' ');
+        caret_line.push_str(context.label);
+    }
+    writeln!(
+        output,
+        "{0:>line_width$} | {caret_line}",
+        "",
+        line_width = context.line_width
+    )
+    .expect("write caret");
+}
+
+fn num_digits(value: u32) -> usize {
+    value.to_string().len()
+}
+
+struct LineColumn {
+    line: u32,
+    column: u32,
+}
+
+struct CaretContext<'a> {
+    line_width: usize,
+    text: &'a str,
+    column: u32,
+    label: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::source::{SourceLocation, SourcePosition, SourceReference};
+
+    #[test]
+    fn renders_basic_context() {
+        let location = SourceLocation {
+            source: SourceReference::Path("/tmp/example.rs".into()),
+            position: SourcePosition::new(Some(2), Some(5)),
+            label: String::from("definition"),
+        };
+        let content = "fn main() {\n    let value = 1;\n    value\n}";
+        let output = {
+            let mut buffer = String::new();
+            render_context(
+                &mut buffer,
+                &location,
+                content,
+                LineColumn { line: 2, column: 5 },
+            );
+            buffer
+        };
+        assert!(output.contains("2 |"));
+        assert!(output.contains("^ definition"));
+    }
+
+    #[test]
+    fn renders_unresolved_location() {
+        let location = SourceLocation::unresolved(
+            String::from("/missing/file.rs"),
+            SourcePosition::new(Some(3), Some(1)),
+            String::from("diagnostic"),
+            String::from("file not found"),
+        );
+        let output = render_locations(&[location]);
+        assert!(output.contains("note: file not found"));
+    }
+}

--- a/crates/weaver-cli/src/output/render.rs
+++ b/crates/weaver-cli/src/output/render.rs
@@ -22,7 +22,7 @@ pub(crate) fn render_locations(locations: &[SourceLocation]) -> String {
             output.push('\n');
         }
         if let Some(group) = grouped.get(key) {
-            render_source_group(&mut output, key, group);
+            render_group(&mut output, key, group);
         }
     }
 
@@ -46,7 +46,7 @@ fn group_locations_by_source(
     (order, grouped)
 }
 
-fn render_source_group(output: &mut String, key: &str, group: &[&SourceLocation]) {
+fn render_group(output: &mut String, key: &str, group: &[&SourceLocation]) {
     if group.is_empty() {
         return;
     }

--- a/crates/weaver-cli/src/output/source.rs
+++ b/crates/weaver-cli/src/output/source.rs
@@ -1,0 +1,169 @@
+//! Source resolution helpers for human-readable output.
+
+use std::path::{Path, PathBuf};
+
+use url::Url;
+
+/// A resolved or unresolved source location.
+#[derive(Debug, Clone)]
+pub(crate) struct SourceLocation {
+    pub(crate) source: SourceReference,
+    pub(crate) position: SourcePosition,
+    pub(crate) label: String,
+}
+
+impl SourceLocation {
+    pub(crate) fn unresolved(
+        display: String,
+        position: SourcePosition,
+        label: String,
+        reason: String,
+    ) -> Self {
+        Self {
+            source: SourceReference::Unresolved { display, reason },
+            position,
+            label,
+        }
+    }
+}
+
+/// Describes how to locate source content on disk.
+#[derive(Debug, Clone)]
+pub(crate) enum SourceReference {
+    /// A local filesystem path.
+    Path(PathBuf),
+    /// A location that could not be resolved.
+    Unresolved { display: String, reason: String },
+}
+
+impl SourceReference {
+    pub(crate) fn display(&self) -> String {
+        match self {
+            Self::Path(path) => path.display().to_string(),
+            Self::Unresolved { display, .. } => display.clone(),
+        }
+    }
+
+    pub(crate) fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::Path(path) => Some(path.as_path()),
+            Self::Unresolved { .. } => None,
+        }
+    }
+
+    pub(crate) fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Path(_) => None,
+            Self::Unresolved { reason, .. } => Some(reason.as_str()),
+        }
+    }
+}
+
+/// Span information for a source location.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SourcePosition {
+    pub(crate) line: Option<u32>,
+    pub(crate) column: Option<u32>,
+}
+
+impl SourcePosition {
+    pub(crate) const fn new(line: Option<u32>, column: Option<u32>) -> Self {
+        Self { line, column }
+    }
+}
+
+/// Creates a source location from a URI string.
+#[must_use]
+pub(crate) fn from_uri(
+    uri: &str,
+    line: Option<u32>,
+    column: Option<u32>,
+    label: impl Into<String>,
+) -> SourceLocation {
+    match resolve_uri(uri) {
+        Ok(path) => SourceLocation {
+            source: SourceReference::Path(path),
+            position: SourcePosition::new(line, column),
+            label: label.into(),
+        },
+        Err(reason) => SourceLocation::unresolved(
+            uri.to_owned(),
+            SourcePosition::new(line, column),
+            label.into(),
+            reason,
+        ),
+    }
+}
+
+/// Creates a source location from a path or URI string.
+#[must_use]
+pub(crate) fn from_path_or_uri(
+    value: &str,
+    line: Option<u32>,
+    column: Option<u32>,
+    label: impl Into<String>,
+) -> SourceLocation {
+    if value.starts_with("file://") {
+        return from_uri(value, line, column, label);
+    }
+
+    SourceLocation {
+        source: SourceReference::Path(PathBuf::from(value)),
+        position: SourcePosition::new(line, column),
+        label: label.into(),
+    }
+}
+
+/// Extracts a `--uri` argument from raw CLI arguments.
+#[must_use]
+pub(crate) fn extract_uri_argument(arguments: &[String]) -> Option<String> {
+    let mut iter = arguments.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--uri" {
+            if let Some(value) = iter.next() {
+                return Some(value.clone());
+            }
+        } else if let Some(rest) = arg.strip_prefix("--uri=") {
+            return Some(rest.to_owned());
+        }
+    }
+    None
+}
+
+fn resolve_uri(uri: &str) -> Result<PathBuf, String> {
+    let parsed = Url::parse(uri).map_err(|error| format!("invalid URI: {error}"))?;
+    if parsed.scheme() != "file" {
+        return Err(String::from("unsupported URI scheme"));
+    }
+    parsed
+        .to_file_path()
+        .map_err(|_| String::from("URI does not map to a local path"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_uri_argument() {
+        let args = vec![
+            String::from("--position"),
+            String::from("1:1"),
+            String::from("--uri"),
+            String::from("file:///tmp/test.rs"),
+        ];
+        assert_eq!(
+            extract_uri_argument(&args).as_deref(),
+            Some("file:///tmp/test.rs")
+        );
+    }
+
+    #[test]
+    fn handles_inline_uri_argument() {
+        let args = vec![String::from("--uri=file:///tmp/test.rs")];
+        assert_eq!(
+            extract_uri_argument(&args).as_deref(),
+            Some("file:///tmp/test.rs")
+        );
+    }
+}

--- a/crates/weaver-cli/src/runtime_utils.rs
+++ b/crates/weaver-cli/src/runtime_utils.rs
@@ -19,7 +19,7 @@ where
     stdout.flush().map_err(AppError::EmitCapabilities)
 }
 
-pub(crate) fn exit_code_from_status(status: i32) -> ExitCode {
+pub(crate) const fn exit_code_from_status(status: i32) -> ExitCode {
     if status >= 0 && status <= u8::MAX as i32 {
         ExitCode::from(status as u8)
     } else {

--- a/crates/weaver-cli/src/runtime_utils.rs
+++ b/crates/weaver-cli/src/runtime_utils.rs
@@ -1,0 +1,28 @@
+//! Runtime helpers for the CLI entrypoints.
+
+use std::io::Write;
+use std::process::ExitCode;
+
+use weaver_config::{CapabilityMatrix, Config};
+
+use crate::AppError;
+
+pub(crate) fn emit_capabilities<W>(config: &Config, stdout: &mut W) -> Result<(), AppError>
+where
+    W: Write,
+{
+    let matrix: CapabilityMatrix = config.capability_matrix();
+    serde_json::to_writer_pretty(&mut *stdout, &matrix).map_err(AppError::SerialiseCapabilities)?;
+    stdout
+        .write_all(b"\n")
+        .map_err(AppError::EmitCapabilities)?;
+    stdout.flush().map_err(AppError::EmitCapabilities)
+}
+
+pub(crate) fn exit_code_from_status(status: i32) -> ExitCode {
+    if (0..=255).contains(&status) {
+        ExitCode::from(status as u8)
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/crates/weaver-cli/src/runtime_utils.rs
+++ b/crates/weaver-cli/src/runtime_utils.rs
@@ -19,7 +19,7 @@ where
     stdout.flush().map_err(AppError::EmitCapabilities)
 }
 
-pub(crate) const fn exit_code_from_status(status: i32) -> ExitCode {
+pub(crate) fn exit_code_from_status(status: i32) -> ExitCode {
     if status >= 0 && status <= u8::MAX as i32 {
         ExitCode::from(status as u8)
     } else {

--- a/crates/weaver-cli/src/runtime_utils.rs
+++ b/crates/weaver-cli/src/runtime_utils.rs
@@ -20,7 +20,7 @@ where
 }
 
 pub(crate) fn exit_code_from_status(status: i32) -> ExitCode {
-    if (0..=255).contains(&status) {
+    if status >= 0 && status <= u8::MAX as i32 {
         ExitCode::from(status as u8)
     } else {
         ExitCode::FAILURE

--- a/crates/weaver-cli/src/tests/behaviour.rs
+++ b/crates/weaver-cli/src/tests/behaviour.rs
@@ -10,6 +10,9 @@ use crate::lifecycle::{LifecycleCommand, LifecycleError};
 use std::cell::RefCell;
 
 use rstest_bdd_macros::{given, scenario, then, when};
+use serde_json::json;
+
+const SAMPLE_RUST_SOURCE: &str = "fn main() {\n    let value = 1;\n    value\n}\n";
 
 #[given("a running fake daemon")]
 fn given_running_daemon(world: &RefCell<TestWorld>) {
@@ -77,12 +80,107 @@ fn given_auto_start_triggered(world: &RefCell<TestWorld>) {
     world.borrow_mut().configure_auto_start_failure();
 }
 
+#[given("a source file named {filename}")]
+fn given_source_file(world: &RefCell<TestWorld>, filename: String) {
+    let filename = filename.trim_matches('"');
+    world
+        .borrow_mut()
+        .create_source_file(filename, SAMPLE_RUST_SOURCE)
+        .expect("failed to create source file");
+}
+
+#[given("a missing source file named {filename}")]
+fn given_missing_source_file(world: &RefCell<TestWorld>, filename: String) {
+    let filename = filename.trim_matches('"');
+    world
+        .borrow_mut()
+        .create_missing_source(filename)
+        .expect("failed to prepare missing source");
+}
+
+#[given("a running fake daemon emitting definition output")]
+fn given_daemon_definition_output(world: &RefCell<TestWorld>) {
+    let uri = world
+        .borrow()
+        .source_uri()
+        .expect("source uri missing")
+        .to_owned();
+    let payload = serde_json::to_string(&vec![json!({
+        "uri": uri,
+        "line": 2,
+        "column": 5
+    })])
+    .expect("serialize definition payload");
+    let lines = daemon_lines_for_stdout(&payload);
+    world
+        .borrow_mut()
+        .start_daemon_with_lines(lines)
+        .expect("failed to start daemon");
+}
+
+#[given("a running fake daemon emitting diagnostics output")]
+fn given_daemon_diagnostics_output(world: &RefCell<TestWorld>) {
+    let payload = serde_json::to_string(&json!({
+        "diagnostics": [
+            { "line": 2, "column": 5, "message": "boom" }
+        ]
+    }))
+    .expect("serialize diagnostics payload");
+    let lines = daemon_lines_for_stdout(&payload);
+    world
+        .borrow_mut()
+        .start_daemon_with_lines(lines)
+        .expect("failed to start daemon");
+}
+
 #[when("the operator runs {command}")]
 fn when_operator_runs(world: &RefCell<TestWorld>, command: String) {
     world
         .borrow_mut()
         .run(&command)
         .expect("failed to run CLI command");
+}
+
+#[when("the operator runs the definition command")]
+fn when_operator_runs_definition(world: &RefCell<TestWorld>) {
+    let uri = world
+        .borrow()
+        .source_uri()
+        .expect("source uri missing")
+        .to_owned();
+    let command = format!("--output human observe get-definition --uri {uri} --position 2:5");
+    world
+        .borrow_mut()
+        .run(&command)
+        .expect("failed to run definition command");
+}
+
+#[when("the operator runs the diagnostics command")]
+fn when_operator_runs_diagnostics(world: &RefCell<TestWorld>) {
+    let uri = world
+        .borrow()
+        .source_uri()
+        .expect("source uri missing")
+        .to_owned();
+    let command = format!("--output human verify diagnostics --uri {uri}");
+    world
+        .borrow_mut()
+        .run(&command)
+        .expect("failed to run diagnostics command");
+}
+
+#[when("the operator runs the json definition command")]
+fn when_operator_runs_json_definition(world: &RefCell<TestWorld>) {
+    let uri = world
+        .borrow()
+        .source_uri()
+        .expect("source uri missing")
+        .to_owned();
+    let command = format!("--output json observe get-definition --uri {uri} --position 2:5");
+    world
+        .borrow_mut()
+        .run(&command)
+        .expect("failed to run json definition command");
 }
 
 #[then("the daemon receives {fixture}")]
@@ -142,6 +240,32 @@ fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) {
     );
 }
 
+#[then("stdout contains {snippet}")]
+fn then_stdout_contains(world: &RefCell<TestWorld>, snippet: String) {
+    let world = world.borrow();
+    let stdout = world.stdout_text().expect("stdout text missing");
+    let snippet = snippet.trim_matches('"');
+    assert!(
+        stdout.contains(snippet),
+        "stdout {:?} did not contain {:?}",
+        stdout,
+        snippet
+    );
+}
+
+#[then("stdout does not contain {snippet}")]
+fn then_stdout_does_not_contain(world: &RefCell<TestWorld>, snippet: String) {
+    let world = world.borrow();
+    let stdout = world.stdout_text().expect("stdout text missing");
+    let snippet = snippet.trim_matches('"');
+    assert!(
+        !stdout.contains(snippet),
+        "stdout {:?} unexpectedly contained {:?}",
+        stdout,
+        snippet
+    );
+}
+
 #[then("the CLI exits with code {status}")]
 fn then_exit_code(world: &RefCell<TestWorld>, status: u8) {
     world
@@ -168,6 +292,11 @@ fn then_capabilities(world: &RefCell<TestWorld>, fixture: String) {
 
 #[scenario(path = "tests/features/weaver_cli.feature")]
 fn weaver_cli_behaviour(world: RefCell<TestWorld>) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/weaver_cli_output.feature")]
+fn weaver_cli_output_behaviour(world: RefCell<TestWorld>) {
     let _ = world;
 }
 

--- a/crates/weaver-cli/src/tests/behaviour.rs
+++ b/crates/weaver-cli/src/tests/behaviour.rs
@@ -14,46 +14,56 @@ use serde_json::json;
 
 const SAMPLE_RUST_SOURCE: &str = "fn main() {\n    let value = 1;\n    value\n}\n";
 
-fn assert_output_contains<F>(
+fn run_command_with_source_uri(
     world: &RefCell<TestWorld>,
-    get_text: F,
-    snippet: String,
-    should_contain: bool,
-    stream_name: &str,
-) where
-    F: FnOnce(&TestWorld) -> anyhow::Result<String>,
-{
-    let world = world.borrow();
-    let text = get_text(&world).unwrap_or_else(|_| panic!("{stream_name} text missing"));
-    let snippet = snippet.trim_matches('"');
-    if should_contain {
-        assert!(
-            text.contains(snippet),
-            "{stream_name} {:?} did not contain {:?}",
-            text,
-            snippet
-        );
-    } else {
-        assert!(
-            !text.contains(snippet),
-            "{stream_name} {:?} unexpectedly contained {:?}",
-            text,
-            snippet
-        );
-    }
-}
-
-fn run_uri_command<F>(world: &RefCell<TestWorld>, command_fn: F, error_msg: &str)
-where
-    F: FnOnce(&str) -> String,
-{
+    command_template: &str,
+    error_msg: &str,
+) {
     let uri = world
         .borrow()
         .source_uri()
         .expect("source uri missing")
         .to_owned();
-    let command = command_fn(&uri);
+    let command = command_template.replace("{uri}", &uri);
     world.borrow_mut().run(&command).expect(error_msg);
+}
+
+fn assert_output_contains<F>(
+    world: &RefCell<TestWorld>,
+    output_getter: F,
+    snippet: String,
+    output_name: &str,
+) where
+    F: FnOnce(&TestWorld) -> anyhow::Result<String>,
+{
+    let world = world.borrow();
+    let text = output_getter(&world).unwrap_or_else(|_| panic!("{output_name} text missing"));
+    let snippet = snippet.trim_matches('"');
+    assert!(
+        text.contains(snippet),
+        "{output_name} {:?} did not contain {:?}",
+        text,
+        snippet
+    );
+}
+
+fn assert_output_does_not_contain<F>(
+    world: &RefCell<TestWorld>,
+    output_getter: F,
+    snippet: String,
+    output_name: &str,
+) where
+    F: FnOnce(&TestWorld) -> anyhow::Result<String>,
+{
+    let world = world.borrow();
+    let text = output_getter(&world).unwrap_or_else(|_| panic!("{output_name} text missing"));
+    let snippet = snippet.trim_matches('"');
+    assert!(
+        !text.contains(snippet),
+        "{output_name} {:?} unexpectedly contained {:?}",
+        text,
+        snippet
+    );
 }
 
 #[given("a running fake daemon")]
@@ -185,27 +195,27 @@ fn when_operator_runs(world: &RefCell<TestWorld>, command: String) {
 
 #[when("the operator runs the definition command")]
 fn when_operator_runs_definition(world: &RefCell<TestWorld>) {
-    run_uri_command(
+    run_command_with_source_uri(
         world,
-        |uri| format!("--output human observe get-definition --uri {uri} --position 2:5"),
+        "--output human observe get-definition --uri {uri} --position 2:5",
         "failed to run definition command",
     );
 }
 
 #[when("the operator runs the diagnostics command")]
 fn when_operator_runs_diagnostics(world: &RefCell<TestWorld>) {
-    run_uri_command(
+    run_command_with_source_uri(
         world,
-        |uri| format!("--output human verify diagnostics --uri {uri}"),
+        "--output human verify diagnostics --uri {uri}",
         "failed to run diagnostics command",
     );
 }
 
 #[when("the operator runs the json definition command")]
 fn when_operator_runs_json_definition(world: &RefCell<TestWorld>) {
-    run_uri_command(
+    run_command_with_source_uri(
         world,
-        |uri| format!("--output json observe get-definition --uri {uri} --position 2:5"),
+        "--output json observe get-definition --uri {uri} --position 2:5",
         "failed to run json definition command",
     );
 }
@@ -256,35 +266,17 @@ fn then_stderr_is(world: &RefCell<TestWorld>, expected: String) {
 
 #[then("stderr contains {snippet}")]
 fn then_stderr_contains(world: &RefCell<TestWorld>, snippet: String) {
-    assert_output_contains(
-        world,
-        |world| world.stderr_text(),
-        snippet,
-        true,
-        "stderr",
-    );
+    assert_output_contains(world, |world| world.stderr_text(), snippet, "stderr");
 }
 
 #[then("stdout contains {snippet}")]
 fn then_stdout_contains(world: &RefCell<TestWorld>, snippet: String) {
-    assert_output_contains(
-        world,
-        |world| world.stdout_text(),
-        snippet,
-        true,
-        "stdout",
-    );
+    assert_output_contains(world, |world| world.stdout_text(), snippet, "stdout");
 }
 
 #[then("stdout does not contain {snippet}")]
 fn then_stdout_does_not_contain(world: &RefCell<TestWorld>, snippet: String) {
-    assert_output_contains(
-        world,
-        |world| world.stdout_text(),
-        snippet,
-        false,
-        "stdout",
-    );
+    assert_output_does_not_contain(world, |world| world.stdout_text(), snippet, "stdout");
 }
 
 #[then("the CLI exits with code {status}")]

--- a/crates/weaver-cli/src/tests/support/mod.rs
+++ b/crates/weaver-cli/src/tests/support/mod.rs
@@ -113,6 +113,9 @@ impl TestWorld {
     fn prepare_source_location(filename: &str) -> Result<(TempDir, PathBuf, String)> {
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path().join(filename);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
         let uri = Url::from_file_path(&path)
             .map_err(|_| anyhow::anyhow!("failed to convert path to URI"))?
             .to_string();

--- a/crates/weaver-cli/src/tests/support/mod.rs
+++ b/crates/weaver-cli/src/tests/support/mod.rs
@@ -98,28 +98,31 @@ impl TestWorld {
     }
 
     pub fn create_source_file(&mut self, filename: &str, content: &str) -> Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-        let path = temp_dir.path().join(filename);
+        let (temp_dir, path, uri) = Self::prepare_source_location(filename)?;
         fs::write(&path, content)?;
-        let uri = Url::from_file_path(&path)
-            .map_err(|_| anyhow::anyhow!("failed to convert path to URI"))?
-            .to_string();
-        self.temp_dir = Some(temp_dir);
-        self.source_uri = Some(uri);
-        self.source_path = Some(path);
+        self.store_source_location(temp_dir, path, uri);
         Ok(())
     }
 
     pub fn create_missing_source(&mut self, filename: &str) -> Result<()> {
+        let (temp_dir, path, uri) = Self::prepare_source_location(filename)?;
+        self.store_source_location(temp_dir, path, uri);
+        Ok(())
+    }
+
+    fn prepare_source_location(filename: &str) -> Result<(TempDir, PathBuf, String)> {
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path().join(filename);
         let uri = Url::from_file_path(&path)
             .map_err(|_| anyhow::anyhow!("failed to convert path to URI"))?
             .to_string();
+        Ok((temp_dir, path, uri))
+    }
+
+    fn store_source_location(&mut self, temp_dir: TempDir, path: PathBuf, uri: String) {
         self.temp_dir = Some(temp_dir);
         self.source_uri = Some(uri);
         self.source_path = Some(path);
-        Ok(())
     }
 
     pub fn source_uri(&self) -> Result<&str> {

--- a/crates/weaver-cli/src/tests/support/mod.rs
+++ b/crates/weaver-cli/src/tests/support/mod.rs
@@ -287,6 +287,10 @@ pub(super) fn default_daemon_lines() -> Vec<String> {
     ]
 }
 
+/// Builds a stdout stream entry plus exit record for a custom payload.
+///
+/// This mirrors the structure of `default_daemon_lines` so sibling test helpers
+/// can emit deterministic stdout-only sequences with a trailing exit event.
 pub(super) fn daemon_lines_for_stdout(payload: &str) -> Vec<String> {
     let stream = serde_json::json!({
         "kind": "stream",

--- a/crates/weaver-cli/src/tests/support/mod.rs
+++ b/crates/weaver-cli/src/tests/support/mod.rs
@@ -138,7 +138,7 @@ impl TestWorld {
         let args = Self::build_args(command);
         let loader = StaticConfigLoader::new(self.config.clone());
         let daemon_binary = self.daemon_binary.as_deref();
-        let mut io = IoStreams::with_terminal_status(&mut self.stdout, &mut self.stderr, false);
+        let mut io = IoStreams::new(&mut self.stdout, &mut self.stderr, false);
         let exit = run_with_daemon_binary(
             args,
             &mut io,

--- a/crates/weaver-cli/src/tests/support/mod.rs
+++ b/crates/weaver-cli/src/tests/support/mod.rs
@@ -102,6 +102,7 @@ impl TestWorld {
         self.daemon_binary = Some(OsString::from("/nonexistent/weaverd"));
     }
 
+    /// Creates a source file fixture and stores its location metadata.
     pub fn create_source_file(&mut self, filename: &str, content: &str) -> Result<()> {
         let (temp_dir, path, uri) = Self::prepare_source_location(filename)?;
         fs::write(&path, content)?;
@@ -109,6 +110,7 @@ impl TestWorld {
         Ok(())
     }
 
+    /// Stores a missing source fixture so callers can reference its URI.
     pub fn create_missing_source(&mut self, filename: &str) -> Result<()> {
         let (temp_dir, path, uri) = Self::prepare_source_location(filename)?;
         self.store_source_location(temp_dir, path, uri);
@@ -144,6 +146,7 @@ impl TestWorld {
         self.source_path = Some(path);
     }
 
+    /// Returns the most recent source URI recorded for the test world.
     pub fn source_uri(&self) -> Result<&str> {
         self.source_uri
             .as_deref()

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -115,7 +115,7 @@ fn test_read_daemon_messages(input: Vec<u8>) -> (Result<i32, AppError>, Vec<u8>,
     let mut cursor = Cursor::new(input);
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
+    let mut io = IoStreams::new(&mut stdout, &mut stderr, false);
     let context = OutputContext::new("observe", "get-definition", Vec::new());
     let result = read_daemon_messages(
         &mut cursor,
@@ -170,7 +170,7 @@ fn run_with_loader_reports_configuration_failures() {
 
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
+    let mut io = IoStreams::new(&mut stdout, &mut stderr, false);
     let exit = run_with_loader(vec![OsString::from("weaver")], &mut io, &FailingLoader);
     assert_eq!(exit, ExitCode::FAILURE);
     let stderr_text = decode_utf8(stderr, "stderr").expect("decode stderr");
@@ -201,7 +201,7 @@ fn run_with_loader_filters_configuration_arguments() {
     let loader = RecordingLoader::new();
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
+    let mut io = IoStreams::new(&mut stdout, &mut stderr, false);
     let exit = run_with_loader(
         vec![
             OsString::from("weaver"),
@@ -265,7 +265,7 @@ where
 
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
+    let mut io = IoStreams::new(&mut stdout, &mut stderr, false);
     let context = OutputContext::new("observe", "noop", Vec::new());
     let status = read_daemon_messages(
         &mut connection,

--- a/crates/weaver-cli/src/tests/unit/auto_start.rs
+++ b/crates/weaver-cli/src/tests/unit/auto_start.rs
@@ -62,7 +62,7 @@ fn auto_start_failure_paths(
     let invocation = make_invocation();
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
+    let mut io = IoStreams::new(&mut stdout, &mut stderr, false);
 
     let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
 
@@ -145,7 +145,7 @@ fn auto_start_succeeds_and_proceeds() {
     let invocation = make_invocation();
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
+    let mut io = IoStreams::new(&mut stdout, &mut stderr, false);
 
     let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
 
@@ -205,7 +205,7 @@ fn auto_start_times_out_when_daemon_slow() {
     let invocation = make_invocation();
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
+    let mut io = IoStreams::new(&mut stdout, &mut stderr, false);
 
     let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
 

--- a/crates/weaver-cli/src/tests/unit/auto_start.rs
+++ b/crates/weaver-cli/src/tests/unit/auto_start.rs
@@ -5,7 +5,7 @@
 
 use crate::lifecycle::LifecycleContext;
 use crate::tests::support::{decode_utf8, default_daemon_lines, respond_to_request};
-use crate::{CommandInvocation, IoStreams, execute_daemon_command};
+use crate::{CommandInvocation, IoStreams, ResolvedOutputFormat, execute_daemon_command};
 use rstest::rstest;
 use std::ffi::OsStr;
 use std::process::ExitCode;
@@ -62,9 +62,9 @@ fn auto_start_failure_paths(
     let invocation = make_invocation();
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::new(&mut stdout, &mut stderr);
+    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
 
-    let exit = execute_daemon_command(invocation, context, &mut io);
+    let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
 
     assert_eq!(exit, ExitCode::FAILURE);
     let stderr_text = decode_utf8(stderr, "stderr").expect("stderr utf8");
@@ -145,9 +145,9 @@ fn auto_start_succeeds_and_proceeds() {
     let invocation = make_invocation();
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::new(&mut stdout, &mut stderr);
+    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
 
-    let exit = execute_daemon_command(invocation, context, &mut io);
+    let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
 
     listener_handle.join().expect("listener thread");
     let stderr_text = decode_utf8(stderr, "stderr").expect("stderr utf8");
@@ -205,9 +205,9 @@ fn auto_start_times_out_when_daemon_slow() {
     let invocation = make_invocation();
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    let mut io = IoStreams::new(&mut stdout, &mut stderr);
+    let mut io = IoStreams::with_terminal_status(&mut stdout, &mut stderr, false);
 
-    let exit = execute_daemon_command(invocation, context, &mut io);
+    let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
 
     let stderr_text = decode_utf8(stderr, "stderr").expect("stderr utf8");
     assert_eq!(exit, ExitCode::FAILURE);

--- a/crates/weaver-cli/tests/features/weaver_cli_output.feature
+++ b/crates/weaver-cli/tests/features/weaver_cli_output.feature
@@ -1,0 +1,33 @@
+Feature: Weaver CLI human-readable output
+
+  Scenario: Rendering definition output with context
+    Given a source file named "example.rs"
+    And a running fake daemon emitting definition output
+    When the operator runs the definition command
+    Then stdout contains "example.rs"
+    And stdout contains "^ definition"
+    And the CLI exits with code 0
+
+  Scenario: Rendering diagnostics output with context
+    Given a source file named "example.rs"
+    And a running fake daemon emitting diagnostics output
+    When the operator runs the diagnostics command
+    Then stdout contains "example.rs"
+    And stdout contains "^ boom"
+    And the CLI exits with code 0
+
+  Scenario: Falling back when source content is missing
+    Given a missing source file named "missing.rs"
+    And a running fake daemon emitting diagnostics output
+    When the operator runs the diagnostics command
+    Then stdout contains "source unavailable"
+    And the CLI exits with code 0
+
+  Scenario: JSON output passes through raw payloads
+    Given a source file named "example.rs"
+    And a running fake daemon emitting definition output
+    When the operator runs the json definition command
+    Then stdout contains "\"uri\""
+    And stdout contains "\"line\":2"
+    And stdout does not contain "^ definition"
+    And the CLI exits with code 0

--- a/crates/weaver-e2e/Cargo.toml
+++ b/crates/weaver-e2e/Cargo.toml
@@ -18,6 +18,7 @@ rstest = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 url = { workspace = true }
+weaver-cli = { path = "../weaver-cli" }
 
 [lints]
 workspace = true

--- a/crates/weaver-e2e/tests/human_output.rs
+++ b/crates/weaver-e2e/tests/human_output.rs
@@ -92,14 +92,21 @@ fn renders_definition_output_with_context() -> Result<(), TestError> {
     let rendered = render_human_output(&context, &json).ok_or(TestError::RenderFailed)?;
     let normalised = rendered.replace(temp_dir.path().to_string_lossy().as_ref(), "<temp>");
 
+    let mut result = Ok(());
     if !normalised.contains("def b():") {
-        return Err(TestError::MissingOutput(String::from("def b():")));
-    }
-    if !normalised.contains("^ definition") {
-        return Err(TestError::MissingOutput(String::from("^ definition")));
+        result = Err(TestError::MissingOutput(String::from("def b():")));
+    } else if !normalised.contains("^ definition") {
+        result = Err(TestError::MissingOutput(String::from("^ definition")));
     }
 
-    client.shutdown()?;
-
-    Ok(())
+    let shutdown_result = client.shutdown();
+    if let Err(error) = result {
+        if let Err(_shutdown_error) = shutdown_result {
+            // Ignore shutdown errors when returning the primary failure.
+        }
+        Err(error)
+    } else {
+        shutdown_result?;
+        Ok(())
+    }
 }

--- a/crates/weaver-e2e/tests/human_output.rs
+++ b/crates/weaver-e2e/tests/human_output.rs
@@ -92,12 +92,13 @@ fn renders_definition_output_with_context() -> Result<(), TestError> {
     let rendered = render_human_output(&context, &json).ok_or(TestError::RenderFailed)?;
     let normalised = rendered.replace(temp_dir.path().to_string_lossy().as_ref(), "<temp>");
 
-    let mut result = Ok(());
-    if !normalised.contains("def b():") {
-        result = Err(TestError::MissingOutput(String::from("def b():")));
+    let result = if !normalised.contains("def b():") {
+        Err(TestError::MissingOutput(String::from("def b():")))
     } else if !normalised.contains("^ definition") {
-        result = Err(TestError::MissingOutput(String::from("^ definition")));
-    }
+        Err(TestError::MissingOutput(String::from("^ definition")))
+    } else {
+        Ok(())
+    };
 
     let shutdown_result = client.shutdown();
     if let Err(error) = result {

--- a/crates/weaver-e2e/tests/human_output.rs
+++ b/crates/weaver-e2e/tests/human_output.rs
@@ -1,0 +1,109 @@
+//! End-to-end tests for human-readable output rendering.
+
+use std::path::Path;
+
+use lsp_types::{GotoDefinitionResponse, Location, Uri};
+use tempfile::TempDir;
+use url::Url;
+
+use weaver_cli::{OutputContext, render_human_output};
+use weaver_e2e::fixtures;
+use weaver_e2e::lsp_client::{LspClient, LspClientError};
+use weaver_e2e::pyrefly_available;
+
+/// Test error type for human output rendering.
+#[derive(Debug, thiserror::Error)]
+enum TestError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("LSP client error: {0}")]
+    LspClient(#[from] LspClientError),
+
+    #[error("invalid file path: cannot convert to URI")]
+    InvalidFilePath,
+
+    #[error("invalid URI: {0}")]
+    InvalidUri(String),
+
+    #[error("no definition location returned")]
+    NoDefinition,
+
+    #[error("failed to render human output")]
+    RenderFailed,
+
+    #[error("expected output to contain {0}")]
+    MissingOutput(String),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(serde::Serialize)]
+struct DefinitionLocation {
+    uri: String,
+    line: u32,
+    column: u32,
+}
+
+fn file_uri(path: &Path) -> Result<Uri, TestError> {
+    let url = Url::from_file_path(path).map_err(|()| TestError::InvalidFilePath)?;
+    url.as_str()
+        .parse()
+        .map_err(|_| TestError::InvalidUri(url.to_string()))
+}
+
+fn first_location(response: Option<GotoDefinitionResponse>) -> Option<Location> {
+    let definition = response?;
+    match definition {
+        GotoDefinitionResponse::Scalar(location) => Some(location),
+        GotoDefinitionResponse::Array(mut locations) => locations.pop(),
+        GotoDefinitionResponse::Link(mut links) => links.pop().map(|link| Location {
+            uri: link.target_uri,
+            range: link.target_selection_range,
+        }),
+    }
+}
+
+#[test]
+fn renders_definition_output_with_context() -> Result<(), TestError> {
+    if !pyrefly_available() {
+        return Ok(());
+    }
+
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.py");
+    std::fs::write(&file_path, fixtures::LINEAR_CHAIN)?;
+
+    let root_uri = file_uri(temp_dir.path())?;
+    let file_uri_value = file_uri(&file_path)?;
+
+    let mut client = LspClient::spawn("uvx", &["pyrefly", "lsp"])?;
+    client.initialize(root_uri)?;
+    client.did_open(file_uri_value.clone(), "python", fixtures::LINEAR_CHAIN)?;
+
+    let response = client.goto_definition_at(&file_uri_value, 1, 4)?;
+    let location = first_location(response).ok_or(TestError::NoDefinition)?;
+
+    let payload = vec![DefinitionLocation {
+        uri: location.uri.to_string(),
+        line: location.range.start.line + 1,
+        column: location.range.start.character + 1,
+    }];
+    let json = serde_json::to_string(&payload)?;
+
+    let context = OutputContext::new("observe", "get-definition", Vec::new());
+    let rendered = render_human_output(&context, &json).ok_or(TestError::RenderFailed)?;
+    let normalised = rendered.replace(temp_dir.path().to_string_lossy().as_ref(), "<temp>");
+
+    if !normalised.contains("def b():") {
+        return Err(TestError::MissingOutput(String::from("def b():")));
+    }
+    if !normalised.contains("^ definition") {
+        return Err(TestError::MissingOutput(String::from("^ definition")));
+    }
+
+    client.shutdown()?;
+
+    Ok(())
+}

--- a/crates/weaver-e2e/tests/human_output.rs
+++ b/crates/weaver-e2e/tests/human_output.rs
@@ -9,7 +9,6 @@ use url::Url;
 use weaver_cli::{OutputContext, render_human_output};
 use weaver_e2e::fixtures;
 use weaver_e2e::lsp_client::{LspClient, LspClientError};
-use weaver_e2e::pyrefly_available;
 
 /// Test error type for human output rendering.
 #[derive(Debug, thiserror::Error)]
@@ -66,11 +65,8 @@ fn first_location(response: Option<GotoDefinitionResponse>) -> Option<Location> 
 }
 
 #[test]
+#[ignore = "requires pyrefly tooling to be available on PATH"]
 fn renders_definition_output_with_context() -> Result<(), TestError> {
-    if !pyrefly_available() {
-        return Ok(());
-    }
-
     let temp_dir = TempDir::new()?;
     let file_path = temp_dir.path().join("test.py");
     std::fs::write(&file_path, fixtures::LINEAR_CHAIN)?;

--- a/crates/weaver-e2e/tests/human_output.rs
+++ b/crates/weaver-e2e/tests/human_output.rs
@@ -57,8 +57,8 @@ fn first_location(response: Option<GotoDefinitionResponse>) -> Option<Location> 
     let definition = response?;
     match definition {
         GotoDefinitionResponse::Scalar(location) => Some(location),
-        GotoDefinitionResponse::Array(mut locations) => locations.pop(),
-        GotoDefinitionResponse::Link(mut links) => links.pop().map(|link| Location {
+        GotoDefinitionResponse::Array(locations) => locations.into_iter().next(),
+        GotoDefinitionResponse::Link(links) => links.into_iter().next().map(|link| Location {
             uri: link.target_uri,
             range: link.target_selection_range,
         }),

--- a/crates/weaver-lsp-host/src/tests/adapter_behaviour.rs
+++ b/crates/weaver-lsp-host/src/tests/adapter_behaviour.rs
@@ -1,11 +1,5 @@
 //! Behavioural tests for the process-based language server adapter.
 
-// rstest-bdd macros generate some non-snake-case identifiers
-#![expect(
-    non_snake_case,
-    reason = "rstest-bdd macros generate non-snake-case identifiers"
-)]
-
 use std::cell::RefCell;
 use std::error::Error;
 use std::path::PathBuf;

--- a/docs/execplans/phase-1-human-readable-output.md
+++ b/docs/execplans/phase-1-human-readable-output.md
@@ -1,0 +1,151 @@
+# Phase 1: Human-Readable Output Rendering
+
+## Goal
+
+Implement human-readable rendering for command outputs that contain code
+locations or diagnostics. The renderer must produce `miette`-style context
+blocks while keeping the JSONL protocol payloads intact for machine use.
+
+## Acceptance Criteria
+
+- Definition, reference, diagnostics, and safety harness failure outputs render
+  file headers, line-numbered context, and caret spans in human-readable mode.
+- JSONL output from `weaverd` remains unchanged; JSON output mode continues to
+  emit the raw payloads without additional rendering.
+- Missing source content falls back to path-and-range output with a clear
+  explanation of why context could not be rendered.
+
+## Design Decisions
+
+1. **CLI-side rendering**: Keep `weaverd` JSONL payloads unchanged and perform
+   human-readable rendering in `weaver-cli`, preserving the canonical transport
+   while allowing richer presentation.
+2. **Output format selection**: Add an `--output` flag with `auto`, `human`, and
+   `json` values. `auto` defaults to `human` when stdout is a TTY and `json`
+   when stdout is redirected, ensuring machine pipelines remain stable.
+3. **`miette` renderer configuration**: Use `miette::GraphicalReportHandler`
+   with Unicode disabled to produce ASCII-only context blocks matching the
+   design doc examples.
+4. **Lightweight response models**: Define CLI-side response structs mirroring
+   `docs/users-guide.md` JSON shapes for definitions, references, diagnostics,
+   and safety harness failures to avoid cross-crate coupling.
+5. **Source grouping and fallback**: Group results by file with one header per
+   file and a context block per location. When source content is unavailable,
+   emit a fallback message that preserves the path and range with the reason.
+
+## Module Structure
+
+```text
+crates/weaver-cli/src/
+  output/
+    mod.rs          # OutputFormat and render entry points (~80 lines)
+    models.rs       # JSON response structs (~140 lines)
+    render.rs       # miette-based rendering helpers (~220 lines)
+    source.rs       # URI -> path, span mapping (~180 lines)
+```
+
+## Implementation Steps
+
+### Step 1: Update dependencies
+
+- Add `miette` (and any required helpers) to the workspace dependencies and
+  `crates/weaver-cli/Cargo.toml`.
+- Upgrade `rstest-bdd` and `rstest-bdd-macros` to v0.4.0 across the workspace,
+  updating uses if required by the new API.
+
+### Step 2: Introduce output format selection
+
+- Add an `OutputFormat` enum (`Auto`, `Human`, `Json`) to `weaver-cli`.
+- Extend CLI parsing in `crates/weaver-cli/src/lib.rs` to accept `--output`.
+- Use TTY detection to resolve `Auto` to `Human` or `Json`.
+
+### Step 3: Define response models for rendering
+
+- Add `output/models.rs` with structs for:
+  - Definitions (`Vec<DefinitionLocation>`)
+  - References (`ReferencesResponse` with locations)
+  - Diagnostics (`DiagnosticsResponse` with line/column/message)
+  - Safety harness failures (path + optional line/column + message)
+- Implement `serde` parsing helpers that fail fast with clear errors.
+
+### Step 4: Build the `miette` renderer
+
+- Convert URI + line/column (1-indexed) to byte offsets, handling multi-line
+  spans and range end defaults for point locations.
+- Use `miette::NamedSource` to load file content and render context blocks with
+  caret spans; group multiple spans per file under a shared header.
+- Provide fallback rendering for unreadable or missing files, including the
+  reason (e.g., "file missing" or "invalid URI").
+
+### Step 5: Wire rendering into CLI output flow
+
+- Update `read_daemon_messages` to accept the resolved `OutputFormat` and the
+  invoked domain/operation.
+- For `human` output, parse JSON payloads for definition, references,
+  diagnostics, and safety harness failure responses; render using the new
+  module.
+- For `json` output (or parse failures), stream the raw payload unchanged.
+
+### Step 6: Add unit tests
+
+- Unit tests for span calculation, multi-line ranges, and file grouping.
+- Unit tests for fallback messaging when source content is missing or the URI
+  is invalid.
+- Unit tests validating JSON parsing for each response model.
+
+### Step 7: Add behavioural tests (rstest-bdd v0.4.0)
+
+- Add a new `.feature` file under `crates/weaver-cli/tests/features/` covering:
+  - Happy path: definition output renders context blocks.
+  - Happy path: diagnostics output renders context blocks.
+  - Unhappy path: missing file falls back to path-and-range explanation.
+  - Format selection: `--output json` passes through raw JSON.
+- Implement or extend step definitions in `crates/weaver-cli/src/tests/` to
+  drive a fake daemon with JSONL responses and assert rendered output.
+
+### Step 8: Update documentation
+
+- Record the output-format decision and renderer behaviour in
+  `docs/weaver-design.md` (section 2.1.4).
+- Update `docs/users-guide.md` output format section to describe `--output`,
+  the TTY-driven default, and the new context block format.
+
+### Step 9: Mark roadmap entry done
+
+- Update `docs/roadmap.md` to mark the human-readable output item complete.
+
+### Step 10: Run quality gates
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt.log
+make lint 2>&1 | tee /tmp/lint.log
+make test 2>&1 | tee /tmp/test.log
+```
+
+Run `make markdownlint`, `make fmt`, and `make nixie` after documentation
+updates, per `AGENTS.md`.
+
+## Files Modified
+
+| File                                                         | Action                                         |
+| ------------------------------------------------------------ | ---------------------------------------------- |
+| `Cargo.toml`                                                 | Bump `rstest-bdd` deps, add `miette`            |
+| `crates/weaver-cli/Cargo.toml`                               | Add `miette` dependency                        |
+| `crates/weaver-cli/src/lib.rs`                               | Add `--output` and renderer integration         |
+| `crates/weaver-cli/src/output/mod.rs`                        | Create                                          |
+| `crates/weaver-cli/src/output/models.rs`                     | Create                                          |
+| `crates/weaver-cli/src/output/render.rs`                     | Create                                          |
+| `crates/weaver-cli/src/output/source.rs`                     | Create                                          |
+| `crates/weaver-cli/tests/features/weaver_cli_output.feature` | Create                                          |
+| `crates/weaver-cli/src/tests/behaviour.rs`                   | Extend steps for new scenarios                  |
+| `crates/weaver-cli/src/tests/support/`                       | Add fixtures for rendered output                |
+| `docs/weaver-design.md`                                      | Record design decisions                         |
+| `docs/users-guide.md`                                        | Document output format changes                  |
+| `docs/roadmap.md`                                            | Mark entry done                                 |
+| `docs/execplans/phase-1-human-readable-output.md`            | Create                                          |
+
+## Dependencies
+
+- `miette` (rendering context blocks)
+- `rstest-bdd` v0.4.0 + `rstest-bdd-macros` v0.4.0

--- a/docs/execplans/phase-1-human-readable-output.md
+++ b/docs/execplans/phase-1-human-readable-output.md
@@ -131,23 +131,23 @@ updates, per `AGENTS.md`.
 
 ## Files Modified
 
-| File                                                         | Action                                         |
-| ------------------------------------------------------------ | ---------------------------------------------- |
-| `Cargo.toml`                                                 | Bump `rstest-bdd` deps                          |
-| `crates/weaver-cli/Cargo.toml`                               | Add output rendering deps                       |
-| `crates/weaver-cli/src/lib.rs`                               | Add `--output` and renderer integration         |
-| `crates/weaver-cli/src/output/mod.rs`                        | Create                                          |
-| `crates/weaver-cli/src/output/models.rs`                     | Create                                          |
-| `crates/weaver-cli/src/output/render.rs`                     | Create                                          |
-| `crates/weaver-cli/src/output/source.rs`                     | Create                                          |
-| `crates/weaver-cli/tests/features/weaver_cli_output.feature` | Create                                          |
-| `crates/weaver-cli/src/tests/behaviour.rs`                   | Extend steps for new scenarios                  |
-| `crates/weaver-cli/src/tests/support/`                       | Add fixtures for rendered output                |
-| `crates/weaver-e2e/tests/`                                   | Extend for human-readable output validation     |
-| `docs/weaver-design.md`                                      | Record design decisions                         |
-| `docs/users-guide.md`                                        | Document output format changes                  |
-| `docs/roadmap.md`                                            | Mark entry done                                 |
-| `docs/execplans/phase-1-human-readable-output.md`            | Create                                          |
+| File                                                         | Action                                      |
+| ------------------------------------------------------------ | ------------------------------------------- |
+| `Cargo.toml`                                                 | Bump `rstest-bdd` deps                      |
+| `crates/weaver-cli/Cargo.toml`                               | Add output rendering deps                   |
+| `crates/weaver-cli/src/lib.rs`                               | Add `--output` and renderer integration     |
+| `crates/weaver-cli/src/output/mod.rs`                        | Create                                      |
+| `crates/weaver-cli/src/output/models.rs`                     | Create                                      |
+| `crates/weaver-cli/src/output/render.rs`                     | Create                                      |
+| `crates/weaver-cli/src/output/source.rs`                     | Create                                      |
+| `crates/weaver-cli/tests/features/weaver_cli_output.feature` | Create                                      |
+| `crates/weaver-cli/src/tests/behaviour.rs`                   | Extend steps for new scenarios              |
+| `crates/weaver-cli/src/tests/support/`                       | Add fixtures for rendered output            |
+| `crates/weaver-e2e/tests/`                                   | Extend for human-readable output validation |
+| `docs/weaver-design.md`                                      | Record design decisions                     |
+| `docs/users-guide.md`                                        | Document output format changes              |
+| `docs/roadmap.md`                                            | Mark entry done                             |
+| `docs/execplans/phase-1-human-readable-output.md`            | Create                                      |
 
 ## Dependencies
 

--- a/docs/execplans/phase-1-human-readable-output.md
+++ b/docs/execplans/phase-1-human-readable-output.md
@@ -23,9 +23,8 @@ blocks while keeping the JSONL protocol payloads intact for machine use.
 2. **Output format selection**: Add an `--output` flag with `auto`, `human`, and
    `json` values. `auto` defaults to `human` when stdout is a TTY and `json`
    when stdout is redirected, ensuring machine pipelines remain stable.
-3. **`miette` renderer configuration**: Use `miette::GraphicalReportHandler`
-   with Unicode disabled to produce ASCII-only context blocks matching the
-   design doc examples.
+3. **Miette-style renderer configuration**: Emit ASCII-only context blocks
+   modelled on `miette` output to match the design doc examples.
 4. **Lightweight response models**: Define CLI-side response structs mirroring
    `docs/users-guide.md` JSON shapes for definitions, references, diagnostics,
    and safety harness failures to avoid cross-crate coupling.
@@ -48,8 +47,6 @@ crates/weaver-cli/src/
 
 ### Step 1: Update dependencies
 
-- Add `miette` (and any required helpers) to the workspace dependencies and
-  `crates/weaver-cli/Cargo.toml`.
 - Upgrade `rstest-bdd` and `rstest-bdd-macros` to v0.4.0 across the workspace,
   updating uses if required by the new API.
 
@@ -68,12 +65,12 @@ crates/weaver-cli/src/
   - Safety harness failures (path + optional line/column + message)
 - Implement `serde` parsing helpers that fail fast with clear errors.
 
-### Step 4: Build the `miette` renderer
+### Step 4: Build the context renderer
 
 - Convert URI + line/column (1-indexed) to byte offsets, handling multi-line
   spans and range end defaults for point locations.
-- Use `miette::NamedSource` to load file content and render context blocks with
-  caret spans; group multiple spans per file under a shared header.
+- Render ASCII context blocks with caret spans and group multiple spans per
+  file under a shared header.
 - Provide fallback rendering for unreadable or missing files, including the
   reason (e.g., "file missing" or "invalid URI").
 
@@ -136,8 +133,8 @@ updates, per `AGENTS.md`.
 
 | File                                                         | Action                                         |
 | ------------------------------------------------------------ | ---------------------------------------------- |
-| `Cargo.toml`                                                 | Bump `rstest-bdd` deps, add `miette`            |
-| `crates/weaver-cli/Cargo.toml`                               | Add `miette` dependency                        |
+| `Cargo.toml`                                                 | Bump `rstest-bdd` deps                          |
+| `crates/weaver-cli/Cargo.toml`                               | Add output rendering deps                       |
 | `crates/weaver-cli/src/lib.rs`                               | Add `--output` and renderer integration         |
 | `crates/weaver-cli/src/output/mod.rs`                        | Create                                          |
 | `crates/weaver-cli/src/output/models.rs`                     | Create                                          |
@@ -154,5 +151,4 @@ updates, per `AGENTS.md`.
 
 ## Dependencies
 
-- `miette` (rendering context blocks)
 - `rstest-bdd` v0.4.0 + `rstest-bdd-macros` v0.4.0

--- a/docs/execplans/phase-1-human-readable-output.md
+++ b/docs/execplans/phase-1-human-readable-output.md
@@ -103,18 +103,24 @@ crates/weaver-cli/src/
 - Implement or extend step definitions in `crates/weaver-cli/src/tests/` to
   drive a fake daemon with JSONL responses and assert rendered output.
 
-### Step 8: Update documentation
+### Step 8: Update end-to-end (e2e) tests
+
+- Extend `crates/weaver-e2e` to validate human-readable rendering for
+  definitions and diagnostics with real language server responses.
+- Add unhappy-path coverage that exercises missing source content fallbacks.
+
+### Step 9: Update documentation
 
 - Record the output-format decision and renderer behaviour in
   `docs/weaver-design.md` (section 2.1.4).
 - Update `docs/users-guide.md` output format section to describe `--output`,
   the TTY-driven default, and the new context block format.
 
-### Step 9: Mark roadmap entry done
+### Step 10: Mark roadmap entry done
 
 - Update `docs/roadmap.md` to mark the human-readable output item complete.
 
-### Step 10: Run quality gates
+### Step 11: Run quality gates
 
 ```bash
 set -o pipefail
@@ -140,6 +146,7 @@ updates, per `AGENTS.md`.
 | `crates/weaver-cli/tests/features/weaver_cli_output.feature` | Create                                          |
 | `crates/weaver-cli/src/tests/behaviour.rs`                   | Extend steps for new scenarios                  |
 | `crates/weaver-cli/src/tests/support/`                       | Add fixtures for rendered output                |
+| `crates/weaver-e2e/tests/`                                   | Extend for human-readable output validation     |
 | `docs/weaver-design.md`                                      | Record design decisions                         |
 | `docs/users-guide.md`                                        | Document output format changes                  |
 | `docs/roadmap.md`                                            | Mark entry done                                 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -86,7 +86,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
     communicate via stdio, server shutdown is handled gracefully on daemon
     stop, and missing server binaries produce clear diagnostic errors.
 
-- [ ] Add human-readable output rendering for commands that return code
+- [x] Add human-readable output rendering for commands that return code
     locations or diagnostics, using `miette` or a compatible renderer to
     show context blocks.
   - Acceptance criteria: Definition, reference, diagnostics, and safety

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -235,8 +235,8 @@ The CLI accepts `--output` with `auto` (default), `human`, and `json` values.
 `auto` selects `human` when stdout is a TTY and `json` when output is
 redirected, so JSON pipelines remain stable. Place `--output` before the
 command domain and operation because arguments after the operation are passed
-directly to the daemon (for example, `weaver --output human observe
-get-definition ...`).
+directly to the daemon (for example,
+`weaver --output human observe get-definition ...`).
 
 When `--output human` is active, commands that return code locations or
 diagnostics render context blocks with file headers, line-numbered source

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -229,7 +229,21 @@ messages include a `stream` field (`stdout` or `stderr`) plus a `data` payload;
 exit messages contain a numeric `status`. The CLI writes each `data` payload to
 the matching host stream and terminates using the exit status provided by the
 final exit message. The `data` payload can be plain text (human-readable) or a
-JSON document (machine-readable). Example JSONL envelope:
+JSON document (machine-readable).
+
+The CLI accepts `--output` with `auto` (default), `human`, and `json` values.
+`auto` selects `human` when stdout is a TTY and `json` when output is
+redirected, so JSON pipelines remain stable. Place `--output` before the
+command domain and operation because arguments after the operation are passed
+directly to the daemon (for example, `weaver --output human observe
+get-definition ...`).
+
+When `--output human` is active, commands that return code locations or
+diagnostics render context blocks with file headers, line-numbered source
+context, and caret spans. If source content is unavailable, the CLI falls back
+to the path and range with an explanation of why context could not be shown.
+
+Example JSONL envelope:
 
 ```json
 {"kind":"stream","stream":"stdout","data":"definition: file:///path/main.rs:42:17\n"}
@@ -321,7 +335,11 @@ TypeScript. Unsupported extensions return an error.
 Human output:
 
 ```text
-definition: <URI>:<LINE>:<COL>
+<PATH>
+  --> <LINE>:<COL>
+   |
+<LINE> | <CODE>
+       | ^ definition
 ```
 
 JSON payload (written to stdout stream):
@@ -345,7 +363,11 @@ weaver observe find-references --uri <URI> --position <LINE:COL>
 Human output:
 
 ```text
-reference: <URI>:<LINE>:<COL>
+<PATH>
+  --> <LINE>:<COL>
+   |
+<LINE> | <CODE>
+       | ^ reference
 ```
 
 JSON payload:
@@ -435,7 +457,11 @@ weaver verify diagnostics --uri <URI>
 Human output:
 
 ```text
-diagnostic: <URI>:<LINE>:<COL> <MESSAGE>
+<PATH>
+  --> <LINE>:<COL>
+   |
+<LINE> | <CODE>
+       | ^ <MESSAGE>
 ```
 
 JSON payload:

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -511,9 +511,9 @@ surfaced by the safety harness.
 
 The CLI exposes an `--output` flag with `auto`, `human`, and `json` values.
 `auto` selects `human` when stdout is a TTY and `json` when output is
-redirected, ensuring pipelines remain stable while still providing rich
-context for interactive use. The human renderer follows `miette`-style ASCII
-output even when a direct `miette` dependency is not used.
+redirected, ensuring pipelines remain stable while still providing rich context
+for interactive use. The human renderer follows `miette`-style ASCII output
+even when a direct `miette` dependency is not used.
 
 Context blocks are required because line-and-column tuples alone are
 insufficient for fast triage. The renderer should show a labelled header with

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -510,10 +510,10 @@ hierarchy edges, structural matches, rewrite results, and verification failures
 surfaced by the safety harness.
 
 The CLI exposes an `--output` flag with `auto`, `human`, and `json` values.
-`auto` selects `human` when stdout is a TTY and `json` when output is
-redirected, ensuring pipelines remain stable while still providing rich context
-for interactive use. The human renderer follows `miette`-style ASCII output
-even when a direct `miette` dependency is not used.
+`auto` selects `human` when stdout is a terminal (TTY) and `json` when output
+is redirected, ensuring pipelines remain stable while still providing rich
+context for interactive use. The human renderer follows `miette`-style ASCII
+output even when a direct `miette` dependency is not used.
 
 Context blocks are required because line-and-column tuples alone are
 insufficient for fast triage. The renderer should show a labelled header with

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -509,6 +509,12 @@ output. This applies to any response containing `Location`, `Range`, or
 hierarchy edges, structural matches, rewrite results, and verification failures
 surfaced by the safety harness.
 
+The CLI exposes an `--output` flag with `auto`, `human`, and `json` values.
+`auto` selects `human` when stdout is a TTY and `json` when output is
+redirected, ensuring pipelines remain stable while still providing rich
+context for interactive use. The human renderer follows `miette`-style ASCII
+output even when a direct `miette` dependency is not used.
+
 Context blocks are required because line-and-column tuples alone are
 insufficient for fast triage. The renderer should show a labelled header with
 the path and coordinate, a small window of surrounding source (defaulting to


### PR DESCRIPTION
## Summary
- Implement Phase 1 of the human-readable weaver-cli output subsystem with an auto-resolving --output flag (auto, human, json) based on stdout being a TTY.
- Refactor unit tests to remove duplication and align with the new test structure.
- Extend test coverage and end-to-end tests to exercise the new rendering path and auto-resolve behavior.
- Upgrade test tooling (rstest-bdd family) to align with the new test structure.

📎 **Task**: https://www.devboxer.com/task/fd1c9cd0-f6c8-472c-9e31-5b2b8e4d840d

## Changes
### Code
- Add a new output subsystem under crates/weaver-cli/src/output with modules: mod.rs, models.rs, render.rs, source.rs
- Introduce OutputFormat, ResolvedOutputFormat, and OutputContext to model and drive rendering
- Extend the CLI to accept a new --output flag and resolve Auto based on stdout
- Wire read_daemon_messages to consume OutputSettings (format + context) and render human output when requested
- Update IoStreams to track whether stdout is a terminal and expose that information for resolution
- Implement render_human_output with domain/operation dispatching for:
  - observe get-definition
  - observe find-references
  - verify diagnostics
  - act (verification failures)
- Add source-resolution helpers (from_uri, from_path_or_uri) and URI argument extraction for fallback rendering
- Wire integration points in lib.rs/main.rs to pass along OutputFormat/OutputContext to the daemon path

### Tests
- Refactor tests to remove duplication and align with the new test structure; extend unit/behaviour tests to exercise new rendering path and auto-resolve behavior
- Add test support for creating temporary sources and test fixtures for daemon payloads
- Add new test suites and features for human-readable output rendering:
  - crates/weaver-cli/tests/features/weaver_cli_output.feature
  - Extended behaviour tests in crates/weaver-cli/src/tests/behaviour.rs
  - End-to-end tests in crates/weaver-e2e/tests/human_output.rs

### Documentation
- Add docs/execplans/phase-1-human-readable-output.md describing Phase 1 plan, acceptance criteria, and design decisions
- Update roadmap and user guides to reflect the new output mode and human rendering expectations
- Update docs/weaver-design.md to document the new --output flag and rendering approach

### End-to-end
- Extend weaver-e2e to validate human-readable rendering for definitions and diagnostics
- Include scenarios that exercise missing source content fallbacks and raw JSON output mode

### Dependencies
- Upgrade rstest-bdd and related macros across the workspace to v0.4.0 to align with new test structure

### Notes
- This PR implements Phase 1 of human-readable output rendering. Further improvements and edge-case handling will be addressed in subsequent PRs.

📎 **Task**: https://www.devboxer.com/task/fd1c9cd0-f6c8-472c-9e31-5b2b8e4d840d
