### PR TITLE
Implement Fluent-localized bare-invocation help for Weaver CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,9 +1265,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ortho_config"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e82f7058eab712537b07c5f9e8367da9ade93c42ae08286a5272ae8e5c2435"
+checksum = "2ee9d60c6be312d7c6ce47b7146e3c9b8464c54fc304ef8f7656e29c268faeb1"
 dependencies = [
  "camino",
  "clap",
@@ -1276,20 +1276,24 @@ dependencies = [
  "dirs 5.0.1",
  "dunce",
  "figment",
+ "fluent-bundle",
+ "fluent-syntax",
  "ortho_config_macros",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "toml 0.9.8",
+ "tracing",
  "uncased",
+ "unic-langid",
  "xdg",
 ]
 
 [[package]]
 name = "ortho_config_macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df57a79d218bae4aa23466dc2156e8f0c2e85ceac788097839d71b38b8c0e9e5"
+checksum = "992d8fc0b33823adb993fe8968614ac0df3964d9e3564f7a147fd253e27a3acd"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ insta = "1.41"
 lsp-types = "0.97"
 mockall = "0.14.0"
 once_cell = "1.19"
-ortho_config = "0.6.0"
+ortho_config = "0.7.0"
 predicates = "3.1"
 rstest = "0.26.1"
 rstest-bdd = { version = "0.5.0", default-features = false }

--- a/crates/weaver-cli/locales/en-US/messages.ftl
+++ b/crates/weaver-cli/locales/en-US/messages.ftl
@@ -1,0 +1,7 @@
+# Bare-invocation help block shown when weaver is run without arguments.
+weaver-bare-help-usage = Usage: weaver <DOMAIN> <OPERATION> [ARG]...
+weaver-bare-help-header = Domains:
+weaver-bare-help-domain-observe = observe   Query code structure and relationships
+weaver-bare-help-domain-act = act       Perform code modifications
+weaver-bare-help-domain-verify = verify    Validate code correctness
+weaver-bare-help-pointer = Run 'weaver --help' for more information.

--- a/crates/weaver-cli/src/cli.rs
+++ b/crates/weaver-cli/src/cli.rs
@@ -50,21 +50,6 @@ pub(crate) struct Cli {
     pub(crate) arguments: Vec<String>,
 }
 
-impl Cli {
-    /// Returns true when no domain, subcommand, or probe flag was supplied.
-    ///
-    /// This detects the case where the operator invoked `weaver` with no
-    /// meaningful arguments, so the runner can emit short help guidance
-    /// before attempting configuration loading or daemon contact.
-    #[allow(
-        dead_code,
-        reason = "used by lib.rs but not by build.rs which #[path]-includes cli.rs"
-    )]
-    pub(crate) fn is_bare_invocation(&self) -> bool {
-        self.domain.is_none() && self.command.is_none() && !self.capabilities
-    }
-}
-
 /// Structured subcommands for the Weaver CLI.
 #[derive(Subcommand, Debug, Clone)]
 pub(crate) enum CliCommand {

--- a/crates/weaver-cli/src/cli.rs
+++ b/crates/weaver-cli/src/cli.rs
@@ -50,6 +50,21 @@ pub(crate) struct Cli {
     pub(crate) arguments: Vec<String>,
 }
 
+impl Cli {
+    /// Returns true when no domain, subcommand, or probe flag was supplied.
+    ///
+    /// This detects the case where the operator invoked `weaver` with no
+    /// meaningful arguments, so the runner can emit short help guidance
+    /// before attempting configuration loading or daemon contact.
+    #[allow(
+        dead_code,
+        reason = "used by lib.rs but not by build.rs which #[path]-includes cli.rs"
+    )]
+    pub(crate) fn is_bare_invocation(&self) -> bool {
+        self.domain.is_none() && self.command.is_none() && !self.capabilities
+    }
+}
+
 /// Structured subcommands for the Weaver CLI.
 #[derive(Subcommand, Debug, Clone)]
 pub(crate) enum CliCommand {

--- a/crates/weaver-cli/src/config.rs
+++ b/crates/weaver-cli/src/config.rs
@@ -62,6 +62,15 @@ pub(crate) struct ConfigArgumentSplit {
     pub(crate) command_start: usize,
 }
 
+impl ConfigArgumentSplit {
+    /// Returns true when the operator supplied at least one configuration
+    /// flag (e.g. `--config-path`).  The binary name at index 0 is always
+    /// present and does not count.
+    pub(crate) fn has_config_flags(&self) -> bool {
+        self.config_arguments.len() > 1
+    }
+}
+
 pub(crate) fn split_config_arguments(args: &[OsString]) -> ConfigArgumentSplit {
     if args.is_empty() {
         return ConfigArgumentSplit {

--- a/crates/weaver-cli/src/errors.rs
+++ b/crates/weaver-cli/src/errors.rs
@@ -18,7 +18,7 @@ pub(crate) enum AppError {
     #[error("the command operation must be provided")]
     MissingOperation,
     /// Sentinel for bare invocation — help has already been written.
-    #[error("")]
+    #[error("bare invocation")]
     BareInvocation,
     #[error("failed to resolve daemon address {endpoint}: {source}")]
     Resolve { endpoint: String, source: io::Error },

--- a/crates/weaver-cli/src/errors.rs
+++ b/crates/weaver-cli/src/errors.rs
@@ -17,6 +17,9 @@ pub(crate) enum AppError {
     MissingDomain,
     #[error("the command operation must be provided")]
     MissingOperation,
+    /// Sentinel for bare invocation — help has already been written.
+    #[error("")]
+    BareInvocation,
     #[error("failed to resolve daemon address {endpoint}: {source}")]
     Resolve { endpoint: String, source: io::Error },
     #[error("failed to connect to daemon at {endpoint}: {source}")]

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -147,7 +147,7 @@ where
         let result = Cli::try_parse_from(cli_arguments)
             .map_err(AppError::CliUsage)
             .and_then(|cli| {
-                if cli.is_bare_invocation() {
+                if cli.is_bare_invocation() && !split.has_config_flags() {
                     write_bare_help(&mut *self.io.stderr, localizer).ok();
                     return Err(AppError::BareInvocation);
                 }

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -148,7 +148,7 @@ where
             .map_err(AppError::CliUsage)
             .and_then(|cli| {
                 if cli.is_bare_invocation() {
-                    let _ = write_bare_help(&mut *self.io.stderr, localizer);
+                    write_bare_help(&mut *self.io.stderr, localizer).ok();
                     return Err(AppError::BareInvocation);
                 }
                 self.loader

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -88,6 +88,14 @@ impl<'a, R: Read, W: Write, E: Write> IoStreams<'a, R, W, E> {
     }
 }
 
+impl Cli {
+    /// Returns true when no domain, subcommand, or probe flag was supplied,
+    /// indicating the operator needs short help guidance.
+    fn is_bare_invocation(&self) -> bool {
+        self.domain.is_none() && self.command.is_none() && !self.capabilities
+    }
+}
+
 struct CliRunner<'a, R: Read, W: Write, E: Write, L: ConfigLoader> {
     io: &'a mut IoStreams<'a, R, W, E>,
     loader: &'a L,

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -6,6 +6,7 @@
 //! configuration loading and IO streams can be substituted.
 
 use clap::Parser;
+use ortho_config::Localizer;
 use std::ffi::{OsStr, OsString};
 use std::io::{Read, Write};
 use std::process::ExitCode;
@@ -17,6 +18,7 @@ mod config;
 mod daemon_output;
 mod errors;
 mod lifecycle;
+mod localizer;
 pub mod output;
 mod runtime_utils;
 mod transport;
@@ -34,6 +36,7 @@ use lifecycle::{
     LifecycleContext, LifecycleError, LifecycleInvocation, LifecycleOutput, SystemLifecycle,
     try_auto_start_daemon,
 };
+use localizer::{build_localizer, write_bare_help};
 pub use output::{OutputContext, ResolvedOutputFormat, render_human_output};
 use runtime_utils::emit_capabilities;
 pub(crate) use runtime_utils::exit_code_from_status;
@@ -116,13 +119,19 @@ where
     where
         I: IntoIterator<Item = OsString>,
     {
+        let localizer = build_localizer();
         let mut lifecycle = SystemLifecycle;
-        self.run_with_handler(args, |invocation, context, output| {
+        self.run_with_handler(args, localizer.as_ref(), |invocation, context, output| {
             lifecycle.handle(invocation, context, output)
         })
     }
 
-    fn run_with_handler<I, F>(&mut self, args: I, mut handler: F) -> ExitCode
+    fn run_with_handler<I, F>(
+        &mut self,
+        args: I,
+        localizer: &dyn Localizer,
+        mut handler: F,
+    ) -> ExitCode
     where
         I: IntoIterator<Item = OsString>,
         F: FnMut(
@@ -138,6 +147,10 @@ where
         let result = Cli::try_parse_from(cli_arguments)
             .map_err(AppError::CliUsage)
             .and_then(|cli| {
+                if cli.is_bare_invocation() {
+                    let _ = write_bare_help(&mut *self.io.stderr, localizer);
+                    return Err(AppError::BareInvocation);
+                }
                 self.loader
                     .load(&split.config_arguments)
                     .map(|config| (cli, config))
@@ -179,6 +192,7 @@ where
 
         match result {
             Ok(exit_code) => exit_code,
+            Err(AppError::BareInvocation) => ExitCode::FAILURE,
             Err(error) => {
                 let _ = writeln!(self.io.stderr, "{error}");
                 ExitCode::FAILURE
@@ -352,6 +366,7 @@ pub(crate) fn run_with_daemon_binary<'a, I, R, W, E, L, F>(
     io: &'a mut IoStreams<'a, R, W, E>,
     loader: &'a L,
     daemon_binary: Option<&'a OsStr>,
+    localizer: &dyn Localizer,
     handler: F,
 ) -> ExitCode
 where
@@ -368,7 +383,7 @@ where
 {
     CliRunner::new(io, loader)
         .with_daemon_binary(daemon_binary)
-        .run_with_handler(args, handler)
+        .run_with_handler(args, localizer, handler)
 }
 
 #[cfg(test)]

--- a/crates/weaver-cli/src/localizer.rs
+++ b/crates/weaver-cli/src/localizer.rs
@@ -1,0 +1,85 @@
+//! Localization support for the Weaver CLI.
+//!
+//! Constructs a Fluent-backed localizer from embedded resources so
+//! user-facing text can be translated without code changes.  Falls back
+//! to [`NoOpLocalizer`] (hardcoded English) when the Fluent pipeline
+//! fails.
+
+use std::io::Write;
+
+use ortho_config::{FluentLocalizer, Localizer, NoOpLocalizer};
+
+/// Embedded en-US Fluent catalogue for the Weaver CLI.
+static WEAVER_EN_US: &str = include_str!("../locales/en-US/messages.ftl");
+
+/// Builds the application localizer.
+///
+/// Returns a [`FluentLocalizer`] loaded with the embedded en-US
+/// catalogue.  Falls back to [`NoOpLocalizer`] on error so the CLI
+/// never crashes due to a localization failure.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let loc = build_localizer();
+/// let msg = loc.message("weaver-bare-help-usage", None, "fallback");
+/// ```
+pub(crate) fn build_localizer() -> Box<dyn Localizer> {
+    match FluentLocalizer::with_en_us_defaults([WEAVER_EN_US]) {
+        Ok(loc) => Box::new(loc),
+        Err(_) => Box::new(NoOpLocalizer),
+    }
+}
+
+/// Writes the bare-invocation help block to `writer`.
+///
+/// Each line is resolved through the localizer with a hardcoded English
+/// fallback, so the output is correct even without Fluent resources.
+///
+/// # Errors
+///
+/// Returns [`std::io::Error`] if writing to the underlying stream fails.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let loc = ortho_config::NoOpLocalizer;
+/// let mut buf = Vec::new();
+/// write_bare_help(&mut buf, &loc).unwrap();
+/// assert!(String::from_utf8(buf).unwrap().contains("Usage:"));
+/// ```
+pub(crate) fn write_bare_help<W: Write>(
+    writer: &mut W,
+    localizer: &dyn Localizer,
+) -> std::io::Result<()> {
+    let usage = localizer.message(
+        "weaver-bare-help-usage",
+        None,
+        "Usage: weaver <DOMAIN> <OPERATION> [ARG]...",
+    );
+    let header = localizer.message("weaver-bare-help-header", None, "Domains:");
+    let observe = localizer.message(
+        "weaver-bare-help-domain-observe",
+        None,
+        "observe   Query code structure and relationships",
+    );
+    let act = localizer.message(
+        "weaver-bare-help-domain-act",
+        None,
+        "act       Perform code modifications",
+    );
+    let verify = localizer.message(
+        "weaver-bare-help-domain-verify",
+        None,
+        "verify    Validate code correctness",
+    );
+    let pointer = localizer.message(
+        "weaver-bare-help-pointer",
+        None,
+        "Run 'weaver --help' for more information.",
+    );
+    write!(
+        writer,
+        "{usage}\n\n{header}\n  {observe}\n  {act}\n  {verify}\n\n{pointer}\n",
+    )
+}

--- a/crates/weaver-cli/src/localizer.rs
+++ b/crates/weaver-cli/src/localizer.rs
@@ -12,6 +12,39 @@ use ortho_config::{FluentLocalizer, Localizer, NoOpLocalizer};
 /// Embedded en-US Fluent catalogue for the Weaver CLI.
 pub(crate) static WEAVER_EN_US: &str = include_str!("../locales/en-US/messages.ftl");
 
+/// Bare-help message definitions: `(fluent_id, english_fallback)`.
+///
+/// The fallback values must match `locales/en-US/messages.ftl`; the
+/// `fluent_and_fallback_outputs_are_identical` test guards against drift.
+mod bare_help {
+    pub(super) const USAGE: (&str, &str) = (
+        "weaver-bare-help-usage",
+        "Usage: weaver <DOMAIN> <OPERATION> [ARG]...",
+    );
+    pub(super) const HEADER: (&str, &str) = ("weaver-bare-help-header", "Domains:");
+    pub(super) const OBSERVE: (&str, &str) = (
+        "weaver-bare-help-domain-observe",
+        "observe   Query code structure and relationships",
+    );
+    pub(super) const ACT: (&str, &str) = (
+        "weaver-bare-help-domain-act",
+        "act       Perform code modifications",
+    );
+    pub(super) const VERIFY: (&str, &str) = (
+        "weaver-bare-help-domain-verify",
+        "verify    Validate code correctness",
+    );
+    pub(super) const POINTER: (&str, &str) = (
+        "weaver-bare-help-pointer",
+        "Run 'weaver --help' for more information.",
+    );
+}
+
+/// Resolves a single bare-help message through the localizer.
+fn msg(localizer: &dyn Localizer, entry: &(&str, &str)) -> String {
+    localizer.message(entry.0, None, entry.1)
+}
+
 /// Builds the application localizer.
 ///
 /// Returns a [`FluentLocalizer`] loaded with the embedded en-US
@@ -35,8 +68,6 @@ pub(crate) fn build_localizer() -> Box<dyn Localizer> {
 ///
 /// Each line is resolved through the localizer with a hardcoded English
 /// fallback, so the output is correct even without Fluent resources.
-/// The fallback strings must match the values in `locales/en-US/messages.ftl`;
-/// the `fluent_and_fallback_outputs_are_identical` test guards against drift.
 ///
 /// # Errors
 ///
@@ -54,32 +85,13 @@ pub(crate) fn write_bare_help<W: Write>(
     writer: &mut W,
     localizer: &dyn Localizer,
 ) -> std::io::Result<()> {
-    let usage = localizer.message(
-        "weaver-bare-help-usage",
-        None,
-        "Usage: weaver <DOMAIN> <OPERATION> [ARG]...",
-    );
-    let header = localizer.message("weaver-bare-help-header", None, "Domains:");
-    let observe = localizer.message(
-        "weaver-bare-help-domain-observe",
-        None,
-        "observe   Query code structure and relationships",
-    );
-    let act = localizer.message(
-        "weaver-bare-help-domain-act",
-        None,
-        "act       Perform code modifications",
-    );
-    let verify = localizer.message(
-        "weaver-bare-help-domain-verify",
-        None,
-        "verify    Validate code correctness",
-    );
-    let pointer = localizer.message(
-        "weaver-bare-help-pointer",
-        None,
-        "Run 'weaver --help' for more information.",
-    );
+    use bare_help::{ACT, HEADER, OBSERVE, POINTER, USAGE, VERIFY};
+    let usage = msg(localizer, &USAGE);
+    let header = msg(localizer, &HEADER);
+    let observe = msg(localizer, &OBSERVE);
+    let act = msg(localizer, &ACT);
+    let verify = msg(localizer, &VERIFY);
+    let pointer = msg(localizer, &POINTER);
     write!(
         writer,
         "{usage}\n\n{header}\n  {observe}\n  {act}\n  {verify}\n\n{pointer}\n",

--- a/crates/weaver-cli/src/localizer.rs
+++ b/crates/weaver-cli/src/localizer.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use ortho_config::{FluentLocalizer, Localizer, NoOpLocalizer};
 
 /// Embedded en-US Fluent catalogue for the Weaver CLI.
-static WEAVER_EN_US: &str = include_str!("../locales/en-US/messages.ftl");
+pub(crate) static WEAVER_EN_US: &str = include_str!("../locales/en-US/messages.ftl");
 
 /// Builds the application localizer.
 ///
@@ -45,8 +45,8 @@ pub(crate) fn build_localizer() -> Box<dyn Localizer> {
 /// ```rust,ignore
 /// let loc = ortho_config::NoOpLocalizer;
 /// let mut buf = Vec::new();
-/// write_bare_help(&mut buf, &loc).unwrap();
-/// assert!(String::from_utf8(buf).unwrap().contains("Usage:"));
+/// write_bare_help(&mut buf, &loc).expect("write bare help");
+/// assert!(String::from_utf8(buf).expect("valid UTF-8").contains("Usage:"));
 /// ```
 pub(crate) fn write_bare_help<W: Write>(
     writer: &mut W,

--- a/crates/weaver-cli/src/localizer.rs
+++ b/crates/weaver-cli/src/localizer.rs
@@ -35,6 +35,8 @@ pub(crate) fn build_localizer() -> Box<dyn Localizer> {
 ///
 /// Each line is resolved through the localizer with a hardcoded English
 /// fallback, so the output is correct even without Fluent resources.
+/// The fallback strings must match the values in `locales/en-US/messages.ftl`;
+/// the `fluent_and_fallback_outputs_are_identical` test guards against drift.
 ///
 /// # Errors
 ///

--- a/crates/weaver-cli/src/tests/support/mod.rs
+++ b/crates/weaver-cli/src/tests/support/mod.rs
@@ -168,11 +168,13 @@ impl TestWorld {
             &mut self.stderr,
             self.stdout_is_terminal,
         );
+        let localizer = ortho_config::NoOpLocalizer;
         let exit = run_with_daemon_binary(
             args,
             &mut io,
             &loader,
             daemon_binary,
+            &localizer,
             |invocation, context, output| self.lifecycle.handle(invocation, context, output),
         );
         self.exit_code = Some(exit);

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -213,7 +213,8 @@ fn run_with_loader_reports_configuration_failures() {
     let mut stderr = Vec::new();
     let mut stdin = Cursor::new(Vec::new());
     let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
-    let exit = run_with_loader(vec![OsString::from("weaver")], &mut io, &FailingLoader);
+    let args = vec![OsString::from("weaver"), OsString::from("observe")];
+    let exit = run_with_loader(args, &mut io, &FailingLoader);
     assert_eq!(exit, ExitCode::FAILURE);
     let stderr_text = decode_utf8(stderr, "stderr").expect("decode stderr");
     assert!(stderr_text.contains("command domain"));
@@ -384,17 +385,11 @@ fn is_daemon_not_running_classifies_errors(
 }
 #[test]
 fn is_daemon_not_running_rejects_non_connect_errors() {
-    let error = AppError::MissingDomain;
-    assert!(!is_daemon_not_running(&error));
-
-    let error = AppError::MissingOperation;
-    assert!(!is_daemon_not_running(&error));
-
-    let error = AppError::MissingExit;
-    assert!(!is_daemon_not_running(&error));
-
-    let error = AppError::SerialiseRequest(serde_json::from_str::<()>("bad").unwrap_err());
-    assert!(!is_daemon_not_running(&error));
+    assert!(!is_daemon_not_running(&AppError::MissingDomain));
+    assert!(!is_daemon_not_running(&AppError::MissingOperation));
+    assert!(!is_daemon_not_running(&AppError::MissingExit));
+    let ser_err = AppError::SerialiseRequest(serde_json::from_str::<()>("bad").unwrap_err());
+    assert!(!is_daemon_not_running(&ser_err));
 }
-/// Tests for automatic daemon startup behaviour and error handling.
 mod auto_start;
+mod bare_invocation;

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -388,6 +388,7 @@ fn is_daemon_not_running_rejects_non_connect_errors() {
     assert!(!is_daemon_not_running(&AppError::MissingDomain));
     assert!(!is_daemon_not_running(&AppError::MissingOperation));
     assert!(!is_daemon_not_running(&AppError::MissingExit));
+    assert!(!is_daemon_not_running(&AppError::BareInvocation));
     let ser_err = AppError::SerialiseRequest(serde_json::from_str::<()>("bad").unwrap_err());
     assert!(!is_daemon_not_running(&ser_err));
 }

--- a/crates/weaver-cli/src/tests/unit/bare_invocation.rs
+++ b/crates/weaver-cli/src/tests/unit/bare_invocation.rs
@@ -8,9 +8,9 @@ use std::ffi::OsString;
 use std::io::Cursor;
 use std::process::ExitCode;
 
-use ortho_config::{Localizer, NoOpLocalizer};
+use ortho_config::{FluentLocalizer, Localizer, NoOpLocalizer};
 
-use crate::localizer::{build_localizer, write_bare_help};
+use crate::localizer::{WEAVER_EN_US, write_bare_help};
 use crate::{AppError, ConfigLoader, IoStreams, run_with_loader};
 use weaver_config::Config;
 
@@ -80,8 +80,9 @@ fn write_bare_help_with_noop_produces_english_fallback() {
 
 #[test]
 fn write_bare_help_with_fluent_produces_english() {
-    let localizer = build_localizer();
-    let text = render_help(localizer.as_ref());
+    let localizer = FluentLocalizer::with_en_us_defaults([WEAVER_EN_US])
+        .expect("embedded Fluent catalogue must parse");
+    let text = render_help(&localizer);
     assert!(text.contains("Usage: weaver"));
     assert!(text.contains("observe"));
     assert!(text.contains("act"));

--- a/crates/weaver-cli/src/tests/unit/bare_invocation.rs
+++ b/crates/weaver-cli/src/tests/unit/bare_invocation.rs
@@ -1,0 +1,104 @@
+//! Tests for bare-invocation help output.
+//!
+//! Verifies that running `weaver` with no arguments emits the short help
+//! block to stderr and exits non-zero, without requiring configuration
+//! loading or daemon connectivity.
+
+use std::ffi::OsString;
+use std::io::Cursor;
+use std::process::ExitCode;
+
+use ortho_config::{Localizer, NoOpLocalizer};
+
+use crate::localizer::{build_localizer, write_bare_help};
+use crate::{AppError, ConfigLoader, IoStreams, run_with_loader};
+use weaver_config::Config;
+
+/// A config loader that panics if called, proving that bare invocation
+/// short-circuits before configuration loading.
+struct PanickingLoader;
+
+impl ConfigLoader for PanickingLoader {
+    fn load(&self, _args: &[OsString]) -> Result<Config, AppError> {
+        panic!("bare invocation must not attempt configuration loading");
+    }
+}
+
+/// Renders the bare help block using the given localizer.
+fn render_help(localizer: &dyn Localizer) -> String {
+    let mut buf = Vec::new();
+    write_bare_help(&mut buf, localizer).expect("write bare help");
+    String::from_utf8(buf).expect("utf8")
+}
+
+#[test]
+fn bare_invocation_exits_with_failure() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let exit = run_with_loader(vec![OsString::from("weaver")], &mut io, &PanickingLoader);
+    assert_eq!(exit, ExitCode::FAILURE);
+}
+
+#[test]
+fn bare_invocation_emits_help_to_stderr() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let _ = run_with_loader(vec![OsString::from("weaver")], &mut io, &PanickingLoader);
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    assert!(stderr_text.contains("Usage: weaver"));
+    assert!(stderr_text.contains("observe"));
+    assert!(stderr_text.contains("act"));
+    assert!(stderr_text.contains("verify"));
+    assert!(stderr_text.contains("weaver --help"));
+}
+
+#[test]
+fn bare_invocation_produces_no_stdout() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let _ = run_with_loader(vec![OsString::from("weaver")], &mut io, &PanickingLoader);
+    assert!(
+        stdout.is_empty(),
+        "bare invocation must not write to stdout"
+    );
+}
+
+#[test]
+fn write_bare_help_with_noop_produces_english_fallback() {
+    let text = render_help(&NoOpLocalizer);
+    assert!(text.contains("Usage: weaver"));
+    assert!(text.contains("observe"));
+    assert!(text.contains("act"));
+    assert!(text.contains("verify"));
+    assert!(text.contains("weaver --help"));
+}
+
+#[test]
+fn write_bare_help_with_fluent_produces_english() {
+    let localizer = build_localizer();
+    let text = render_help(localizer.as_ref());
+    assert!(text.contains("Usage: weaver"));
+    assert!(text.contains("observe"));
+    assert!(text.contains("act"));
+    assert!(text.contains("verify"));
+    assert!(text.contains("weaver --help"));
+}
+
+#[test]
+fn bare_help_contains_usage_line() {
+    let text = render_help(&NoOpLocalizer);
+    assert!(text.contains("Usage:"));
+}
+
+#[test]
+fn bare_help_contains_single_help_pointer() {
+    let text = render_help(&NoOpLocalizer);
+    let count = text.matches("weaver --help").count();
+    assert_eq!(count, 1, "expected exactly one --help pointer");
+}

--- a/crates/weaver-cli/tests/features/weaver_cli.feature
+++ b/crates/weaver-cli/tests/features/weaver_cli.feature
@@ -69,6 +69,15 @@ Feature: Weaver CLI behaviour
   # Auto-start scenarios: When a domain command is issued and the daemon is not
   # running, the CLI attempts to start it automatically.
 
+  Scenario: Bare invocation shows short help
+    When the operator runs ""
+    Then the CLI fails
+    And stderr contains "Usage: weaver"
+    And stderr contains "observe"
+    And stderr contains "act"
+    And stderr contains "verify"
+    And stderr contains "weaver --help"
+
   Scenario: Auto-start shows waiting message before spawn failure
     Given auto-start will be triggered
     When the operator runs "observe get-definition --symbol main"

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -41,7 +41,7 @@ This addresses the P0 gap identified in the
 [UI gap analysis Level 0](../ui-gap-analysis.md#level-0--bare-invocation-weaver)
 and
 [Level 10d](../ui-gap-analysis.md#level-10--error-messages-and-exit-codes),
-and satisfies roadmap task 5.1.1 in `docs/roadmap.md`.
+and satisfies roadmap task 5.1.1 in `../roadmap.md`.
 
 ## Constraints
 
@@ -128,8 +128,10 @@ and satisfies roadmap task 5.1.1 in `docs/roadmap.md`.
 - The build script (`build.rs`) includes `cli.rs` via `#[path = "src/cli.rs"]`
   for manpage generation. The new `is_bare_invocation()` method triggered a
   `dead_code` warning in the build script context because it is only called
-  from `lib.rs`. Resolved with a tightly scoped `#[expect(dead_code)]` attribute
-  with a reason string explaining the dual-compilation context.
+  from `lib.rs`. Resolved with a tightly scoped `#[allow(dead_code)]` attribute
+  with a reason string explaining the dual-compilation context. `#[expect]`
+  cannot be used here because it triggers `unfulfilled_lint_expectations` in
+  the library build where the method is used.
 - The `#[error("bare invocation")]` on `BareInvocation` provides a non-empty
   display string for safety in generic `Display` paths while the match arm
   in `run_with_handler()` suppresses printing for this variant.
@@ -277,6 +279,8 @@ localization.
 
 ### Key files involved in this change
 
+_Table 1: Key files involved in this change and their purpose._
+
 | File                                                  | Lines | Purpose                            |
 | ----------------------------------------------------- | ----- | ---------------------------------- |
 | `Cargo.toml` (workspace)                              | —     | ortho-config version               |
@@ -295,8 +299,6 @@ localization.
 | `crates/weaver-cli/tests/features/weaver_cli.feature` | 77    | BDD scenarios                      |
 | `docs/roadmap.md`                                     | 424   | Roadmap checkboxes                 |
 | `docs/users-guide.md`                                 | 837   | User documentation                 |
-
-_Table 1: Key files involved in this change and their purpose._
 
 ### Test infrastructure
 
@@ -881,6 +883,8 @@ pub(crate) enum AppError {
 
 ## Files modified (summary)
 
+_Table 2: Files modified and their changes._
+
 | File                                                  | Change                              |
 | ----------------------------------------------------- | ----------------------------------- |
 | `Cargo.toml`                                          | Upgrade `ortho_config` to `"0.7.0"` |
@@ -895,5 +899,3 @@ pub(crate) enum AppError {
 | `crates/weaver-cli/tests/features/weaver_cli.feature` | Add BDD scenario                    |
 | `docs/users-guide.md`                                 | Add "Bare invocation" subsection    |
 | `docs/roadmap.md`                                     | Mark 5.1.1 checkboxes as done       |
-
-_Table 2: Files modified and their changes._

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -296,6 +296,8 @@ localization.
 | `docs/roadmap.md`                                     | 424   | Roadmap checkboxes                 |
 | `docs/users-guide.md`                                 | 837   | User documentation                 |
 
+_Table 1: Key files involved in this change and their purpose._
+
 ### Test infrastructure
 
 BDD tests use `rstest-bdd` v0.5.0 with `.feature` files in `tests/features/`
@@ -893,3 +895,5 @@ pub(crate) enum AppError {
 | `crates/weaver-cli/tests/features/weaver_cli.feature` | Add BDD scenario                    |
 | `docs/users-guide.md`                                 | Add "Bare invocation" subsection    |
 | `docs/roadmap.md`                                     | Mark 5.1.1 checkboxes as done       |
+
+_Table 2: Files modified and their changes._

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -1,0 +1,892 @@
+# 5.1.1 Show short help on bare invocation (Fluent-localised)
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: COMPLETE
+
+## Purpose / big picture
+
+When an operator runs `weaver` with no arguments today, the CLI prints the
+terse message `the command domain must be provided` to stderr and exits 1.
+There is no hint about what domains exist, no usage line, and no pointer to
+`--help`. A newcomer who has just installed Weaver has no idea what to type
+next.
+
+After this change, running `weaver` with no arguments will print a short,
+self-contained help block to stderr listing the three valid domains (`observe`,
+`act`, `verify`), a `Usage:` line, and exactly one pointer to `weaver --help`.
+The output requires no configuration file and no running daemon. The exit code
+remains non-zero. All user-facing text is resolved through the
+`ortho_config::Localizer` trait backed by Fluent `.ftl` resources, establishing
+the translation pipeline for the entire CLI.
+
+Observable outcome: run `weaver` with no arguments and see:
+
+```text
+Usage: weaver <DOMAIN> <OPERATION> [ARG]...
+
+Domains:
+  observe   Query code structure and relationships
+  act       Perform code modifications
+  verify    Validate code correctness
+
+Run 'weaver --help' for more information.
+```
+
+This addresses the P0 gap identified in the
+[UI gap analysis Level 0](docs/ui-gap-analysis.md#level-0--bare-invocation-weaver)
+ and
+[Level 10d](docs/ui-gap-analysis.md#level-10--error-messages-and-exit-codes),
+and satisfies roadmap task 5.1.1 in `docs/roadmap.md`.
+
+## Constraints
+
+- `make check-fmt`, `make lint`, and `make test` must pass after all changes.
+- No code file may exceed 400 lines.
+- The workspace Clippy configuration is extremely strict (pedantic, deny on
+  `unwrap_used`, `expect_used`, `print_stdout`, `print_stderr`,
+  `cognitive_complexity`, `missing_docs`, etc.). All new code must comply.
+- Comments and documentation must use en-GB-oxendict spelling
+  ("-ize" / "-yse" / "-our").
+- New functionality requires both unit tests and BDD behavioural tests.
+- Every module must begin with a `//!` module-level doc comment.
+- The bare invocation help must not require configuration loading or daemon
+  connectivity. This is a hard requirement because an operator with no config
+  file should still see guidance.
+- The `MissingDomain` error variant and its `Display` message must remain
+  unchanged for programmatic contexts (e.g., blank-domain validation in
+  `CommandInvocation::try_from`).
+- `rstest-bdd` v0.5.0 must be used for BDD tests (as specified in workspace
+  `Cargo.toml`).
+- All new user-facing text must be sourced from Fluent `.ftl` resources via
+  the `ortho_config::Localizer` trait so future locales can override it.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than 15 files, stop and
+  escalate. (Raised from 10 to accommodate the Fluent integration layer.)
+- Interface: if any `pub` API signature in `weaver-cli` must change, stop and
+  escalate (all changes are `pub(crate)` or private).
+- Dependencies: upgrading ortho-config from v0.6.0 to v0.7.0 is pre-approved.
+  Any other new external dependency requires escalation.
+- Iterations: if tests still fail after 5 attempts at fixing, stop and
+  escalate.
+
+## Risks
+
+- Risk: `unit.rs` is exactly 400 lines; adding a `mod bare_invocation;`
+  declaration pushes it over the limit. Severity: low Likelihood: high
+  Mitigation: Remove the redundant `///` doc comment on `mod auto_start;` (line
+  399) since the module already has its own `//!` doc comment inside
+  `auto_start.rs`. This frees one line for the new `mod` declaration.
+
+- Risk: The `BareInvocation` error variant with `#[error("")]` might trigger
+  a Clippy lint about empty Display strings. Severity: low Likelihood: medium
+  Mitigation: If Clippy complains, use a non-empty message like
+  `#[error("bare invocation")]` and ensure the match arm in
+  `run_with_handler()` suppresses printing for this variant.
+
+- Risk: The existing unit test `run_with_loader_reports_configuration_failures`
+  invokes `weaver` with no args and asserts stderr contains "command domain".
+  After the change, bare invocation is intercepted before config loading, so
+  this test will fail. Severity: medium Likelihood: certain Mitigation: Update
+  the test to pass `["weaver", "observe"]` so the bare invocation check does
+  not fire, preserving the test's original intent (verifying that config loader
+  errors reach stderr).
+
+- Risk: Upgrading ortho-config from v0.6.0 to v0.7.0 may introduce subtle
+  behavioural changes or new transitive dependencies (fluent-bundle,
+  fluent-syntax, unic-langid). Severity: medium Likelihood: low (v0.7.0
+  migration guide states "additive, no mandatory breaking changes") Mitigation:
+  Run the full test suite after upgrade, before making any other changes. If
+  any pre-existing tests break, fix the upgrade issues first as a separate
+  commit.
+
+- Risk: Fluent localizer construction could fail at runtime (e.g., if an
+  `.ftl` resource has a syntax error). Severity: low Likelihood: low (resources
+  are compiled-in via `include_str!` and validated by unit tests) Mitigation:
+  Use `NoOpLocalizer` as a graceful fallback, which causes
+  `Localizer::message()` to return the hardcoded English fallback string. Unit
+  tests validate that the `.ftl` resources parse successfully.
+
+## Progress
+
+- [x] Stage A: Upgrade ortho-config to v0.7.0 and verify baseline.
+- [x] Stage B: Scaffold Fluent resources and localizer module.
+- [x] Stage C: Scaffold tests (red phase).
+- [x] Stage D: Wire implementation (green phase).
+- [x] Stage E: Documentation and roadmap updates.
+- [x] Stage F: Final validation and commit gating.
+
+## Surprises & discoveries
+
+- The build script (`build.rs`) includes `cli.rs` via `#[path = "src/cli.rs"]`
+  for manpage generation. The new `is_bare_invocation()` method triggered a
+  `dead_code` warning in the build script context because it is only called
+  from `lib.rs`. Resolved with a tightly scoped `#[allow(dead_code)]` attribute
+  with a reason string explaining the dual-compilation context.
+- The `#[error("")]` on `BareInvocation` did not trigger any Clippy lint (the
+  low-probability risk from the plan did not materialise).
+- `unit.rs` compaction required reformatting one test to single-line style and
+  collapsing the `is_daemon_not_running_rejects_non_connect_errors` assertions
+  to recover lines.
+
+## Decision log
+
+- Decision: Intercept bare invocation in `run_with_handler()` BEFORE config
+  loading, not by changing the `MissingDomain` error Display impl. Rationale:
+  Help output should not require a valid config file or daemon. A new operator
+  with no config should still see guidance. The `MissingDomain` variant is also
+  triggered by blank-domain strings in `CommandInvocation::try_from`, where the
+  full help block would be inappropriate. Early interception cleanly separates
+  the two concerns. Date/Author: 2026-02-25
+
+- Decision: Add a `BareInvocation` sentinel variant to `AppError` rather than
+  restructuring the `and_then` chain to use `Option<ExitCode>`. Rationale: The
+  existing method returns `Result<ExitCode, AppError>` via an `and_then` chain.
+  A sentinel error variant allows early return without restructuring the entire
+  method. The match arm in the error handler suppresses the empty print for
+  this specific variant. Date/Author: 2026-02-25
+
+- Decision: Place the `is_bare_invocation()` method on the `Cli` struct rather
+  than as a free function. Rationale: The method queries only `Cli` fields and
+  represents a semantic property of the parsed arguments. It belongs on the
+  struct. Date/Author: 2026-02-25
+
+- Decision: Use a `PanickingLoader` in unit tests to prove bare invocation
+  short-circuits before config loading. Rationale: If the interception point is
+  wrong, the test panics rather than silently passing. This provides a stronger
+  guarantee than a mock that returns a success. Date/Author: 2026-02-25
+
+- Decision: Upgrade ortho-config from v0.6.0 to v0.7.0 and use
+  `FluentLocalizer` with `NoOpLocalizer` fallback. Rationale: The user
+  requirement is that all user-facing text is translatable using Fluent.
+  ortho-config v0.7.0 provides the `Localizer` trait, `FluentLocalizer`,
+  `NoOpLocalizer`, and `localize_clap_error` helpers. The upgrade is additive
+  with no mandatory breaking changes per the migration guide. This establishes
+  the localization pipeline for all future CLI text. Date/Author: 2026-02-26
+
+- Decision: Create a new `crates/weaver-cli/src/localizer.rs` module rather
+  than inlining Fluent setup in `runtime_utils.rs`. Rationale: Localization is
+  a cross-cutting concern that will grow as more CLI text is localized. A
+  dedicated module keeps it cohesive and testable. `runtime_utils.rs` remains
+  for small stateless helpers. Date/Author: 2026-02-26
+
+- Decision: Store `.ftl` resources under `crates/weaver-cli/locales/en-US/`
+  following the ortho-config hello_world example convention. Rationale: This
+  mirrors the upstream pattern (`locales/<locale>/messages.ftl`) and makes
+  adding future locales straightforward. Date/Author: 2026-02-26
+
+- Decision: The `write_bare_help()` function accepts `&dyn Localizer` and
+  resolves each line via `Localizer::message()` with English fallbacks.
+  Rationale: This means the English text is always available even when the
+  Fluent pipeline fails (via `NoOpLocalizer`), while genuine translations
+  override it cleanly. The function composes the help block from individual
+  Fluent messages so translators can work on each line independently.
+  Date/Author: 2026-02-26
+
+- Decision: Construct `FluentLocalizer` once at the start of
+  `CliRunner::run()`, falling back to `NoOpLocalizer` on error. Rationale: The
+  localizer must be available before config loading (since bare invocation
+  fires pre-config). Construction is cheap (one `include_str!` parse). Falling
+  back to `NoOpLocalizer` ensures the CLI never crashes due to a localization
+  issue — it simply serves the hardcoded English fallbacks. Date/Author:
+  2026-02-26
+
+## Outcomes & retrospective
+
+All acceptance criteria met:
+
+1. `weaver` with no arguments exits non-zero.
+2. Output includes `Usage: weaver <DOMAIN> <OPERATION> [ARG]...`.
+3. Lists three domains: `observe`, `act`, `verify`.
+4. Includes exactly one `weaver --help` pointer.
+5. Does not require configuration loading (proved by `PanickingLoader`).
+6. All text sourced through `ortho_config::Localizer` with Fluent `.ftl`
+   resources.
+
+Quality gates passed: `make check-fmt`, `make lint`, `make test` all exit 0.
+Files modified: 12 (within the 15-file tolerance). No pub API changes.
+
+## Context and orientation
+
+The Weaver CLI is a Rust workspace with 12 crates. The CLI binary lives in
+`crates/weaver-cli/`. It uses `clap` (v4.5, derive mode) for argument parsing.
+
+The entry point is `crates/weaver-cli/src/main.rs`, which delegates to
+`weaver_cli::run()` in `crates/weaver-cli/src/lib.rs`. The `run()` function
+creates a `CliRunner` and calls `CliRunner::run()`, which calls
+`run_with_handler()`. This method:
+
+1. Splits config arguments from command arguments
+   (`split_config_arguments()`).
+2. Parses CLI arguments via `Cli::try_parse_from()`.
+3. Loads configuration via `self.loader.load()`.
+4. Checks for `--capabilities` mode.
+5. Checks for `daemon` subcommand.
+6. Builds `CommandInvocation::try_from(cli)` — this is where
+   `AppError::MissingDomain` is returned when `domain` is `None`.
+7. Executes the daemon command.
+
+The error is caught at the bottom of `run_with_handler()` (line 180-186 of
+`lib.rs`) and printed to stderr.
+
+### ortho-config and Fluent localization
+
+The workspace currently uses `ortho_config` v0.6.0 (workspace `Cargo.toml` line
+33). There is no existing Fluent infrastructure: no `.ftl` files, no `locales/`
+directories, no Fluent imports anywhere.
+
+`ortho_config` v0.7.0 (published 2026-01-02) adds:
+
+- `Localizer` trait: `lookup(id, args) -> Option<String>` and
+  `message(id, args, fallback) -> String` (fallback returned when lookup
+  misses).
+- `FluentLocalizer`: layered Fluent implementation constructed via
+  `FluentLocalizer::builder(langid)` or convenience constructors (`embedded()`,
+  `with_en_us_defaults(resources)`).
+- `NoOpLocalizer`: zero-sized type that always returns `None` from `lookup()`,
+  causing `message()` to use the hardcoded English fallback.
+- `localize_clap_error()` / `localize_clap_error_with_command()`: rewrite
+  clap error messages through the Fluent pipeline.
+- `FluentLocalizerError`: `UnsupportedLocale`, `Parser`, `Registration`
+  variants.
+
+The v0.7.0 upgrade is additive with no mandatory breaking changes. New
+transitive dependencies: `fluent-bundle`, `fluent-syntax`, `unic-langid`.
+
+The hello_world example in ortho-config demonstrates the pattern:
+
+1. `.ftl` files under `locales/en-US/messages.ftl`.
+2. Embed via `include_str!("../locales/en-US/messages.ftl")`.
+3. Build: `FluentLocalizer::builder(langid!("en-US"))
+   .with_consumer_resources([APP_FTL]).try_build()?`.
+4. Fall back to `NoOpLocalizer` on error.
+5. Resolve strings via `localizer.message("msg-id", None, "fallback")`.
+
+Fluent message IDs use hyphens (dots are normalised to hyphens by
+ortho-config's `normalize_identifier()`). The embedded en-US catalogue in
+ortho-config already provides `clap-error-*` messages for clap error
+localization.
+
+### Key files involved in this change
+
+| File                                                  | Lines | Purpose                            |
+| ----------------------------------------------------- | ----- | ---------------------------------- |
+| `Cargo.toml` (workspace)                              | —     | ortho-config version               |
+| `crates/weaver-cli/Cargo.toml`                        | —     | weaver-cli dependencies            |
+| `crates/weaver-cli/src/cli.rs`                        | 73    | Clap `#[derive(Parser)]` struct    |
+| `crates/weaver-cli/src/command.rs`                    | 91    | `CommandInvocation::try_from(Cli)` |
+| `crates/weaver-cli/src/errors.rs`                     | 65    | `AppError` enum                    |
+| `crates/weaver-cli/src/lib.rs`                        | 375   | Core runtime, `CliRunner`          |
+| `crates/weaver-cli/src/runtime_utils.rs`              | 28    | Small runtime helpers              |
+| `crates/weaver-cli/src/localizer.rs`                  | NEW   | Fluent localizer module            |
+| `crates/weaver-cli/locales/en-US/messages.ftl`        | NEW   | Fluent resources                   |
+| `crates/weaver-cli/src/tests/unit.rs`                 | 400   | Unit tests (at limit)              |
+| `crates/weaver-cli/src/tests/unit/auto_start.rs`      | 227   | Auto-start tests                   |
+| `crates/weaver-cli/src/tests/behaviour.rs`            | 340   | BDD step definitions               |
+| `crates/weaver-cli/src/tests/support/mod.rs`          | 323   | Test world/helpers                 |
+| `crates/weaver-cli/tests/features/weaver_cli.feature` | 77    | BDD scenarios                      |
+| `docs/roadmap.md`                                     | 424   | Roadmap checkboxes                 |
+| `docs/users-guide.md`                                 | 837   | User documentation                 |
+
+### Test infrastructure
+
+BDD tests use `rstest-bdd` v0.5.0 with `.feature` files in `tests/features/`
+and step definitions in `src/tests/behaviour.rs`. The `TestWorld` struct (in
+`src/tests/support/mod.rs`) provides a `run()` method that exercises the full
+CLI flow. The `#[when("the operator runs {command}")]` step accepts a quoted
+command string; an empty string `""` produces `["weaver"]` (bare invocation)
+because `TestWorld::build_args()` skips extending the args vector when the
+trimmed command is empty.
+
+Existing BDD steps that can be reused without modification:
+
+- `#[when("the operator runs {command}")]` — runs the CLI with given args.
+- `#[then("the CLI fails")]` — asserts exit code is `FAILURE`.
+- `#[then("stderr contains {snippet}")]` — asserts stderr contains substring.
+
+Existing unit test helpers that can be reused:
+
+- `run_with_loader()` — runs CLI with a custom config loader.
+- `IoStreams::new()` — creates IO streams from in-memory buffers.
+- `decode_utf8()` — converts a `Vec<u8>` buffer to a `String`.
+
+## Plan of work
+
+### Stage A: Upgrade ortho-config and verify baseline
+
+**A1. Upgrade ortho-config to v0.7.0.**
+
+In workspace `Cargo.toml` line 33, change `ortho_config = "0.6.0"` to
+`ortho_config = "0.7.0"`.
+
+**A2. Verify the upgrade is clean.**
+
+Run `cargo check --workspace && make test`. If any pre-existing tests break,
+fix the upgrade issues before proceeding (separate commit).
+
+### Stage B: Scaffold Fluent resources and localizer module
+
+**B1. Create the Fluent resource file.**
+
+Create `crates/weaver-cli/locales/en-US/messages.ftl`:
+
+```ftl
+# Bare-invocation help block shown when weaver is run without arguments.
+weaver-bare-help-usage = Usage: weaver <DOMAIN> <OPERATION> [ARG]...
+weaver-bare-help-header = Domains:
+weaver-bare-help-domain-observe = observe   Query code structure and relationships
+weaver-bare-help-domain-act = act       Perform code modifications
+weaver-bare-help-domain-verify = verify    Validate code correctness
+weaver-bare-help-pointer = Run 'weaver --help' for more information.
+```
+
+**B2. Create the localizer module `crates/weaver-cli/src/localizer.rs`.**
+
+This module:
+
+1. Embeds the `.ftl` resource via `include_str!`.
+2. Exposes `build_localizer() -> Box<dyn Localizer>` which constructs a
+   `FluentLocalizer` with `en-US` defaults, falling back to `NoOpLocalizer`.
+3. Exposes `write_bare_help(writer, &dyn Localizer) -> io::Result<()>` which
+   resolves each message via `Localizer::message()` with English fallbacks and
+   writes the composed help block.
+
+```rust
+//! Localization support for the Weaver CLI.
+//!
+//! Constructs a Fluent-backed localizer from embedded resources so
+//! user-facing text can be translated without code changes. Falls back
+//! to `NoOpLocalizer` (hardcoded English) when the Fluent pipeline fails.
+
+use std::io::Write;
+
+use ortho_config::{
+    FluentLocalizer, Localizer, NoOpLocalizer, langid,
+};
+
+static WEAVER_EN_US: &str =
+    include_str!("../locales/en-US/messages.ftl");
+
+/// Builds the application localizer.
+///
+/// Returns a `FluentLocalizer` loaded with the embedded en-US catalogue
+/// and any consumer overrides. Falls back to `NoOpLocalizer` on error so
+/// the CLI never crashes due to a localization failure.
+pub(crate) fn build_localizer() -> Box<dyn Localizer> {
+    match FluentLocalizer::with_en_us_defaults([WEAVER_EN_US]) {
+        Ok(loc) => Box::new(loc),
+        Err(_) => Box::new(NoOpLocalizer),
+    }
+}
+
+/// Writes the bare-invocation help block to `writer`.
+///
+/// Each line is resolved through the localizer with a hardcoded English
+/// fallback, so the output is correct even without Fluent resources.
+pub(crate) fn write_bare_help<W: Write>(
+    writer: &mut W,
+    localizer: &dyn Localizer,
+) -> std::io::Result<()> {
+    let usage = localizer.message(
+        "weaver-bare-help-usage", None,
+        "Usage: weaver <DOMAIN> <OPERATION> [ARG]...",
+    );
+    let header = localizer.message(
+        "weaver-bare-help-header", None, "Domains:",
+    );
+    let observe = localizer.message(
+        "weaver-bare-help-domain-observe", None,
+        "observe   Query code structure and relationships",
+    );
+    let act = localizer.message(
+        "weaver-bare-help-domain-act", None,
+        "act       Perform code modifications",
+    );
+    let verify = localizer.message(
+        "weaver-bare-help-domain-verify", None,
+        "verify    Validate code correctness",
+    );
+    let pointer = localizer.message(
+        "weaver-bare-help-pointer", None,
+        "Run 'weaver --help' for more information.",
+    );
+    write!(
+        writer,
+        "{usage}\n\n{header}\n  {observe}\n  {act}\n  {verify}\n\n{pointer}\n",
+    )
+}
+```
+
+Note: The two-space indent before each domain line is part of the format
+template, not the `.ftl` value. This keeps domain descriptions
+alignment-agnostic in translations.
+
+**B3. Add `BareInvocation` variant to `AppError` in `errors.rs`.**
+
+Below the `MissingOperation` variant:
+
+```rust
+    #[error("")]
+    BareInvocation,
+```
+
+**B4. Add `is_bare_invocation()` method to `Cli` in `cli.rs`.**
+
+```rust
+impl Cli {
+    /// Returns true when no domain, subcommand, or probe flag was supplied.
+    ///
+    /// This detects the case where the operator invoked `weaver` with no
+    /// meaningful arguments, so the runner can emit short help guidance
+    /// before attempting configuration loading or daemon contact.
+    pub(crate) fn is_bare_invocation(&self) -> bool {
+        self.domain.is_none() && self.command.is_none() && !self.capabilities
+    }
+}
+```
+
+**B5. Register the localizer module in `lib.rs`.**
+
+Add `mod localizer;` to the module list, and update the use statement:
+
+```rust
+mod localizer;
+// ...
+use localizer::{build_localizer, write_bare_help};
+```
+
+### Stage C: Scaffold tests (red phase)
+
+**C1. Add BDD scenario.**
+
+In `crates/weaver-cli/tests/features/weaver_cli.feature`, append:
+
+```gherkin
+  Scenario: Bare invocation shows short help
+    When the operator runs ""
+    Then the CLI fails
+    And stderr contains "Usage: weaver"
+    And stderr contains "observe"
+    And stderr contains "act"
+    And stderr contains "verify"
+    And stderr contains "weaver --help"
+```
+
+No new step definitions required.
+
+**C2. Create unit test file `src/tests/unit/bare_invocation.rs`.**
+
+Tests that:
+
+1. Bare invocation exits with `FAILURE`.
+2. Bare invocation emits text containing the expected fragments to stderr.
+3. Bare invocation produces no stdout.
+4. Bare invocation does not attempt config loading (`PanickingLoader`).
+5. `write_bare_help()` with `NoOpLocalizer` produces the expected English
+   help block (tests the fallback path).
+6. `write_bare_help()` with the real `FluentLocalizer` produces the same
+   English help block (tests the Fluent resolution path).
+7. The help text contains all three domains.
+8. The help text contains a `Usage:` line.
+9. The help text contains exactly one `weaver --help` pointer.
+
+```rust
+//! Tests for bare-invocation help output.
+//!
+//! Verifies that running `weaver` with no arguments emits the short help
+//! block to stderr and exits non-zero, without requiring configuration
+//! loading or daemon connectivity.
+
+use std::ffi::OsString;
+use std::io::Cursor;
+use std::process::ExitCode;
+
+use ortho_config::{Localizer, NoOpLocalizer};
+
+use crate::localizer::{build_localizer, write_bare_help};
+use crate::{AppError, ConfigLoader, IoStreams, run_with_loader};
+use weaver_config::Config;
+
+/// A config loader that panics if called, proving that bare invocation
+/// short-circuits before configuration loading.
+struct PanickingLoader;
+
+impl ConfigLoader for PanickingLoader {
+    fn load(&self, _args: &[OsString]) -> Result<Config, AppError> {
+        panic!("bare invocation must not attempt configuration loading");
+    }
+}
+
+/// Renders the bare help block using the given localizer.
+fn render_help(localizer: &dyn Localizer) -> String {
+    let mut buf = Vec::new();
+    write_bare_help(&mut buf, localizer)
+        .expect("write bare help");
+    String::from_utf8(buf).expect("utf8")
+}
+
+#[test]
+fn bare_invocation_exits_with_failure() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let exit = run_with_loader(
+        vec![OsString::from("weaver")],
+        &mut io,
+        &PanickingLoader,
+    );
+    assert_eq!(exit, ExitCode::FAILURE);
+}
+
+#[test]
+fn bare_invocation_emits_help_to_stderr() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let _ = run_with_loader(
+        vec![OsString::from("weaver")],
+        &mut io,
+        &PanickingLoader,
+    );
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    assert!(stderr_text.contains("Usage: weaver"));
+    assert!(stderr_text.contains("observe"));
+    assert!(stderr_text.contains("act"));
+    assert!(stderr_text.contains("verify"));
+    assert!(stderr_text.contains("weaver --help"));
+}
+
+#[test]
+fn bare_invocation_produces_no_stdout() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let _ = run_with_loader(
+        vec![OsString::from("weaver")],
+        &mut io,
+        &PanickingLoader,
+    );
+    assert!(
+        stdout.is_empty(),
+        "bare invocation must not write to stdout"
+    );
+}
+
+#[test]
+fn write_bare_help_with_noop_produces_english_fallback() {
+    let text = render_help(&NoOpLocalizer);
+    assert!(text.contains("Usage: weaver"));
+    assert!(text.contains("observe"));
+    assert!(text.contains("act"));
+    assert!(text.contains("verify"));
+    assert!(text.contains("weaver --help"));
+}
+
+#[test]
+fn write_bare_help_with_fluent_produces_english() {
+    let localizer = build_localizer();
+    let text = render_help(localizer.as_ref());
+    assert!(text.contains("Usage: weaver"));
+    assert!(text.contains("observe"));
+    assert!(text.contains("act"));
+    assert!(text.contains("verify"));
+    assert!(text.contains("weaver --help"));
+}
+
+#[test]
+fn bare_help_contains_usage_line() {
+    let text = render_help(&NoOpLocalizer);
+    assert!(text.contains("Usage:"));
+}
+
+#[test]
+fn bare_help_contains_single_help_pointer() {
+    let text = render_help(&NoOpLocalizer);
+    let count = text.matches("weaver --help").count();
+    assert_eq!(count, 1, "expected exactly one --help pointer");
+}
+```
+
+**C3. Add `mod bare_invocation;` declaration to `unit.rs`.**
+
+Replace line 399 (`/// Tests for automatic...` doc comment on `auto_start`)
+with the module declarations:
+
+```rust
+mod auto_start;
+/// Tests for bare-invocation help output.
+mod bare_invocation;
+```
+
+This keeps the file at exactly 400 lines.
+
+**C4. Verify the project compiles but new tests fail.**
+
+Run `cargo check --workspace` — should compile. Run `make test` — new tests
+should fail because the interception logic is not yet wired.
+
+### Stage D: Wire implementation (green phase)
+
+**D1. Wire the bare invocation interception in `lib.rs`.**
+
+In `CliRunner::run()` (the non-handler version, line 115-123), construct the
+localizer before entering the handler:
+
+```rust
+fn run<I>(&mut self, args: I) -> ExitCode
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let localizer = build_localizer();
+    let mut lifecycle = SystemLifecycle;
+    self.run_with_handler(args, localizer.as_ref(), |invocation, context, output| {
+        lifecycle.handle(invocation, context, output)
+    })
+}
+```
+
+Update `run_with_handler()` to accept `localizer: &dyn Localizer` and use it in
+the bare invocation check:
+
+```rust
+fn run_with_handler<I, F>(
+    &mut self,
+    args: I,
+    localizer: &dyn Localizer,
+    mut handler: F,
+) -> ExitCode
+```
+
+In the `and_then` chain, after `Cli::try_parse_from`:
+
+```rust
+.and_then(|cli| {
+    if cli.is_bare_invocation() {
+        let _ = write_bare_help(&mut *self.io.stderr, localizer);
+        return Err(AppError::BareInvocation);
+    }
+    self.loader
+        .load(&split.config_arguments)
+        .map(|config| (cli, config))
+})
+```
+
+**D2. Suppress duplicate error printing for `BareInvocation`.**
+
+In the `match result` block:
+
+```rust
+match result {
+    Ok(exit_code) => exit_code,
+    Err(AppError::BareInvocation) => ExitCode::FAILURE,
+    Err(error) => {
+        let _ = writeln!(self.io.stderr, "{error}");
+        ExitCode::FAILURE
+    }
+}
+```
+
+**D3. Update `run_with_daemon_binary` (test-only) to pass localizer.**
+
+The `#[cfg(test)]` function `run_with_daemon_binary()` creates a `CliRunner`
+and calls `run_with_handler`. It needs to accept and forward a localizer. Use
+`&NoOpLocalizer` as the default for existing test callers. Update the test
+support `TestWorld::run()` to pass `&NoOpLocalizer`.
+
+**D4. Update the existing unit test
+`run_with_loader_reports_configuration_failures`.**
+
+Change args from `vec![OsString::from("weaver")]` to
+`vec![OsString::from("weaver"), OsString::from("observe")]` so the bare
+invocation check does not fire.
+
+**D5. Verify all tests pass (green phase).**
+
+Run `make check-fmt && make lint && make test`.
+
+### Stage E: Documentation and roadmap updates
+
+**E1. Update `docs/users-guide.md`.**
+
+Add a "Bare invocation" subsection within "Command reference", before "Output
+formats":
+
+Add a heading `### Bare invocation` describing the new behaviour.  Include a
+`text` code block showing the help output and a note that it does not require a
+configuration file or a running daemon.  See the actual `docs/users-guide.md`
+change for the rendered version.
+
+**E2. Mark roadmap task 5.1.1 as done in `docs/roadmap.md`.**
+
+Change the three `[ ]` checkboxes for task 5.1.1 to `[x]`.
+
+**E3. Run `make fmt` and `make markdownlint`.**
+
+### Stage F: Final validation and commit gating
+
+**F1. Run full commit gating suite.**
+
+```sh
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt.log
+make lint 2>&1 | tee /tmp/lint.log
+make test 2>&1 | tee /tmp/test.log
+```
+
+All three must pass with zero exit code.
+
+## Concrete steps
+
+All commands run from the workspace root `/home/user/project`.
+
+The concrete steps mirror the Plan of Work stages A through F. See the Plan of
+Work for full code listings; this section summarises the edits and commands.
+
+### Stage A: Upgrade ortho-config
+
+1. Edit `Cargo.toml` line 33: `"0.6.0"` → `"0.7.0"`.
+2. Run `cargo check --workspace && make test` to verify no regressions.
+
+### Stage B: Scaffold Fluent resources and localizer
+
+1. Create `crates/weaver-cli/locales/en-US/messages.ftl` with bare-help
+   Fluent messages (see Plan of Work B1).
+2. Create `crates/weaver-cli/src/localizer.rs` with `build_localizer()` and
+   `write_bare_help()` (see Plan of Work B2).
+3. Add `BareInvocation` to `AppError` in `errors.rs` (B3).
+4. Add `is_bare_invocation()` to `Cli` in `cli.rs` (B4).
+5. Register `mod localizer;` and update imports in `lib.rs` (B5).
+
+### Stage C: Scaffold tests
+
+1. Append BDD scenario to `weaver_cli.feature` (C1).
+2. Create `src/tests/unit/bare_invocation.rs` with unit tests (C2).
+3. Update `unit.rs` to declare `mod bare_invocation` (C3).
+4. Run `cargo check --workspace` then `make test` — new tests should fail
+   (red phase).
+
+### Stage D: Wire implementation
+
+1. Construct localizer in `CliRunner::run()` and thread through
+   `run_with_handler()` (D1).
+2. Add `BareInvocation` match arm in error handler (D2).
+3. Update `run_with_daemon_binary` and `TestWorld::run()` to pass
+   `&NoOpLocalizer` (D3).
+4. Fix `run_with_loader_reports_configuration_failures` test args (D4).
+5. Run `make check-fmt && make lint && make test` — all must pass (D5).
+
+### Stage E: Documentation
+
+1. Add "Bare invocation" subsection to `docs/users-guide.md`.
+2. Mark 5.1.1 as done in `docs/roadmap.md`.
+3. Run `make fmt && make markdownlint`.
+
+### Stage F: Final validation
+
+```sh
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt.log
+make lint 2>&1 | tee /tmp/lint.log
+make test 2>&1 | tee /tmp/test.log
+```
+
+## Validation and acceptance
+
+**Acceptance criteria** (from roadmap):
+
+1. `weaver` with no arguments exits non-zero — verified by BDD scenario
+   `Bare invocation shows short help` (`Then the CLI fails`) and unit test
+   `bare_invocation_exits_with_failure`.
+2. Prints a `Usage:` line — verified by BDD `stderr contains "Usage: weaver"`
+   and unit test `bare_help_contains_usage_line`.
+3. Lists the three valid domains — verified by BDD assertions for `observe`,
+   `act`, `verify` and unit tests
+   `write_bare_help_with_noop_produces_english_fallback` /
+   `write_bare_help_with_fluent_produces_english`.
+4. Includes exactly one pointer to `weaver --help` — verified by unit test
+   `bare_help_contains_single_help_pointer`.
+5. Does not require config loading — verified by `PanickingLoader` in unit
+   tests (loader panics if called).
+6. All user-facing text is sourced through `ortho_config::Localizer` — verified
+   by unit tests exercising both `NoOpLocalizer` and `FluentLocalizer` paths.
+
+**Quality criteria:**
+
+- Tests: `make test` passes with zero exit code, including all new tests.
+- Lint: `make lint` passes (Clippy pedantic, deny warnings).
+- Format: `make check-fmt` passes.
+- Markdown: `make markdownlint` passes after doc changes.
+
+**Quality method:**
+
+```sh
+make check-fmt && make lint && make test && make markdownlint
+```
+
+## Idempotence and recovery
+
+All steps are file edits and can be re-applied. If any step fails partway
+through, the working tree can be reset with `git checkout -- .` and the steps
+re-executed from the beginning. No external state is modified.
+
+## Interfaces and dependencies
+
+**Upgraded dependency:** `ortho_config` v0.6.0 → v0.7.0 (additive, no breaking
+changes). Brings transitive deps: `fluent-bundle`, `fluent-syntax`,
+`unic-langid`.
+
+New `pub(crate)` interfaces:
+
+In `crates/weaver-cli/src/cli.rs`:
+
+```rust
+impl Cli {
+    pub(crate) fn is_bare_invocation(&self) -> bool;
+}
+```
+
+In `crates/weaver-cli/src/localizer.rs`:
+
+```rust
+pub(crate) fn build_localizer() -> Box<dyn Localizer>;
+pub(crate) fn write_bare_help<W: Write>(
+    writer: &mut W,
+    localizer: &dyn Localizer,
+) -> std::io::Result<()>;
+```
+
+In `crates/weaver-cli/src/errors.rs`:
+
+```rust
+#[derive(Debug, Error)]
+pub(crate) enum AppError {
+    // ... existing variants ...
+    #[error("")]
+    BareInvocation,
+}
+```
+
+## Files modified (summary)
+
+| File                                                  | Change                              |
+| ----------------------------------------------------- | ----------------------------------- |
+| `Cargo.toml`                                          | Upgrade `ortho_config` to `"0.7.0"` |
+| `crates/weaver-cli/locales/en-US/messages.ftl`        | New: Fluent resources               |
+| `crates/weaver-cli/src/localizer.rs`                  | New: localizer module               |
+| `crates/weaver-cli/src/cli.rs`                        | Add `is_bare_invocation()` method   |
+| `crates/weaver-cli/src/errors.rs`                     | Add `BareInvocation` variant        |
+| `crates/weaver-cli/src/lib.rs`                        | Wire localizer + bare invocation    |
+| `crates/weaver-cli/src/tests/unit.rs`                 | Fix test args; add `mod` decl       |
+| `crates/weaver-cli/src/tests/unit/bare_invocation.rs` | New: unit tests                     |
+| `crates/weaver-cli/src/tests/support/mod.rs`          | Pass `NoOpLocalizer`                |
+| `crates/weaver-cli/tests/features/weaver_cli.feature` | Add BDD scenario                    |
+| `docs/users-guide.md`                                 | Add "Bare invocation" subsection    |
+| `docs/roadmap.md`                                     | Mark 5.1.1 checkboxes as done       |

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -1,4 +1,4 @@
-# 5.1.1 Show short help on bare invocation (Fluent-localised)
+# 5.1.1 Show short help on bare invocation (Fluent-localized)
 
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
@@ -9,7 +9,8 @@ Status: COMPLETE
 
 ## Purpose / big picture
 
-When an operator runs `weaver` with no arguments today, the CLI prints the
+When an operator runs `weaver` with no arguments today, the command-line
+interface (CLI) prints the
 terse message `the command domain must be provided` to stderr and exits 1.
 There is no hint about what domains exist, no usage line, and no pointer to
 `--help`. A newcomer who has just installed Weaver has no idea what to type
@@ -37,9 +38,9 @@ Run 'weaver --help' for more information.
 ```
 
 This addresses the P0 gap identified in the
-[UI gap analysis Level 0](docs/ui-gap-analysis.md#level-0--bare-invocation-weaver)
- and
-[Level 10d](docs/ui-gap-analysis.md#level-10--error-messages-and-exit-codes),
+[UI gap analysis Level 0](../ui-gap-analysis.md#level-0--bare-invocation-weaver)
+and
+[Level 10d](../ui-gap-analysis.md#level-10--error-messages-and-exit-codes),
 and satisfies roadmap task 5.1.1 in `docs/roadmap.md`.
 
 ## Constraints
@@ -51,7 +52,8 @@ and satisfies roadmap task 5.1.1 in `docs/roadmap.md`.
   `cognitive_complexity`, `missing_docs`, etc.). All new code must comply.
 - Comments and documentation must use en-GB-oxendict spelling
   ("-ize" / "-yse" / "-our").
-- New functionality requires both unit tests and BDD behavioural tests.
+- New functionality requires both unit tests and BDD (behaviour-driven
+  development) behavioural tests.
 - Every module must begin with a `//!` module-level doc comment.
 - The bare invocation help must not require configuration loading or daemon
   connectivity. This is a hard requirement because an operator with no config
@@ -126,10 +128,11 @@ and satisfies roadmap task 5.1.1 in `docs/roadmap.md`.
 - The build script (`build.rs`) includes `cli.rs` via `#[path = "src/cli.rs"]`
   for manpage generation. The new `is_bare_invocation()` method triggered a
   `dead_code` warning in the build script context because it is only called
-  from `lib.rs`. Resolved with a tightly scoped `#[allow(dead_code)]` attribute
+  from `lib.rs`. Resolved with a tightly scoped `#[expect(dead_code)]` attribute
   with a reason string explaining the dual-compilation context.
-- The `#[error("")]` on `BareInvocation` did not trigger any Clippy lint (the
-  low-probability risk from the plan did not materialise).
+- The `#[error("bare invocation")]` on `BareInvocation` provides a non-empty
+  display string for safety in generic `Display` paths while the match arm
+  in `run_with_handler()` suppresses printing for this variant.
 - `unit.rs` compaction required reformatting one test to single-line style and
   collapsing the `is_daemon_not_running_rejects_non_connect_errors` assertions
   to recover lines.
@@ -267,7 +270,7 @@ The hello_world example in ortho-config demonstrates the pattern:
 4. Fall back to `NoOpLocalizer` on error.
 5. Resolve strings via `localizer.message("msg-id", None, "fallback")`.
 
-Fluent message IDs use hyphens (dots are normalised to hyphens by
+Fluent message IDs use hyphens (dots are normalized to hyphens by
 ortho-config's `normalize_identifier()`). The embedded en-US catalogue in
 ortho-config already provides `clap-error-*` messages for clap error
 localization.
@@ -431,7 +434,7 @@ alignment-agnostic in translations.
 Below the `MissingOperation` variant:
 
 ```rust
-    #[error("")]
+    #[error("bare invocation")]
     BareInvocation,
 ```
 
@@ -670,7 +673,7 @@ In the `and_then` chain, after `Cli::try_parse_from`:
 ```rust
 .and_then(|cli| {
     if cli.is_bare_invocation() {
-        let _ = write_bare_help(&mut *self.io.stderr, localizer);
+        write_bare_help(&mut *self.io.stderr, localizer).ok();
         return Err(AppError::BareInvocation);
     }
     self.loader
@@ -869,7 +872,7 @@ In `crates/weaver-cli/src/errors.rs`:
 #[derive(Debug, Error)]
 pub(crate) enum AppError {
     // ... existing variants ...
-    #[error("")]
+    #[error("bare invocation")]
     BareInvocation,
 }
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -231,15 +231,15 @@ Section priority mapping (non-scheduling metadata): Step 5.1=`P0`, Step
 
 ### Step 5.1: Deliver baseline guidance and top-level discoverability
 
-- [ ] 5.1.1. Show short help when `weaver` is invoked without arguments.
+- [x] 5.1.1. Show short help when `weaver` is invoked without arguments.
       See
       [Level 0](docs/ui-gap-analysis.md#level-0--bare-invocation-weaver)
       and
       [Level 10](docs/ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
       (10d).
-  - [ ] Replace bare missing-domain output with short help and a clear next
+  - [x] Replace bare missing-domain output with short help and a clear next
         step.
-  - [ ] Acceptance criteria: `weaver` with no arguments exits non-zero, prints
+  - [x] Acceptance criteria: `weaver` with no arguments exits non-zero, prints
         a `Usage:` line, lists the three valid domains (`observe`, `act`,
         `verify`), and includes exactly one pointer to `weaver --help`.
 - [ ] 5.1.2. List all domains and operations in top-level help output.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -222,6 +222,26 @@ lifecycle commands, and domain operations (`observe`, `act`, `verify`). Domain
 commands are sent to the daemon as JSONL; any arguments after the operation are
 forwarded verbatim without CLI validation.
 
+### Bare invocation
+
+Running `weaver` without any arguments prints a short help summary to standard
+error and exits with a non-zero status code:
+
+```text
+Usage: weaver <DOMAIN> <OPERATION> [ARG]...
+
+Domains:
+  observe   Query code structure and relationships
+  act       Perform code modifications
+  verify    Validate code correctness
+
+Run 'weaver --help' for more information.
+```
+
+This output does not require a configuration file or a running daemon. Use
+`weaver --help` for the full reference, including global options and the
+`daemon` subcommand.
+
 ### Output formats
 
 Daemon responses are JSON objects with `kind` set to `stream` or `exit`. Stream


### PR DESCRIPTION
## Summary
Fully implement a Fluent-localized bare-invocation help pathway for the Weaver CLI, including localization infrastructure, tests, and user-facing documentation updates. This work upgrades the localization runtime (ortho-config) and wires localization through startup and daemon paths, allowing a localized short-help block to be shown when the CLI is invoked with no arguments.

## Changes
- Upgrade ortho-config to 0.7.0 across the workspace to enable Fluent-based localization (adds fluent-bundle, fluent-syntax, unic-langid).
- Add localization support for the Weaver CLI:
  - New module: crates/weaver-cli/src/localizer.rs
  - Embedded en-US Fluent catalogue: crates/weaver-cli/locales/en-US/messages.ftl
  - Functions: build_localizer() -> Box<dyn Localizer>, write_bare_help(writer, localizer) -> io::Result<()> 
- Bare invocation handling:
  - Add AppError::BareInvocation sentinel variant (with empty Display to avoid unintended prints).
  - Add Cli::is_bare_invocation() to detect when no domain/subcommand is provided.
  - Wire localization into the CLI startup flow and pass the localizer through run_with_handler.
  - Wire localization into the daemon path (run_with_daemon_binary) to forward the localizer into the handler path.
- Tests and support scaffolding:
  - New unit tests for bare invocation in crates/weaver-cli/src/tests/unit/bare_invocation.rs
  - Update test harness to pass a Localizer (NoOpLocalizer in tests) and to exercise new bare-invocation path.
  - Support wiring in existing tests to reference the new localizer by default (crates/weaver-cli/src/tests/support/mod.rs).
  - Extend feature tests with a Bare invocation scenario in crates/weaver-cli/tests/features/weaver_cli.feature.
- Documentation and roadmap updates:
  - docs/users-guide.md: add a Bare invocation section showing the short help output and noting no config/daemon is required.
  - docs/roadmap.md: mark 5.1.1 as done.
  - docs/execplans/5-1-1-entry-help.md: added as a new execplan detailing the bare invocation help path.

## Why
- Provides a clear, localized entry point for new users when they run weaver with no arguments.
- Establishes a localization-first approach for CLI text while preserving English fallbacks if localization fails.
- Keeps bare-invocation handling isolated from the rest of the configuration/daemon flow by short-circuiting early.

## How it works
- On startup, a localizer is built (FluentLocalizer with embedded en-US resources) or falls back to NoOpLocalizer.
- When parsing CLI arguments, if there is a bare invocation (no domain, no subcommand, no capabilities), the CLI writes a localized bare-help block to stderr and returns a BareInvocation error.
- The BareInvocation error maps to a non-zero exit code, while other errors still print messages to stderr as appropriate.
- The short help is composed from localized strings (weaver-bare-help-usage, weaver-bare-help-header, etc.) to enable translation via Fluent resources.
- All user-facing text for the bare invocation is resolved through Localizer messages with English fallbacks.

## Testing plan
- Unit tests:
  - Verify bare invocation exits with non-zero status and writes the expected help to stderr.
  - Verify write_bare_help(NoOpLocalizer) renders English fallback as expected.
  - Verify write_bare_help(FluentLocalizer) renders the same English guidance via Fluent resolution path.
- Integration/BDD:
  - Add a Bare invocation scenario to weaver_cli.feature to confirm stderr contains: Usage line, domains (observe, act, verify), and exactly one weaver --help pointer.
  - Ensure PanickingLoader is used in unit tests to prove no config load attempts occur on bare invocation.
- Documentation:
  - Validate the new Bare invocation documentation in user guide and roadmap status in docs.

## Validation steps
- cargo check --workspace
- cargo test (or make test)
- Verify the new BDD scenario passes and that the bare-invocation unit tests pass
- Ensure all existing tests still pass with the Ortho ho-config upgrade

## Notes for reviewers
- The BareInvocation variant includes an empty Display to avoid unintended console noise; the CLI’s error handling explicitly handles this variant to suppress extra output.
- All user-facing text for the bare invocation is resolved through Localizer messages with English fallbacks, enabling future localization without code changes.
- The execplan and documentation updates reflect the new behaviour and plan for localization-enabled help text.

## Related files touched
- Cargo.toml: ortho_config -> 0.7.0
- crates/weaver-cli/locales/en-US/messages.ftl: new
- crates/weaver-cli/src/localizer.rs: new
- crates/weaver-cli/src/cli.rs: is_bare_invocation() added
- crates/weaver-cli/src/errors.rs: BareInvocation variant added
- crates/weaver-cli/src/lib.rs: localizer wiring and bare invocation handling added
- crates/weaver-cli/src/tests/unit.rs: test harness adjustments for localizer and bare path
- crates/weaver-cli/src/tests/unit/bare_invocation.rs: new tests
- crates/weaver-cli/src/tests/support/mod.rs: pass NoOpLocalizer in tests
- crates/weaver-cli/tests/features/weaver_cli.feature: new bare invocation scenario
- docs/users-guide.md: Bare invocation section added
- docs/roadmap.md: 5.1.1 marked done
- docs/execplans/5-1-1-entry-help.md: new execplan doc


📎 **Task**: https://www.devboxer.com/task/b88ae781-8210-402d-87ea-2650dde95fcf