### PR TITLE
Add rope actuator plugin with runtime wiring, e2e tests, and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ dependencies = [
 name = "weaver-e2e"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "camino",
  "insta",
  "lsp-types",
@@ -2668,6 +2669,19 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "weaver-config",
+]
+
+[[package]]
+name = "weaver-plugin-rope"
+version = "0.1.0"
+dependencies = [
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "weaver-plugins",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ dependencies = [
 name = "weaver-plugin-rope"
 version = "0.1.0"
 dependencies = [
+ "mockall",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
@@ -2739,6 +2740,7 @@ dependencies = [
  "derive_more 1.0.0",
  "dirs 5.0.1",
  "lsp-types",
+ "mockall",
  "nix 0.28.0",
  "once_cell",
  "ortho_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/weaver-graph",
     "crates/weaverd",
     "crates/weaver-lsp-host",
+    "crates/weaver-plugin-rope",
     "crates/weaver-plugins",
     "crates/weaver-sandbox",
     "crates/weaver-syntax",

--- a/crates/weaver-e2e/Cargo.toml
+++ b/crates/weaver-e2e/Cargo.toml
@@ -14,6 +14,7 @@ camino = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+assert_cmd = { workspace = true }
 rstest = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
+++ b/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
@@ -280,7 +280,7 @@ fn refactor_pipeline_with_observe_and_jq_snapshot() {
     );
 
     let output = Command::new("bash")
-        .args(["-lc", shell_script])
+        .args(["-c", shell_script])
         .env("WEAVER_BIN", weaver_bin)
         .env("WEAVER_ENDPOINT", endpoint.as_str())
         .output()

--- a/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
+++ b/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
@@ -69,7 +69,10 @@ impl FakeDaemon {
     }
 
     fn join(self) {
-        self.join_handle.join().ok();
+        assert!(
+            self.join_handle.join().is_ok(),
+            "fake daemon thread should not panic"
+        );
     }
 }
 

--- a/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
+++ b/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
@@ -1,0 +1,237 @@
+//! End-to-end CLI ergonomics snapshots for `act refactor`.
+//!
+//! These tests run the `weaver` binary with a fake daemon endpoint to capture
+//! user-facing command ergonomics, including a shell pipeline that chains an
+//! observe query through `jq` into an actuator command.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::process::Output;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use assert_cmd::Command;
+use insta::assert_debug_snapshot;
+use serde::Serialize;
+use serde_json::json;
+
+#[derive(Debug, Serialize)]
+struct Transcript {
+    command: String,
+    status: i32,
+    stdout: String,
+    stderr: String,
+    requests: Vec<serde_json::Value>,
+}
+
+#[derive(Debug)]
+struct FakeDaemon {
+    address: SocketAddr,
+    requests: Arc<Mutex<Vec<serde_json::Value>>>,
+    join_handle: thread::JoinHandle<()>,
+}
+
+#[expect(
+    deprecated,
+    reason = "assert_cmd::cargo::cargo_bin resolves workspace binaries for e2e tests"
+)]
+fn weaver_binary_path() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("weaver")
+}
+
+impl FakeDaemon {
+    fn start(expected_requests: usize) -> Result<Self, std::io::Error> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let address = listener.local_addr()?;
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let shared_requests = Arc::clone(&requests);
+
+        let join_handle = thread::spawn(move || {
+            serve_requests(&listener, expected_requests, &shared_requests);
+        });
+
+        Ok(Self {
+            address,
+            requests,
+            join_handle,
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        format!("tcp://{}", self.address)
+    }
+
+    fn requests(&self) -> Vec<serde_json::Value> {
+        self.requests
+            .lock()
+            .map(|items| items.clone())
+            .unwrap_or_default()
+    }
+
+    fn join(self) {
+        std::mem::drop(self.join_handle.join());
+    }
+}
+
+fn serve_requests(
+    listener: &TcpListener,
+    expected_requests: usize,
+    requests: &Arc<Mutex<Vec<serde_json::Value>>>,
+) {
+    for _ in 0..expected_requests {
+        let Ok((stream, _)) = listener.accept() else {
+            return;
+        };
+        if respond_to_request(stream, requests).is_err() {
+            return;
+        }
+    }
+}
+
+fn respond_to_request(
+    stream: TcpStream,
+    requests: &Arc<Mutex<Vec<serde_json::Value>>>,
+) -> Result<(), std::io::Error> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line)?;
+
+    let parsed_request: serde_json::Value = serde_json::from_str(request_line.trim())
+        .unwrap_or_else(|_| {
+            json!({
+                "invalid_request": request_line.trim(),
+            })
+        });
+
+    if let Ok(mut guard) = requests.lock() {
+        guard.push(parsed_request.clone());
+    }
+
+    let operation = parsed_request
+        .get("command")
+        .and_then(|command| command.get("operation"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+
+    let payload = match operation {
+        "get-definition" => json!([{ "symbol": "renamed_symbol" }]).to_string(),
+        "refactor" => json!({
+            "status": "ok",
+            "files_written": 1,
+            "files_deleted": 0
+        })
+        .to_string(),
+        _ => json!({ "status": "unexpected", "operation": operation }).to_string(),
+    };
+
+    let mut writer = stream;
+    write_json_line(
+        &mut writer,
+        &json!({
+            "kind": "stream",
+            "stream": "stdout",
+            "data": payload,
+        }),
+    )?;
+    write_json_line(&mut writer, &json!({ "kind": "exit", "status": 0 }))
+}
+
+fn write_json_line(
+    writer: &mut impl Write,
+    payload: &serde_json::Value,
+) -> Result<(), std::io::Error> {
+    writer.write_all(payload.to_string().as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+fn output_to_transcript(
+    command: String,
+    output: &Output,
+    requests: Vec<serde_json::Value>,
+) -> Transcript {
+    let status = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    Transcript {
+        command,
+        status,
+        stdout,
+        stderr,
+        requests,
+    }
+}
+
+#[test]
+fn refactor_actuator_isolation_cli_snapshot() {
+    let daemon = FakeDaemon::start(1).expect("fake daemon should start");
+    let endpoint = daemon.endpoint();
+
+    let command_string = String::from(
+        "weaver --daemon-socket tcp://<daemon-endpoint> --output json act refactor --provider rope --refactoring rename --file src/main.py new_name=renamed_symbol offset=4",
+    );
+
+    let mut command = Command::new(weaver_binary_path());
+    let output = command
+        .args([
+            "--daemon-socket",
+            endpoint.as_str(),
+            "--output",
+            "json",
+            "act",
+            "refactor",
+            "--provider",
+            "rope",
+            "--refactoring",
+            "rename",
+            "--file",
+            "src/main.py",
+            "new_name=renamed_symbol",
+            "offset=4",
+        ])
+        .output()
+        .expect("command should execute");
+
+    let transcript = output_to_transcript(command_string, &output, daemon.requests());
+    daemon.join();
+
+    assert_debug_snapshot!("refactor_actuator_isolation", transcript);
+}
+
+#[test]
+fn refactor_pipeline_with_observe_and_jq_snapshot() {
+    let jq_available = Command::new("jq").arg("--version").output().is_ok();
+    if !jq_available {
+        std::mem::drop(writeln!(
+            std::io::stderr().lock(),
+            "Skipping test: jq not available on PATH"
+        ));
+        return;
+    }
+
+    let daemon = FakeDaemon::start(2).expect("fake daemon should start");
+    let endpoint = daemon.endpoint();
+    let weaver_bin = weaver_binary_path();
+
+    let shell_script = concat!(
+        "\"$WEAVER_BIN\" --daemon-socket \"$WEAVER_ENDPOINT\" --output json ",
+        "observe get-definition --symbol old_symbol ",
+        "| jq -r '.[0].symbol' ",
+        "| xargs -I{} \"$WEAVER_BIN\" --daemon-socket \"$WEAVER_ENDPOINT\" --output json ",
+        "act refactor --provider rope --refactoring rename --file src/main.py new_name={} offset=4"
+    );
+
+    let output = Command::new("bash")
+        .args(["-lc", shell_script])
+        .env("WEAVER_BIN", weaver_bin)
+        .env("WEAVER_ENDPOINT", endpoint.as_str())
+        .output()
+        .expect("pipeline command should execute");
+
+    let command_string =
+        String::from("weaver observe get-definition | jq -r '.[0].symbol' | weaver act refactor");
+    let transcript = output_to_transcript(command_string, &output, daemon.requests());
+    daemon.join();
+
+    assert_debug_snapshot!("refactor_pipeline_observe_jq", transcript);
+}

--- a/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
+++ b/crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
@@ -69,7 +69,7 @@ impl FakeDaemon {
     }
 
     fn join(self) {
-        std::mem::drop(self.join_handle.join());
+        self.join_handle.join().ok();
     }
 }
 
@@ -202,10 +202,11 @@ fn refactor_actuator_isolation_cli_snapshot() {
 fn refactor_pipeline_with_observe_and_jq_snapshot() {
     let jq_available = Command::new("jq").arg("--version").output().is_ok();
     if !jq_available {
-        std::mem::drop(writeln!(
+        writeln!(
             std::io::stderr().lock(),
             "Skipping test: jq not available on PATH"
-        ));
+        )
+        .ok();
         return;
     }
 

--- a/crates/weaver-e2e/tests/snapshots/refactor_rope_cli_snapshots__refactor_actuator_isolation.snap
+++ b/crates/weaver-e2e/tests/snapshots/refactor_rope_cli_snapshots__refactor_actuator_isolation.snap
@@ -1,0 +1,28 @@
+---
+source: crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
+expression: transcript
+---
+Transcript {
+    command: "weaver --daemon-socket tcp://<daemon-endpoint> --output json act refactor --provider rope --refactoring rename --file src/main.py new_name=renamed_symbol offset=4",
+    status: 0,
+    stdout: "{\"files_deleted\":0,\"files_written\":1,\"status\":\"ok\"}",
+    stderr: "",
+    requests: [
+        Object {
+            "arguments": Array [
+                String("--provider"),
+                String("rope"),
+                String("--refactoring"),
+                String("rename"),
+                String("--file"),
+                String("src/main.py"),
+                String("new_name=renamed_symbol"),
+                String("offset=4"),
+            ],
+            "command": Object {
+                "domain": String("act"),
+                "operation": String("refactor"),
+            },
+        },
+    ],
+}

--- a/crates/weaver-e2e/tests/snapshots/refactor_rope_cli_snapshots__refactor_pipeline_observe_jq.snap
+++ b/crates/weaver-e2e/tests/snapshots/refactor_rope_cli_snapshots__refactor_pipeline_observe_jq.snap
@@ -1,0 +1,38 @@
+---
+source: crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs
+expression: transcript
+---
+Transcript {
+    command: "weaver observe get-definition | jq -r '.[0].symbol' | weaver act refactor",
+    status: 0,
+    stdout: "{\"files_deleted\":0,\"files_written\":1,\"status\":\"ok\"}",
+    stderr: "",
+    requests: [
+        Object {
+            "arguments": Array [
+                String("--symbol"),
+                String("old_symbol"),
+            ],
+            "command": Object {
+                "domain": String("observe"),
+                "operation": String("get-definition"),
+            },
+        },
+        Object {
+            "arguments": Array [
+                String("--provider"),
+                String("rope"),
+                String("--refactoring"),
+                String("rename"),
+                String("--file"),
+                String("src/main.py"),
+                String("new_name=renamed_symbol"),
+                String("offset=4"),
+            ],
+            "command": Object {
+                "domain": String("act"),
+                "operation": String("refactor"),
+            },
+        },
+    ],
+}

--- a/crates/weaver-plugin-rope/Cargo.toml
+++ b/crates/weaver-plugin-rope/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "weaver-plugin-rope"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+serde_json.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+weaver-plugins = { path = "../weaver-plugins" }
+
+[dev-dependencies]
+rstest.workspace = true
+rstest-bdd.workspace = true
+rstest-bdd-macros.workspace = true
+
+[lints]
+workspace = true

--- a/crates/weaver-plugin-rope/Cargo.toml
+++ b/crates/weaver-plugin-rope/Cargo.toml
@@ -10,6 +10,7 @@ thiserror.workspace = true
 weaver-plugins = { path = "../weaver-plugins" }
 
 [dev-dependencies]
+mockall.workspace = true
 rstest.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-macros.workspace = true

--- a/crates/weaver-plugin-rope/src/lib.rs
+++ b/crates/weaver-plugin-rope/src/lib.rs
@@ -275,13 +275,14 @@ fn parse_rename_arguments(
         .parse::<usize>()
         .map_err(|error| format!("offset must be a non-negative integer: {error}"))?;
 
-    let new_name = json_value_to_string(new_name_value)
+    let new_name = new_name_value
+        .as_str()
         .ok_or_else(|| String::from("new_name argument must be a string"))?;
     if new_name.trim().is_empty() {
         return Err(String::from("new_name argument must not be empty"));
     }
 
-    Ok((offset, new_name))
+    Ok((offset, String::from(new_name)))
 }
 
 fn json_value_to_string(value: &serde_json::Value) -> Option<String> {

--- a/crates/weaver-plugin-rope/src/lib.rs
+++ b/crates/weaver-plugin-rope/src/lib.rs
@@ -1,0 +1,358 @@
+//! Rope-backed actuator plugin entrypoint and request dispatcher.
+//!
+//! This crate implements a one-shot plugin protocol handler compatible with
+//! `weaver-plugins`. The plugin reads exactly one JSONL request from stdin,
+//! executes a refactoring operation, and writes one JSONL response to stdout.
+
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+use thiserror::Error;
+use weaver_plugins::protocol::{
+    DiagnosticSeverity, FilePayload, PluginDiagnostic, PluginOutput, PluginRequest, PluginResponse,
+};
+
+const PYTHON_BINARY: &str = "python3";
+const PYTHON_RENAME_SCRIPT: &str = concat!(
+    "import os,sys\n",
+    "from rope.base.project import Project\n",
+    "from rope.refactor.rename import Rename\n",
+    "root, rel_path, offset_s, new_name = sys.argv[1:5]\n",
+    "offset = int(offset_s)\n",
+    "project = Project(root)\n",
+    "try:\n",
+    "    resource = project.get_resource(rel_path)\n",
+    "    renamer = Rename(project, resource, offset)\n",
+    "    changes = renamer.get_changes(new_name)\n",
+    "    project.do(changes)\n",
+    "    with open(os.path.join(root, rel_path), 'r', encoding='utf-8') as handle:\n",
+    "        sys.stdout.write(handle.read())\n",
+    "finally:\n",
+    "    project.close()\n",
+);
+
+/// Refactoring adapter abstraction used to keep behaviour deterministic in tests.
+pub trait RopeAdapter {
+    /// Executes a rename operation and returns the modified file content.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the adapter cannot complete the operation.
+    fn rename(
+        &self,
+        file: &FilePayload,
+        offset: usize,
+        new_name: &str,
+    ) -> Result<String, RopeAdapterError>;
+}
+
+/// Adapter that delegates to the Python `rope` library.
+pub struct PythonRopeAdapter;
+
+impl RopeAdapter for PythonRopeAdapter {
+    fn rename(
+        &self,
+        file: &FilePayload,
+        offset: usize,
+        new_name: &str,
+    ) -> Result<String, RopeAdapterError> {
+        validate_relative_path(file.path())?;
+
+        let workspace =
+            TempDir::new().map_err(|source| RopeAdapterError::WorkspaceCreate { source })?;
+        let absolute_path = write_workspace_file(workspace.path(), file.path(), file.content())?;
+
+        let relative_path = path_to_slash(file.path());
+        let mut command = Command::new(PYTHON_BINARY);
+        command.arg("-c");
+        command.arg(PYTHON_RENAME_SCRIPT);
+        command.arg(workspace.path());
+        command.arg(relative_path);
+        command.arg(offset.to_string());
+        command.arg(new_name);
+
+        let output = command
+            .output()
+            .map_err(|source| RopeAdapterError::Spawn { source })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            return Err(RopeAdapterError::EngineFailed {
+                message: if stderr.is_empty() {
+                    String::from("python rope adapter failed without stderr output")
+                } else {
+                    stderr
+                },
+            });
+        }
+
+        let modified =
+            String::from_utf8(output.stdout).map_err(|source| RopeAdapterError::InvalidOutput {
+                message: source.to_string(),
+            })?;
+
+        let _ = absolute_path;
+        Ok(modified)
+    }
+}
+
+/// Errors raised while dispatching plugin requests.
+#[derive(Debug, Error)]
+pub enum PluginDispatchError {
+    /// Writing the plugin response to stdout failed.
+    #[error("failed to write plugin response: {source}")]
+    Write {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Serialising the response payload failed.
+    #[error("failed to serialize plugin response: {source}")]
+    Serialize {
+        /// Underlying serialization error.
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// Errors raised by rope adapter implementations.
+#[derive(Debug, Error)]
+pub enum RopeAdapterError {
+    /// Temporary workspace allocation failed.
+    #[error("failed to create temporary workspace: {source}")]
+    WorkspaceCreate {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Writing request files to the temporary workspace failed.
+    #[error("failed to materialize workspace file '{}': {source}", path.display())]
+    WorkspaceWrite {
+        /// File path being written.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Spawning the Python runtime failed.
+    #[error("failed to spawn python runtime: {source}")]
+    Spawn {
+        /// Underlying process spawn error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The Python adapter completed with a non-zero status.
+    #[error("python rope adapter failed: {message}")]
+    EngineFailed {
+        /// Error message captured from stderr.
+        message: String,
+    },
+    /// The adapter returned malformed output.
+    #[error("python rope adapter returned invalid output: {message}")]
+    InvalidOutput {
+        /// Parsing error details.
+        message: String,
+    },
+    /// Request path was invalid for sandboxed execution.
+    #[error("invalid file path for rope operation: {message}")]
+    InvalidPath {
+        /// Validation message.
+        message: String,
+    },
+}
+
+/// Executes one plugin request from `stdin` and writes one response to `stdout`.
+///
+/// # Errors
+///
+/// Returns an error if the response cannot be serialized or written.
+pub fn run_with_adapter<R: RopeAdapter>(
+    stdin: &mut impl BufRead,
+    stdout: &mut impl Write,
+    adapter: &R,
+) -> Result<(), PluginDispatchError> {
+    let response = match read_request(stdin) {
+        Ok(request) => execute_request(adapter, &request),
+        Err(message) => failure_response(message),
+    };
+
+    let payload = serde_json::to_string(&response)
+        .map_err(|source| PluginDispatchError::Serialize { source })?;
+    stdout
+        .write_all(payload.as_bytes())
+        .map_err(|source| PluginDispatchError::Write { source })?;
+    stdout
+        .write_all(b"\n")
+        .map_err(|source| PluginDispatchError::Write { source })?;
+    stdout
+        .flush()
+        .map_err(|source| PluginDispatchError::Write { source })
+}
+
+/// Executes one plugin request using the default Python-backed adapter.
+///
+/// # Errors
+///
+/// Returns an error if the response cannot be written.
+pub fn run(stdin: &mut impl BufRead, stdout: &mut impl Write) -> Result<(), PluginDispatchError> {
+    run_with_adapter(stdin, stdout, &PythonRopeAdapter)
+}
+
+fn read_request(stdin: &mut impl BufRead) -> Result<PluginRequest, String> {
+    let mut line = String::new();
+    let bytes_read = stdin
+        .read_line(&mut line)
+        .map_err(|error| format!("failed to read request: {error}"))?;
+
+    if bytes_read == 0 {
+        return Err(String::from("plugin request was empty"));
+    }
+
+    serde_json::from_str(line.trim())
+        .map_err(|error| format!("invalid plugin request JSON: {error}"))
+}
+
+fn execute_request<R: RopeAdapter>(adapter: &R, request: &PluginRequest) -> PluginResponse {
+    match request.operation() {
+        "rename" => execute_rename(adapter, request),
+        other => failure_response(format!("unsupported refactoring operation '{other}'")),
+    }
+}
+
+fn execute_rename<R: RopeAdapter>(adapter: &R, request: &PluginRequest) -> PluginResponse {
+    let operation = parse_rename_arguments(request.arguments());
+    let (offset, new_name) = match operation {
+        Ok(args) => args,
+        Err(message) => return failure_response(message),
+    };
+
+    let Some(file) = request.files().first() else {
+        return failure_response(String::from("rename operation requires one file payload"));
+    };
+
+    let modified = match adapter.rename(file, offset, &new_name) {
+        Ok(modified) => modified,
+        Err(error) => return failure_response(error.to_string()),
+    };
+
+    if modified == file.content() {
+        return failure_response(String::from("rename operation produced no content changes"));
+    }
+
+    let patch = build_search_replace_patch(file.path(), file.content(), &modified);
+    PluginResponse::success(PluginOutput::Diff { content: patch })
+}
+
+fn parse_rename_arguments(
+    arguments: &HashMap<String, serde_json::Value>,
+) -> Result<(usize, String), String> {
+    let offset_value = arguments
+        .get("offset")
+        .ok_or_else(|| String::from("rename operation requires 'offset' argument"))?;
+    let new_name_value = arguments
+        .get("new_name")
+        .ok_or_else(|| String::from("rename operation requires 'new_name' argument"))?;
+
+    let offset_string = json_value_to_string(offset_value)
+        .ok_or_else(|| String::from("offset argument must be a string or number"))?;
+    let offset = offset_string
+        .parse::<usize>()
+        .map_err(|error| format!("offset must be a non-negative integer: {error}"))?;
+
+    let new_name = json_value_to_string(new_name_value)
+        .ok_or_else(|| String::from("new_name argument must be a string"))?;
+    if new_name.trim().is_empty() {
+        return Err(String::from("new_name argument must not be empty"));
+    }
+
+    Ok((offset, new_name))
+}
+
+fn json_value_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => Some(text.to_owned()),
+        serde_json::Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+fn write_workspace_file(
+    workspace_root: &Path,
+    relative_path: &Path,
+    content: &str,
+) -> Result<PathBuf, RopeAdapterError> {
+    let absolute_path = workspace_root.join(relative_path);
+
+    if let Some(parent) = absolute_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| RopeAdapterError::WorkspaceWrite {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    std::fs::write(&absolute_path, content).map_err(|source| RopeAdapterError::WorkspaceWrite {
+        path: absolute_path.clone(),
+        source,
+    })?;
+
+    Ok(absolute_path)
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), RopeAdapterError> {
+    if path.is_absolute() {
+        return Err(RopeAdapterError::InvalidPath {
+            message: String::from("absolute paths are not allowed"),
+        });
+    }
+
+    let has_parent_traversal = path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)));
+    if has_parent_traversal {
+        return Err(RopeAdapterError::InvalidPath {
+            message: String::from("path traversal is not allowed"),
+        });
+    }
+
+    Ok(())
+}
+
+fn build_search_replace_patch(path: &Path, original: &str, modified: &str) -> String {
+    let unix_path = path_to_slash(path);
+    let original_block = ensure_trailing_newline(original);
+    let modified_block = ensure_trailing_newline(modified);
+
+    format!(
+        "diff --git a/{unix_path} b/{unix_path}\n<<<<<<< SEARCH\n{original_block}=======\n{modified_block}>>>>>>> REPLACE\n"
+    )
+}
+
+fn ensure_trailing_newline(content: &str) -> String {
+    if content.ends_with('\n') {
+        return content.to_owned();
+    }
+    format!("{content}\n")
+}
+
+fn path_to_slash(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<String>>()
+        .join("/")
+}
+
+fn failure_response(message: String) -> PluginResponse {
+    PluginResponse::failure(vec![PluginDiagnostic::new(
+        DiagnosticSeverity::Error,
+        message,
+    )])
+}

--- a/crates/weaver-plugin-rope/src/main.rs
+++ b/crates/weaver-plugin-rope/src/main.rs
@@ -1,0 +1,17 @@
+//! Binary entrypoint for the rope actuator plugin.
+
+use std::io::{self, BufReader, Write};
+
+use weaver_plugin_rope::run;
+
+fn main() {
+    let stdin = io::stdin();
+    let mut reader = BufReader::new(stdin.lock());
+    let stdout = io::stdout();
+    let mut writer = stdout.lock();
+
+    if let Err(error) = run(&mut reader, &mut writer) {
+        std::mem::drop(writeln!(io::stderr().lock(), "{error}"));
+        std::process::exit(1);
+    }
+}

--- a/crates/weaver-plugin-rope/src/main.rs
+++ b/crates/weaver-plugin-rope/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut writer = stdout.lock();
 
     if let Err(error) = run(&mut reader, &mut writer) {
-        std::mem::drop(writeln!(io::stderr().lock(), "{error}"));
+        writeln!(io::stderr().lock(), "{error}").ok();
         std::process::exit(1);
     }
 }

--- a/crates/weaver-plugin-rope/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rope/src/tests/behaviour.rs
@@ -1,0 +1,154 @@
+//! Behaviour-driven tests for rope plugin request dispatch.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use weaver_plugins::protocol::{
+    DiagnosticSeverity, FilePayload, PluginDiagnostic, PluginOutput, PluginRequest, PluginResponse,
+};
+
+use crate::{RopeAdapter, RopeAdapterError, execute_request};
+
+#[derive(Default)]
+struct World {
+    request: Option<PluginRequest>,
+    response: Option<PluginResponse>,
+    adapter_mode: AdapterMode,
+}
+
+#[derive(Default, Clone, Copy)]
+enum AdapterMode {
+    #[default]
+    Success,
+    NoChange,
+    Fails,
+}
+
+#[fixture]
+fn world() -> World {
+    World::default()
+}
+
+struct BehaviourAdapter {
+    mode: AdapterMode,
+}
+
+impl RopeAdapter for BehaviourAdapter {
+    fn rename(
+        &self,
+        file: &FilePayload,
+        _offset: usize,
+        _new_name: &str,
+    ) -> Result<String, RopeAdapterError> {
+        match self.mode {
+            AdapterMode::Success => Ok(file.content().replace("old_name", "new_name")),
+            AdapterMode::NoChange => Ok(file.content().to_owned()),
+            AdapterMode::Fails => Err(RopeAdapterError::EngineFailed {
+                message: String::from("rope engine failed"),
+            }),
+        }
+    }
+}
+
+fn build_request(operation: &str, with_offset: bool, with_new_name: bool) -> PluginRequest {
+    let mut arguments = HashMap::new();
+    if with_offset {
+        arguments.insert(
+            String::from("offset"),
+            serde_json::Value::String(String::from("4")),
+        );
+    }
+    if with_new_name {
+        arguments.insert(
+            String::from("new_name"),
+            serde_json::Value::String(String::from("new_name")),
+        );
+    }
+
+    PluginRequest::with_arguments(
+        operation,
+        vec![FilePayload::new(
+            PathBuf::from("src/main.py"),
+            "def old_name():\n    return 1\n",
+        )],
+        arguments,
+    )
+}
+
+#[given("a rename request with required arguments")]
+fn given_valid_rename(world: &mut World) {
+    world.request = Some(build_request("rename", true, true));
+}
+
+#[given("a rename request missing offset")]
+fn given_missing_offset(world: &mut World) {
+    world.request = Some(build_request("rename", false, true));
+}
+
+#[given("an unsupported extract method request")]
+fn given_unsupported_operation(world: &mut World) {
+    world.request = Some(build_request("extract_method", true, true));
+}
+
+#[given("a rope adapter that fails")]
+fn given_failing_adapter(world: &mut World) {
+    world.adapter_mode = AdapterMode::Fails;
+}
+
+#[given("a rope adapter that returns unchanged content")]
+fn given_no_change_adapter(world: &mut World) {
+    world.adapter_mode = AdapterMode::NoChange;
+}
+
+#[when("the plugin executes the request")]
+fn when_execute(world: &mut World) {
+    let request = world.request.as_ref().expect("request should be present");
+    let adapter = BehaviourAdapter {
+        mode: world.adapter_mode,
+    };
+    world.response = Some(execute_request(&adapter, request));
+}
+
+#[then("the plugin returns successful diff output")]
+fn then_successful_diff(world: &mut World) {
+    let response = world.response.as_ref().expect("response should be present");
+    assert!(response.is_success());
+    assert!(matches!(response.output(), PluginOutput::Diff { .. }));
+}
+
+#[then("the plugin returns failure diagnostics")]
+fn then_failure_diagnostics(world: &mut World) {
+    let response = world.response.as_ref().expect("response should be present");
+    assert!(!response.is_success());
+    assert!(response.output() == &PluginOutput::Empty);
+    assert!(
+        response
+            .diagnostics()
+            .iter()
+            .any(|diag| diag.severity() == DiagnosticSeverity::Error)
+    );
+}
+
+#[then("the failure message contains {text}")]
+fn then_failure_contains(world: &mut World, text: String) {
+    let needle = text.trim_matches('"');
+    let response = world.response.as_ref().expect("response should be present");
+    let diagnostics: Vec<&PluginDiagnostic> = response.diagnostics().iter().collect();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message().contains(needle)),
+        "expected diagnostics to contain '{needle}', got: {:?}",
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message())
+            .collect::<Vec<&str>>()
+    );
+}
+
+#[scenario(path = "tests/features/rope_plugin.feature")]
+fn rope_plugin_behaviour(world: World) {
+    let _ = world;
+}

--- a/crates/weaver-plugin-rope/src/tests/mod.rs
+++ b/crates/weaver-plugin-rope/src/tests/mod.rs
@@ -1,0 +1,139 @@
+//! Unit and behavioural tests for the rope actuator plugin.
+
+mod behaviour;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use rstest::rstest;
+use weaver_plugins::protocol::{FilePayload, PluginOutput, PluginRequest};
+
+use crate::{RopeAdapter, RopeAdapterError, execute_request};
+
+struct MockAdapter {
+    result: Result<String, RopeAdapterError>,
+}
+
+impl RopeAdapter for MockAdapter {
+    fn rename(
+        &self,
+        _file: &FilePayload,
+        _offset: usize,
+        _new_name: &str,
+    ) -> Result<String, RopeAdapterError> {
+        self.result.clone()
+    }
+}
+
+impl Clone for RopeAdapterError {
+    fn clone(&self) -> Self {
+        match self {
+            Self::WorkspaceCreate { source } => Self::WorkspaceCreate {
+                source: std::io::Error::new(source.kind(), source.to_string()),
+            },
+            Self::WorkspaceWrite { path, source } => Self::WorkspaceWrite {
+                path: path.clone(),
+                source: std::io::Error::new(source.kind(), source.to_string()),
+            },
+            Self::Spawn { source } => Self::Spawn {
+                source: std::io::Error::new(source.kind(), source.to_string()),
+            },
+            Self::EngineFailed { message } => Self::EngineFailed {
+                message: message.clone(),
+            },
+            Self::InvalidOutput { message } => Self::InvalidOutput {
+                message: message.clone(),
+            },
+            Self::InvalidPath { message } => Self::InvalidPath {
+                message: message.clone(),
+            },
+        }
+    }
+}
+
+fn request_with_args(arguments: HashMap<String, serde_json::Value>) -> PluginRequest {
+    PluginRequest::with_arguments(
+        "rename",
+        vec![FilePayload::new(
+            PathBuf::from("src/main.py"),
+            "def old_name():\n    return 1\n",
+        )],
+        arguments,
+    )
+}
+
+#[test]
+fn rename_success_returns_diff_output() {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::String(String::from("4")),
+    );
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("def new_name():\n    return 1\n")),
+    };
+
+    let response = execute_request(&adapter, &request_with_args(arguments));
+    assert!(response.is_success());
+    assert!(matches!(response.output(), PluginOutput::Diff { .. }));
+}
+
+#[test]
+fn rename_missing_offset_returns_failure() {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("unused")),
+    };
+
+    let response = execute_request(&adapter, &request_with_args(arguments));
+    assert!(!response.is_success());
+}
+
+#[test]
+fn unsupported_operation_returns_failure() {
+    let adapter = MockAdapter {
+        result: Ok(String::from("unused")),
+    };
+    let request = PluginRequest::new("extract_method", Vec::new());
+
+    let response = execute_request(&adapter, &request);
+    assert!(!response.is_success());
+}
+
+#[rstest]
+#[case::no_change(String::from("def old_name():\n    return 1\n"))]
+#[case::adapter_error(String::new())]
+fn rename_non_mutating_or_error_returns_failure(#[case] output: String) {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::String(String::from("4")),
+    );
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+
+    let adapter = if output.is_empty() {
+        MockAdapter {
+            result: Err(RopeAdapterError::EngineFailed {
+                message: String::from("rope failed"),
+            }),
+        }
+    } else {
+        MockAdapter { result: Ok(output) }
+    };
+
+    let response = execute_request(&adapter, &request_with_args(arguments));
+    assert!(!response.is_success());
+}

--- a/crates/weaver-plugin-rope/src/tests/mod.rs
+++ b/crates/weaver-plugin-rope/src/tests/mod.rs
@@ -74,7 +74,7 @@ fn rename_success_returns_diff_output(rename_arguments: HashMap<String, serde_js
 }
 
 fn remove_offset(arguments: &mut HashMap<String, serde_json::Value>) {
-    drop(arguments.remove("offset"));
+    arguments.remove("offset");
 }
 
 fn set_boolean_offset(arguments: &mut HashMap<String, serde_json::Value>) {

--- a/crates/weaver-plugin-rope/src/tests/mod.rs
+++ b/crates/weaver-plugin-rope/src/tests/mod.rs
@@ -102,11 +102,19 @@ fn set_empty_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
     );
 }
 
+fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::Number(serde_json::Number::from(42)),
+    );
+}
+
 #[rstest]
 #[case::missing_offset(remove_offset as fn(&mut _), Some("offset"))]
 #[case::boolean_offset(set_boolean_offset as fn(&mut _), Some("offset"))]
 #[case::negative_offset(set_negative_offset as fn(&mut _), Some("non-negative integer"))]
 #[case::numeric_offset_succeeds(set_numeric_offset as fn(&mut _), None)]
+#[case::numeric_new_name(set_numeric_new_name as fn(&mut _), Some("new_name argument must be a string"))]
 #[case::empty_new_name(set_empty_new_name as fn(&mut _), Some("new_name"))]
 fn rename_argument_validation(
     #[case] mutate: fn(&mut HashMap<String, serde_json::Value>),

--- a/crates/weaver-plugin-rope/src/tests/mod.rs
+++ b/crates/weaver-plugin-rope/src/tests/mod.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use rstest::rstest;
 use weaver_plugins::protocol::{FilePayload, PluginOutput, PluginRequest};
 
-use crate::{RopeAdapter, RopeAdapterError, execute_request};
+use crate::{RopeAdapter, RopeAdapterError, execute_request, run_with_adapter};
 
 struct MockAdapter {
     result: Result<String, RopeAdapterError>,
@@ -78,13 +78,14 @@ fn rename_success_returns_diff_output() {
         result: Ok(String::from("def new_name():\n    return 1\n")),
     };
 
-    let response = execute_request(&adapter, &request_with_args(arguments));
+    let response = execute_request(&adapter, &request_with_args(arguments))
+        .expect("execute_request should succeed");
     assert!(response.is_success());
     assert!(matches!(response.output(), PluginOutput::Diff { .. }));
 }
 
 #[test]
-fn rename_missing_offset_returns_failure() {
+fn rename_missing_offset_returns_error() {
     let mut arguments = HashMap::new();
     arguments.insert(
         String::from("new_name"),
@@ -95,25 +96,37 @@ fn rename_missing_offset_returns_failure() {
         result: Ok(String::from("unused")),
     };
 
-    let response = execute_request(&adapter, &request_with_args(arguments));
-    assert!(!response.is_success());
+    let err = execute_request(&adapter, &request_with_args(arguments))
+        .expect_err("missing offset should fail");
+    assert!(
+        err.contains("offset"),
+        "expected error mentioning 'offset', got: {err}"
+    );
 }
 
 #[test]
-fn unsupported_operation_returns_failure() {
+fn unsupported_operation_returns_error() {
     let adapter = MockAdapter {
         result: Ok(String::from("unused")),
     };
     let request = PluginRequest::new("extract_method", Vec::new());
 
-    let response = execute_request(&adapter, &request);
-    assert!(!response.is_success());
+    let err = execute_request(&adapter, &request).expect_err("unsupported operation should fail");
+    assert!(
+        err.contains("unsupported"),
+        "expected error mentioning 'unsupported', got: {err}"
+    );
+}
+
+enum FailureScenario {
+    NoChange,
+    AdapterError,
 }
 
 #[rstest]
-#[case::no_change(String::from("def old_name():\n    return 1\n"))]
-#[case::adapter_error(String::new())]
-fn rename_non_mutating_or_error_returns_failure(#[case] output: String) {
+#[case::no_change(FailureScenario::NoChange)]
+#[case::adapter_error(FailureScenario::AdapterError)]
+fn rename_non_mutating_or_error_returns_failure(#[case] scenario: FailureScenario) {
     let mut arguments = HashMap::new();
     arguments.insert(
         String::from("offset"),
@@ -124,16 +137,191 @@ fn rename_non_mutating_or_error_returns_failure(#[case] output: String) {
         serde_json::Value::String(String::from("new_name")),
     );
 
-    let adapter = if output.is_empty() {
-        MockAdapter {
+    let adapter = match &scenario {
+        FailureScenario::AdapterError => MockAdapter {
             result: Err(RopeAdapterError::EngineFailed {
                 message: String::from("rope failed"),
             }),
-        }
-    } else {
-        MockAdapter { result: Ok(output) }
+        },
+        FailureScenario::NoChange => MockAdapter {
+            result: Ok(String::from("def old_name():\n    return 1\n")),
+        },
     };
 
-    let response = execute_request(&adapter, &request_with_args(arguments));
+    let err = execute_request(&adapter, &request_with_args(arguments))
+        .expect_err("failure scenario should return Err");
+
+    match scenario {
+        FailureScenario::NoChange => assert!(
+            err.contains("no content changes"),
+            "expected no-change diagnostic, got: {err}"
+        ),
+        FailureScenario::AdapterError => assert!(
+            err.contains("rope failed"),
+            "expected adapter error message, got: {err}"
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// stdin/stdout dispatch layer tests (run_with_adapter)
+// ---------------------------------------------------------------------------
+
+fn valid_request_json() -> String {
+    let request = request_with_args({
+        let mut args = HashMap::new();
+        args.insert(
+            String::from("offset"),
+            serde_json::Value::String(String::from("4")),
+        );
+        args.insert(
+            String::from("new_name"),
+            serde_json::Value::String(String::from("new_name")),
+        );
+        args
+    });
+    serde_json::to_string(&request).expect("serialize request")
+}
+
+#[test]
+fn run_with_adapter_writes_success_response_to_stdout() {
+    let input = format!("{}\n", valid_request_json());
+    let mut stdin = std::io::Cursor::new(input.into_bytes());
+    let mut stdout = Vec::new();
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("def new_name():\n    return 1\n")),
+    };
+    run_with_adapter(&mut stdin, &mut stdout, &adapter).expect("dispatch should succeed");
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let response: weaver_plugins::protocol::PluginResponse =
+        serde_json::from_str(output.trim()).expect("parse response");
+    assert!(response.is_success());
+}
+
+#[test]
+fn run_with_adapter_returns_failure_for_empty_stdin() {
+    let mut stdin = std::io::Cursor::new(Vec::new());
+    let mut stdout = Vec::new();
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("unused")),
+    };
+    run_with_adapter(&mut stdin, &mut stdout, &adapter).expect("dispatch should succeed");
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let response: weaver_plugins::protocol::PluginResponse =
+        serde_json::from_str(output.trim()).expect("parse response");
     assert!(!response.is_success());
+}
+
+#[test]
+fn run_with_adapter_returns_failure_for_invalid_json() {
+    let mut stdin = std::io::Cursor::new(b"not valid json\n".to_vec());
+    let mut stdout = Vec::new();
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("unused")),
+    };
+    run_with_adapter(&mut stdin, &mut stdout, &adapter).expect("dispatch should succeed");
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let response: weaver_plugins::protocol::PluginResponse =
+        serde_json::from_str(output.trim()).expect("parse response");
+    assert!(!response.is_success());
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rename_offset_as_number_value_succeeds() {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::Number(serde_json::Number::from(4)),
+    );
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("def new_name():\n    return 1\n")),
+    };
+
+    let response = execute_request(&adapter, &request_with_args(arguments))
+        .expect("numeric offset should succeed");
+    assert!(response.is_success());
+}
+
+#[test]
+fn rename_offset_as_boolean_returns_error() {
+    let mut arguments = HashMap::new();
+    arguments.insert(String::from("offset"), serde_json::Value::Bool(true));
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("unused")),
+    };
+
+    let err = execute_request(&adapter, &request_with_args(arguments))
+        .expect_err("boolean offset should fail");
+    assert!(
+        err.contains("offset"),
+        "expected error mentioning 'offset', got: {err}"
+    );
+}
+
+#[test]
+fn rename_empty_new_name_returns_error() {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::String(String::from("4")),
+    );
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("  ")),
+    );
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("unused")),
+    };
+
+    let err = execute_request(&adapter, &request_with_args(arguments))
+        .expect_err("empty new_name should fail");
+    assert!(
+        err.contains("new_name"),
+        "expected error mentioning 'new_name', got: {err}"
+    );
+}
+
+#[test]
+fn rename_negative_offset_string_returns_error() {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::String(String::from("-1")),
+    );
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+
+    let adapter = MockAdapter {
+        result: Ok(String::from("unused")),
+    };
+
+    let err = execute_request(&adapter, &request_with_args(arguments))
+        .expect_err("negative offset should fail");
+    assert!(
+        err.contains("non-negative integer"),
+        "expected error mentioning 'non-negative integer', got: {err}"
+    );
 }

--- a/crates/weaver-plugin-rope/tests/features/rope_plugin.feature
+++ b/crates/weaver-plugin-rope/tests/features/rope_plugin.feature
@@ -1,0 +1,32 @@
+Feature: Rope actuator plugin
+
+  Scenario: Rename succeeds with diff output
+    Given a rename request with required arguments
+    When the plugin executes the request
+    Then the plugin returns successful diff output
+
+  Scenario: Rename fails when offset is missing
+    Given a rename request missing offset
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "offset"
+
+  Scenario: Unsupported operation fails with diagnostics
+    Given an unsupported extract method request
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "unsupported"
+
+  Scenario: Adapter failures are surfaced
+    Given a rename request with required arguments
+    And a rope adapter that fails
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "rope engine failed"
+
+  Scenario: Unchanged output is treated as failure
+    Given a rename request with required arguments
+    And a rope adapter that returns unchanged content
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "no content changes"

--- a/crates/weaverd/Cargo.toml
+++ b/crates/weaverd/Cargo.toml
@@ -25,6 +25,7 @@ tempfile.workspace = true
 
 [dev-dependencies]
 derive_more = { version = "1.0", features = ["as_ref", "deref"] }
+mockall.workspace = true
 rstest.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-macros.workspace = true

--- a/crates/weaverd/src/dispatch/act/refactor/behaviour.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/behaviour.rs
@@ -110,7 +110,8 @@ impl RefactorWorld {
             &self.request,
             &mut writer,
             &mut backends,
-            RefactorDependencies::new(self.workspace.path(), &runtime),
+            self.workspace.path(),
+            &runtime,
         )
         .map(|dispatch| dispatch.status);
 

--- a/crates/weaverd/src/dispatch/act/refactor/behaviour.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/behaviour.rs
@@ -1,0 +1,237 @@
+//! Behavioural tests for the `act refactor` handler.
+
+use std::path::PathBuf;
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use tempfile::TempDir;
+use weaver_config::{CapabilityMatrix, Config, SocketEndpoint};
+use weaver_plugins::{PluginError, PluginOutput, PluginRequest, PluginResponse};
+
+use super::*;
+
+const ORIGINAL_CONTENT: &str = "hello world\n";
+const UPDATED_CONTENT: &str = "hello woven\n";
+const VALID_DIFF: &str = concat!(
+    "diff --git a/notes.txt b/notes.txt\n",
+    "<<<<<<< SEARCH\n",
+    "hello world\n",
+    "=======\n",
+    "hello woven\n",
+    ">>>>>>> REPLACE\n",
+);
+const MALFORMED_DIFF: &str = concat!(
+    "diff --git a/notes.txt\n",
+    "<<<<<<< SEARCH\n",
+    "hello world\n",
+    "=======\n",
+    "hello woven\n",
+    ">>>>>>> REPLACE\n",
+);
+
+#[derive(Clone, Copy, Default)]
+enum RuntimeMode {
+    #[default]
+    DiffSuccess,
+    RuntimeError,
+    MalformedDiff,
+}
+
+struct MockRuntime {
+    mode: RuntimeMode,
+}
+
+impl RefactorPluginRuntime for MockRuntime {
+    fn execute(
+        &self,
+        _provider: &str,
+        _request: &PluginRequest,
+    ) -> Result<PluginResponse, PluginError> {
+        match self.mode {
+            RuntimeMode::DiffSuccess => Ok(PluginResponse::success(PluginOutput::Diff {
+                content: String::from(VALID_DIFF),
+            })),
+            RuntimeMode::RuntimeError => Err(PluginError::NotFound {
+                name: String::from("rope"),
+            }),
+            RuntimeMode::MalformedDiff => Ok(PluginResponse::success(PluginOutput::Diff {
+                content: String::from(MALFORMED_DIFF),
+            })),
+        }
+    }
+}
+
+struct RefactorWorld {
+    workspace: TempDir,
+    request: CommandRequest,
+    runtime_mode: RuntimeMode,
+    dispatch_result: Option<Result<i32, DispatchError>>,
+    response_stream: String,
+}
+
+impl RefactorWorld {
+    fn new() -> Self {
+        Self {
+            workspace: TempDir::new().expect("workspace"),
+            request: command_request(vec![
+                String::from("--provider"),
+                String::from("rope"),
+                String::from("--refactoring"),
+                String::from("rename"),
+                String::from("--file"),
+                String::from("notes.txt"),
+            ]),
+            runtime_mode: RuntimeMode::DiffSuccess,
+            dispatch_result: None,
+            response_stream: String::new(),
+        }
+    }
+
+    fn path(&self, relative: &str) -> PathBuf {
+        self.workspace.path().join(relative)
+    }
+
+    fn write_file(&self, relative: &str, content: &str) {
+        std::fs::write(self.path(relative), content).expect("write file");
+    }
+
+    fn read_file(&self, relative: &str) -> String {
+        std::fs::read_to_string(self.path(relative)).expect("read file")
+    }
+
+    fn execute(&mut self) {
+        let runtime = MockRuntime {
+            mode: self.runtime_mode,
+        };
+        let mut output = Vec::new();
+        let mut writer = ResponseWriter::new(&mut output);
+        let mut backends = build_backends();
+        let result = handle(
+            &self.request,
+            &mut writer,
+            &mut backends,
+            RefactorDependencies::new(self.workspace.path(), &runtime),
+        )
+        .map(|dispatch| dispatch.status);
+
+        self.dispatch_result = Some(result);
+        self.response_stream = String::from_utf8(output).expect("response utf8");
+    }
+}
+
+fn command_request(arguments: Vec<String>) -> CommandRequest {
+    CommandRequest {
+        command: CommandDescriptor {
+            domain: String::from("act"),
+            operation: String::from("refactor"),
+        },
+        arguments,
+        patch: None,
+    }
+}
+
+fn build_backends() -> FusionBackends<SemanticBackendProvider> {
+    let config = Config {
+        daemon_socket: SocketEndpoint::unix("/tmp/weaver-test/socket.sock"),
+        ..Config::default()
+    };
+    let provider = SemanticBackendProvider::new(CapabilityMatrix::default());
+    FusionBackends::new(config, provider)
+}
+
+#[fixture]
+fn world() -> RefactorWorld {
+    RefactorWorld::new()
+}
+
+#[given("a workspace file for refactoring")]
+fn given_workspace_file(world: &mut RefactorWorld) {
+    world.write_file("notes.txt", ORIGINAL_CONTENT);
+}
+
+#[given("a valid act refactor request")]
+fn given_valid_request(world: &mut RefactorWorld) {
+    world.request = command_request(vec![
+        String::from("--provider"),
+        String::from("rope"),
+        String::from("--refactoring"),
+        String::from("rename"),
+        String::from("--file"),
+        String::from("notes.txt"),
+        String::from("offset=1"),
+        String::from("new_name=woven"),
+    ]);
+}
+
+#[given("a refactor request missing provider")]
+fn given_missing_provider_request(world: &mut RefactorWorld) {
+    world.request = command_request(vec![
+        String::from("--refactoring"),
+        String::from("rename"),
+        String::from("--file"),
+        String::from("notes.txt"),
+    ]);
+}
+
+#[given("a runtime error from the refactor plugin")]
+fn given_runtime_error(world: &mut RefactorWorld) {
+    world.runtime_mode = RuntimeMode::RuntimeError;
+}
+
+#[given("a malformed diff response from the refactor plugin")]
+fn given_malformed_diff(world: &mut RefactorWorld) {
+    world.runtime_mode = RuntimeMode::MalformedDiff;
+}
+
+#[when("the act refactor command executes")]
+fn when_refactor_executes(world: &mut RefactorWorld) {
+    world.execute();
+}
+
+#[then("the refactor command succeeds")]
+fn then_refactor_succeeds(world: &mut RefactorWorld) {
+    let result = world.dispatch_result.as_ref().expect("result missing");
+    let status = result.as_ref().expect("status should be present");
+    assert_eq!(*status, 0);
+}
+
+#[then("the refactor command fails with status 1")]
+fn then_refactor_fails_status_one(world: &mut RefactorWorld) {
+    let result = world.dispatch_result.as_ref().expect("result missing");
+    let status = result.as_ref().expect("status should be present");
+    assert_eq!(*status, 1);
+}
+
+#[then("the refactor command is rejected as invalid arguments")]
+fn then_refactor_rejected_invalid_arguments(world: &mut RefactorWorld) {
+    let result = world.dispatch_result.as_ref().expect("result missing");
+    assert!(matches!(
+        result,
+        Err(DispatchError::InvalidArguments { .. })
+    ));
+}
+
+#[then("the target file is updated")]
+fn then_target_file_updated(world: &mut RefactorWorld) {
+    let updated = world.read_file("notes.txt");
+    assert_eq!(updated, UPDATED_CONTENT);
+}
+
+#[then("the target file is unchanged")]
+fn then_target_file_unchanged(world: &mut RefactorWorld) {
+    let updated = world.read_file("notes.txt");
+    assert_eq!(updated, ORIGINAL_CONTENT);
+}
+
+#[then("the stderr stream contains {text}")]
+fn then_stderr_contains(world: &mut RefactorWorld, text: String) {
+    let needle = text.trim_matches('"');
+    assert!(
+        world.response_stream.contains(needle),
+        "expected response stream to contain '{needle}', got: {}",
+        world.response_stream
+    );
+}
+
+#[scenario(path = "tests/features/refactor.feature")]
+fn refactor_behaviour(#[from(world)] _world: RefactorWorld) {}

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -1,0 +1,216 @@
+//! Unit tests for the `act refactor` handler.
+
+use std::path::Path;
+
+use rstest::rstest;
+use tempfile::TempDir;
+use weaver_config::{CapabilityMatrix, Config, SocketEndpoint};
+use weaver_plugins::{PluginError, PluginOutput, PluginRequest, PluginResponse};
+
+use super::{
+    DispatchError, FusionBackends, RefactorDependencies, RefactorPluginRuntime, ResponseWriter,
+    default_runtime, handle, resolve_rope_plugin_path,
+};
+use crate::dispatch::request::{CommandDescriptor, CommandRequest};
+use crate::semantic_provider::SemanticBackendProvider;
+
+enum MockRuntimeResult {
+    Success(PluginResponse),
+    NotFound(String),
+}
+
+struct MockRuntime {
+    result: MockRuntimeResult,
+}
+
+impl RefactorPluginRuntime for MockRuntime {
+    fn execute(
+        &self,
+        _provider: &str,
+        _request: &PluginRequest,
+    ) -> Result<PluginResponse, PluginError> {
+        match &self.result {
+            MockRuntimeResult::Success(response) => Ok(response.clone()),
+            MockRuntimeResult::NotFound(name) => Err(PluginError::NotFound { name: name.clone() }),
+        }
+    }
+}
+
+fn command_request(arguments: Vec<String>) -> CommandRequest {
+    CommandRequest {
+        command: CommandDescriptor {
+            domain: String::from("act"),
+            operation: String::from("refactor"),
+        },
+        arguments,
+        patch: None,
+    }
+}
+
+fn build_backends() -> FusionBackends<SemanticBackendProvider> {
+    let config = Config {
+        daemon_socket: SocketEndpoint::unix("/tmp/weaver-test/socket.sock"),
+        ..Config::default()
+    };
+    let provider = SemanticBackendProvider::new(CapabilityMatrix::default());
+    FusionBackends::new(config, provider)
+}
+
+#[test]
+fn handle_returns_error_for_missing_provider() {
+    let request = command_request(vec![
+        String::from("--refactoring"),
+        String::from("rename"),
+        String::from("--file"),
+        String::from("notes.txt"),
+    ]);
+    let mut backends = build_backends();
+    let mut output = Vec::new();
+    let mut writer = ResponseWriter::new(&mut output);
+    let runtime = MockRuntime {
+        result: MockRuntimeResult::NotFound(String::from("rope")),
+    };
+
+    let result = handle(
+        &request,
+        &mut writer,
+        &mut backends,
+        RefactorDependencies::new(Path::new("/tmp/workspace"), &runtime),
+    );
+
+    assert!(matches!(
+        result,
+        Err(DispatchError::InvalidArguments { .. })
+    ));
+}
+
+#[test]
+fn handle_runtime_error_returns_status_one() {
+    let workspace = TempDir::new().expect("workspace");
+    let file_path = workspace.path().join("notes.txt");
+    std::fs::write(&file_path, "hello\n").expect("write");
+
+    let request = command_request(vec![
+        String::from("--provider"),
+        String::from("rope"),
+        String::from("--refactoring"),
+        String::from("rename"),
+        String::from("--file"),
+        String::from("notes.txt"),
+    ]);
+    let runtime = MockRuntime {
+        result: MockRuntimeResult::NotFound(String::from("rope")),
+    };
+    let mut backends = build_backends();
+    let mut output = Vec::new();
+    let mut writer = ResponseWriter::new(&mut output);
+
+    let result = handle(
+        &request,
+        &mut writer,
+        &mut backends,
+        RefactorDependencies::new(workspace.path(), &runtime),
+    )
+    .expect("dispatch result");
+
+    assert_eq!(result.status, 1);
+    let stderr = String::from_utf8(output).expect("stderr utf8");
+    assert!(stderr.contains("act refactor failed"));
+}
+
+#[rstest]
+#[case::analysis(PluginOutput::Analysis { data: serde_json::json!({"k": "v"}) })]
+#[case::empty(PluginOutput::Empty)]
+fn handle_non_diff_output_returns_status_one(#[case] output_variant: PluginOutput) {
+    let workspace = TempDir::new().expect("workspace");
+    let file_path = workspace.path().join("notes.txt");
+    std::fs::write(&file_path, "hello\n").expect("write");
+
+    let request = command_request(vec![
+        String::from("--provider"),
+        String::from("rope"),
+        String::from("--refactoring"),
+        String::from("rename"),
+        String::from("--file"),
+        String::from("notes.txt"),
+    ]);
+    let runtime = MockRuntime {
+        result: MockRuntimeResult::Success(PluginResponse::success(output_variant)),
+    };
+    let mut backends = build_backends();
+    let mut output = Vec::new();
+    let mut writer = ResponseWriter::new(&mut output);
+
+    let result = handle(
+        &request,
+        &mut writer,
+        &mut backends,
+        RefactorDependencies::new(workspace.path(), &runtime),
+    )
+    .expect("dispatch result");
+
+    assert_eq!(result.status, 1);
+    let stderr = String::from_utf8(output).expect("stderr utf8");
+    assert!(stderr.contains("did not return diff output"));
+}
+
+#[test]
+fn handle_diff_output_applies_patch_through_apply_patch_pipeline() {
+    let workspace = TempDir::new().expect("workspace");
+    let relative_file = String::from("notes.txt");
+    let file_path = workspace.path().join(&relative_file);
+    std::fs::write(&file_path, "hello world\n").expect("write");
+
+    let diff = concat!(
+        "diff --git a/notes.txt b/notes.txt\n",
+        "<<<<<<< SEARCH\n",
+        "hello world\n",
+        "=======\n",
+        "hello woven\n",
+        ">>>>>>> REPLACE\n",
+    );
+    let runtime = MockRuntime {
+        result: MockRuntimeResult::Success(PluginResponse::success(PluginOutput::Diff {
+            content: String::from(diff),
+        })),
+    };
+    let request = command_request(vec![
+        String::from("--provider"),
+        String::from("rope"),
+        String::from("--refactoring"),
+        String::from("rename"),
+        String::from("--file"),
+        relative_file.clone(),
+    ]);
+    let mut backends = build_backends();
+    let mut output = Vec::new();
+    let mut writer = ResponseWriter::new(&mut output);
+
+    let result = handle(
+        &request,
+        &mut writer,
+        &mut backends,
+        RefactorDependencies::new(workspace.path(), &runtime),
+    )
+    .expect("dispatch result");
+
+    assert_eq!(result.status, 0);
+    let updated = std::fs::read_to_string(workspace.path().join(relative_file)).expect("read");
+    assert_eq!(updated, "hello woven\n");
+    let stdout = String::from_utf8(output).expect("stdout utf8");
+    assert!(stdout.contains("\"kind\":\"stream\""));
+}
+
+#[test]
+fn resolve_rope_plugin_path_makes_relative_overrides_absolute() {
+    let path = resolve_rope_plugin_path(Some(std::ffi::OsString::from("bin/rope")));
+    assert!(path.is_absolute());
+}
+
+#[test]
+fn default_runtime_returns_shared_trait_object() {
+    let runtime = default_runtime();
+    let request = PluginRequest::new("rename", Vec::new());
+    let result = runtime.execute("rope", &request);
+    assert!(result.is_err());
+}

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -8,8 +8,8 @@ use weaver_config::{CapabilityMatrix, Config, SocketEndpoint};
 use weaver_plugins::{PluginError, PluginOutput, PluginRequest, PluginResponse};
 
 use super::{
-    DispatchError, FusionBackends, RefactorDependencies, RefactorPluginRuntime, ResponseWriter,
-    default_runtime, handle, resolve_rope_plugin_path,
+    DispatchError, FusionBackends, RefactorPluginRuntime, ResponseWriter, default_runtime, handle,
+    resolve_rope_plugin_path,
 };
 use crate::dispatch::request::{CommandDescriptor, CommandRequest};
 use crate::semantic_provider::SemanticBackendProvider;
@@ -75,7 +75,8 @@ fn handle_returns_error_for_missing_provider() {
         &request,
         &mut writer,
         &mut backends,
-        RefactorDependencies::new(Path::new("/tmp/workspace"), &runtime),
+        Path::new("/tmp/workspace"),
+        &runtime,
     );
 
     assert!(matches!(
@@ -109,7 +110,8 @@ fn handle_runtime_error_returns_status_one() {
         &request,
         &mut writer,
         &mut backends,
-        RefactorDependencies::new(workspace.path(), &runtime),
+        workspace.path(),
+        &runtime,
     )
     .expect("dispatch result");
 
@@ -145,7 +147,8 @@ fn handle_non_diff_output_returns_status_one(#[case] output_variant: PluginOutpu
         &request,
         &mut writer,
         &mut backends,
-        RefactorDependencies::new(workspace.path(), &runtime),
+        workspace.path(),
+        &runtime,
     )
     .expect("dispatch result");
 
@@ -190,7 +193,8 @@ fn handle_diff_output_applies_patch_through_apply_patch_pipeline() {
         &request,
         &mut writer,
         &mut backends,
-        RefactorDependencies::new(workspace.path(), &runtime),
+        workspace.path(),
+        &runtime,
     )
     .expect("dispatch result");
 

--- a/crates/weaverd/src/dispatch/router.rs
+++ b/crates/weaverd/src/dispatch/router.rs
@@ -213,9 +213,11 @@ impl DomainRouter {
             "refactor" => act::refactor::handle(
                 request,
                 writer,
-                backends,
-                &self.workspace_root,
-                self.refactor_runtime.as_ref(),
+                act::refactor::RefactorContext {
+                    backends,
+                    workspace_root: &self.workspace_root,
+                    runtime: self.refactor_runtime.as_ref(),
+                },
             ),
             _ => Self::route_fallback(&DomainRoutingContext::ACT, operation.as_str(), writer),
         }

--- a/crates/weaverd/src/dispatch/router.rs
+++ b/crates/weaverd/src/dispatch/router.rs
@@ -143,6 +143,22 @@ impl DomainRouter {
         }
     }
 
+    /// Creates a domain router with a custom refactor runtime.
+    #[cfg(test)]
+    #[expect(
+        dead_code,
+        reason = "builder for test-injected runtimes; used by future tests"
+    )]
+    pub fn with_runtime(
+        workspace_root: PathBuf,
+        runtime: Arc<dyn act::refactor::RefactorPluginRuntime + Send + Sync>,
+    ) -> Self {
+        Self {
+            workspace_root,
+            refactor_runtime: runtime,
+        }
+    }
+
     /// Routes a command request to the appropriate domain handler.
     ///
     /// # Errors
@@ -198,10 +214,8 @@ impl DomainRouter {
                 request,
                 writer,
                 backends,
-                act::refactor::RefactorDependencies::new(
-                    &self.workspace_root,
-                    self.refactor_runtime.as_ref(),
-                ),
+                &self.workspace_root,
+                self.refactor_runtime.as_ref(),
             ),
             _ => Self::route_fallback(&DomainRoutingContext::ACT, operation.as_str(), writer),
         }

--- a/crates/weaverd/tests/features/refactor.feature
+++ b/crates/weaverd/tests/features/refactor.feature
@@ -1,0 +1,32 @@
+Feature: Act refactor
+
+  Scenario: Refactor applies a valid plugin diff
+    Given a workspace file for refactoring
+    And a valid act refactor request
+    When the act refactor command executes
+    Then the refactor command succeeds
+    And the target file is updated
+
+  Scenario: Refactor reports plugin runtime failures
+    Given a workspace file for refactoring
+    And a valid act refactor request
+    And a runtime error from the refactor plugin
+    When the act refactor command executes
+    Then the refactor command fails with status 1
+    And the target file is unchanged
+    And the stderr stream contains "act refactor failed"
+
+  Scenario: Refactor rejects malformed plugin diffs
+    Given a workspace file for refactoring
+    And a valid act refactor request
+    And a malformed diff response from the refactor plugin
+    When the act refactor command executes
+    Then the refactor command fails with status 1
+    And the target file is unchanged
+
+  Scenario: Refactor validates required arguments
+    Given a workspace file for refactoring
+    And a refactor request missing provider
+    When the act refactor command executes
+    Then the refactor command is rejected as invalid arguments
+    And the target file is unchanged

--- a/docs/execplans/3-1-1a-plugin-for-rope.md
+++ b/docs/execplans/3-1-1a-plugin-for-rope.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE (2026-02-13)
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root.
@@ -91,12 +91,19 @@ Observable success:
 
 - [x] (2026-02-12 00:00Z) Drafted ExecPlan at
       `docs/execplans/3-1-1a-plugin-for-rope.md`.
-- [ ] Validate assumptions about plugin bootstrap and executable discovery.
-- [ ] Implement rope plugin crate and protocol adapter.
-- [ ] Wire `act refactor` to execute plugin and pass diff through Double-Lock.
-- [ ] Add unit and `rstest-bdd` behavioural tests for happy/unhappy/edge paths.
-- [ ] Update design/user docs and mark roadmap item done.
-- [ ] Run `make check-fmt`, `make lint`, and `make test` successfully.
+- [x] (2026-02-13 01:30Z) Validated plugin bootstrap assumptions and added
+      executable override via `WEAVER_ROPE_PLUGIN_PATH`.
+- [x] (2026-02-13 02:00Z) Implemented `crates/weaver-plugin-rope/` with
+      protocol handling, rope adapter boundary, and error mapping.
+- [x] (2026-02-13 02:20Z) Wired `act refactor` to execute plugins and route
+      diff output through the existing Double-Lock apply-patch flow.
+- [x] (2026-02-13 02:50Z) Added unit, behavioural (`rstest-bdd` 0.5.0), and
+      e2e (`assert_cmd` + `insta`) tests for happy, unhappy, and edge paths.
+- [x] (2026-02-13 03:00Z) Updated design and user documentation and marked the
+      roadmap rope entry as done.
+- [x] (2026-02-13 03:20Z) Ran full quality gates successfully:
+      `make fmt`, `make check-fmt`, `make lint`, `make test`,
+      `make markdownlint`, and `make nixie`.
 
 ## Surprises & Discoveries
 
@@ -123,9 +130,30 @@ Observable success:
   Rationale: deterministic tests with clear unhappy-path coverage. Date/Author:
   2026-02-12 / Codex
 
+- Decision: add e2e command-ergonomics snapshots with a fake daemon instead of
+  requiring a real rope runtime in e2e tests. Rationale: validates CLI usage
+  and JSONL command shapes deterministically while keeping tests hermetic.
+  Date/Author: 2026-02-13 / Codex
+
 ## Outcomes & Retrospective
 
-Pending implementation.
+- `act refactor --provider rope` now executes a sandboxed plugin runtime in
+  `weaverd`, requiring `PluginOutput::Diff` and forwarding diff application to
+  the existing `act apply-patch` Double-Lock path.
+- Added `crates/weaver-plugin-rope/` as the first concrete actuator plugin.
+  The first shipped operation is `rename`, with required arguments `offset` and
+  `new_name`.
+- Added daemon/runtime unit tests and behavioural tests to cover success,
+  runtime failures, malformed diff responses, missing arguments, and no-change
+  edge cases.
+- Added end-to-end ergonomics tests in `crates/weaver-e2e/` using
+  `assert_cmd` and `insta` for:
+  - isolated `act refactor` invocation;
+  - pipeline invocation chaining `observe` output through `jq`.
+- Updated `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+  to reflect shipped behaviour and configuration.
+- Full repository quality gates passed after implementation and documentation
+  updates.
 
 ## Context and orientation
 
@@ -157,8 +185,7 @@ Testing and style references:
 
 Define the concrete scope for Phase 3.1.1a:
 
-- supported rope operations for first release (`rename` and one additional
-  rope-native operation, e.g. `extract_method`),
+- supported rope operations for first release (`rename` only),
 - required operation arguments and error envelopes,
 - plugin executable discovery/bootstrap strategy for `weaverd`.
 

--- a/docs/execplans/3-1-1a-plugin-for-rope.md
+++ b/docs/execplans/3-1-1a-plugin-for-rope.md
@@ -1,0 +1,372 @@
+# Implement the first actuator plugin for `rope`
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root.
+
+`PLANS.md` is not present in this repository, so no additional plan governance
+applies beyond `AGENTS.md` and this ExecPlan.
+
+## Purpose / big picture
+
+Deliver the first real specialist actuator plugin by integrating `rope` for
+Python refactoring. After this work, `weaver act refactor --provider rope`
+executes a sandboxed rope-backed plugin, receives a unified diff, and applies
+it through the existing Double-Lock safety harness so no filesystem changes are
+committed on syntactic or semantic failure.
+
+Observable success:
+
+- `act refactor` with `--provider rope` succeeds for supported operations and
+  modifies files only after lock verification.
+- Unsupported operations, missing arguments, timeout, plugin protocol errors,
+  and lock failures return structured failures and leave files unchanged.
+- Unit and behavioural tests (`rstest-bdd` v0.5.0) cover happy paths,
+  unhappy paths, and edge cases.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+  reflect the shipped behaviour.
+- `make check-fmt`, `make lint`, and `make test` succeed.
+
+## Constraints
+
+- Keep all execution synchronous (no async runtime introduction).
+- Keep plugin execution sandboxed via `weaver-sandbox` and
+  `weaver-plugins::process::SandboxExecutor`.
+- Do not bypass the Double-Lock harness for plugin-produced edits.
+- Continue using `rstest-bdd` v0.5.0 and write new behavioural tests with
+  mutable world fixtures (`&mut World`) for new scenarios.
+- Keep module-level `//!` comments and rustdoc for public items; follow
+  guidance in `docs/rust-doctest-dry-guide.md`.
+- Keep files under 400 lines by splitting modules where needed.
+- Prefer dependency injection and trait boundaries for non-deterministic
+  concerns (process spawning, rope adapter behaviour), per
+  `docs/reliable-testing-in-rust-via-dependency-injection.md`.
+- Run quality gates with `tee` and `set -o pipefail` before finishing.
+- Update user-facing docs and roadmap status in the same change.
+
+## Tolerances (exception triggers)
+
+- Scope: if delivery requires touching more than 24 files or ~2200 net lines,
+  stop and escalate.
+- Interface: if public protocol schema in
+  `crates/weaver-plugins/src/protocol/mod.rs` must break compatibility, stop
+  and escalate.
+- Dependencies: if adding new external crates beyond those already in the
+  workspace becomes necessary, stop and escalate with justification.
+- Iterations: if the same failing test loop repeats 5 times without progress,
+  stop and escalate.
+- Tooling: if rope cannot be executed in CI-compatible tests without unstable
+  harness workarounds, stop and escalate with options.
+
+## Risks
+
+- Risk: `rope` runtime dependency may be missing in some environments.
+  Severity: high. Likelihood: medium. Mitigation: keep runtime behaviour
+  explicit when rope is unavailable and use DI-based unit/BDD tests that do not
+  require a global rope installation.
+
+- Risk: plugin diff output may not match `apply-patch` parser expectations.
+  Severity: high. Likelihood: medium. Mitigation: reuse `apply_patch`
+  parser/executor path for plugin diffs and add contract tests around diff
+  format compatibility.
+
+- Risk: sandbox profile may be too restrictive for rope adapter execution.
+  Severity: medium. Likelihood: medium. Mitigation: explicitly model required
+  executable/path allowances in manifest bootstrap and add failure tests for
+  denied execution.
+
+- Risk: adding runtime plugin state to dispatch may increase coupling.
+  Severity: medium. Likelihood: medium. Mitigation: introduce a small runtime
+  abstraction and keep routing logic thin, with unit tests around dependency
+  boundaries.
+
+## Progress
+
+- [x] (2026-02-12 00:00Z) Drafted ExecPlan at
+      `docs/execplans/3-1-1a-plugin-for-rope.md`.
+- [ ] Validate assumptions about plugin bootstrap and executable discovery.
+- [ ] Implement rope plugin crate and protocol adapter.
+- [ ] Wire `act refactor` to execute plugin and pass diff through Double-Lock.
+- [ ] Add unit and `rstest-bdd` behavioural tests for happy/unhappy/edge paths.
+- [ ] Update design/user docs and mark roadmap item done.
+- [ ] Run `make check-fmt`, `make lint`, and `make test` successfully.
+
+## Surprises & Discoveries
+
+- Observation: project memory MCP resources were not available in this session
+  (`list_mcp_resources` returned no servers/resources). Evidence: tool output
+  returned empty resource lists. Impact: planning relied on repository docs and
+  code inspection only.
+
+## Decision Log
+
+- Decision: implement a dedicated rope plugin executable crate in this phase,
+  rather than embedding rope-specific logic into `weaverd`. Rationale:
+  preserves plugin architecture boundaries and keeps specialist refactoring
+  logic replaceable. Date/Author: 2026-02-12 / Codex
+
+- Decision: route plugin-produced unified diffs through the existing
+  `act apply-patch` execution path rather than introducing a second
+  patch-application implementation. Rationale: avoids duplicated
+  safety-critical logic and guarantees lock behaviour parity. Date/Author:
+  2026-02-12 / Codex
+
+- Decision: use DI boundaries for rope-adapter invocation and plugin runtime
+  integration so tests do not depend on a system-wide rope installation.
+  Rationale: deterministic tests with clear unhappy-path coverage. Date/Author:
+  2026-02-12 / Codex
+
+## Outcomes & Retrospective
+
+Pending implementation.
+
+## Context and orientation
+
+Relevant existing components:
+
+- `crates/weaver-plugins/` provides manifest, registry, process execution, and
+  runner abstractions for sandboxed plugins.
+- `crates/weaverd/src/dispatch/act/refactor/mod.rs` currently parses request
+  arguments and builds a `PluginRequest`, but returns a "plugin execution not
+  yet available" status.
+- `crates/weaverd/src/dispatch/act/apply_patch/mod.rs` contains the existing
+  patch parser + transaction flow that already enforces Double-Lock semantics.
+- `crates/weaverd/src/process/launch.rs` constructs the dispatch runtime.
+- `docs/roadmap.md` Phase 3 still marks rope plugin as incomplete.
+- `docs/users-guide.md` currently documents `act refactor` as not yet wired
+  end-to-end.
+
+Testing and style references:
+
+- `docs/rust-testing-with-rstest-fixtures.md`
+- `docs/rstest-bdd-users-guide.md`
+- `docs/reliable-testing-in-rust-via-dependency-injection.md`
+- `docs/complexity-antipatterns-and-refactoring-strategies.md`
+- `docs/rust-doctest-dry-guide.md`
+
+## Plan of work
+
+### Stage A: finalise runtime contract and boundaries
+
+Define the concrete scope for Phase 3.1.1a:
+
+- supported rope operations for first release (`rename` and one additional
+  rope-native operation, e.g. `extract_method`),
+- required operation arguments and error envelopes,
+- plugin executable discovery/bootstrap strategy for `weaverd`.
+
+Record these decisions in `docs/weaver-design.md` before implementation.
+
+Go/no-go check:
+
+- A single written contract exists for request arguments, plugin output, and
+  failure semantics.
+
+### Stage B: implement the rope plugin executable crate
+
+Add new crate `crates/weaver-plugin-rope/` (workspace member) that:
+
+- reads one `PluginRequest` JSONL line from stdin,
+- validates operation + arguments,
+- performs rope-backed refactoring via an adapter boundary,
+- emits one `PluginResponse` JSONL line to stdout, with `PluginOutput::Diff`
+  on success or diagnostics on failure.
+
+Implementation notes:
+
+- Keep main orchestration small; split argument parsing, rope adapter, and diff
+  rendering into focused modules to avoid high cognitive complexity.
+- Add rustdoc usage examples for public APIs where non-trivial.
+- Ensure error mapping is explicit and stable.
+
+Go/no-go check:
+
+- `cargo test -p weaver-plugin-rope` passes including unhappy-path coverage.
+
+### Stage C: add daemon plugin runtime bootstrap for rope
+
+Extend `weaverd` runtime construction so `DomainRouter`/`act refactor` can
+execute plugins, including rope manifest registration.
+
+Likely touch points:
+
+- `crates/weaverd/src/process/launch.rs`
+- `crates/weaverd/src/dispatch/handler.rs`
+- `crates/weaverd/src/dispatch/router.rs`
+- new small runtime wiring module under `crates/weaverd/src/dispatch/`
+
+Requirements:
+
+- register rope plugin manifest with absolute executable path,
+- return clear configuration/runtime errors when rope plugin is unavailable,
+- keep runtime state testable via trait abstraction or injected executor.
+
+Go/no-go check:
+
+- unit tests can execute `act refactor` path with a mock executor without
+  spawning external processes.
+
+### Stage D: wire `act refactor` through plugin execution + Double-Lock
+
+Replace current stub behaviour in
+`crates/weaverd/src/dispatch/act/refactor/mod.rs` with end-to-end flow:
+
+- parse and validate refactor arguments,
+- read target file payload,
+- execute provider plugin via runtime runner,
+- require diff output for actuator success,
+- feed diff through shared patch-execution path used by `apply-patch`,
+- return structured success/failure to caller.
+
+Refactor/compose `apply_patch` internals as needed so this path reuses existing
+patch validation and transaction logic rather than copying it.
+
+Go/no-go check:
+
+- successful rope response writes validated changes,
+- syntactic/semantic failures leave files unchanged,
+- invalid plugin responses fail safely.
+
+### Stage E: tests (unit + behavioural)
+
+Add or update tests in both plugin and daemon layers.
+
+Unit tests:
+
+- rope plugin argument validation and operation dispatch,
+- rope adapter error mapping,
+- diff payload construction and protocol serialization,
+- refactor handler flow using mock plugin executor and lock outcomes.
+
+Behavioural tests (`rstest-bdd` v0.5.0, `&mut` worlds):
+
+- happy: rope rename operation produces diff and commits after locks pass,
+- unhappy: missing required operation argument,
+- unhappy: unsupported refactoring operation,
+- unhappy: plugin timeout/non-zero execution error,
+- edge: plugin returns malformed/empty diff and filesystem remains unchanged,
+- edge: lock rejection rolls back changes.
+
+Likely files:
+
+- `crates/weaver-plugin-rope/tests/features/rope_plugin.feature`
+- `crates/weaver-plugin-rope/src/tests/behaviour.rs`
+- `crates/weaverd/tests/features/refactor_rope.feature`
+- `crates/weaverd/src/tests/refactor_rope_behaviour.rs`
+
+### Stage F: documentation and roadmap updates
+
+Update docs to match shipped behaviour:
+
+- `docs/weaver-design.md`: add Phase 3.1.1a design decisions for rope adapter,
+  runtime bootstrap, and diff-to-Double-Lock path.
+- `docs/users-guide.md`: remove "not yet available" note for `act refactor`
+  and document rope-supported operations, arguments, and failure modes.
+- `docs/roadmap.md`: mark the rope plugin checklist item as done.
+
+### Stage G: full quality gates
+
+Run formatting, lint, tests, and markdown checks with `tee` and
+`set -o pipefail`, review logs, and only then finalize.
+
+## Concrete steps
+
+1. Create the new crate and module skeletons.
+2. Implement protocol handler, rope adapter boundary, and error mapping.
+3. Add rope plugin unit tests and BDD scenarios.
+4. Implement plugin runtime bootstrap in `weaverd` and inject into dispatch.
+5. Replace refactor stub with plugin execution and shared patch application.
+6. Add `weaverd` unit tests and BDD scenarios for refactor behaviour.
+7. Update design docs, user docs, and roadmap status.
+8. Run quality gates and inspect logs.
+
+Commands (run from repository root):
+
+    set -o pipefail && make fmt 2>&1 | tee /tmp/3-1-1a-make-fmt.log
+    set -o pipefail && make check-fmt 2>&1 | tee /tmp/3-1-1a-check-fmt.log
+    set -o pipefail && make lint 2>&1 | tee /tmp/3-1-1a-make-lint.log
+    set -o pipefail && make test 2>&1 | tee /tmp/3-1-1a-make-test.log
+    set -o pipefail && make markdownlint 2>&1 | tee /tmp/3-1-1a-markdownlint.log
+    set -o pipefail && make nixie 2>&1 | tee /tmp/3-1-1a-nixie.log
+
+Targeted test loops while implementing:
+
+    set -o pipefail && cargo test -p weaver-plugin-rope 2>&1 | tee /tmp/3-1-1a-rope-plugin-test.log
+    set -o pipefail && cargo test -p weaverd refactor 2>&1 | tee /tmp/3-1-1a-weaverd-refactor-test.log
+
+## Validation and acceptance
+
+The feature is accepted when all items below are true:
+
+- `weaver act refactor --provider rope ...` executes the rope plugin path,
+  returns status 0 on success, and writes verified edits.
+- `act refactor` failures from plugin/runtime/lock validation are surfaced with
+  clear errors and no partial filesystem writes.
+- Unit tests cover request validation, runtime error mapping, and diff handoff
+  to the Double-Lock path.
+- BDD tests cover happy/unhappy/edge scenarios using `rstest-bdd` v0.5.0.
+- `docs/weaver-design.md` records the decisions made by this implementation.
+- `docs/users-guide.md` documents user-visible behaviour and configuration.
+- `docs/roadmap.md` marks rope plugin entry as done.
+- `make check-fmt`, `make lint`, and `make test` pass.
+
+## Idempotence and recovery
+
+- Implementation steps are re-runnable.
+- If plugin execution fails, no edits are committed because commit only happens
+  after Double-Lock success.
+- If sandbox/plugin bootstrap fails, fix configuration or executable path and
+  re-run tests.
+- If markdown checks fail, run `make fmt` and re-run markdown validation before
+  repeating Rust gates.
+
+## Artifacts and notes
+
+Expected artifacts:
+
+- New crate: `crates/weaver-plugin-rope/`
+- New/updated refactor runtime wiring in `crates/weaverd/src/dispatch/`
+- New behavioural feature files and step definitions for rope plugin and
+  `act refactor`
+- Updated docs:
+  `docs/weaver-design.md`, `docs/users-guide.md`, `docs/roadmap.md`
+
+## Interfaces and dependencies
+
+Planned interfaces (final names may vary but intent must hold):
+
+- In `crates/weaver-plugin-rope/src/adapter.rs`:
+
+      pub trait RopeAdapter {
+          fn execute(&self, request: &PluginRequest) -> Result<PluginOutput, RopeAdapterError>;
+      }
+
+- In `crates/weaverd/src/dispatch/act/refactor/...`:
+
+      pub trait RefactorPluginRuntime {
+          fn execute(
+              &self,
+              provider: &str,
+              request: &PluginRequest,
+          ) -> Result<PluginResponse, PluginError>;
+      }
+
+- In `crates/weaverd/src/dispatch/act/apply_patch/...` (shared path): expose a
+  crate-visible helper that executes a patch string through the existing parser
+  and `ContentTransaction` flow, so refactor and apply-patch share the same
+  safety-critical implementation.
+
+Dependency expectations:
+
+- Prefer existing workspace dependencies; avoid adding new third-party crates
+  unless justified by a documented escalation.
+
+## Revision note
+
+Initial draft created for roadmap item: "Phase 3 -> first actuator plugin ->
+rope".

--- a/docs/execplans/3-1-1a-plugin-for-rope.md
+++ b/docs/execplans/3-1-1a-plugin-for-rope.md
@@ -1,8 +1,9 @@
 # Implement the first actuator plugin for `rope`
 
-This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
-`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
-`Outcomes & Retrospective` must be kept up to date as work proceeds.
+This Execution Plan (ExecPlan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
 
 Status: COMPLETE (2026-02-13)
 
@@ -40,8 +41,8 @@ Observable success:
 - Do not bypass the Double-Lock harness for plugin-produced edits.
 - Continue using `rstest-bdd` v0.5.0 and write new behavioural tests with
   mutable world fixtures (`&mut World`) for new scenarios.
-- Add e2e command ergonomics tests in `crates/weaver-e2e/` using `assert_cmd`
-  and `insta` snapshots for CLI usage flows.
+- Add end-to-end (e2e) command ergonomics tests in `crates/weaver-e2e/` using
+  `assert_cmd` and `insta` snapshots for CLI usage flows.
 - Keep module-level `//!` comments and rustdoc for public items; follow
   guidance in `docs/rust-doctest-dry-guide.md`.
 - Keep files under 400 lines by splitting modules where needed.
@@ -107,10 +108,10 @@ Observable success:
 
 ## Surprises & Discoveries
 
-- Observation: project memory MCP resources were not available in this session
-  (`list_mcp_resources` returned no servers/resources). Evidence: tool output
-  returned empty resource lists. Impact: planning relied on repository docs and
-  code inspection only.
+- Observation: project memory Model Context Protocol (MCP) resources were not
+  available in this session (`list_mcp_resources` returned no
+  servers/resources). Evidence: tool output returned empty resource lists.
+  Impact: planning relied on repository docs and code inspection only.
 
 ## Decision Log
 
@@ -181,7 +182,7 @@ Testing and style references:
 
 ## Plan of work
 
-### Stage A: finalise runtime contract and boundaries
+### Stage A: finalize runtime contract and boundaries
 
 Define the concrete scope for Phase 3.1.1a:
 
@@ -200,7 +201,7 @@ Go/no-go check:
 
 Add new crate `crates/weaver-plugin-rope/` (workspace member) that:
 
-- reads one `PluginRequest` JSONL line from stdin,
+- reads one `PluginRequest` JSON Lines (JSONL) line from stdin,
 - validates operation + arguments,
 - performs rope-backed refactoring via an adapter boundary,
 - emits one `PluginResponse` JSONL line to stdout, with `PluginOutput::Diff`
@@ -222,7 +223,7 @@ Go/no-go check:
 Extend `weaverd` runtime construction so `DomainRouter`/`act refactor` can
 execute plugins, including rope manifest registration.
 
-Likely touch points:
+Likely touchpoints:
 
 - `crates/weaverd/src/process/launch.rs`
 - `crates/weaverd/src/dispatch/handler.rs`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -171,7 +171,7 @@ language-specific tools.*
 
 - [ ] Develop the first set of actuator plugins:
 
-  - [ ] A plugin for `rope` to provide advanced Python refactoring.
+  - [x] A plugin for `rope` to provide advanced Python refactoring.
 
   - [ ] A plugin for `srgn` to provide high-performance, precision
         syntactic editing.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -530,21 +530,32 @@ weaver act refactor --provider <PLUGIN> --refactoring <OP> --file <PATH> [KEY=VA
 
 Arguments:
 
-| Flag            | Description                                                         |
-| --------------- | ------------------------------------------------------------------- |
-| `--provider`    | Name of the registered plugin (e.g. `rope`).                        |
-| `--refactoring` | Refactoring operation to request (e.g. `rename`, `extract_method`). |
-| `--file`        | Path to the target file (relative to workspace root).               |
-| `KEY=VALUE`     | Extra key-value arguments forwarded to the plugin.                  |
+| Flag            | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| `--provider`    | Name of the registered plugin (e.g. `rope`).           |
+| `--refactoring` | Refactoring operation to request (currently `rename`). |
+| `--file`        | Path to the target file (relative to workspace root).  |
+| `KEY=VALUE`     | Extra key-value arguments forwarded to the plugin.     |
 
 The plugin receives the file content in-band as part of the JSONL request and
 does not need filesystem access. The daemon validates the resulting diff
 through both the syntactic (Tree-sitter) and semantic (LSP) locks before
 writing to disk.
 
-> **Note:** Full plugin execution requires a configured plugin registry. The
-> `act refactor` command validates arguments and builds the plugin request in
-> Phase 3.1.1; end-to-end plugin invocation is wired in Phase 3.2.
+For the built-in `rope` actuator, `rename` requires `offset=<BYTE_OFFSET>` and
+`new_name=<IDENTIFIER>` in the trailing `KEY=VALUE` arguments.
+
+The daemon ships with a default `rope` actuator registration. By default it
+expects the plugin executable at `/usr/bin/weaver-plugin-rope`. Override the
+path with:
+
+```sh
+WEAVER_ROPE_PLUGIN_PATH=/absolute/path/to/weaver-plugin-rope
+```
+
+The override path is resolved to an absolute path at daemon startup. If the
+plugin executable cannot be launched, `act refactor` returns a structured
+failure and does not modify the filesystem.
 
 ## Plugin system
 
@@ -594,6 +605,13 @@ plugins do not need filesystem access.
 The daemon maintains a `PluginRegistry` that stores validated plugin manifests
 keyed by name. Plugins can be looked up by name, kind, language, or a
 combination thereof (e.g. "find all actuator plugins for Python").
+
+For the first actuator rollout, `weaverd` registers the `rope` plugin using:
+
+- name: `rope`
+- kind: `actuator`
+- language: `python`
+- executable: `/usr/bin/weaver-plugin-rope` (or `WEAVER_ROPE_PLUGIN_PATH`)
 
 ### Safety harness integration
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -545,7 +545,7 @@ writing to disk.
 For the built-in `rope` actuator, `rename` requires `offset=<BYTE_OFFSET>` and
 `new_name=<IDENTIFIER>` in the trailing `KEY=VALUE` arguments.
 
-The daemon ships with a default `rope` actuator registration. By default it
+The daemon ships with a default `rope` actuator registration. By default, it
 expects the plugin executable at `/usr/bin/weaver-plugin-rope`. Override the
 path with:
 


### PR DESCRIPTION
## Summary
- Adds a dedicated rope actuator plugin crate (crates/weaver-plugin-rope) with a one-shot rope-based refactor operation and a Python rope adapter boundary, wired into the weaver runtime.
- Wires plugin execution through the daemon runtime (weaverd) so rope-based refactoring results flow through the existing apply-patch Double-Lock path.
- Introduces end-to-end tests and CLI ergonomics snapshots, including a fake daemon for deterministic tests.
- Updates the ExecPlan and alignment with governance/docs to reflect shipped rope plugin and runtime wiring.
- This PR contains substantial code changes beyond documentation, not merely planning.

## Changes
### Documentation
- Added ExecPlan: docs/execplans/3-1-1a-plugin-for-rope.md (living document outlining purpose, constraints, risks, progress, decisions, and a Stage A–G plan for rope-based actuator integration).
- Updated roadmap and design/docs references to reflect shipped rope plugin and runtime wiring (docs/weaver-design.md, docs/users-guide.md, docs/roadmap.md).

### Code
- New crate: crates/weaver-plugin-rope with Cargo.toml and source files (lib.rs, main.rs).
  - Provides a RopeAdapter trait and a PythonRopeAdapter implementing rope-based rename refactor via a generated Python script executed in a temporary workspace.
  - Exposes run and run_with_adapter functions to dispatch a single PluginRequest to a RopeAdapter and emit a PluginResponse.
  - Handles validation of file paths, sandboxed workspace creation, and error mapping for robust CI-friendly testing.
- End-to-end wiring in weaverd:
  - crates/weaverd/src/dispatch/router.rs updated to instantiate and use a RefactorRuntime via DomainRouter for the refactor domain, wiring dependencies for rope-based execution.
  - Added SandboxRefactorRuntime and associated runtime wiring (default_runtime, resolve_rope_plugin_path) to enable plugin discovery and execution.
  - DomainRouter::new now wires a runtime so act refactor can execute a plugin through the runtime.
- Binary entry for rope plugin:
  - crates/weaver-plugin-rope/src/main.rs and crates/weaver-plugin-rope/src/lib.rs implement the plugin protocol and adapter usage.
- Tests
  - New behaviour tests: crates/weaver-plugin-rope/src/tests/behaviour.rs and crates/weaver-plugin-rope/src/tests/mod.rs.
  - Feature tests for rope plugin behavior: crates/weaver-plugin-rope/tests/features/rope_plugin.feature.
  - End-to-end CLI ergonomics snapshots added: crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs and corresponding snapshots.
  - E2E test dependencies updated accordingly in crates/weaver-e2e/Cargo.toml.
- Additional tests and scaffolding to support deterministic rope adapter behaviour and plugin request handling in unit/BDD tests.

### Rationale
- Establishes a dedicated rope plugin executable crate to keep rope/refactoring logic separate from the daemon, enabling swap-in/DI-based testing and reliable CI without requiring a system-wide rope installation.
- Reuses existing Double-Lock safe apply-patch flow for patch application, avoiding duplication of critical safety logic.
- Introduces a Bulldog-friendly design: one-shot rope operation (rename) with explicit arguments, and deterministic adapter boundaries for tests.

### Plan alignment
- ExecPlan document (docs/execplans/3-1-1a-plugin-for-rope.md) reflects Stage A–G plan and the rope actuator rollout.
- docs/weaver-design.md, docs/users-guide.md, and docs/roadmap.md updated to reflect shipped rope plugin and runtime wiring.

### Revision note
- Initial draft created to map Phase 3 -> first actuator rope plugin implementation and runtime integration.

📎 Task: https://www.devboxer.com/task/abbb65ed-f29f-42da-b73f-6d1aa2410d11

📎 Task: https://www.devboxer.com/task/33450ba1-c1f7-4278-8ebd-89bbced1a8c0