### PR TITLE
Add rust-analyzer actuator plugin with tests and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "weaver-plugin-rust-analyzer"
+version = "0.1.0"
+dependencies = [
+ "lsp-types",
+ "mockall",
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "url",
+ "weaver-plugins",
+]
+
+[[package]]
 name = "weaver-plugins"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/weaver-graph",
     "crates/weaverd",
     "crates/weaver-lsp-host",
+    "crates/weaver-plugin-rust-analyzer",
     "crates/weaver-plugin-rope",
     "crates/weaver-plugins",
     "crates/weaver-sandbox",

--- a/crates/weaver-e2e/tests/refactor_rust_analyzer_cli_snapshots.rs
+++ b/crates/weaver-e2e/tests/refactor_rust_analyzer_cli_snapshots.rs
@@ -1,0 +1,295 @@
+//! End-to-end CLI ergonomics snapshots for `act refactor`.
+//!
+//! These tests run the `weaver` binary with a fake daemon endpoint to capture
+//! user-facing command ergonomics, including a shell pipeline that chains an
+//! observe query through `jq` into an actuator command.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::process::Output;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use std::{io, thread};
+
+use assert_cmd::Command;
+use insta::assert_debug_snapshot;
+use serde::Serialize;
+use serde_json::json;
+
+#[derive(Debug, Serialize)]
+struct Transcript {
+    command: String,
+    status: i32,
+    stdout: String,
+    stderr: String,
+    requests: Vec<serde_json::Value>,
+}
+
+#[derive(Debug)]
+struct FakeDaemon {
+    address: SocketAddr,
+    requests: Arc<Mutex<Vec<serde_json::Value>>>,
+    join_handle: thread::JoinHandle<()>,
+}
+
+#[expect(
+    deprecated,
+    reason = "assert_cmd::cargo::cargo_bin resolves workspace binaries for e2e tests"
+)]
+fn weaver_binary_path() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("weaver")
+}
+
+impl FakeDaemon {
+    fn start(expected_requests: usize) -> Result<Self, std::io::Error> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let address = listener.local_addr()?;
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let shared_requests = Arc::clone(&requests);
+
+        let join_handle = thread::spawn(move || {
+            serve_requests(&listener, expected_requests, &shared_requests);
+        });
+
+        Ok(Self {
+            address,
+            requests,
+            join_handle,
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        format!("tcp://{}", self.address)
+    }
+
+    #[expect(
+        clippy::expect_used,
+        reason = "poisoned mutex in test fixture must surface as panic for clear diagnostics"
+    )]
+    fn requests(&self) -> Vec<serde_json::Value> {
+        self.requests
+            .lock()
+            .expect("request mutex should not be poisoned")
+            .clone()
+    }
+
+    fn join(self) {
+        assert!(
+            self.join_handle.join().is_ok(),
+            "fake daemon thread should not panic"
+        );
+    }
+}
+
+const ACCEPT_TIMEOUT: Duration = Duration::from_secs(10);
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[expect(
+    clippy::expect_used,
+    reason = "non-blocking configuration is fundamental to the deadline mechanism"
+)]
+fn serve_requests(
+    listener: &TcpListener,
+    expected_requests: usize,
+    requests: &Arc<Mutex<Vec<serde_json::Value>>>,
+) {
+    listener
+        .set_nonblocking(true)
+        .expect("non-blocking mode should be supported");
+
+    for _ in 0..expected_requests {
+        let Some(stream) = accept_before_deadline(listener) else {
+            return;
+        };
+        if respond_to_request(stream, requests).is_err() {
+            return;
+        }
+    }
+}
+
+/// Polls `listener.accept()` until a connection arrives or the deadline elapses.
+#[expect(
+    clippy::expect_used,
+    reason = "restoring blocking mode on accepted stream must succeed for correct I/O"
+)]
+fn accept_before_deadline(listener: &TcpListener) -> Option<TcpStream> {
+    let deadline = Instant::now() + ACCEPT_TIMEOUT;
+
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream
+                    .set_nonblocking(false)
+                    .expect("blocking mode should be supported");
+                return Some(stream);
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                assert!(
+                    Instant::now() < deadline,
+                    "fake daemon timed out waiting for CLI connection \
+                     after {ACCEPT_TIMEOUT:?}"
+                );
+                thread::sleep(ACCEPT_POLL_INTERVAL);
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+fn response_payload_for_operation(operation: &str) -> String {
+    match operation {
+        "get-definition" => json!([{ "symbol": "renamed_name" }]).to_string(),
+        "refactor" => json!({
+            "status": "ok",
+            "files_written": 1,
+            "files_deleted": 0
+        })
+        .to_string(),
+        _ => json!({ "status": "unexpected", "operation": operation }).to_string(),
+    }
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "poisoned mutex in test fixture must surface as panic for clear diagnostics"
+)]
+fn respond_to_request(
+    stream: TcpStream,
+    requests: &Arc<Mutex<Vec<serde_json::Value>>>,
+) -> Result<(), std::io::Error> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line)?;
+
+    let parsed_request: serde_json::Value = serde_json::from_str(request_line.trim())
+        .unwrap_or_else(|_| {
+            json!({
+                "invalid_request": request_line.trim(),
+            })
+        });
+
+    requests
+        .lock()
+        .expect("request mutex should not be poisoned")
+        .push(parsed_request.clone());
+
+    let operation = parsed_request
+        .get("command")
+        .and_then(|command| command.get("operation"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+
+    let payload = response_payload_for_operation(operation);
+
+    let mut writer = stream;
+    write_json_line(
+        &mut writer,
+        &json!({
+            "kind": "stream",
+            "stream": "stdout",
+            "data": payload,
+        }),
+    )?;
+    write_json_line(&mut writer, &json!({ "kind": "exit", "status": 0 }))
+}
+
+fn write_json_line(
+    writer: &mut impl Write,
+    payload: &serde_json::Value,
+) -> Result<(), std::io::Error> {
+    writer.write_all(payload.to_string().as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+fn output_to_transcript(
+    command: String,
+    output: &Output,
+    requests: Vec<serde_json::Value>,
+) -> Transcript {
+    let status = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    Transcript {
+        command,
+        status,
+        stdout,
+        stderr,
+        requests,
+    }
+}
+
+#[test]
+fn refactor_rust_analyzer_actuator_isolation_cli_snapshot() {
+    let daemon = FakeDaemon::start(1).expect("fake daemon should start");
+    let endpoint = daemon.endpoint();
+
+    let command_string = String::from(
+        "weaver --daemon-socket tcp://<daemon-endpoint> --output json act refactor --provider rust-analyzer --refactoring rename --file src/main.rs new_name=renamed_name offset=3",
+    );
+
+    let mut command = Command::new(weaver_binary_path());
+    let output = command
+        .args([
+            "--daemon-socket",
+            endpoint.as_str(),
+            "--output",
+            "json",
+            "act",
+            "refactor",
+            "--provider",
+            "rust-analyzer",
+            "--refactoring",
+            "rename",
+            "--file",
+            "src/main.rs",
+            "new_name=renamed_name",
+            "offset=3",
+        ])
+        .output()
+        .expect("command should execute");
+
+    let transcript = output_to_transcript(command_string, &output, daemon.requests());
+    daemon.join();
+
+    assert_debug_snapshot!("refactor_rust_analyzer_actuator_isolation", transcript);
+}
+
+#[test]
+fn refactor_rust_analyzer_pipeline_with_observe_and_jq_snapshot() {
+    let jq_available = Command::new("jq").arg("--version").output().is_ok();
+    if !jq_available {
+        writeln!(
+            std::io::stderr().lock(),
+            "Skipping test: jq not available on PATH"
+        )
+        .ok();
+        return;
+    }
+
+    let daemon = FakeDaemon::start(2).expect("fake daemon should start");
+    let endpoint = daemon.endpoint();
+    let weaver_bin = weaver_binary_path();
+
+    let shell_script = concat!(
+        "\"$WEAVER_BIN\" --daemon-socket \"$WEAVER_ENDPOINT\" --output json ",
+        "observe get-definition --symbol old_name ",
+        "| jq -r '.[0].symbol' ",
+        "| xargs -I{} \"$WEAVER_BIN\" --daemon-socket \"$WEAVER_ENDPOINT\" --output json ",
+        "act refactor --provider rust-analyzer --refactoring rename --file src/main.rs new_name={} offset=3"
+    );
+
+    let output = Command::new("bash")
+        .args(["-c", shell_script])
+        .env("WEAVER_BIN", weaver_bin)
+        .env("WEAVER_ENDPOINT", endpoint.as_str())
+        .output()
+        .expect("pipeline command should execute");
+
+    let command_string =
+        String::from("weaver observe get-definition | jq -r '.[0].symbol' | weaver act refactor");
+    let transcript = output_to_transcript(command_string, &output, daemon.requests());
+    daemon.join();
+
+    assert_debug_snapshot!("refactor_rust_analyzer_pipeline_observe_jq", transcript);
+}

--- a/crates/weaver-e2e/tests/snapshots/refactor_rust_analyzer_cli_snapshots__refactor_rust_analyzer_actuator_isolation.snap
+++ b/crates/weaver-e2e/tests/snapshots/refactor_rust_analyzer_cli_snapshots__refactor_rust_analyzer_actuator_isolation.snap
@@ -1,0 +1,28 @@
+---
+source: crates/weaver-e2e/tests/refactor_rust_analyzer_cli_snapshots.rs
+expression: transcript
+---
+Transcript {
+    command: "weaver --daemon-socket tcp://<daemon-endpoint> --output json act refactor --provider rust-analyzer --refactoring rename --file src/main.rs new_name=renamed_name offset=3",
+    status: 0,
+    stdout: "{\"files_deleted\":0,\"files_written\":1,\"status\":\"ok\"}",
+    stderr: "",
+    requests: [
+        Object {
+            "arguments": Array [
+                String("--provider"),
+                String("rust-analyzer"),
+                String("--refactoring"),
+                String("rename"),
+                String("--file"),
+                String("src/main.rs"),
+                String("new_name=renamed_name"),
+                String("offset=3"),
+            ],
+            "command": Object {
+                "domain": String("act"),
+                "operation": String("refactor"),
+            },
+        },
+    ],
+}

--- a/crates/weaver-e2e/tests/snapshots/refactor_rust_analyzer_cli_snapshots__refactor_rust_analyzer_pipeline_observe_jq.snap
+++ b/crates/weaver-e2e/tests/snapshots/refactor_rust_analyzer_cli_snapshots__refactor_rust_analyzer_pipeline_observe_jq.snap
@@ -1,0 +1,38 @@
+---
+source: crates/weaver-e2e/tests/refactor_rust_analyzer_cli_snapshots.rs
+expression: transcript
+---
+Transcript {
+    command: "weaver observe get-definition | jq -r '.[0].symbol' | weaver act refactor",
+    status: 0,
+    stdout: "{\"files_deleted\":0,\"files_written\":1,\"status\":\"ok\"}",
+    stderr: "",
+    requests: [
+        Object {
+            "arguments": Array [
+                String("--symbol"),
+                String("old_name"),
+            ],
+            "command": Object {
+                "domain": String("observe"),
+                "operation": String("get-definition"),
+            },
+        },
+        Object {
+            "arguments": Array [
+                String("--provider"),
+                String("rust-analyzer"),
+                String("--refactoring"),
+                String("rename"),
+                String("--file"),
+                String("src/main.rs"),
+                String("new_name=renamed_name"),
+                String("offset=3"),
+            ],
+            "command": Object {
+                "domain": String("act"),
+                "operation": String("refactor"),
+            },
+        },
+    ],
+}

--- a/crates/weaver-plugin-rust-analyzer/Cargo.toml
+++ b/crates/weaver-plugin-rust-analyzer/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "weaver-plugin-rust-analyzer"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+lsp-types.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+url.workspace = true
+weaver-plugins = { path = "../weaver-plugins" }
+
+[dev-dependencies]
+mockall.workspace = true
+rstest.workspace = true
+rstest-bdd.workspace = true
+rstest-bdd-macros.workspace = true
+
+[lints]
+workspace = true

--- a/crates/weaver-plugin-rust-analyzer/src/lib.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lib.rs
@@ -1,0 +1,323 @@
+//! rust-analyzer-backed actuator plugin entrypoint and request dispatcher.
+//!
+//! This crate implements a one-shot plugin protocol handler compatible with
+//! `weaver-plugins`. The plugin reads exactly one JSONL request from stdin,
+//! executes a refactoring operation, and writes one JSONL response to stdout.
+
+#[cfg(test)]
+mod tests;
+
+mod lsp;
+
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::path::{Component, Path, PathBuf};
+
+use thiserror::Error;
+use weaver_plugins::protocol::{
+    DiagnosticSeverity, FilePayload, PluginDiagnostic, PluginOutput, PluginRequest, PluginResponse,
+};
+
+pub use lsp::RustAnalyzerLspAdapter;
+
+/// Refactoring adapter abstraction used to keep behaviour deterministic in tests.
+pub trait RustAnalyzerAdapter {
+    /// Executes a rename operation and returns the modified file content.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the adapter cannot complete the operation.
+    fn rename(
+        &self,
+        file: &FilePayload,
+        offset: usize,
+        new_name: &str,
+    ) -> Result<String, RustAnalyzerAdapterError>;
+}
+
+/// Errors raised while dispatching plugin requests.
+#[derive(Debug, Error)]
+pub enum PluginDispatchError {
+    /// Writing the plugin response to stdout failed.
+    #[error("failed to write plugin response: {source}")]
+    Write {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Serializing the response payload failed.
+    #[error("failed to serialize plugin response: {source}")]
+    Serialize {
+        /// Underlying serialization error.
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// Errors raised by rust-analyzer adapter implementations.
+#[derive(Debug, Error)]
+pub enum RustAnalyzerAdapterError {
+    /// Temporary workspace allocation failed.
+    #[error("failed to create temporary workspace: {source}")]
+    WorkspaceCreate {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Writing request files to the temporary workspace failed.
+    #[error("failed to materialize workspace file '{}': {source}", path.display())]
+    WorkspaceWrite {
+        /// File path being written.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Spawning the rust-analyzer process failed.
+    #[error("failed to spawn rust-analyzer process: {source}")]
+    Spawn {
+        /// Underlying process spawn error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// rust-analyzer completed with a protocol or server failure.
+    #[error("rust-analyzer adapter failed: {message}")]
+    EngineFailed {
+        /// Error details captured from LSP exchange.
+        message: String,
+    },
+    /// rust-analyzer returned malformed output.
+    #[error("rust-analyzer adapter returned invalid output: {message}")]
+    InvalidOutput {
+        /// Parsing or protocol error details.
+        message: String,
+    },
+    /// Request path was invalid for sandboxed execution.
+    #[error("invalid file path for rust-analyzer operation: {message}")]
+    InvalidPath {
+        /// Validation message.
+        message: String,
+    },
+}
+
+/// Executes one plugin request from `stdin` and writes one response to `stdout`.
+///
+/// # Errors
+///
+/// Returns an error if the response cannot be serialized or written.
+pub fn run_with_adapter<R: RustAnalyzerAdapter>(
+    stdin: &mut impl BufRead,
+    stdout: &mut impl Write,
+    adapter: &R,
+) -> Result<(), PluginDispatchError> {
+    let response = match read_request(stdin).and_then(|request| execute_request(adapter, &request))
+    {
+        Ok(resp) => resp,
+        Err(message) => failure_response(message),
+    };
+
+    let payload = serde_json::to_string(&response)
+        .map_err(|source| PluginDispatchError::Serialize { source })?;
+    stdout
+        .write_all(payload.as_bytes())
+        .map_err(|source| PluginDispatchError::Write { source })?;
+    stdout
+        .write_all(b"\n")
+        .map_err(|source| PluginDispatchError::Write { source })?;
+    stdout
+        .flush()
+        .map_err(|source| PluginDispatchError::Write { source })
+}
+
+/// Executes one plugin request using the default rust-analyzer-backed adapter.
+///
+/// # Errors
+///
+/// Returns an error if the response cannot be written.
+pub fn run(stdin: &mut impl BufRead, stdout: &mut impl Write) -> Result<(), PluginDispatchError> {
+    run_with_adapter(stdin, stdout, &RustAnalyzerLspAdapter)
+}
+
+fn read_request(stdin: &mut impl BufRead) -> Result<PluginRequest, String> {
+    let mut line = String::new();
+    let bytes_read = stdin
+        .read_line(&mut line)
+        .map_err(|error| format!("failed to read request: {error}"))?;
+
+    if bytes_read == 0 {
+        return Err(String::from("plugin request was empty"));
+    }
+
+    serde_json::from_str(line.trim())
+        .map_err(|error| format!("invalid plugin request JSON: {error}"))
+}
+
+fn execute_request<R: RustAnalyzerAdapter>(
+    adapter: &R,
+    request: &PluginRequest,
+) -> Result<PluginResponse, String> {
+    match request.operation() {
+        "rename" => execute_rename(adapter, request),
+        other => Err(format!("unsupported refactoring operation '{other}'")),
+    }
+}
+
+fn execute_rename<R: RustAnalyzerAdapter>(
+    adapter: &R,
+    request: &PluginRequest,
+) -> Result<PluginResponse, String> {
+    let (offset, new_name) = parse_rename_arguments(request.arguments())?;
+
+    let files = request.files();
+    let file = match files {
+        [single] => single,
+        other => {
+            return Err(format!(
+                "rename operation requires exactly one file payload, got {}",
+                other.len()
+            ));
+        }
+    };
+
+    validate_relative_path(file.path()).map_err(|error| error.to_string())?;
+
+    let modified = adapter
+        .rename(file, offset, &new_name)
+        .map_err(|error| error.to_string())?;
+
+    if modified == file.content() {
+        return Err(String::from("rename operation produced no content changes"));
+    }
+
+    let patch = build_search_replace_patch(file.path(), file.content(), &modified);
+    Ok(PluginResponse::success(PluginOutput::Diff {
+        content: patch,
+    }))
+}
+
+fn parse_rename_arguments(
+    arguments: &HashMap<String, serde_json::Value>,
+) -> Result<(usize, String), String> {
+    let offset_value = arguments
+        .get("offset")
+        .ok_or_else(|| String::from("rename operation requires 'offset' argument"))?;
+    let new_name_value = arguments
+        .get("new_name")
+        .ok_or_else(|| String::from("rename operation requires 'new_name' argument"))?;
+
+    let offset_string = json_value_to_string(offset_value)
+        .ok_or_else(|| String::from("offset argument must be a string or number"))?;
+    let offset = offset_string
+        .parse::<usize>()
+        .map_err(|error| format!("offset must be a non-negative integer: {error}"))?;
+
+    let new_name = new_name_value
+        .as_str()
+        .ok_or_else(|| String::from("new_name argument must be a string"))?;
+    if new_name.trim().is_empty() {
+        return Err(String::from("new_name argument must not be empty"));
+    }
+
+    Ok((offset, String::from(new_name)))
+}
+
+fn json_value_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => Some(text.to_owned()),
+        serde_json::Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+fn write_workspace_file(
+    workspace_root: &Path,
+    relative_path: &Path,
+    content: &str,
+) -> Result<PathBuf, RustAnalyzerAdapterError> {
+    let absolute_path = workspace_root.join(relative_path);
+
+    if let Some(parent) = absolute_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| {
+            RustAnalyzerAdapterError::WorkspaceWrite {
+                path: parent.to_path_buf(),
+                source,
+            }
+        })?;
+    }
+
+    std::fs::write(&absolute_path, content).map_err(|source| {
+        RustAnalyzerAdapterError::WorkspaceWrite {
+            path: absolute_path.clone(),
+            source,
+        }
+    })?;
+
+    Ok(absolute_path)
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), RustAnalyzerAdapterError> {
+    if path.is_absolute() {
+        return Err(RustAnalyzerAdapterError::InvalidPath {
+            message: String::from("absolute paths are not allowed"),
+        });
+    }
+
+    let has_parent_traversal = path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir));
+    if has_parent_traversal {
+        return Err(RustAnalyzerAdapterError::InvalidPath {
+            message: String::from("path traversal is not allowed"),
+        });
+    }
+
+    let has_windows_prefix = path
+        .components()
+        .any(|component| matches!(component, Component::Prefix(_)));
+    if has_windows_prefix {
+        return Err(RustAnalyzerAdapterError::InvalidPath {
+            message: String::from("windows path prefixes are not allowed"),
+        });
+    }
+
+    Ok(())
+}
+
+fn build_search_replace_patch(path: &Path, original: &str, modified: &str) -> String {
+    let unix_path = path_to_slash(path);
+    let sep_after_original = if original.ends_with('\n') { "" } else { "\n" };
+    let sep_after_modified = if modified.ends_with('\n') { "" } else { "\n" };
+
+    format!(
+        concat!(
+            "diff --git a/{unix_path} b/{unix_path}\n",
+            "<<<<<<< SEARCH\n",
+            "{original}{sep_a}",
+            "=======\n",
+            "{modified}{sep_b}",
+            ">>>>>>> REPLACE\n",
+        ),
+        unix_path = unix_path,
+        original = original,
+        sep_a = sep_after_original,
+        modified = modified,
+        sep_b = sep_after_modified,
+    )
+}
+
+fn path_to_slash(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<String>>()
+        .join("/")
+}
+
+pub(crate) fn failure_response(message: String) -> PluginResponse {
+    PluginResponse::failure(vec![PluginDiagnostic::new(
+        DiagnosticSeverity::Error,
+        message,
+    )])
+}

--- a/crates/weaver-plugin-rust-analyzer/src/lib.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lib.rs
@@ -104,6 +104,12 @@ pub enum RustAnalyzerAdapterError {
         /// Error details captured from LSP exchange.
         message: String,
     },
+    /// A JSON-RPC response was not received within the bounded read loop.
+    #[error("rust-analyzer response timed out: {message}")]
+    ResponseTimeout {
+        /// Timeout context including expected request ID.
+        message: String,
+    },
     /// rust-analyzer returned malformed output.
     #[error("rust-analyzer adapter returned invalid output: {message}")]
     InvalidOutput {

--- a/crates/weaver-plugin-rust-analyzer/src/lsp/jsonrpc.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lsp/jsonrpc.rs
@@ -1,0 +1,236 @@
+//! JSON-RPC helpers for the rust-analyzer adapter.
+
+use std::io::{BufRead, Write};
+
+use serde::{Deserialize, Serialize};
+
+use crate::RustAnalyzerAdapterError;
+
+/// Parameters for issuing a JSON-RPC request.
+pub(super) struct JsonRpcRequestSpec<'a> {
+    /// Correlation ID for the request/response pair.
+    pub id: i64,
+    /// Method name.
+    pub method: &'a str,
+    /// Request parameters payload.
+    pub params: serde_json::Value,
+}
+
+/// Sends a JSON-RPC request and waits for the matching response ID.
+pub(super) fn send_request(
+    writer: &mut impl Write,
+    reader: &mut impl BufRead,
+    spec: JsonRpcRequestSpec<'_>,
+) -> Result<serde_json::Value, RustAnalyzerAdapterError> {
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0",
+        id: spec.id,
+        method: spec.method,
+        params: Some(spec.params),
+    };
+
+    let payload = serde_json::to_string(&request).map_err(|source| {
+        RustAnalyzerAdapterError::InvalidOutput {
+            message: format!(
+                "failed to serialize JSON-RPC request '{}': {source}",
+                spec.method
+            ),
+        }
+    })?;
+    write_lsp_message(writer, &payload)?;
+    read_response_for_id(reader, writer, spec.id)
+}
+
+/// Sends a JSON-RPC notification.
+pub(super) fn send_notification(
+    writer: &mut impl Write,
+    method: &str,
+    params: Option<serde_json::Value>,
+) -> Result<(), RustAnalyzerAdapterError> {
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0",
+        method,
+        params,
+    };
+
+    let payload = serde_json::to_string(&notification).map_err(|source| {
+        RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("failed to serialize JSON-RPC notification '{method}': {source}"),
+        }
+    })?;
+    write_lsp_message(writer, &payload)
+}
+
+fn read_response_for_id(
+    reader: &mut impl BufRead,
+    writer: &mut impl Write,
+    expected_id: i64,
+) -> Result<serde_json::Value, RustAnalyzerAdapterError> {
+    loop {
+        let message = read_lsp_message(reader)?;
+        let rpc: JsonRpcMessage = serde_json::from_str(&message).map_err(|source| {
+            RustAnalyzerAdapterError::InvalidOutput {
+                message: format!("failed to deserialize JSON-RPC message: {source}"),
+            }
+        })?;
+
+        if let Some(method) = rpc.method {
+            if let Some(server_request_id) = rpc.id {
+                acknowledge_server_request(writer, server_request_id, &method)?;
+            }
+            continue;
+        }
+
+        if rpc.id != Some(expected_id) {
+            continue;
+        }
+
+        if let Some(error) = rpc.error {
+            return Err(RustAnalyzerAdapterError::EngineFailed {
+                message: format!(
+                    "JSON-RPC request failed with code {}: {}",
+                    error.code, error.message
+                ),
+            });
+        }
+
+        return Ok(rpc.result.unwrap_or(serde_json::Value::Null));
+    }
+}
+
+fn acknowledge_server_request(
+    writer: &mut impl Write,
+    request_id: i64,
+    method: &str,
+) -> Result<(), RustAnalyzerAdapterError> {
+    let response = JsonRpcServerResponse {
+        jsonrpc: "2.0",
+        id: request_id,
+        result: serde_json::Value::Null,
+    };
+    let payload = serde_json::to_string(&response).map_err(|source| {
+        RustAnalyzerAdapterError::InvalidOutput {
+            message: format!(
+                "failed to serialize response for server request '{method}': {source}"
+            ),
+        }
+    })?;
+    write_lsp_message(writer, &payload)
+}
+
+fn write_lsp_message(
+    writer: &mut impl Write,
+    content: &str,
+) -> Result<(), RustAnalyzerAdapterError> {
+    let header = format!("Content-Length: {}\r\n\r\n", content.len());
+    writer.write_all(header.as_bytes()).map_err(|source| {
+        RustAnalyzerAdapterError::EngineFailed {
+            message: format!("failed to write LSP header: {source}"),
+        }
+    })?;
+    writer.write_all(content.as_bytes()).map_err(|source| {
+        RustAnalyzerAdapterError::EngineFailed {
+            message: format!("failed to write LSP payload: {source}"),
+        }
+    })?;
+    writer
+        .flush()
+        .map_err(|source| RustAnalyzerAdapterError::EngineFailed {
+            message: format!("failed to flush LSP payload: {source}"),
+        })
+}
+
+fn read_lsp_message(reader: &mut impl BufRead) -> Result<String, RustAnalyzerAdapterError> {
+    let content_length = read_content_length(reader)?;
+    let mut content = vec![0_u8; content_length];
+    std::io::Read::read_exact(reader, &mut content).map_err(|source| {
+        RustAnalyzerAdapterError::EngineFailed {
+            message: format!("failed to read LSP payload: {source}"),
+        }
+    })?;
+
+    String::from_utf8(content).map_err(|source| RustAnalyzerAdapterError::InvalidOutput {
+        message: format!("LSP payload was not valid UTF-8: {source}"),
+    })
+}
+
+fn read_content_length(reader: &mut impl BufRead) -> Result<usize, RustAnalyzerAdapterError> {
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line).map_err(|source| {
+            RustAnalyzerAdapterError::EngineFailed {
+                message: format!("failed reading LSP header line: {source}"),
+            }
+        })?;
+
+        if bytes_read == 0 {
+            return Err(RustAnalyzerAdapterError::EngineFailed {
+                message: String::from("unexpected EOF while reading LSP headers"),
+            });
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            break;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("Content-Length: ") {
+            content_length =
+                Some(
+                    value
+                        .parse()
+                        .map_err(|source| RustAnalyzerAdapterError::InvalidOutput {
+                            message: format!("invalid Content-Length header '{value}': {source}"),
+                        })?,
+                );
+        }
+    }
+
+    content_length.ok_or_else(|| RustAnalyzerAdapterError::InvalidOutput {
+        message: String::from("LSP message missing Content-Length header"),
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest<'a> {
+    jsonrpc: &'static str,
+    id: i64,
+    method: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcNotification<'a> {
+    jsonrpc: &'static str,
+    method: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcServerResponse {
+    jsonrpc: &'static str,
+    id: i64,
+    result: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcMessage {
+    #[serde(default)]
+    id: Option<i64>,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    result: Option<serde_json::Value>,
+    #[serde(default)]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+}

--- a/crates/weaver-plugin-rust-analyzer/src/lsp/mod.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lsp/mod.rs
@@ -1,0 +1,231 @@
+//! rust-analyzer LSP adapter implementation.
+//!
+//! The adapter starts a short-lived rust-analyzer process, executes one
+//! rename request over JSON-RPC 2.0 / LSP framing, and returns the modified
+//! file content for diff generation.
+
+mod jsonrpc;
+mod text_edits;
+
+use std::io::{BufReader, BufWriter};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use lsp_types::{DidOpenTextDocumentParams, TextDocumentItem, Uri, WorkspaceEdit};
+use serde_json::json;
+use tempfile::TempDir;
+use weaver_plugins::protocol::FilePayload;
+
+use crate::{RustAnalyzerAdapter, RustAnalyzerAdapterError, write_workspace_file};
+
+use self::jsonrpc::{JsonRpcRequestSpec, send_notification, send_request};
+use self::text_edits::{
+    apply_workspace_edit, byte_offset_to_lsp_position, ensure_response_is_object,
+    parse_workspace_edit, path_to_file_uri, write_stub_cargo_toml,
+};
+
+const RUST_ANALYZER_BINARY: &str = "rust-analyzer";
+const INITIALIZE_REQUEST_ID: i64 = 1;
+const RENAME_REQUEST_ID: i64 = 2;
+const SHUTDOWN_REQUEST_ID: i64 = 3;
+
+/// Adapter implementation that delegates rename operations to rust-analyzer.
+pub struct RustAnalyzerLspAdapter;
+
+struct PreparedWorkspace {
+    workspace: TempDir,
+    file_uri: Uri,
+    workspace_uri: Uri,
+}
+
+struct RustAnalyzerProcess {
+    child: Child,
+    reader: BufReader<ChildStdout>,
+    writer: BufWriter<ChildStdin>,
+}
+
+impl RustAnalyzerAdapter for RustAnalyzerLspAdapter {
+    fn rename(
+        &self,
+        file: &FilePayload,
+        offset: usize,
+        new_name: &str,
+    ) -> Result<String, RustAnalyzerAdapterError> {
+        let prepared = prepare_workspace(file)?;
+        let mut process = start_rust_analyzer(&prepared)?;
+
+        initialize_session(&mut process, &prepared.workspace_uri)?;
+        open_document(&mut process, &prepared.file_uri, file.content())?;
+
+        let position = byte_offset_to_lsp_position(file.content(), offset)?;
+        let workspace_edit =
+            request_rename_edit(&mut process, &prepared.file_uri, position, new_name)?;
+        let updated_content =
+            apply_workspace_edit(file.content(), workspace_edit, &prepared.file_uri)?;
+
+        shutdown_session(&mut process)?;
+        finish_session(process)?;
+
+        Ok(updated_content)
+    }
+}
+
+fn prepare_workspace(file: &FilePayload) -> Result<PreparedWorkspace, RustAnalyzerAdapterError> {
+    let workspace =
+        TempDir::new().map_err(|source| RustAnalyzerAdapterError::WorkspaceCreate { source })?;
+    write_stub_cargo_toml(workspace.path())?;
+    let absolute_file_path = write_workspace_file(workspace.path(), file.path(), file.content())?;
+
+    let file_uri = path_to_file_uri(&absolute_file_path)?;
+    let workspace_uri = path_to_file_uri(workspace.path())?;
+
+    Ok(PreparedWorkspace {
+        workspace,
+        file_uri,
+        workspace_uri,
+    })
+}
+
+fn start_rust_analyzer(
+    prepared: &PreparedWorkspace,
+) -> Result<RustAnalyzerProcess, RustAnalyzerAdapterError> {
+    let mut child = Command::new(RUST_ANALYZER_BINARY)
+        .current_dir(prepared.workspace.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|source| RustAnalyzerAdapterError::Spawn { source })?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| RustAnalyzerAdapterError::EngineFailed {
+            message: String::from("rust-analyzer stdin pipe was unavailable"),
+        })?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| RustAnalyzerAdapterError::EngineFailed {
+            message: String::from("rust-analyzer stdout pipe was unavailable"),
+        })?;
+
+    Ok(RustAnalyzerProcess {
+        child,
+        reader: BufReader::new(stdout),
+        writer: BufWriter::new(stdin),
+    })
+}
+
+fn initialize_session(
+    process: &mut RustAnalyzerProcess,
+    workspace_uri: &Uri,
+) -> Result<(), RustAnalyzerAdapterError> {
+    let initialize_result = send_request(
+        &mut process.writer,
+        &mut process.reader,
+        JsonRpcRequestSpec {
+            id: INITIALIZE_REQUEST_ID,
+            method: "initialize",
+            params: json!({
+                "processId": std::process::id(),
+                "rootUri": workspace_uri.as_str(),
+                "workspaceFolders": [{
+                    "uri": workspace_uri.as_str(),
+                    "name": "workspace",
+                }],
+                "capabilities": {
+                    "general": {
+                        "positionEncodings": ["utf-16"],
+                    },
+                },
+            }),
+        },
+    )?;
+    ensure_response_is_object(&initialize_result, "initialize")?;
+
+    send_notification(&mut process.writer, "initialized", Some(json!({})))
+}
+
+fn open_document(
+    process: &mut RustAnalyzerProcess,
+    file_uri: &Uri,
+    content: &str,
+) -> Result<(), RustAnalyzerAdapterError> {
+    let did_open = DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: file_uri.clone(),
+            language_id: String::from("rust"),
+            version: 1,
+            text: content.to_owned(),
+        },
+    };
+
+    send_notification(
+        &mut process.writer,
+        "textDocument/didOpen",
+        Some(serde_json::to_value(did_open).map_err(|source| {
+            RustAnalyzerAdapterError::InvalidOutput {
+                message: format!("failed to serialize didOpen params: {source}"),
+            }
+        })?),
+    )
+}
+
+fn request_rename_edit(
+    process: &mut RustAnalyzerProcess,
+    file_uri: &Uri,
+    position: lsp_types::Position,
+    new_name: &str,
+) -> Result<WorkspaceEdit, RustAnalyzerAdapterError> {
+    let result = send_request(
+        &mut process.writer,
+        &mut process.reader,
+        JsonRpcRequestSpec {
+            id: RENAME_REQUEST_ID,
+            method: "textDocument/rename",
+            params: json!({
+                "textDocument": {
+                    "uri": file_uri.as_str(),
+                },
+                "position": position,
+                "newName": new_name,
+            }),
+        },
+    )?;
+
+    parse_workspace_edit(result)
+}
+
+fn shutdown_session(process: &mut RustAnalyzerProcess) -> Result<(), RustAnalyzerAdapterError> {
+    send_request(
+        &mut process.writer,
+        &mut process.reader,
+        JsonRpcRequestSpec {
+            id: SHUTDOWN_REQUEST_ID,
+            method: "shutdown",
+            params: serde_json::Value::Null,
+        },
+    )?;
+
+    send_notification(&mut process.writer, "exit", None)
+}
+
+fn finish_session(mut process: RustAnalyzerProcess) -> Result<(), RustAnalyzerAdapterError> {
+    drop(process.writer);
+    drop(process.reader);
+
+    let status = process
+        .child
+        .wait()
+        .map_err(|source| RustAnalyzerAdapterError::EngineFailed {
+            message: format!("failed to wait for rust-analyzer process: {source}"),
+        })?;
+
+    if !status.success() {
+        return Err(RustAnalyzerAdapterError::EngineFailed {
+            message: format!("rust-analyzer exited with status {status}"),
+        });
+    }
+
+    Ok(())
+}

--- a/crates/weaver-plugin-rust-analyzer/src/lsp/mod.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lsp/mod.rs
@@ -289,8 +289,8 @@ fn finish_session(mut process: RustAnalyzerProcess) -> Result<(), RustAnalyzerAd
 }
 
 fn force_terminate_process(child: &mut Child) {
-    drop(child.kill());
-    drop(child.wait());
+    child.kill().ok();
+    child.wait().ok();
 }
 
 fn parse_position_encoding(

--- a/crates/weaver-plugin-rust-analyzer/src/lsp/text_edits.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lsp/text_edits.rs
@@ -1,0 +1,343 @@
+//! Workspace edit and position conversion helpers.
+
+use std::path::Path;
+
+use lsp_types::{
+    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, OneOf, Position, TextEdit, Uri,
+    WorkspaceEdit,
+};
+
+use crate::RustAnalyzerAdapterError;
+
+/// Parses a rename result payload to a workspace edit.
+pub(super) fn parse_workspace_edit(
+    result: serde_json::Value,
+) -> Result<WorkspaceEdit, RustAnalyzerAdapterError> {
+    if result.is_null() {
+        return Err(RustAnalyzerAdapterError::EngineFailed {
+            message: String::from("rust-analyzer returned no workspace edit for rename"),
+        });
+    }
+
+    serde_json::from_value(result).map_err(|source| RustAnalyzerAdapterError::InvalidOutput {
+        message: format!("failed to deserialize workspace edit: {source}"),
+    })
+}
+
+/// Ensures an LSP response payload is a JSON object.
+pub(super) fn ensure_response_is_object(
+    response: &serde_json::Value,
+    method: &str,
+) -> Result<(), RustAnalyzerAdapterError> {
+    if response.is_object() {
+        return Ok(());
+    }
+
+    Err(RustAnalyzerAdapterError::InvalidOutput {
+        message: format!("{method} response payload was not a JSON object"),
+    })
+}
+
+/// Converts a byte offset into an LSP UTF-16 position.
+pub(super) fn byte_offset_to_lsp_position(
+    content: &str,
+    offset: usize,
+) -> Result<Position, RustAnalyzerAdapterError> {
+    if offset > content.len() {
+        return Err(RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("offset {offset} is beyond file length {}", content.len()),
+        });
+    }
+    if !content.is_char_boundary(offset) {
+        return Err(RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("offset {offset} is not at a UTF-8 character boundary"),
+        });
+    }
+
+    let prefix = slice_to_checked(content, offset, "prefix")?;
+    let line =
+        u32::try_from(prefix.bytes().filter(|byte| *byte == b'\n').count()).map_err(|source| {
+            RustAnalyzerAdapterError::InvalidOutput {
+                message: format!("line count exceeds u32 range: {source}"),
+            }
+        })?;
+
+    let line_start = prefix
+        .rfind('\n')
+        .map_or(0, |index| index + '\n'.len_utf8());
+    let line_prefix = slice_range_checked(content, line_start, offset, "line prefix")?;
+    let character = u32::try_from(line_prefix.encode_utf16().count()).map_err(|source| {
+        RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("character offset exceeds u32 range: {source}"),
+        }
+    })?;
+
+    Ok(Position { line, character })
+}
+
+/// Applies a workspace edit to the original content and returns the updated text.
+pub(super) fn apply_workspace_edit(
+    original: &str,
+    workspace_edit: WorkspaceEdit,
+    file_uri: &Uri,
+) -> Result<String, RustAnalyzerAdapterError> {
+    let mut edits = collect_text_edits(workspace_edit, file_uri)?;
+    if edits.is_empty() {
+        return Ok(String::from(original));
+    }
+
+    let mut ranges = edits
+        .drain(..)
+        .map(|edit| {
+            let start = lsp_position_to_byte_offset(original, edit.range.start)?;
+            let end = lsp_position_to_byte_offset(original, edit.range.end)?;
+            if end < start {
+                return Err(RustAnalyzerAdapterError::InvalidOutput {
+                    message: format!("edit range end precedes start (start={start}, end={end})"),
+                });
+            }
+            Ok((start, end, edit.new_text))
+        })
+        .collect::<Result<Vec<(usize, usize, String)>, RustAnalyzerAdapterError>>()?;
+
+    ranges.sort_by(|left, right| right.0.cmp(&left.0));
+
+    let mut updated = String::from(original);
+    for (start, end, replacement) in ranges {
+        if end > updated.len() || start > end {
+            return Err(RustAnalyzerAdapterError::InvalidOutput {
+                message: format!("edit range [{start}, {end}) is out of bounds"),
+            });
+        }
+        if !updated.is_char_boundary(start) || !updated.is_char_boundary(end) {
+            return Err(RustAnalyzerAdapterError::InvalidOutput {
+                message: format!("edit range [{start}, {end}) is not UTF-8 aligned"),
+            });
+        }
+
+        updated.replace_range(start..end, &replacement);
+    }
+
+    Ok(updated)
+}
+
+fn collect_text_edits(
+    workspace_edit: WorkspaceEdit,
+    file_uri: &Uri,
+) -> Result<Vec<TextEdit>, RustAnalyzerAdapterError> {
+    let mut edits = Vec::new();
+
+    if let Some(changes) = workspace_edit.changes
+        && let Some(file_edits) = changes.get(file_uri)
+    {
+        edits.extend(file_edits.clone());
+    }
+
+    if let Some(document_changes) = workspace_edit.document_changes {
+        collect_document_changes(&mut edits, document_changes, file_uri)?;
+    }
+
+    Ok(edits)
+}
+
+fn collect_document_changes(
+    target: &mut Vec<TextEdit>,
+    document_changes: DocumentChanges,
+    file_uri: &Uri,
+) -> Result<(), RustAnalyzerAdapterError> {
+    match document_changes {
+        DocumentChanges::Edits(text_document_edits) => {
+            for document_edit in text_document_edits {
+                append_document_edits(
+                    target,
+                    &document_edit.text_document.uri,
+                    document_edit.edits,
+                    file_uri,
+                );
+            }
+            Ok(())
+        }
+        DocumentChanges::Operations(operations) => {
+            for operation in operations {
+                collect_operation(target, operation, file_uri)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn collect_operation(
+    target: &mut Vec<TextEdit>,
+    operation: DocumentChangeOperation,
+    file_uri: &Uri,
+) -> Result<(), RustAnalyzerAdapterError> {
+    match operation {
+        DocumentChangeOperation::Edit(document_edit) => {
+            append_document_edits(
+                target,
+                &document_edit.text_document.uri,
+                document_edit.edits,
+                file_uri,
+            );
+            Ok(())
+        }
+        DocumentChangeOperation::Op(resource_operation) => {
+            Err(RustAnalyzerAdapterError::InvalidOutput {
+                message: format!(
+                    "workspace edit includes unsupported resource operation: {resource_operation:?}"
+                ),
+            })
+        }
+    }
+}
+
+fn append_document_edits(
+    target: &mut Vec<TextEdit>,
+    uri: &Uri,
+    edits: Vec<OneOf<TextEdit, AnnotatedTextEdit>>,
+    requested_uri: &Uri,
+) {
+    if uri != requested_uri {
+        return;
+    }
+
+    for edit in edits {
+        match edit {
+            OneOf::Left(text_edit) => target.push(text_edit),
+            OneOf::Right(annotated_text_edit) => target.push(annotated_text_edit.text_edit),
+        }
+    }
+}
+
+fn lsp_position_to_byte_offset(
+    content: &str,
+    position: Position,
+) -> Result<usize, RustAnalyzerAdapterError> {
+    let line_start = find_line_start_offset(content, position.line)?;
+    let from_line_start = slice_from_checked(content, line_start, "line start")?;
+    let line_end = from_line_start
+        .find('\n')
+        .map_or(content.len(), |relative| line_start + relative);
+    let line_content = slice_range_checked(content, line_start, line_end, "line content")?;
+
+    let mut utf16_units = 0_u32;
+    for (index, character) in line_content.char_indices() {
+        if utf16_units == position.character {
+            return Ok(line_start + index);
+        }
+
+        let char_width = u32::try_from(character.len_utf16()).map_err(|source| {
+            RustAnalyzerAdapterError::InvalidOutput {
+                message: format!("character width conversion failed: {source}"),
+            }
+        })?;
+        utf16_units += char_width;
+
+        if utf16_units > position.character {
+            return Err(RustAnalyzerAdapterError::InvalidOutput {
+                message: format!("position {position:?} splits a UTF-16 code unit sequence"),
+            });
+        }
+    }
+
+    if utf16_units == position.character {
+        return Ok(line_end);
+    }
+
+    Err(RustAnalyzerAdapterError::InvalidOutput {
+        message: format!("position {position:?} exceeds line UTF-16 width {utf16_units}"),
+    })
+}
+
+fn find_line_start_offset(
+    content: &str,
+    target_line: u32,
+) -> Result<usize, RustAnalyzerAdapterError> {
+    if target_line == 0 {
+        return Ok(0);
+    }
+
+    let mut current_line = 0_u32;
+    for (index, character) in content.char_indices() {
+        if character == '\n' {
+            current_line += 1;
+            if current_line == target_line {
+                return Ok(index + '\n'.len_utf8());
+            }
+        }
+    }
+
+    Err(RustAnalyzerAdapterError::InvalidOutput {
+        message: format!("line {target_line} is beyond the end of the document"),
+    })
+}
+
+/// Writes a minimal `Cargo.toml` so rust-analyzer can open the workspace.
+pub(super) fn write_stub_cargo_toml(workspace_root: &Path) -> Result<(), RustAnalyzerAdapterError> {
+    let cargo_toml = workspace_root.join("Cargo.toml");
+    let content = concat!(
+        "[package]\n",
+        "name = \"weaver-rust-analyzer-workspace\"\n",
+        "version = \"0.1.0\"\n",
+        "edition = \"2024\"\n",
+    );
+
+    std::fs::write(&cargo_toml, content).map_err(|source| {
+        RustAnalyzerAdapterError::WorkspaceWrite {
+            path: cargo_toml,
+            source,
+        }
+    })
+}
+
+/// Converts an absolute path to an `lsp_types::Uri` using `file://` encoding.
+pub(super) fn path_to_file_uri(path: &Path) -> Result<Uri, RustAnalyzerAdapterError> {
+    let file_url =
+        url::Url::from_file_path(path).map_err(|()| RustAnalyzerAdapterError::InvalidPath {
+            message: format!("failed to convert '{}' to file:// URI", path.display()),
+        })?;
+
+    file_url
+        .as_str()
+        .parse()
+        .map_err(|source| RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("failed to parse file URI '{}': {source}", file_url.as_str()),
+        })
+}
+
+fn slice_to_checked<'a>(
+    content: &'a str,
+    end: usize,
+    slice_name: &str,
+) -> Result<&'a str, RustAnalyzerAdapterError> {
+    content
+        .get(..end)
+        .ok_or_else(|| RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("invalid UTF-8 slice for {slice_name}: ..{end}"),
+        })
+}
+
+fn slice_from_checked<'a>(
+    content: &'a str,
+    start: usize,
+    slice_name: &str,
+) -> Result<&'a str, RustAnalyzerAdapterError> {
+    content
+        .get(start..)
+        .ok_or_else(|| RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("invalid UTF-8 slice for {slice_name}: {start}.."),
+        })
+}
+
+fn slice_range_checked<'a>(
+    content: &'a str,
+    start: usize,
+    end: usize,
+    slice_name: &str,
+) -> Result<&'a str, RustAnalyzerAdapterError> {
+    content
+        .get(start..end)
+        .ok_or_else(|| RustAnalyzerAdapterError::InvalidOutput {
+            message: format!("invalid UTF-8 slice for {slice_name}: {start}..{end}"),
+        })
+}

--- a/crates/weaver-plugin-rust-analyzer/src/main.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/main.rs
@@ -1,0 +1,17 @@
+//! Binary entrypoint for the rust-analyzer actuator plugin.
+
+use std::io::{self, BufReader, Write};
+
+use weaver_plugin_rust_analyzer::run;
+
+fn main() {
+    let stdin = io::stdin();
+    let mut reader = BufReader::new(stdin.lock());
+    let stdout = io::stdout();
+    let mut writer = stdout.lock();
+
+    if let Err(error) = run(&mut reader, &mut writer) {
+        writeln!(io::stderr().lock(), "{error}").ok();
+        std::process::exit(1);
+    }
+}

--- a/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
@@ -10,7 +10,9 @@ use weaver_plugins::protocol::{
     DiagnosticSeverity, FilePayload, PluginOutput, PluginRequest, PluginResponse,
 };
 
-use crate::{RustAnalyzerAdapter, RustAnalyzerAdapterError, execute_request, failure_response};
+use crate::{
+    ByteOffset, RustAnalyzerAdapter, RustAnalyzerAdapterError, execute_request, failure_response,
+};
 
 #[derive(Default)]
 struct World {
@@ -38,7 +40,7 @@ mock! {
         fn rename(
             &self,
             file: &FilePayload,
-            offset: usize,
+            offset: ByteOffset,
             new_name: &str,
         ) -> Result<String, RustAnalyzerAdapterError>;
     }
@@ -53,7 +55,7 @@ fn should_invoke_rename(request: &PluginRequest) -> bool {
 
 fn configure_adapter_for_mode(adapter: &mut MockBehaviourAdapter, mode: AdapterMode) {
     adapter.expect_rename().once().returning(
-        move |file: &FilePayload, _offset: usize, _new_name: &str| match mode {
+        move |file: &FilePayload, _offset: ByteOffset, _new_name: &str| match mode {
             AdapterMode::Success => Ok(file.content().replace("old_name", "new_name")),
             AdapterMode::NoChange => Ok(file.content().to_owned()),
             AdapterMode::Fails => Err(RustAnalyzerAdapterError::EngineFailed {

--- a/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
@@ -1,0 +1,175 @@
+//! Behaviour-driven tests for rust-analyzer plugin request dispatch.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use mockall::mock;
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use weaver_plugins::protocol::{
+    DiagnosticSeverity, FilePayload, PluginOutput, PluginRequest, PluginResponse,
+};
+
+use crate::{RustAnalyzerAdapter, RustAnalyzerAdapterError, execute_request, failure_response};
+
+#[derive(Default)]
+struct World {
+    request: Option<PluginRequest>,
+    execute_result: Option<Result<PluginResponse, String>>,
+    adapter_mode: AdapterMode,
+}
+
+#[derive(Default, Clone, Copy)]
+enum AdapterMode {
+    #[default]
+    Success,
+    NoChange,
+    Fails,
+}
+
+#[fixture]
+fn world() -> World {
+    World::default()
+}
+
+mock! {
+    BehaviourAdapter {}
+    impl RustAnalyzerAdapter for BehaviourAdapter {
+        fn rename(
+            &self,
+            file: &FilePayload,
+            offset: usize,
+            new_name: &str,
+        ) -> Result<String, RustAnalyzerAdapterError>;
+    }
+}
+
+fn should_invoke_rename(request: &PluginRequest) -> bool {
+    request.operation() == "rename"
+        && !request.files().is_empty()
+        && request.arguments().contains_key("offset")
+        && request.arguments().contains_key("new_name")
+}
+
+fn configure_adapter_for_mode(adapter: &mut MockBehaviourAdapter, mode: AdapterMode) {
+    adapter.expect_rename().once().returning(
+        move |file: &FilePayload, _offset: usize, _new_name: &str| match mode {
+            AdapterMode::Success => Ok(file.content().replace("old_name", "new_name")),
+            AdapterMode::NoChange => Ok(file.content().to_owned()),
+            AdapterMode::Fails => Err(RustAnalyzerAdapterError::EngineFailed {
+                message: String::from("rust-analyzer adapter failed"),
+            }),
+        },
+    );
+}
+
+fn build_request(operation: &str, with_offset: bool, with_new_name: bool) -> PluginRequest {
+    let mut arguments = HashMap::new();
+    if with_offset {
+        arguments.insert(
+            String::from("offset"),
+            serde_json::Value::String(String::from("3")),
+        );
+    }
+    if with_new_name {
+        arguments.insert(
+            String::from("new_name"),
+            serde_json::Value::String(String::from("new_name")),
+        );
+    }
+
+    PluginRequest::with_arguments(
+        operation,
+        vec![FilePayload::new(
+            PathBuf::from("src/main.rs"),
+            "fn old_name() -> i32 {\n    1\n}\n",
+        )],
+        arguments,
+    )
+}
+
+#[given("a rename request with required arguments")]
+fn given_valid_rename(world: &mut World) {
+    world.request = Some(build_request("rename", true, true));
+}
+
+#[given("a rename request missing offset")]
+fn given_missing_offset(world: &mut World) {
+    world.request = Some(build_request("rename", false, true));
+}
+
+#[given("an unsupported extract method request")]
+fn given_unsupported_operation(world: &mut World) {
+    world.request = Some(build_request("extract_method", true, true));
+}
+
+#[given("a rust analyzer adapter that fails")]
+fn given_failing_adapter(world: &mut World) {
+    world.adapter_mode = AdapterMode::Fails;
+}
+
+#[given("a rust analyzer adapter that returns unchanged content")]
+fn given_no_change_adapter(world: &mut World) {
+    world.adapter_mode = AdapterMode::NoChange;
+}
+
+#[when("the plugin executes the request")]
+fn when_execute(world: &mut World) {
+    let request = world.request.as_ref().expect("request should be present");
+    let mut adapter = MockBehaviourAdapter::new();
+    if should_invoke_rename(request) {
+        configure_adapter_for_mode(&mut adapter, world.adapter_mode);
+    }
+    world.execute_result = Some(execute_request(&adapter, request));
+}
+
+/// Resolves the world's execute result to a `PluginResponse`, converting
+/// `Err` outcomes to failure responses for assertion consistency.
+fn resolved_response(world: &World) -> PluginResponse {
+    match world
+        .execute_result
+        .as_ref()
+        .expect("execute result should be present")
+    {
+        Ok(resp) => resp.clone(),
+        Err(msg) => failure_response(msg.clone()),
+    }
+}
+
+#[then("the plugin returns successful diff output")]
+fn then_successful_diff(world: &mut World) {
+    let response = resolved_response(world);
+    assert!(response.is_success());
+    assert!(matches!(response.output(), PluginOutput::Diff { .. }));
+}
+
+#[then("the plugin returns failure diagnostics")]
+fn then_failure_diagnostics(world: &mut World) {
+    let response = resolved_response(world);
+    assert!(!response.is_success());
+    assert_eq!(response.output(), &PluginOutput::Empty);
+    assert!(
+        response
+            .diagnostics()
+            .iter()
+            .any(|diag| diag.severity() == DiagnosticSeverity::Error)
+    );
+}
+
+#[then("the failure message contains {text}")]
+fn then_failure_contains(world: &mut World, text: String) {
+    let needle = text.trim_matches('"');
+    let response = resolved_response(world);
+    let diagnostics = response.diagnostics();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message().contains(needle)),
+        "expected diagnostics to contain '{needle}', got: {diagnostics:?}",
+    );
+}
+
+#[scenario(path = "tests/features/rust_analyzer_plugin.feature")]
+fn rust_analyzer_plugin_behaviour(world: World) {
+    let _ = world;
+}

--- a/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
@@ -1,0 +1,225 @@
+//! Unit and behavioural tests for the rust-analyzer actuator plugin.
+
+mod behaviour;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use mockall::mock;
+use rstest::{fixture, rstest};
+use weaver_plugins::protocol::{FilePayload, PluginOutput, PluginRequest};
+
+use crate::{RustAnalyzerAdapter, RustAnalyzerAdapterError, execute_request, run_with_adapter};
+
+mock! {
+    Adapter {}
+    impl RustAnalyzerAdapter for Adapter {
+        fn rename(
+            &self,
+            file: &FilePayload,
+            offset: usize,
+            new_name: &str,
+        ) -> Result<String, RustAnalyzerAdapterError>;
+    }
+}
+
+/// Builds a `MockAdapter` that expects a single rename call returning `result`.
+fn adapter_returning(result: Result<String, RustAnalyzerAdapterError>) -> MockAdapter {
+    let mut adapter = MockAdapter::new();
+    adapter
+        .expect_rename()
+        .once()
+        .return_once(move |_file, _offset, _new_name| result);
+    adapter
+}
+
+/// Builds a `MockAdapter` where rename is never expected.
+fn adapter_unused() -> MockAdapter {
+    MockAdapter::new()
+}
+
+#[fixture]
+fn rename_arguments() -> HashMap<String, serde_json::Value> {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::String(String::from("3")),
+    );
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+    arguments
+}
+
+fn request_with_args(arguments: HashMap<String, serde_json::Value>) -> PluginRequest {
+    PluginRequest::with_arguments(
+        "rename",
+        vec![FilePayload::new(
+            PathBuf::from("src/main.rs"),
+            "fn old_name() -> i32 {\n    1\n}\n",
+        )],
+        arguments,
+    )
+}
+
+#[rstest]
+fn rename_success_returns_diff_output(rename_arguments: HashMap<String, serde_json::Value>) {
+    let adapter = adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")));
+
+    let response = execute_request(&adapter, &request_with_args(rename_arguments))
+        .expect("execute_request should succeed");
+    assert!(response.is_success());
+    assert!(matches!(response.output(), PluginOutput::Diff { .. }));
+}
+
+fn remove_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("offset");
+}
+
+fn set_boolean_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(String::from("offset"), serde_json::Value::Bool(true));
+}
+
+fn set_negative_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::String(String::from("-1")),
+    );
+}
+
+fn set_numeric_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("offset"),
+        serde_json::Value::Number(serde_json::Number::from(3)),
+    );
+}
+
+fn set_empty_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("  ")),
+    );
+}
+
+fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::Number(serde_json::Number::from(42)),
+    );
+}
+
+#[rstest]
+#[case::missing_offset(remove_offset as fn(&mut _), Some("offset"))]
+#[case::boolean_offset(set_boolean_offset as fn(&mut _), Some("offset"))]
+#[case::negative_offset(set_negative_offset as fn(&mut _), Some("non-negative integer"))]
+#[case::numeric_offset_succeeds(set_numeric_offset as fn(&mut _), None)]
+#[case::numeric_new_name(set_numeric_new_name as fn(&mut _), Some("new_name argument must be a string"))]
+#[case::empty_new_name(set_empty_new_name as fn(&mut _), Some("new_name"))]
+fn rename_argument_validation(
+    #[case] mutate: fn(&mut HashMap<String, serde_json::Value>),
+    #[case] expected_error: Option<&str>,
+    mut rename_arguments: HashMap<String, serde_json::Value>,
+) {
+    mutate(&mut rename_arguments);
+
+    if let Some(needle) = expected_error {
+        let adapter = adapter_unused();
+        let err = execute_request(&adapter, &request_with_args(rename_arguments))
+            .expect_err("invalid arguments should fail");
+        assert!(
+            err.contains(needle),
+            "expected error mentioning '{needle}', got: {err}"
+        );
+    } else {
+        let adapter = adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")));
+        let response = execute_request(&adapter, &request_with_args(rename_arguments))
+            .expect("valid arguments should succeed");
+        assert!(response.is_success());
+    }
+}
+
+#[test]
+fn unsupported_operation_returns_error() {
+    let adapter = adapter_unused();
+    let request = PluginRequest::new("extract_method", Vec::new());
+
+    let err = execute_request(&adapter, &request).expect_err("unsupported operation should fail");
+    assert!(
+        err.contains("unsupported"),
+        "expected error mentioning 'unsupported', got: {err}"
+    );
+}
+
+enum FailureScenario {
+    NoChange,
+    AdapterError,
+}
+
+#[rstest]
+#[case::no_change(FailureScenario::NoChange)]
+#[case::adapter_error(FailureScenario::AdapterError)]
+fn rename_non_mutating_or_error_returns_failure(
+    #[case] scenario: FailureScenario,
+    rename_arguments: HashMap<String, serde_json::Value>,
+) {
+    let adapter = match &scenario {
+        FailureScenario::AdapterError => {
+            adapter_returning(Err(RustAnalyzerAdapterError::EngineFailed {
+                message: String::from("rust-analyzer adapter failed"),
+            }))
+        }
+        FailureScenario::NoChange => {
+            adapter_returning(Ok(String::from("fn old_name() -> i32 {\n    1\n}\n")))
+        }
+    };
+
+    let err = execute_request(&adapter, &request_with_args(rename_arguments))
+        .expect_err("failure scenario should return Err");
+
+    match scenario {
+        FailureScenario::NoChange => assert!(
+            err.contains("no content changes"),
+            "expected no-change diagnostic, got: {err}"
+        ),
+        FailureScenario::AdapterError => assert!(
+            err.contains("rust-analyzer adapter failed"),
+            "expected adapter error message, got: {err}"
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// stdin/stdout dispatch layer tests (run_with_adapter)
+// ---------------------------------------------------------------------------
+
+fn valid_request_json() -> String {
+    let request = request_with_args(rename_arguments());
+    serde_json::to_string(&request).expect("serialize request")
+}
+
+/// Dispatches `input` through `run_with_adapter` and parses the response.
+fn dispatch_stdin(input: &[u8], adapter: &MockAdapter) -> weaver_plugins::protocol::PluginResponse {
+    let mut stdin = std::io::Cursor::new(input.to_vec());
+    let mut stdout = Vec::new();
+    run_with_adapter(&mut stdin, &mut stdout, adapter).expect("dispatch should succeed");
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    serde_json::from_str(output.trim()).expect("parse response")
+}
+
+#[rstest]
+#[case::success(
+    format!("{}\n", valid_request_json()).into_bytes(),
+    adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n"))),
+    true
+)]
+#[case::empty_stdin(Vec::new(), adapter_unused(), false)]
+#[case::invalid_json(b"not valid json\n".to_vec(), adapter_unused(), false)]
+fn run_with_adapter_dispatch_layer(
+    #[case] input: Vec<u8>,
+    #[case] adapter: MockAdapter,
+    #[case] expect_success: bool,
+) {
+    let response = dispatch_stdin(&input, &adapter);
+    assert_eq!(response.is_success(), expect_success);
+}

--- a/crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature
+++ b/crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature
@@ -1,0 +1,32 @@
+Feature: rust-analyzer actuator plugin
+
+  Scenario: Rename succeeds with diff output
+    Given a rename request with required arguments
+    When the plugin executes the request
+    Then the plugin returns successful diff output
+
+  Scenario: Rename fails when offset is missing
+    Given a rename request missing offset
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "offset"
+
+  Scenario: Unsupported operation fails with diagnostics
+    Given an unsupported extract method request
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "unsupported"
+
+  Scenario: Adapter failures are surfaced
+    Given a rename request with required arguments
+    And a rust analyzer adapter that fails
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "rust-analyzer adapter failed"
+
+  Scenario: Unchanged output is treated as failure
+    Given a rename request with required arguments
+    And a rust analyzer adapter that returns unchanged content
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "no content changes"

--- a/crates/weaverd/src/dispatch/act/refactor/plugin_paths.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/plugin_paths.rs
@@ -1,0 +1,58 @@
+//! Plugin path constants and resolution helpers for `act refactor`.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use crate::dispatch::router::DISPATCH_TARGET;
+
+/// Environment variable overriding the rope plugin executable path.
+pub(super) const ROPE_PLUGIN_PATH_ENV: &str = "WEAVER_ROPE_PLUGIN_PATH";
+/// Default executable path for the rope plugin.
+pub(super) const DEFAULT_ROPE_PLUGIN_PATH: &str = "/usr/bin/weaver-plugin-rope";
+/// Registered rope plugin provider name.
+pub(super) const ROPE_PLUGIN_NAME: &str = "rope";
+/// Registered rope plugin provider version.
+pub(super) const ROPE_PLUGIN_VERSION: &str = "0.1.0";
+
+/// Environment variable overriding the rust-analyzer plugin executable path.
+pub(super) const RUST_ANALYZER_PLUGIN_PATH_ENV: &str = "WEAVER_RUST_ANALYZER_PLUGIN_PATH";
+/// Default executable path for the rust-analyzer plugin.
+pub(super) const DEFAULT_RUST_ANALYZER_PLUGIN_PATH: &str = "/usr/bin/weaver-plugin-rust-analyzer";
+/// Registered rust-analyzer plugin provider name.
+pub(super) const RUST_ANALYZER_PLUGIN_NAME: &str = "rust-analyzer";
+/// Registered rust-analyzer plugin provider version.
+pub(super) const RUST_ANALYZER_PLUGIN_VERSION: &str = "0.1.0";
+/// Timeout budget for rust-analyzer plugin execution.
+pub(super) const RUST_ANALYZER_PLUGIN_TIMEOUT_SECS: u64 = 60;
+
+/// Converts an optional executable override to an absolute rope plugin path.
+pub(super) fn resolve_rope_plugin_path(raw_override: Option<OsString>) -> PathBuf {
+    resolve_plugin_path(raw_override, DEFAULT_ROPE_PLUGIN_PATH)
+}
+
+/// Converts an optional executable override to an absolute rust-analyzer path.
+pub(super) fn resolve_rust_analyzer_plugin_path(raw_override: Option<OsString>) -> PathBuf {
+    resolve_plugin_path(raw_override, DEFAULT_RUST_ANALYZER_PLUGIN_PATH)
+}
+
+fn resolve_plugin_path(raw_override: Option<OsString>, default_path: &str) -> PathBuf {
+    let candidate = raw_override
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(default_path));
+    if candidate.is_absolute() {
+        return candidate;
+    }
+
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.join(candidate),
+        Err(error) => {
+            tracing::warn!(
+                target: DISPATCH_TARGET,
+                path = %candidate.display(),
+                %error,
+                "cannot resolve relative plugin path against working directory; using path as-is"
+            );
+            candidate
+        }
+    }
+}

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -9,7 +9,7 @@ use weaver_plugins::{PluginError, PluginOutput, PluginRequest, PluginResponse};
 
 use super::{
     DispatchError, FusionBackends, RefactorContext, RefactorPluginRuntime, ResponseWriter,
-    default_runtime, handle, resolve_rope_plugin_path,
+    default_runtime, handle, resolve_rope_plugin_path, resolve_rust_analyzer_plugin_path,
 };
 use crate::dispatch::request::{CommandDescriptor, CommandRequest};
 use crate::semantic_provider::SemanticBackendProvider;
@@ -228,6 +228,14 @@ fn handle_diff_output_applies_patch_through_apply_patch_pipeline(socket_dir: Tem
 #[test]
 fn resolve_rope_plugin_path_makes_relative_overrides_absolute() {
     let path = resolve_rope_plugin_path(Some(std::ffi::OsString::from("bin/rope")));
+    assert!(path.is_absolute());
+}
+
+#[test]
+fn resolve_rust_analyzer_plugin_path_makes_relative_overrides_absolute() {
+    let path = resolve_rust_analyzer_plugin_path(Some(std::ffi::OsString::from(
+        "bin/rust-analyzer-plugin",
+    )));
     assert!(path.is_absolute());
 }
 

--- a/docs/execplans/3-1-1b-plugin-for-rust-analyzer.md
+++ b/docs/execplans/3-1-1b-plugin-for-rust-analyzer.md
@@ -1,0 +1,124 @@
+# Implement the rust-analyzer actuator plugin
+
+This Execution Plan (ExecPlan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: COMPLETE (2026-02-17)
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root.
+
+`PLANS.md` is not present in this repository, so no additional plan governance
+applies beyond `AGENTS.md` and this ExecPlan.
+
+## Purpose / big picture
+
+Deliver the second specialist actuator plugin by integrating `rust-analyzer`
+for Rust refactoring. After this work, the following command executes a
+sandboxed rust-analyzer-backed plugin:
+
+```sh
+weaver act refactor --provider rust-analyzer --refactoring rename --file src/main.rs offset=42 new_name=better_name
+```
+
+The command receives a unified diff and applies it through the existing
+Double-Lock safety harness.
+
+Observable success:
+
+- `act refactor` with `--provider rust-analyzer` succeeds for supported
+  operations and modifies files only after lock verification.
+- Unsupported operations, missing arguments, plugin protocol errors, and lock
+  failures return structured failures and leave files unchanged.
+- Unit, behavioural (`rstest-bdd` v0.5.0), and end-to-end tests cover happy,
+  unhappy, and edge cases.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+  reflect shipped behaviour.
+- `make check-fmt`, `make lint`, and `make test` succeed.
+
+## Constraints
+
+- Keep all execution synchronous (no async runtime introduction).
+- Keep plugin execution sandboxed via `weaver-sandbox` and
+  `weaver-plugins::process::SandboxExecutor`.
+- Do not bypass the Double-Lock harness for plugin-produced edits.
+- Continue using `rstest-bdd` v0.5.0 and write behavioural tests with mutable
+  world fixtures (`&mut World`).
+- Add end-to-end command ergonomics tests in `crates/weaver-e2e/` using
+  `assert_cmd` and `insta` snapshots.
+- Keep files under 400 lines by splitting modules where needed.
+- Use DI boundaries so tests do not require a system rust-analyzer install.
+- Run quality gates with `tee` and `set -o pipefail` before finishing.
+
+## Tolerances (exception triggers)
+
+- Scope: if delivery requires touching more than 26 files or ~2400 net lines,
+  stop and escalate.
+- Interface: if public protocol schema in
+  `crates/weaver-plugins/src/protocol/mod.rs` must break compatibility, stop
+  and escalate.
+- Dependencies: if adding new external crates beyond existing workspace
+  dependencies becomes necessary, stop and escalate with justification.
+- Iterations: if the same failing test loop repeats 5 times without progress,
+  stop and escalate.
+
+## Risks
+
+- Risk: rust-analyzer startup and indexing can exceed default plugin timeout.
+  Severity: high. Likelihood: medium. Mitigation: register a 60-second timeout
+  for the rust-analyzer actuator.
+- Risk: LSP `WorkspaceEdit` response shape may include unsupported resource
+  operations. Severity: medium. Likelihood: medium. Mitigation: validate and
+  surface clear adapter errors.
+- Risk: LSP position encoding and UTF-8 offsets can mismatch. Severity: high.
+  Likelihood: medium. Mitigation: convert offsets using UTF-16-aware helpers.
+
+## Progress
+
+- [x] (2026-02-17 00:00Z) Added `crates/weaver-plugin-rust-analyzer/` crate
+      with request dispatch, adapter trait boundary, and binary entrypoint.
+- [x] (2026-02-17 00:20Z) Implemented production adapter using rust-analyzer
+      LSP JSON-RPC flow with workspace-edit application.
+- [x] (2026-02-17 00:35Z) Wired runtime registration in `weaverd` for the
+      rust-analyzer provider and added path resolution tests.
+- [x] (2026-02-17 00:45Z) Added unit and behavioural tests for plugin dispatch,
+      plus e2e CLI snapshots for rust-analyzer command ergonomics.
+- [x] (2026-02-17 01:00Z) Updated design docs, user guide, and roadmap status.
+- [x] (2026-02-17 01:15Z) Ran full quality gates successfully.
+
+## Surprises & Discoveries
+
+- Observation: project memory MCP resources were unavailable in this session
+  (`list_mcp_resources` returned no servers/resources). Work relied on local
+  docs and source inspection.
+- Observation: `crates/weaverd/src/dispatch/act/refactor/mod.rs` was near the
+  400-line cap. Path-resolution logic was extracted into `plugin_paths.rs`
+  before adding the new provider.
+
+## Decision Log
+
+- Decision: mirror `weaver-plugin-rope` crate shape for rust-analyzer.
+  Rationale: consistent plugin ergonomics and lower maintenance overhead.
+  Date/Author: 2026-02-17 / Codex
+- Decision: implement rust-analyzer integration through short-lived LSP
+  JSON-RPC 2.0 stdio exchange rather than custom analysis logic. Rationale:
+  semantic correctness and alignment with existing LSP strategy. Date/Author:
+  2026-02-17 / Codex
+- Decision: keep all unit/BDD tests mock-based at adapter boundary.
+  Rationale: deterministic test suite without requiring rust-analyzer on host.
+  Date/Author: 2026-02-17 / Codex
+
+## Outcomes & Retrospective
+
+- Added `weaver-plugin-rust-analyzer` as the second actuator plugin with
+  `rename` support (`offset`, `new_name`) and structured failure diagnostics.
+- Registered rust-analyzer provider in `weaverd` with language `rust`, default
+  executable `/usr/bin/weaver-plugin-rust-analyzer`, override via
+  `WEAVER_RUST_ANALYZER_PLUGIN_PATH`, and timeout `60s`.
+- Added plugin unit tests, `rstest-bdd` behavioural tests, and e2e CLI
+  snapshot coverage for actuator isolation and observe→jq→act pipelines.
+- Updated `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+  to capture behaviour and design decisions.
+- Full quality gates passed before completion.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -173,7 +173,7 @@ language-specific tools.*
 
   - [x] A plugin for `rope` to provide advanced Python refactoring.
 
-  - [ ] A plugin for `rust-analyzer` to provide advanced Rust refactoring.
+  - [x] A plugin for `rust-analyzer` to provide advanced Rust refactoring.
 
   - [ ] A plugin for `srgn` to provide high-performance, precision
         syntactic editing.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -530,27 +530,36 @@ weaver act refactor --provider <PLUGIN> --refactoring <OP> --file <PATH> [KEY=VA
 
 Arguments:
 
-| Flag            | Description                                            |
-| --------------- | ------------------------------------------------------ |
-| `--provider`    | Name of the registered plugin (e.g. `rope`).           |
-| `--refactoring` | Refactoring operation to request (currently `rename`). |
-| `--file`        | Path to the target file (relative to workspace root).  |
-| `KEY=VALUE`     | Extra key-value arguments forwarded to the plugin.     |
+| Flag            | Description                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `--provider`    | Name of the registered plugin (e.g. `rope`, `rust-analyzer`). |
+| `--refactoring` | Refactoring operation to request (currently `rename`).        |
+| `--file`        | Path to the target file (relative to workspace root).         |
+| `KEY=VALUE`     | Extra key-value arguments forwarded to the plugin.            |
 
 The plugin receives the file content in-band as part of the JSONL request and
 does not need filesystem access. The daemon validates the resulting diff
 through both the syntactic (Tree-sitter) and semantic (LSP) locks before
 writing to disk.
 
-For the built-in `rope` actuator, `rename` requires `offset=<BYTE_OFFSET>` and
+For the built-in actuators, `rename` requires `offset=<BYTE_OFFSET>` and
 `new_name=<IDENTIFIER>` in the trailing `KEY=VALUE` arguments.
 
-The daemon ships with a default `rope` actuator registration. By default, it
-expects the plugin executable at `/usr/bin/weaver-plugin-rope`. Override the
-path with:
+The daemon ships with default actuator registrations:
+
+- `rope` for Python (`timeout_secs = 30`)
+- `rust-analyzer` for Rust (`timeout_secs = 60`)
+
+By default, it expects plugin executables at:
+
+- `/usr/bin/weaver-plugin-rope`
+- `/usr/bin/weaver-plugin-rust-analyzer`
+
+Override these paths with:
 
 ```sh
 WEAVER_ROPE_PLUGIN_PATH=/absolute/path/to/weaver-plugin-rope
+WEAVER_RUST_ANALYZER_PLUGIN_PATH=/absolute/path/to/weaver-plugin-rust-analyzer
 ```
 
 The override path is resolved to an absolute path at daemon startup. If the
@@ -606,12 +615,19 @@ The daemon maintains a `PluginRegistry` that stores validated plugin manifests
 keyed by name. Plugins can be looked up by name, kind, language, or a
 combination thereof (e.g. "find all actuator plugins for Python").
 
-For the first actuator rollout, `weaverd` registers the `rope` plugin using:
+For the current actuator rollout, `weaverd` registers:
 
-- name: `rope`
-- kind: `actuator`
-- language: `python`
-- executable: `/usr/bin/weaver-plugin-rope` (or `WEAVER_ROPE_PLUGIN_PATH`)
+- `rope`
+  - kind: `actuator`
+  - language: `python`
+  - executable: `/usr/bin/weaver-plugin-rope` (or `WEAVER_ROPE_PLUGIN_PATH`)
+  - timeout: `30s`
+- `rust-analyzer`
+  - kind: `actuator`
+  - language: `rust`
+  - executable: `/usr/bin/weaver-plugin-rust-analyzer`
+    (or `WEAVER_RUST_ANALYZER_PLUGIN_PATH`)
+  - timeout: `60s`
 
 ### Safety harness integration
 


### PR DESCRIPTION
## Summary
- Implemented a new rust-analyzer actuator plugin (weaver-plugin-rust-analyzer) with a production LSP-based adapter, plus unit, behavioural, and end-to-end tests.
- Integrated rust-analyzer plugin into the weaver runtime wiring, including path resolution and timeout configuration.
- Added extensive end-to-end CLI snapshots to verify ergonomics of observe→jq→act pipelines.
- Introduced supportive LSP & text-edit tooling to translate rust-analyzer workspace edits into file diffs.
- Updated documentation references and the runtime design to cover the new provider.

## Changes

### New crate: weaver-plugin-rust-analyzer
- Added a dedicated actuator plugin following the rope plugin structure for consistency.
- Contains production adapter (RustAnalyzerLspAdapter) and a lightweight JSON-RPC 2.0 over stdio flow with LSP framing.
- Exposes a single operation: rename, executed in a sandboxed rust-analyzer session.
- Entry point binary at crates/weaver-plugin-rust-analyzer/src/main.rs and library at crates/weaver-plugin-rust-analyzer/src/lib.rs.

### Core functionality
- run_with_adapter(stdin, stdout, adapter) and run(stdin, stdout) orchestration for a single plugin request.
- Request dispatch supports rename with arguments: offset and new_name, plus a single file payload.
- Generates a diff patch (diff-like format) to apply changes via the existing patch pipeline.

### LSP / JSON-RPC integration
- Implemented a short-lived LSP flow: initialize, textDocument/didOpen, textDocument/rename, shutdown, and exit.
- JSON-RPC helpers (jsonrpc.rs) for sending requests/notifications and receiving results.
- Workspace edit handling: parse, validate, and apply workspace edits to the original content.
- Robust error handling paths for protocol errors and adapter failures.

### Workspace and sandboxing
- Temporary workspace with a minimal Cargo.toml and the target Rust file to provide rust-analyzer semantic context.
- Functions for writing workspace files, validating safe relative paths, and converting paths to file:// URIs.

### Text edits and patching
- Implemented workspace edit collection and patch generation in text_edits.rs.
- Includes utilities to convert LSP positions to byte offsets and vice versa, with UTF-16 awareness.

### Path resolution utilities
- Added weaverd support for rust-analyzer path resolution via new module crates/weaverd/src/dispatch/act/refactor/plugin_paths.rs.
- Introduces WEAVER_RUST_ANALYZER_PLUGIN_PATH and related defaults and timeouts (60s).
- Refactor in weaverd to register rust-analyzer alongside rope, using matched language metadata and timeout.

### Entry points and runtime wiring
- Added main binary (src/main.rs) and exported RustAnalyzerLspAdapter in lib.rs.
- Updated runtime registration (weaverd) to include rust-analyzer plugin and its timeout.

### Tests
- Unit tests and behavioural tests under crates/weaver-plugin-rust-analyzer/src/tests/ (behaviour.rs, mod.rs).
- Behavioural tests use mock adapters to validate dispatch logic and error handling.
- End-to-end CLI snapshots added for rust-analyzer-related flows:
  - weaver act refactor with rust-analyzer (CLI isolation)
  - pipeline observe get-definition | jq ... | weaver act refactor
- End-to-end tests live under crates/weaver-e2e/tests/... with auto-generated insta snapshots.

### Documentation
- Updated docs to reflect rust-analyzer as an actuator provider with a 60s timeout.
- Enhanced users guide for multi-plugin providers and how to override plugin paths.
- Expanded roadmap with rust-analyzer provider status and design decisions in weaver-design.md, and related docs.

### Build / CI
- Cargo.toml updated to include the new weaver-plugin-rust-analyzer crate in the workspace.
- Cargo.lock updated to reflect new dependencies and packages.
- Snapshot tests and end-to-end ergonomics checks wired into existing test framework.

## Testing plan
- [x] Unit tests for the RustAnalyzerLspAdapter rename workflow and error paths.
- [x] Behavioural tests covering rename success, missing arguments, unsupported operations, adapter failures, and non-changing output.
- [x] End-to-end CLI tests with end-to-end snapshots for actuator isolation and observe→jq pipelines.
- [x] Compatibility tests ensuring path resolution honors absolute vs relative overrides and platform agnosticism.
- [x] Snapshot verification for CLI ergonomics using insta snapshots.

## How to run locally
- Unit tests for the rust-analyzer plugin:
  - cargo test -p weaver-plugin-rust-analyzer
- Full workspace tests (as per project setup):
  - cargo test
- End-to-end CLI tests rely on jq and a Rust toolchain; ensure dependencies are on PATH and run via the existing test suite.

## Notes for reviewers
- The rust-analyzer integration uses a short-lived LSP session to perform a single rename operation and materialize a WorkspaceEdit diff.
- All user-visible changes go through the existing Double-Lock path to ensure syntactic and semantic safety.
- The new plugin path resolution mirrors rope’s approach to keep behavior consistent and predictable in varied environments.


📎 **Task**: https://www.devboxer.com/task/711d6404-b5e3-4f0d-88e6-9932522f3fcc