### PR TITLE
Scaffold Sempai Core and Facade with core types, diagnostics, tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c2f82143577edb4921b71ede051dac62ca3c16084e918bf7b40c96ae10eb33"
 
 [[package]]
+name = "sempai"
+version = "0.1.0"
+dependencies = [
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
+ "sempai_core",
+ "serde_json",
+]
+
+[[package]]
+name = "sempai_core"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ members = [
     "crates/weaver-plugins",
     "crates/weaver-sandbox",
     "crates/weaver-syntax",
+    "crates/sempai-core",
+    "crates/sempai",
 ]
 resolver = "2"
 

--- a/crates/sempai-core/Cargo.toml
+++ b/crates/sempai-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sempai_core"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+rstest-bdd = { workspace = true }
+rstest-bdd-macros = { workspace = true }
+insta = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sempai-core/Cargo.toml
+++ b/crates/sempai-core/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
+[features]
+test-support = []
+
 [dependencies]
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/sempai-core/src/capture.rs
+++ b/crates/sempai-core/src/capture.rs
@@ -1,0 +1,78 @@
+//! Capture types for match result bindings.
+//!
+//! A capture represents a named sub-region of a match, bound to a
+//! metavariable such as `$X` or `$...ARGS`.  Single-node captures use
+//! [`CaptureValue::Node`]; ellipsis captures that bind multiple nodes use
+//! [`CaptureValue::Nodes`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::span::Span;
+
+/// A single captured syntax node.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::{CapturedNode, LineCol, Span};
+///
+/// let node = CapturedNode::new(
+///     Span::new(0, 5, LineCol::new(0, 0), LineCol::new(0, 5)),
+///     String::from("identifier"),
+///     Some(String::from("hello")),
+/// );
+/// assert_eq!(node.kind(), "identifier");
+/// assert_eq!(node.text(), Some("hello"));
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapturedNode {
+    /// The span of the captured node in the source.
+    pub span: Span,
+    /// The Tree-sitter node kind (e.g. `"identifier"`, `"function_item"`).
+    pub kind: String,
+    /// The source text of the captured node, if available.
+    ///
+    /// This is `None` when streaming mode omits text to avoid re-slicing.
+    pub text: Option<String>,
+}
+
+impl CapturedNode {
+    /// Creates a new captured node.
+    #[must_use]
+    pub const fn new(span: Span, kind: String, text: Option<String>) -> Self {
+        Self { span, kind, text }
+    }
+
+    /// Returns a reference to the captured span.
+    #[must_use]
+    pub const fn span(&self) -> &Span {
+        &self.span
+    }
+
+    /// Returns the Tree-sitter node kind.
+    #[must_use]
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Returns the source text, if captured.
+    #[must_use]
+    pub fn text(&self) -> Option<&str> {
+        self.text.as_deref()
+    }
+}
+
+/// A capture binding produced by query execution.
+///
+/// Single metavariables (`$X`) produce [`Node`](Self::Node) captures.
+/// Ellipsis metavariables (`$...ARGS`) produce [`Nodes`](Self::Nodes)
+/// captures containing zero or more nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CaptureValue {
+    /// A single captured node.
+    Node(CapturedNode),
+    /// Multiple captured nodes (from an ellipsis metavariable).
+    Nodes(Vec<CapturedNode>),
+}

--- a/crates/sempai-core/src/capture.rs
+++ b/crates/sempai-core/src/capture.rs
@@ -39,7 +39,11 @@ pub struct CapturedNode {
 impl CapturedNode {
     /// Creates a new captured node.
     #[must_use]
-    pub const fn new(span: Span, kind: String, text: Option<String>) -> Self {
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "heap types cannot be used in const contexts"
+    )]
+    pub fn new(span: Span, kind: String, text: Option<String>) -> Self {
         Self { span, kind, text }
     }
 

--- a/crates/sempai-core/src/config.rs
+++ b/crates/sempai-core/src/config.rs
@@ -1,0 +1,88 @@
+//! Engine configuration for performance and safety limits.
+
+/// Engine configuration controlling match limits, capture sizes, and feature
+/// gates.
+///
+/// # Defaults
+///
+/// The default configuration provides generous but bounded limits suitable
+/// for interactive use:
+///
+/// - `max_matches_per_rule`: 10 000
+/// - `max_capture_text_bytes`: 1 048 576 (1 MiB)
+/// - `max_deep_search_nodes`: 100 000
+/// - `enable_hcl`: `false`
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::EngineConfig;
+///
+/// let config = EngineConfig::default();
+/// assert_eq!(config.max_matches_per_rule(), 10_000);
+/// assert!(!config.enable_hcl());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineConfig {
+    /// Maximum number of matches emitted per rule before truncation.
+    max_matches_per_rule: usize,
+    /// Maximum bytes of source text captured per match.
+    max_capture_text_bytes: usize,
+    /// Maximum syntax tree nodes visited during deep ellipsis matching.
+    max_deep_search_nodes: usize,
+    /// Whether HCL support is enabled.
+    enable_hcl: bool,
+}
+
+impl EngineConfig {
+    /// Creates a new engine configuration with explicit values.
+    #[must_use]
+    pub const fn new(
+        max_matches_per_rule: usize,
+        max_capture_text_bytes: usize,
+        max_deep_search_nodes: usize,
+        enable_hcl: bool,
+    ) -> Self {
+        Self {
+            max_matches_per_rule,
+            max_capture_text_bytes,
+            max_deep_search_nodes,
+            enable_hcl,
+        }
+    }
+
+    /// Returns the maximum matches per rule.
+    #[must_use]
+    pub const fn max_matches_per_rule(&self) -> usize {
+        self.max_matches_per_rule
+    }
+
+    /// Returns the maximum capture text bytes.
+    #[must_use]
+    pub const fn max_capture_text_bytes(&self) -> usize {
+        self.max_capture_text_bytes
+    }
+
+    /// Returns the maximum deep search nodes.
+    #[must_use]
+    pub const fn max_deep_search_nodes(&self) -> usize {
+        self.max_deep_search_nodes
+    }
+
+    /// Returns whether HCL support is enabled.
+    #[must_use]
+    pub const fn enable_hcl(&self) -> bool {
+        self.enable_hcl
+    }
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self {
+            max_matches_per_rule: 10_000,
+            max_capture_text_bytes: 1_048_576,
+            max_deep_search_nodes: 100_000,
+            enable_hcl: false,
+        }
+    }
+}

--- a/crates/sempai-core/src/config.rs
+++ b/crates/sempai-core/src/config.rs
@@ -1,5 +1,73 @@
 //! Engine configuration for performance and safety limits.
 
+/// Numeric engine limits controlling match counts, capture sizes, and
+/// search depth.
+///
+/// Grouping these into a dedicated struct prevents accidental transposition
+/// of the three positional `usize` parameters.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::EngineLimits;
+///
+/// let limits = EngineLimits::new(5_000, 512_000, 50_000);
+/// assert_eq!(limits.max_matches_per_rule(), 5_000);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EngineLimits {
+    /// Maximum number of matches emitted per rule before truncation.
+    matches_per_rule: usize,
+    /// Maximum bytes of source text captured per match.
+    capture_text_bytes: usize,
+    /// Maximum syntax tree nodes visited during deep ellipsis matching.
+    deep_search_nodes: usize,
+}
+
+impl EngineLimits {
+    /// Creates a new set of engine limits.
+    #[must_use]
+    pub const fn new(
+        matches_per_rule: usize,
+        capture_text_bytes: usize,
+        deep_search_nodes: usize,
+    ) -> Self {
+        Self {
+            matches_per_rule,
+            capture_text_bytes,
+            deep_search_nodes,
+        }
+    }
+
+    /// Returns the maximum matches per rule.
+    #[must_use]
+    pub const fn max_matches_per_rule(&self) -> usize {
+        self.matches_per_rule
+    }
+
+    /// Returns the maximum capture text bytes.
+    #[must_use]
+    pub const fn max_capture_text_bytes(&self) -> usize {
+        self.capture_text_bytes
+    }
+
+    /// Returns the maximum deep search nodes.
+    #[must_use]
+    pub const fn max_deep_search_nodes(&self) -> usize {
+        self.deep_search_nodes
+    }
+}
+
+impl Default for EngineLimits {
+    fn default() -> Self {
+        Self {
+            matches_per_rule: 10_000,
+            capture_text_bytes: 1_048_576,
+            deep_search_nodes: 100_000,
+        }
+    }
+}
+
 /// Engine configuration controlling match limits, capture sizes, and feature
 /// gates.
 ///
@@ -16,20 +84,16 @@
 /// # Example
 ///
 /// ```
-/// use sempai_core::EngineConfig;
+/// use sempai_core::{EngineConfig, EngineLimits};
 ///
 /// let config = EngineConfig::default();
-/// assert_eq!(config.max_matches_per_rule(), 10_000);
+/// assert_eq!(config.limits().max_matches_per_rule(), 10_000);
 /// assert!(!config.enable_hcl());
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EngineConfig {
-    /// Maximum number of matches emitted per rule before truncation.
-    max_matches_per_rule: usize,
-    /// Maximum bytes of source text captured per match.
-    max_capture_text_bytes: usize,
-    /// Maximum syntax tree nodes visited during deep ellipsis matching.
-    max_deep_search_nodes: usize,
+    /// Numeric limits for match counts, capture sizes, and search depth.
+    limits: EngineLimits,
     /// Whether HCL support is enabled.
     enable_hcl: bool,
 }
@@ -37,52 +101,37 @@ pub struct EngineConfig {
 impl EngineConfig {
     /// Creates a new engine configuration with explicit values.
     #[must_use]
-    pub const fn new(
-        max_matches_per_rule: usize,
-        max_capture_text_bytes: usize,
-        max_deep_search_nodes: usize,
-        enable_hcl: bool,
-    ) -> Self {
-        Self {
-            max_matches_per_rule,
-            max_capture_text_bytes,
-            max_deep_search_nodes,
-            enable_hcl,
-        }
+    pub const fn new(limits: EngineLimits, enable_hcl: bool) -> Self {
+        Self { limits, enable_hcl }
+    }
+
+    /// Returns the numeric engine limits.
+    #[must_use]
+    pub const fn limits(&self) -> &EngineLimits {
+        &self.limits
     }
 
     /// Returns the maximum matches per rule.
     #[must_use]
     pub const fn max_matches_per_rule(&self) -> usize {
-        self.max_matches_per_rule
+        self.limits.matches_per_rule
     }
 
     /// Returns the maximum capture text bytes.
     #[must_use]
     pub const fn max_capture_text_bytes(&self) -> usize {
-        self.max_capture_text_bytes
+        self.limits.capture_text_bytes
     }
 
     /// Returns the maximum deep search nodes.
     #[must_use]
     pub const fn max_deep_search_nodes(&self) -> usize {
-        self.max_deep_search_nodes
+        self.limits.deep_search_nodes
     }
 
     /// Returns whether HCL support is enabled.
     #[must_use]
     pub const fn enable_hcl(&self) -> bool {
         self.enable_hcl
-    }
-}
-
-impl Default for EngineConfig {
-    fn default() -> Self {
-        Self {
-            max_matches_per_rule: 10_000,
-            max_capture_text_bytes: 1_048_576,
-            max_deep_search_nodes: 100_000,
-            enable_hcl: false,
-        }
     }
 }

--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -1,0 +1,255 @@
+//! Diagnostic types for structured error reporting.
+//!
+//! All user-facing failures in the Sempai pipeline — parse errors, validation
+//! failures, unsupported modes — are surfaced through a [`DiagnosticReport`]
+//! containing one or more [`Diagnostic`] entries.  Each diagnostic carries a
+//! stable [`DiagnosticCode`], a human-readable message, an optional source
+//! location, and supplementary notes.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Stable error codes for Sempai diagnostics.
+///
+/// Each variant corresponds to a documented `E_SEMPAI_*` error code.  The
+/// [`NotImplemented`](Self::NotImplemented) variant is used by stub methods
+/// that have not yet been implemented.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::DiagnosticCode;
+///
+/// let code = DiagnosticCode::ESempaiYamlParse;
+/// assert_eq!(format!("{code}"), "E_SEMPAI_YAML_PARSE");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum DiagnosticCode {
+    /// YAML rule file parse failure.
+    ESempaiYamlParse,
+    /// One-liner DSL parse failure.
+    ESempaiDslParse,
+    /// Schema validation failure.
+    ESempaiSchemaInvalid,
+    /// Unsupported execution mode.
+    ESempaiUnsupportedMode,
+    /// Negated branch inside `pattern-either` / `any`.
+    ESempaiInvalidNotInOr,
+    /// Conjunction with no positive match-producing term.
+    ESempaiMissingPositiveTermInAnd,
+    /// Pattern snippet failed to parse as host language.
+    ESempaiPatternSnippetParseFailed,
+    /// Unsupported constraint in current context.
+    ESempaiUnsupportedConstraint,
+    /// Invalid Tree-sitter query syntax.
+    ESempaiTsQueryInvalid,
+    /// Feature not yet implemented (used by stub methods).
+    NotImplemented,
+}
+
+impl fmt::Display for DiagnosticCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ESempaiYamlParse => f.write_str("E_SEMPAI_YAML_PARSE"),
+            Self::ESempaiDslParse => f.write_str("E_SEMPAI_DSL_PARSE"),
+            Self::ESempaiSchemaInvalid => f.write_str("E_SEMPAI_SCHEMA_INVALID"),
+            Self::ESempaiUnsupportedMode => f.write_str("E_SEMPAI_UNSUPPORTED_MODE"),
+            Self::ESempaiInvalidNotInOr => f.write_str("E_SEMPAI_INVALID_NOT_IN_OR"),
+            Self::ESempaiMissingPositiveTermInAnd => {
+                f.write_str("E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND")
+            }
+            Self::ESempaiPatternSnippetParseFailed => {
+                f.write_str("E_SEMPAI_PATTERN_SNIPPET_PARSE_FAILED")
+            }
+            Self::ESempaiUnsupportedConstraint => f.write_str("E_SEMPAI_UNSUPPORTED_CONSTRAINT"),
+            Self::ESempaiTsQueryInvalid => f.write_str("E_SEMPAI_TS_QUERY_INVALID"),
+            Self::NotImplemented => f.write_str("NOT_IMPLEMENTED"),
+        }
+    }
+}
+
+/// A byte range within a rule file or DSL string for diagnostic locations.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::SourceSpan;
+///
+/// let span = SourceSpan::new(0, 42, None);
+/// assert_eq!(span.start(), 0);
+/// assert_eq!(span.end(), 42);
+/// assert!(span.uri().is_none());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceSpan {
+    /// Start byte offset (inclusive).
+    start: u32,
+    /// End byte offset (exclusive).
+    end: u32,
+    /// Optional URI of the source file containing this span.
+    uri: Option<String>,
+}
+
+impl SourceSpan {
+    /// Creates a new source span.
+    #[must_use]
+    pub const fn new(start: u32, end: u32, uri: Option<String>) -> Self {
+        Self { start, end, uri }
+    }
+
+    /// Returns the inclusive start byte offset.
+    #[must_use]
+    pub const fn start(&self) -> u32 {
+        self.start
+    }
+
+    /// Returns the exclusive end byte offset.
+    #[must_use]
+    pub const fn end(&self) -> u32 {
+        self.end
+    }
+
+    /// Returns the source file URI, if available.
+    #[must_use]
+    pub fn uri(&self) -> Option<&str> {
+        self.uri.as_deref()
+    }
+}
+
+/// A single diagnostic entry within a report.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::{Diagnostic, DiagnosticCode};
+///
+/// let diag = Diagnostic::new(
+///     DiagnosticCode::ESempaiYamlParse,
+///     String::from("unexpected key 'patterns'"),
+///     None,
+///     vec![],
+/// );
+/// assert_eq!(diag.code(), DiagnosticCode::ESempaiYamlParse);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Diagnostic {
+    /// The stable error code.
+    code: DiagnosticCode,
+    /// A human-readable description of the problem.
+    message: String,
+    /// The source location where the problem was detected, if available.
+    span: Option<SourceSpan>,
+    /// Additional notes providing context or suggestions.
+    notes: Vec<String>,
+}
+
+impl Diagnostic {
+    /// Creates a new diagnostic.
+    #[must_use]
+    pub const fn new(
+        code: DiagnosticCode,
+        message: String,
+        span: Option<SourceSpan>,
+        notes: Vec<String>,
+    ) -> Self {
+        Self {
+            code,
+            message,
+            span,
+            notes,
+        }
+    }
+
+    /// Returns the diagnostic code.
+    #[must_use]
+    pub const fn code(&self) -> DiagnosticCode {
+        self.code
+    }
+
+    /// Returns the diagnostic message.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the source span, if available.
+    #[must_use]
+    pub const fn span(&self) -> Option<&SourceSpan> {
+        self.span.as_ref()
+    }
+
+    /// Returns the supplementary notes.
+    #[must_use]
+    pub fn notes(&self) -> &[String] {
+        &self.notes
+    }
+}
+
+/// Summarises the first diagnostic in a report for the `Display` impl.
+fn diagnostic_summary(diagnostics: &[Diagnostic]) -> String {
+    diagnostics.first().map_or_else(
+        || String::from("empty diagnostic report"),
+        |d| format!("{}: {}", d.code, d.message),
+    )
+}
+
+/// A collection of diagnostics produced during compilation or execution.
+///
+/// Used as the error type in `Engine` method signatures.  Contains one or
+/// more individual [`Diagnostic`] entries.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::{DiagnosticCode, DiagnosticReport};
+///
+/// let report = DiagnosticReport::not_implemented("compile_yaml");
+/// assert_eq!(report.diagnostics()[0].code(), DiagnosticCode::NotImplemented);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
+#[error("{}", diagnostic_summary(&self.diagnostics))]
+pub struct DiagnosticReport {
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl DiagnosticReport {
+    /// Creates a report from a vector of diagnostics.
+    #[must_use]
+    pub const fn new(diagnostics: Vec<Diagnostic>) -> Self {
+        Self { diagnostics }
+    }
+
+    /// Creates a single-diagnostic report indicating that a feature is not
+    /// yet implemented.
+    #[must_use]
+    pub fn not_implemented(feature: &str) -> Self {
+        Self {
+            diagnostics: vec![Diagnostic::new(
+                DiagnosticCode::NotImplemented,
+                format!("{feature} is not yet implemented"),
+                None,
+                vec![],
+            )],
+        }
+    }
+
+    /// Returns the diagnostics in this report.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+
+    /// Returns `true` if the report contains no diagnostics.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+
+    /// Returns the number of diagnostics in the report.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.diagnostics.len()
+    }
+}

--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -28,24 +28,34 @@ use serde::{Deserialize, Serialize};
 #[non_exhaustive]
 pub enum DiagnosticCode {
     /// YAML rule file parse failure.
+    #[serde(rename = "E_SEMPAI_YAML_PARSE")]
     ESempaiYamlParse,
     /// One-liner DSL parse failure.
+    #[serde(rename = "E_SEMPAI_DSL_PARSE")]
     ESempaiDslParse,
     /// Schema validation failure.
+    #[serde(rename = "E_SEMPAI_SCHEMA_INVALID")]
     ESempaiSchemaInvalid,
     /// Unsupported execution mode.
+    #[serde(rename = "E_SEMPAI_UNSUPPORTED_MODE")]
     ESempaiUnsupportedMode,
     /// Negated branch inside `pattern-either` / `any`.
+    #[serde(rename = "E_SEMPAI_INVALID_NOT_IN_OR")]
     ESempaiInvalidNotInOr,
     /// Conjunction with no positive match-producing term.
+    #[serde(rename = "E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND")]
     ESempaiMissingPositiveTermInAnd,
     /// Pattern snippet failed to parse as host language.
+    #[serde(rename = "E_SEMPAI_PATTERN_SNIPPET_PARSE_FAILED")]
     ESempaiPatternSnippetParseFailed,
     /// Unsupported constraint in current context.
+    #[serde(rename = "E_SEMPAI_UNSUPPORTED_CONSTRAINT")]
     ESempaiUnsupportedConstraint,
     /// Invalid Tree-sitter query syntax.
+    #[serde(rename = "E_SEMPAI_TS_QUERY_INVALID")]
     ESempaiTsQueryInvalid,
     /// Feature not yet implemented (used by stub methods).
+    #[serde(rename = "NOT_IMPLEMENTED")]
     NotImplemented,
 }
 
@@ -206,7 +216,8 @@ fn diagnostic_summary(diagnostics: &[Diagnostic]) -> String {
 /// use sempai_core::{DiagnosticCode, DiagnosticReport};
 ///
 /// let report = DiagnosticReport::not_implemented("compile_yaml");
-/// assert_eq!(report.diagnostics()[0].code(), DiagnosticCode::NotImplemented);
+/// let first = report.diagnostics().first().expect("at least one");
+/// assert_eq!(first.code(), DiagnosticCode::NotImplemented);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
 #[error("{}", diagnostic_summary(&self.diagnostics))]

--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -105,7 +105,11 @@ pub struct SourceSpan {
 impl SourceSpan {
     /// Creates a new source span.
     #[must_use]
-    pub const fn new(start: u32, end: u32, uri: Option<String>) -> Self {
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "heap types cannot be used in const contexts"
+    )]
+    pub fn new(start: u32, end: u32, uri: Option<String>) -> Self {
         Self { start, end, uri }
     }
 
@@ -158,7 +162,11 @@ pub struct Diagnostic {
 impl Diagnostic {
     /// Creates a new diagnostic.
     #[must_use]
-    pub const fn new(
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "heap types cannot be used in const contexts"
+    )]
+    pub fn new(
         code: DiagnosticCode,
         message: String,
         span: Option<SourceSpan>,
@@ -228,7 +236,11 @@ pub struct DiagnosticReport {
 impl DiagnosticReport {
     /// Creates a report from a vector of diagnostics.
     #[must_use]
-    pub const fn new(diagnostics: Vec<Diagnostic>) -> Self {
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "heap types cannot be used in const contexts"
+    )]
+    pub fn new(diagnostics: Vec<Diagnostic>) -> Self {
         Self { diagnostics }
     }
 

--- a/crates/sempai-core/src/language.rs
+++ b/crates/sempai-core/src/language.rs
@@ -1,0 +1,46 @@
+//! Supported host language identifiers for Sempai queries.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// A supported host language identifier.
+///
+/// Sempai uses this to select the appropriate Tree-sitter grammar, wrapper
+/// templates, and token rewrite rules for pattern compilation.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::Language;
+///
+/// let lang = Language::Rust;
+/// assert_eq!(format!("{lang}"), "rust");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Language {
+    /// The Rust programming language.
+    Rust,
+    /// The Python programming language.
+    Python,
+    /// The TypeScript programming language.
+    TypeScript,
+    /// The Go programming language.
+    Go,
+    /// HCL (the configuration language used by Terraform and similar tools).
+    Hcl,
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Rust => f.write_str("rust"),
+            Self::Python => f.write_str("python"),
+            Self::TypeScript => f.write_str("type_script"),
+            Self::Go => f.write_str("go"),
+            Self::Hcl => f.write_str("hcl"),
+        }
+    }
+}

--- a/crates/sempai-core/src/language.rs
+++ b/crates/sempai-core/src/language.rs
@@ -1,6 +1,7 @@
 //! Supported host language identifiers for Sempai queries.
 
 use std::fmt;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
@@ -42,6 +43,37 @@ impl fmt::Display for Language {
             Self::TypeScript => f.write_str("typescript"),
             Self::Go => f.write_str("go"),
             Self::Hcl => f.write_str("hcl"),
+        }
+    }
+}
+
+/// Error returned when a string does not match any known language name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageParseError {
+    name: String,
+}
+
+impl fmt::Display for LanguageParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown language: {}", self.name)
+    }
+}
+
+impl std::error::Error for LanguageParseError {}
+
+impl FromStr for Language {
+    type Err = LanguageParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "rust" => Ok(Self::Rust),
+            "python" => Ok(Self::Python),
+            "typescript" => Ok(Self::TypeScript),
+            "go" => Ok(Self::Go),
+            "hcl" => Ok(Self::Hcl),
+            _ => Err(LanguageParseError {
+                name: String::from(s),
+            }),
         }
     }
 }

--- a/crates/sempai-core/src/language.rs
+++ b/crates/sempai-core/src/language.rs
@@ -26,6 +26,7 @@ pub enum Language {
     /// The Python programming language.
     Python,
     /// The TypeScript programming language.
+    #[serde(rename = "typescript")]
     TypeScript,
     /// The Go programming language.
     Go,
@@ -38,7 +39,7 @@ impl fmt::Display for Language {
         match self {
             Self::Rust => f.write_str("rust"),
             Self::Python => f.write_str("python"),
-            Self::TypeScript => f.write_str("type_script"),
+            Self::TypeScript => f.write_str("typescript"),
             Self::Go => f.write_str("go"),
             Self::Hcl => f.write_str("hcl"),
         }

--- a/crates/sempai-core/src/lib.rs
+++ b/crates/sempai-core/src/lib.rs
@@ -1,0 +1,43 @@
+//! Core data model, diagnostics, and planning types for the Sempai query
+//! engine.
+//!
+//! This crate provides the canonical type definitions used throughout the
+//! Sempai pipeline: language identifiers, source spans, match results,
+//! capture bindings, diagnostic reports, and engine configuration.  It is
+//! re-exported by the `sempai` facade crate for stable public consumption.
+//!
+//! # Core types
+//!
+//! - [`Language`] — supported host language identifiers
+//! - [`Span`] and [`LineCol`] — byte and line/column source positions
+//! - [`Match`] — a successful rule binding with captures
+//! - [`CaptureValue`] and [`CapturedNode`] — metavariable bindings
+//! - [`DiagnosticReport`] and [`Diagnostic`] — structured error reporting
+//! - [`EngineConfig`] — performance and safety limits
+//!
+//! # Example
+//!
+//! ```
+//! use sempai_core::{Language, LineCol, Span};
+//!
+//! let lang = Language::Python;
+//! let span = Span::new(0, 10, LineCol::new(0, 0), LineCol::new(0, 10));
+//! assert_eq!(span.start_byte(), 0);
+//! ```
+
+mod capture;
+mod config;
+mod diagnostic;
+mod language;
+mod match_result;
+mod span;
+
+pub use capture::{CaptureValue, CapturedNode};
+pub use config::EngineConfig;
+pub use diagnostic::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
+pub use language::Language;
+pub use match_result::Match;
+pub use span::{LineCol, Span};
+
+#[cfg(test)]
+mod tests;

--- a/crates/sempai-core/src/lib.rs
+++ b/crates/sempai-core/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Core types
 //!
-//! - [`Language`] — supported host language identifiers
+//! - [`Language`] and [`LanguageParseError`] — supported host language identifiers
 //! - [`Span`] and [`LineCol`] — byte and line/column source positions
 //! - [`Match`] — a successful rule binding with captures
 //! - [`CaptureValue`] and [`CapturedNode`] — metavariable bindings
@@ -35,9 +35,12 @@ mod span;
 pub use capture::{CaptureValue, CapturedNode};
 pub use config::{EngineConfig, EngineLimits};
 pub use diagnostic::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
-pub use language::Language;
+pub use language::{Language, LanguageParseError};
 pub use match_result::Match;
 pub use span::{LineCol, Span};
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 
 #[cfg(test)]
 mod tests;

--- a/crates/sempai-core/src/lib.rs
+++ b/crates/sempai-core/src/lib.rs
@@ -13,7 +13,7 @@
 //! - [`Match`] — a successful rule binding with captures
 //! - [`CaptureValue`] and [`CapturedNode`] — metavariable bindings
 //! - [`DiagnosticReport`] and [`Diagnostic`] — structured error reporting
-//! - [`EngineConfig`] — performance and safety limits
+//! - [`EngineConfig`] and [`EngineLimits`] — performance and safety limits
 //!
 //! # Example
 //!
@@ -33,7 +33,7 @@ mod match_result;
 mod span;
 
 pub use capture::{CaptureValue, CapturedNode};
-pub use config::EngineConfig;
+pub use config::{EngineConfig, EngineLimits};
 pub use diagnostic::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
 pub use language::Language;
 pub use match_result::Match;

--- a/crates/sempai-core/src/match_result.rs
+++ b/crates/sempai-core/src/match_result.rs
@@ -1,0 +1,100 @@
+//! Match result type produced by query execution.
+//!
+//! A [`Match`] represents a successful binding of a rule query against a
+//! source file, including the matched span, optional focus span, and named
+//! capture bindings.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::capture::CaptureValue;
+use crate::span::Span;
+
+/// A match result produced by query execution.
+///
+/// # Example
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use sempai_core::{LineCol, Match, Span};
+///
+/// let span = Span::new(12, 42, LineCol::new(2, 0), LineCol::new(4, 0));
+/// let m = Match::new(
+///     String::from("my-rule"),
+///     String::from("file:///app.py"),
+///     span,
+///     None,
+///     BTreeMap::new(),
+/// );
+/// assert_eq!(m.rule_id(), "my-rule");
+/// assert!(m.focus().is_none());
+/// assert!(m.captures().is_empty());
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Match {
+    /// The identifier of the rule that produced this match.
+    pub rule_id: String,
+    /// The URI of the source file.
+    pub uri: String,
+    /// The span of the entire match in the source.
+    pub span: Span,
+    /// The focus span selected for downstream actuation, if any.
+    pub focus: Option<Span>,
+    /// Named capture bindings keyed by metavariable name.
+    pub captures: BTreeMap<String, CaptureValue>,
+}
+
+impl Match {
+    /// Creates a new match result.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "constructor mirrors the five public fields of the Match struct"
+    )]
+    #[must_use]
+    pub const fn new(
+        rule_id: String,
+        uri: String,
+        span: Span,
+        focus: Option<Span>,
+        captures: BTreeMap<String, CaptureValue>,
+    ) -> Self {
+        Self {
+            rule_id,
+            uri,
+            span,
+            focus,
+            captures,
+        }
+    }
+
+    /// Returns the rule identifier.
+    #[must_use]
+    pub fn rule_id(&self) -> &str {
+        &self.rule_id
+    }
+
+    /// Returns the source file URI.
+    #[must_use]
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    /// Returns the match span.
+    #[must_use]
+    pub const fn span(&self) -> &Span {
+        &self.span
+    }
+
+    /// Returns the focus span, if any.
+    #[must_use]
+    pub const fn focus(&self) -> Option<&Span> {
+        self.focus.as_ref()
+    }
+
+    /// Returns the capture bindings.
+    #[must_use]
+    pub const fn captures(&self) -> &BTreeMap<String, CaptureValue> {
+        &self.captures
+    }
+}

--- a/crates/sempai-core/src/span.rs
+++ b/crates/sempai-core/src/span.rs
@@ -1,0 +1,108 @@
+//! Source span and position types for locating code regions.
+
+use serde::{Deserialize, Serialize};
+
+/// A line and column position within a source file.
+///
+/// Both fields are zero-indexed to match Tree-sitter conventions.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::LineCol;
+///
+/// let pos = LineCol::new(10, 4);
+/// assert_eq!(pos.line(), 10);
+/// assert_eq!(pos.column(), 4);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineCol {
+    /// Zero-indexed line number.
+    pub line: u32,
+    /// Zero-indexed column number (byte offset within the line).
+    pub column: u32,
+}
+
+impl LineCol {
+    /// Creates a new line/column position.
+    #[must_use]
+    pub const fn new(line: u32, column: u32) -> Self {
+        Self { line, column }
+    }
+
+    /// Returns the zero-indexed line number.
+    #[must_use]
+    pub const fn line(&self) -> u32 {
+        self.line
+    }
+
+    /// Returns the zero-indexed column number.
+    #[must_use]
+    pub const fn column(&self) -> u32 {
+        self.column
+    }
+}
+
+/// A byte and line/column span in a UTF-8 source.
+///
+/// The byte range is half-open: `start_byte` is inclusive and `end_byte` is
+/// exclusive.  The `start` and `end` positions provide human-readable
+/// line/column equivalents.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::{LineCol, Span};
+///
+/// let span = Span::new(10, 42, LineCol::new(2, 0), LineCol::new(4, 0));
+/// assert_eq!(span.start_byte(), 10);
+/// assert_eq!(span.end_byte(), 42);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Span {
+    /// Start byte offset (inclusive).
+    pub start_byte: u32,
+    /// End byte offset (exclusive).
+    pub end_byte: u32,
+    /// Start position as line and column.
+    pub start: LineCol,
+    /// End position as line and column.
+    pub end: LineCol,
+}
+
+impl Span {
+    /// Creates a new span from byte offsets and line/column positions.
+    #[must_use]
+    pub const fn new(start_byte: u32, end_byte: u32, start: LineCol, end: LineCol) -> Self {
+        Self {
+            start_byte,
+            end_byte,
+            start,
+            end,
+        }
+    }
+
+    /// Returns the inclusive start byte offset.
+    #[must_use]
+    pub const fn start_byte(&self) -> u32 {
+        self.start_byte
+    }
+
+    /// Returns the exclusive end byte offset.
+    #[must_use]
+    pub const fn end_byte(&self) -> u32 {
+        self.end_byte
+    }
+
+    /// Returns the start line/column position.
+    #[must_use]
+    pub const fn start(&self) -> &LineCol {
+        &self.start
+    }
+
+    /// Returns the end line/column position.
+    #[must_use]
+    pub const fn end(&self) -> &LineCol {
+        &self.end
+    }
+}

--- a/crates/sempai-core/src/test_support.rs
+++ b/crates/sempai-core/src/test_support.rs
@@ -55,7 +55,7 @@ pub enum RangeParseError {
 /// ```
 /// use sempai_core::test_support::parse_byte_range;
 ///
-/// let (start, end) = parse_byte_range("10..42").unwrap();
+/// let (start, end) = parse_byte_range("10..42").expect("valid byte range");
 /// assert_eq!(start, 10);
 /// assert_eq!(end, 42);
 /// ```
@@ -77,7 +77,7 @@ pub fn parse_byte_range(range: &str) -> Result<(u32, u32), RangeParseError> {
 /// ```
 /// use sempai_core::test_support::parse_line_range;
 ///
-/// let (start, end) = parse_line_range("2:0..4:0").unwrap();
+/// let (start, end) = parse_line_range("2:0..4:0").expect("valid line range");
 /// assert_eq!(start.line(), 2);
 /// assert_eq!(start.column(), 0);
 /// assert_eq!(end.line(), 4);

--- a/crates/sempai-core/src/test_support.rs
+++ b/crates/sempai-core/src/test_support.rs
@@ -111,3 +111,61 @@ pub fn parse_line_range(range: &str) -> Result<(LineCol, LineCol), RangeParseErr
 
     Ok((parse_linecol(start_str)?, parse_linecol(end_str)?))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quoted_string_parses_valid_input() {
+        let qs: QuotedString = "\"foo\"".parse().expect("valid quoted string");
+        assert_eq!(qs.as_str(), "foo");
+    }
+
+    #[test]
+    fn quoted_string_parses_empty_quoted_content() {
+        let qs: QuotedString = "\"\"".parse().expect("valid empty quoted string");
+        assert_eq!(qs.as_str(), "");
+    }
+
+    #[test]
+    fn quoted_string_rejects_missing_opening_quote() {
+        let result = "foo\"".parse::<QuotedString>();
+        assert!(result.is_err());
+        let err = result.expect_err("should be error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("foo\""),
+            "error should include original input, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn quoted_string_rejects_missing_closing_quote() {
+        let result = "\"foo".parse::<QuotedString>();
+        assert!(result.is_err());
+        let err = result.expect_err("should be error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("\"foo"),
+            "error should include original input, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn quoted_string_rejects_unquoted_input() {
+        let result = "bare".parse::<QuotedString>();
+        assert!(result.is_err());
+        let err = result.expect_err("should be error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bare"),
+            "error should include original input, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn quoted_string_rejects_single_quote() {
+        assert!("'foo'".parse::<QuotedString>().is_err());
+    }
+}

--- a/crates/sempai-core/src/test_support.rs
+++ b/crates/sempai-core/src/test_support.rs
@@ -7,17 +7,31 @@ use std::str::FromStr;
 
 use crate::LineCol;
 
+/// Error returned when a string is not wrapped in balanced double-quotes.
+#[derive(Debug, thiserror::Error)]
+#[error("expected a double-quoted string, got: {0}")]
+pub struct QuotedStringParseError(String);
+
 /// A quoted string value from a Gherkin feature file.
 ///
 /// Parses by stripping surrounding double-quote characters.
+///
+/// # Errors
+///
+/// Returns [`QuotedStringParseError`] if the input does not start and end
+/// with a double-quote character.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QuotedString(String);
 
 impl FromStr for QuotedString {
-    type Err = std::convert::Infallible;
+    type Err = QuotedStringParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.trim_matches('"').to_owned()))
+        let value = s
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .ok_or_else(|| QuotedStringParseError(s.to_owned()))?;
+        Ok(Self(value.to_owned()))
     }
 }
 

--- a/crates/sempai-core/src/test_support.rs
+++ b/crates/sempai-core/src/test_support.rs
@@ -3,7 +3,11 @@
 //! This module is gated behind the `test-support` Cargo feature and provides
 //! reusable types for behaviour-driven test steps.
 
+use std::fmt;
+use std::num::ParseIntError;
 use std::str::FromStr;
+
+use crate::LineCol;
 
 /// A quoted string value from a Gherkin feature file.
 ///
@@ -25,4 +29,90 @@ impl QuotedString {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+}
+
+/// Error returned when a range string cannot be parsed.
+#[derive(Debug)]
+pub enum RangeParseError {
+    /// The range string did not contain the expected `..` separator.
+    MissingSeparator(String),
+    /// A position component did not contain the expected `:` separator.
+    MissingColon(String),
+    /// A numeric component could not be parsed.
+    InvalidNumber(ParseIntError),
+}
+
+impl fmt::Display for RangeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingSeparator(s) => {
+                write!(f, "range must contain '..': {s}")
+            }
+            Self::MissingColon(s) => {
+                write!(f, "position must contain ':': {s}")
+            }
+            Self::InvalidNumber(e) => write!(f, "invalid number: {e}"),
+        }
+    }
+}
+
+impl From<ParseIntError> for RangeParseError {
+    fn from(err: ParseIntError) -> Self {
+        Self::InvalidNumber(err)
+    }
+}
+
+/// Parses a `"start..end"` byte range into a `(start, end)` pair.
+///
+/// # Errors
+///
+/// Returns [`RangeParseError`] if the string does not contain `..` or the
+/// parts are not valid `u32` values.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::test_support::parse_byte_range;
+///
+/// let (start, end) = parse_byte_range("10..42").unwrap();
+/// assert_eq!(start, 10);
+/// assert_eq!(end, 42);
+/// ```
+pub fn parse_byte_range(range: &str) -> Result<(u32, u32), RangeParseError> {
+    let (start, end) = range
+        .split_once("..")
+        .ok_or_else(|| RangeParseError::MissingSeparator(String::from(range)))?;
+    Ok((start.parse()?, end.parse()?))
+}
+
+/// Parses a `"line:col..line:col"` range into two [`LineCol`] values.
+///
+/// # Errors
+///
+/// Returns [`RangeParseError`] if the string format is invalid.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::test_support::parse_line_range;
+///
+/// let (start, end) = parse_line_range("2:0..4:0").unwrap();
+/// assert_eq!(start.line(), 2);
+/// assert_eq!(start.column(), 0);
+/// assert_eq!(end.line(), 4);
+/// assert_eq!(end.column(), 0);
+/// ```
+pub fn parse_line_range(range: &str) -> Result<(LineCol, LineCol), RangeParseError> {
+    let (start_str, end_str) = range
+        .split_once("..")
+        .ok_or_else(|| RangeParseError::MissingSeparator(String::from(range)))?;
+
+    let parse_linecol = |s: &str| -> Result<LineCol, RangeParseError> {
+        let (line, col) = s
+            .split_once(':')
+            .ok_or_else(|| RangeParseError::MissingColon(String::from(s)))?;
+        Ok(LineCol::new(line.parse()?, col.parse()?))
+    };
+
+    Ok((parse_linecol(start_str)?, parse_linecol(end_str)?))
 }

--- a/crates/sempai-core/src/test_support.rs
+++ b/crates/sempai-core/src/test_support.rs
@@ -1,0 +1,28 @@
+//! Shared test utilities for Sempai BDD tests.
+//!
+//! This module is gated behind the `test-support` Cargo feature and provides
+//! reusable types for behaviour-driven test steps.
+
+use std::str::FromStr;
+
+/// A quoted string value from a Gherkin feature file.
+///
+/// Parses by stripping surrounding double-quote characters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuotedString(String);
+
+impl FromStr for QuotedString {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.trim_matches('"').to_owned()))
+    }
+}
+
+impl QuotedString {
+    /// Returns the inner string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}

--- a/crates/sempai-core/src/test_support.rs
+++ b/crates/sempai-core/src/test_support.rs
@@ -3,8 +3,6 @@
 //! This module is gated behind the `test-support` Cargo feature and provides
 //! reusable types for behaviour-driven test steps.
 
-use std::fmt;
-use std::num::ParseIntError;
 use std::str::FromStr;
 
 use crate::LineCol;
@@ -32,34 +30,17 @@ impl QuotedString {
 }
 
 /// Error returned when a range string cannot be parsed.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RangeParseError {
     /// The range string did not contain the expected `..` separator.
+    #[error("range must contain '..': {0}")]
     MissingSeparator(String),
     /// A position component did not contain the expected `:` separator.
+    #[error("position must contain ':': {0}")]
     MissingColon(String),
     /// A numeric component could not be parsed.
-    InvalidNumber(ParseIntError),
-}
-
-impl fmt::Display for RangeParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::MissingSeparator(s) => {
-                write!(f, "range must contain '..': {s}")
-            }
-            Self::MissingColon(s) => {
-                write!(f, "position must contain ':': {s}")
-            }
-            Self::InvalidNumber(e) => write!(f, "invalid number: {e}"),
-        }
-    }
-}
-
-impl From<ParseIntError> for RangeParseError {
-    fn from(err: ParseIntError) -> Self {
-        Self::InvalidNumber(err)
-    }
+    #[error(transparent)]
+    InvalidNumber(#[from] std::num::ParseIntError),
 }
 
 /// Parses a `"start..end"` byte range into a `(start, end)` pair.

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -52,25 +52,41 @@ fn world() -> TestWorld {
 // Given steps
 // ---------------------------------------------------------------------------
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "BDD step macro expands all Gherkin parameters as separate function arguments"
-)]
-#[given("a span from byte {start_byte} to byte {end_byte} on lines {sl}:{sc} to {el}:{ec}")]
-fn given_span(
-    world: &mut TestWorld,
-    start_byte: u32,
-    end_byte: u32,
-    sl: u32,
-    sc: u32,
-    el: u32,
-    ec: u32,
-) {
+#[given("a span from bytes {byte_range} at lines {line_range}")]
+fn given_span(world: &mut TestWorld, byte_range: QuotedString, line_range: QuotedString) {
+    // Parse byte range: "10..42"
+    let bytes: Vec<u32> = byte_range
+        .as_str()
+        .split("..")
+        .map(|s| s.parse().expect("valid byte offset"))
+        .collect();
+    let start_byte = *bytes.first().expect("start byte");
+    let end_byte = *bytes.get(1).expect("end byte");
+
+    // Parse line range: "2:0..4:0"
+    let positions: Vec<&str> = line_range.as_str().split("..").collect();
+    let start_str = positions.first().expect("start position");
+    let end_str = positions.get(1).expect("end position");
+    let start: Vec<u32> = start_str
+        .split(':')
+        .map(|s| s.parse().expect("valid line:col"))
+        .collect();
+    let end: Vec<u32> = end_str
+        .split(':')
+        .map(|s| s.parse().expect("valid line:col"))
+        .collect();
+
     world.span = Some(Span::new(
         start_byte,
         end_byte,
-        LineCol::new(sl, sc),
-        LineCol::new(el, ec),
+        LineCol::new(
+            *start.first().expect("start line"),
+            *start.get(1).expect("start col"),
+        ),
+        LineCol::new(
+            *end.first().expect("end line"),
+            *end.get(1).expect("end col"),
+        ),
     ));
 }
 

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -1,0 +1,179 @@
+//! Behaviour-driven tests for `sempai_core` types.
+
+use std::str::FromStr;
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+
+use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, Language, LineCol, Span};
+
+// ---------------------------------------------------------------------------
+// Typed wrappers for Gherkin step parameters
+// ---------------------------------------------------------------------------
+
+/// A quoted string value from a Gherkin feature file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QuotedString(String);
+
+impl FromStr for QuotedString {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.trim_matches('"').to_owned()))
+    }
+}
+
+impl QuotedString {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test world
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct TestWorld {
+    span: Option<Span>,
+    language: Option<Language>,
+    round_tripped_language: Option<Language>,
+    report: Option<DiagnosticReport>,
+    formatted_output: Option<String>,
+    json_output: Option<String>,
+}
+
+#[fixture]
+fn world() -> TestWorld {
+    TestWorld::default()
+}
+
+// ---------------------------------------------------------------------------
+// Given steps
+// ---------------------------------------------------------------------------
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "BDD step macro expands all Gherkin parameters as separate function arguments"
+)]
+#[given("a span from byte {start_byte} to byte {end_byte} on lines {sl}:{sc} to {el}:{ec}")]
+fn given_span(
+    world: &mut TestWorld,
+    start_byte: u32,
+    end_byte: u32,
+    sl: u32,
+    sc: u32,
+    el: u32,
+    ec: u32,
+) {
+    world.span = Some(Span::new(
+        start_byte,
+        end_byte,
+        LineCol::new(sl, sc),
+        LineCol::new(el, ec),
+    ));
+}
+
+#[given("language {name}")]
+fn given_language(world: &mut TestWorld, name: QuotedString) {
+    let lang = match name.as_str() {
+        "rust" => Language::Rust,
+        "python" => Language::Python,
+        "type_script" => Language::TypeScript,
+        "go" => Language::Go,
+        "hcl" => Language::Hcl,
+        other => panic!("unknown language: {other}"),
+    };
+    world.language = Some(lang);
+}
+
+#[given("a diagnostic with code {code} and message {message}")]
+fn given_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
+    let diag_code = match code.as_str() {
+        "E_SEMPAI_YAML_PARSE" => DiagnosticCode::ESempaiYamlParse,
+        "E_SEMPAI_DSL_PARSE" => DiagnosticCode::ESempaiDslParse,
+        other => panic!("unsupported diagnostic code: {other}"),
+    };
+    let report = DiagnosticReport::new(vec![Diagnostic::new(
+        diag_code,
+        message.as_str().to_owned(),
+        None,
+        vec![],
+    )]);
+    world.report = Some(report);
+}
+
+#[given("a not-implemented report for feature {feature}")]
+fn given_not_implemented_report(world: &mut TestWorld, feature: QuotedString) {
+    world.report = Some(DiagnosticReport::not_implemented(feature.as_str()));
+}
+
+// ---------------------------------------------------------------------------
+// When steps
+// ---------------------------------------------------------------------------
+
+#[when("the span is serialized to JSON")]
+fn when_serialize_span(world: &mut TestWorld) {
+    let span = world.span.as_ref().expect("span should be set");
+    world.json_output = Some(serde_json::to_string(span).expect("serialize span"));
+}
+
+#[when("the language is serialized and deserialized")]
+fn when_language_round_trip(world: &mut TestWorld) {
+    let lang = world.language.expect("language should be set");
+    let json = serde_json::to_string(&lang).expect("serialize language");
+    let deserialized: Language = serde_json::from_str(&json).expect("deserialize language");
+    world.round_tripped_language = Some(deserialized);
+}
+
+#[when("the diagnostic report is formatted")]
+fn when_format_report(world: &mut TestWorld) {
+    let report = world.report.as_ref().expect("report should be set");
+    world.formatted_output = Some(format!("{report}"));
+}
+
+// ---------------------------------------------------------------------------
+// Then steps
+// ---------------------------------------------------------------------------
+
+#[then("the JSON contains key {key} with value {value}")]
+fn then_json_contains(world: &mut TestWorld, key: QuotedString, value: QuotedString) {
+    let json = world.json_output.as_ref().expect("JSON should be set");
+    let expected = format!("\"{}\":{}", key.as_str(), value.as_str());
+    assert!(
+        json.contains(&expected),
+        "expected JSON to contain '{expected}', got: {json}"
+    );
+}
+
+#[then("the round-tripped language equals the original")]
+fn then_language_round_trip_equals(world: &mut TestWorld) {
+    let original = world.language.expect("original language should be set");
+    let round_tripped = world
+        .round_tripped_language
+        .expect("round-tripped language should be set");
+    assert_eq!(original, round_tripped);
+}
+
+#[then("the formatted output contains {snippet}")]
+fn then_formatted_contains(world: &mut TestWorld, snippet: QuotedString) {
+    let output = world
+        .formatted_output
+        .as_ref()
+        .expect("formatted output should be set");
+    assert!(
+        output.contains(snippet.as_str()),
+        "expected output to contain '{}', got: {}",
+        snippet.as_str(),
+        output
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario registration
+// ---------------------------------------------------------------------------
+
+#[scenario(path = "tests/features/sempai_core.feature")]
+fn sempai_core_behaviour(world: TestWorld) {
+    let _ = world;
+}

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -3,41 +3,8 @@
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
-use crate::test_support::QuotedString;
-use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, Language, LineCol, Span};
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parses a `"start..end"` byte range into a `(start, end)` pair.
-fn parse_byte_range(range: &str) -> (u32, u32) {
-    let parts: Vec<u32> = range
-        .split("..")
-        .map(|s| s.parse().expect("valid byte offset"))
-        .collect();
-    (
-        *parts.first().expect("start byte"),
-        *parts.get(1).expect("end byte"),
-    )
-}
-
-/// Parses a `"line:col..line:col"` range into two [`LineCol`] values.
-fn parse_line_range(range: &str) -> (LineCol, LineCol) {
-    let positions: Vec<&str> = range.split("..").collect();
-    let start_str = positions.first().expect("start position");
-    let end_str = positions.get(1).expect("end position");
-
-    let parse_linecol = |s: &str| -> LineCol {
-        let parts: Vec<u32> = s
-            .split(':')
-            .map(|p| p.parse().expect("valid line:col"))
-            .collect();
-        LineCol::new(*parts.first().expect("line"), *parts.get(1).expect("col"))
-    };
-
-    (parse_linecol(start_str), parse_linecol(end_str))
-}
+use crate::test_support::{QuotedString, parse_byte_range, parse_line_range};
+use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, Language, Span};
 
 // ---------------------------------------------------------------------------
 // Test world
@@ -64,8 +31,8 @@ fn world() -> TestWorld {
 
 #[given("a span from bytes {byte_range} at lines {line_range}")]
 fn given_span(world: &mut TestWorld, byte_range: QuotedString, line_range: QuotedString) {
-    let (start_byte, end_byte) = parse_byte_range(byte_range.as_str());
-    let (start_lc, end_lc) = parse_line_range(line_range.as_str());
+    let (start_byte, end_byte) = parse_byte_range(byte_range.as_str()).expect("valid byte range");
+    let (start_lc, end_lc) = parse_line_range(line_range.as_str()).expect("valid line range");
     world.span = Some(Span::new(start_byte, end_byte, start_lc, end_lc));
 }
 

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -1,48 +1,42 @@
 //! Behaviour-driven tests for `sempai_core` types.
 
-use std::str::FromStr;
-
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
+use crate::test_support::QuotedString;
 use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, Language, LineCol, Span};
-
-// ---------------------------------------------------------------------------
-// Typed wrappers for Gherkin step parameters
-// ---------------------------------------------------------------------------
-
-/// A quoted string value from a Gherkin feature file.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct QuotedString(String);
-
-impl FromStr for QuotedString {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.trim_matches('"').to_owned()))
-    }
-}
-
-impl QuotedString {
-    fn as_str(&self) -> &str {
-        &self.0
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Parses a language name string into a [`Language`] variant.
-fn parse_language(name: &str) -> Language {
-    match name {
-        "rust" => Language::Rust,
-        "python" => Language::Python,
-        "typescript" => Language::TypeScript,
-        "go" => Language::Go,
-        "hcl" => Language::Hcl,
-        other => panic!("unknown language: {other}"),
-    }
+/// Parses a `"start..end"` byte range into a `(start, end)` pair.
+fn parse_byte_range(range: &str) -> (u32, u32) {
+    let parts: Vec<u32> = range
+        .split("..")
+        .map(|s| s.parse().expect("valid byte offset"))
+        .collect();
+    (
+        *parts.first().expect("start byte"),
+        *parts.get(1).expect("end byte"),
+    )
+}
+
+/// Parses a `"line:col..line:col"` range into two [`LineCol`] values.
+fn parse_line_range(range: &str) -> (LineCol, LineCol) {
+    let positions: Vec<&str> = range.split("..").collect();
+    let start_str = positions.first().expect("start position");
+    let end_str = positions.get(1).expect("end position");
+
+    let parse_linecol = |s: &str| -> LineCol {
+        let parts: Vec<u32> = s
+            .split(':')
+            .map(|p| p.parse().expect("valid line:col"))
+            .collect();
+        LineCol::new(*parts.first().expect("line"), *parts.get(1).expect("col"))
+    };
+
+    (parse_linecol(start_str), parse_linecol(end_str))
 }
 
 // ---------------------------------------------------------------------------
@@ -70,45 +64,14 @@ fn world() -> TestWorld {
 
 #[given("a span from bytes {byte_range} at lines {line_range}")]
 fn given_span(world: &mut TestWorld, byte_range: QuotedString, line_range: QuotedString) {
-    // Parse byte range: "10..42"
-    let bytes: Vec<u32> = byte_range
-        .as_str()
-        .split("..")
-        .map(|s| s.parse().expect("valid byte offset"))
-        .collect();
-    let start_byte = *bytes.first().expect("start byte");
-    let end_byte = *bytes.get(1).expect("end byte");
-
-    // Parse line range: "2:0..4:0"
-    let positions: Vec<&str> = line_range.as_str().split("..").collect();
-    let start_str = positions.first().expect("start position");
-    let end_str = positions.get(1).expect("end position");
-    let start: Vec<u32> = start_str
-        .split(':')
-        .map(|s| s.parse().expect("valid line:col"))
-        .collect();
-    let end: Vec<u32> = end_str
-        .split(':')
-        .map(|s| s.parse().expect("valid line:col"))
-        .collect();
-
-    world.span = Some(Span::new(
-        start_byte,
-        end_byte,
-        LineCol::new(
-            *start.first().expect("start line"),
-            *start.get(1).expect("start col"),
-        ),
-        LineCol::new(
-            *end.first().expect("end line"),
-            *end.get(1).expect("end col"),
-        ),
-    ));
+    let (start_byte, end_byte) = parse_byte_range(byte_range.as_str());
+    let (start_lc, end_lc) = parse_line_range(line_range.as_str());
+    world.span = Some(Span::new(start_byte, end_byte, start_lc, end_lc));
 }
 
 #[given("language {name}")]
 fn given_language(world: &mut TestWorld, name: QuotedString) {
-    world.language = Some(parse_language(name.as_str()));
+    world.language = Some(name.as_str().parse().expect("valid language name"));
 }
 
 #[given("a diagnostic with code {code} and message {message}")]

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -30,6 +30,22 @@ impl QuotedString {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parses a language name string into a [`Language`] variant.
+fn parse_language(name: &str) -> Language {
+    match name {
+        "rust" => Language::Rust,
+        "python" => Language::Python,
+        "typescript" => Language::TypeScript,
+        "go" => Language::Go,
+        "hcl" => Language::Hcl,
+        other => panic!("unknown language: {other}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Test world
 // ---------------------------------------------------------------------------
 
@@ -92,15 +108,7 @@ fn given_span(world: &mut TestWorld, byte_range: QuotedString, line_range: Quote
 
 #[given("language {name}")]
 fn given_language(world: &mut TestWorld, name: QuotedString) {
-    let lang = match name.as_str() {
-        "rust" => Language::Rust,
-        "python" => Language::Python,
-        "type_script" => Language::TypeScript,
-        "go" => Language::Go,
-        "hcl" => Language::Hcl,
-        other => panic!("unknown language: {other}"),
-    };
-    world.language = Some(lang);
+    world.language = Some(parse_language(name.as_str()));
 }
 
 #[given("a diagnostic with code {code} and message {message}")]
@@ -155,10 +163,21 @@ fn when_format_report(world: &mut TestWorld) {
 #[then("the JSON contains key {key} with value {value}")]
 fn then_json_contains(world: &mut TestWorld, key: QuotedString, value: QuotedString) {
     let json = world.json_output.as_ref().expect("JSON should be set");
-    let expected = format!("\"{}\":{}", key.as_str(), value.as_str());
-    assert!(
-        json.contains(&expected),
-        "expected JSON to contain '{expected}', got: {json}"
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).expect("JSON output should be valid");
+    let actual = parsed.get(key.as_str()).unwrap_or_else(|| {
+        panic!(
+            "expected JSON to contain key '{}', got: {json}",
+            key.as_str()
+        )
+    });
+    let expected: serde_json::Value = serde_json::from_str(value.as_str())
+        .unwrap_or_else(|_| serde_json::Value::String(value.as_str().to_owned()));
+    assert_eq!(
+        actual,
+        &expected,
+        "expected JSON key '{}' to have value {expected:?}, got {actual:?}",
+        key.as_str()
     );
 }
 

--- a/crates/sempai-core/src/tests/capture_tests.rs
+++ b/crates/sempai-core/src/tests/capture_tests.rs
@@ -1,0 +1,78 @@
+//! Tests for [`CapturedNode`] and [`CaptureValue`].
+
+use crate::{CaptureValue, CapturedNode, LineCol, Span};
+
+fn sample_span() -> Span {
+    Span::new(0, 5, LineCol::new(0, 0), LineCol::new(0, 5))
+}
+
+#[test]
+fn captured_node_construction_and_accessors() {
+    let node = CapturedNode::new(
+        sample_span(),
+        String::from("identifier"),
+        Some(String::from("hello")),
+    );
+    assert_eq!(node.kind(), "identifier");
+    assert_eq!(node.text(), Some("hello"));
+    assert_eq!(node.span().start_byte(), 0);
+}
+
+#[test]
+fn captured_node_text_can_be_none() {
+    let node = CapturedNode::new(sample_span(), String::from("string_literal"), None);
+    assert!(node.text().is_none());
+}
+
+#[test]
+fn captured_node_serde_round_trip() {
+    let node = CapturedNode::new(
+        sample_span(),
+        String::from("identifier"),
+        Some(String::from("foo")),
+    );
+    let json = serde_json::to_string(&node).expect("serialize");
+    let deserialized: CapturedNode = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized.kind(), "identifier");
+    assert_eq!(deserialized.text(), Some("foo"));
+}
+
+#[test]
+fn capture_value_node_serde_round_trip() {
+    let node = CapturedNode::new(
+        sample_span(),
+        String::from("identifier"),
+        Some(String::from("x")),
+    );
+    let value = CaptureValue::Node(node);
+    let json = serde_json::to_string(&value).expect("serialize");
+
+    // Verify the tagged format includes "kind" field
+    assert!(json.contains("\"kind\":\"node\""));
+
+    let deserialized: CaptureValue = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(deserialized, CaptureValue::Node(_)));
+}
+
+#[test]
+fn capture_value_nodes_serde_round_trip() {
+    let nodes = vec![
+        CapturedNode::new(
+            sample_span(),
+            String::from("identifier"),
+            Some(String::from("a")),
+        ),
+        CapturedNode::new(
+            Span::new(10, 15, LineCol::new(1, 0), LineCol::new(1, 5)),
+            String::from("identifier"),
+            Some(String::from("b")),
+        ),
+    ];
+    let value = CaptureValue::Nodes(nodes);
+    let json = serde_json::to_string(&value).expect("serialize");
+
+    assert!(json.contains("\"kind\":\"nodes\""));
+
+    let deserialized: CaptureValue = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(deserialized, CaptureValue::Nodes(ref v) if v.len() == 2));
+}

--- a/crates/sempai-core/src/tests/capture_tests.rs
+++ b/crates/sempai-core/src/tests/capture_tests.rs
@@ -76,3 +76,15 @@ fn capture_value_nodes_serde_round_trip() {
     let deserialized: CaptureValue = serde_json::from_str(&json).expect("deserialize");
     assert!(matches!(deserialized, CaptureValue::Nodes(ref v) if v.len() == 2));
 }
+
+#[test]
+fn capture_value_empty_nodes_serde_round_trip() {
+    let nodes: Vec<CapturedNode> = Vec::new();
+    let value = CaptureValue::Nodes(nodes);
+    let json = serde_json::to_string(&value).expect("serialize");
+
+    assert!(json.contains("\"kind\":\"nodes\""));
+
+    let deserialized: CaptureValue = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(deserialized, CaptureValue::Nodes(ref v) if v.is_empty()));
+}

--- a/crates/sempai-core/src/tests/capture_tests.rs
+++ b/crates/sempai-core/src/tests/capture_tests.rs
@@ -1,15 +1,18 @@
 //! Tests for [`CapturedNode`] and [`CaptureValue`].
 
+use rstest::{fixture, rstest};
+
 use crate::{CaptureValue, CapturedNode, LineCol, Span};
 
+#[fixture]
 fn sample_span() -> Span {
     Span::new(0, 5, LineCol::new(0, 0), LineCol::new(0, 5))
 }
 
-#[test]
-fn captured_node_construction_and_accessors() {
+#[rstest]
+fn captured_node_construction_and_accessors(sample_span: Span) {
     let node = CapturedNode::new(
-        sample_span(),
+        sample_span,
         String::from("identifier"),
         Some(String::from("hello")),
     );
@@ -18,16 +21,16 @@ fn captured_node_construction_and_accessors() {
     assert_eq!(node.span().start_byte(), 0);
 }
 
-#[test]
-fn captured_node_text_can_be_none() {
-    let node = CapturedNode::new(sample_span(), String::from("string_literal"), None);
+#[rstest]
+fn captured_node_text_can_be_none(sample_span: Span) {
+    let node = CapturedNode::new(sample_span, String::from("string_literal"), None);
     assert!(node.text().is_none());
 }
 
-#[test]
-fn captured_node_serde_round_trip() {
+#[rstest]
+fn captured_node_serde_round_trip(sample_span: Span) {
     let node = CapturedNode::new(
-        sample_span(),
+        sample_span,
         String::from("identifier"),
         Some(String::from("foo")),
     );
@@ -37,54 +40,52 @@ fn captured_node_serde_round_trip() {
     assert_eq!(deserialized.text(), Some("foo"));
 }
 
-#[test]
-fn capture_value_node_serde_round_trip() {
-    let node = CapturedNode::new(
-        sample_span(),
-        String::from("identifier"),
-        Some(String::from("x")),
+/// Builds a [`CaptureValue`] variant for parameterised serde testing.
+fn build_capture_value(variant: &str, span: Span) -> (CaptureValue, &'static str, usize) {
+    match variant {
+        "single_node" => {
+            let node = CapturedNode::new(span, String::from("identifier"), Some(String::from("x")));
+            (CaptureValue::Node(node), "node", 1)
+        }
+        "multiple_nodes" => {
+            let nodes = vec![
+                CapturedNode::new(span, String::from("identifier"), Some(String::from("a"))),
+                CapturedNode::new(
+                    Span::new(10, 15, LineCol::new(1, 0), LineCol::new(1, 5)),
+                    String::from("identifier"),
+                    Some(String::from("b")),
+                ),
+            ];
+            (CaptureValue::Nodes(nodes), "nodes", 2)
+        }
+        "empty_nodes" => {
+            let nodes: Vec<CapturedNode> = Vec::new();
+            (CaptureValue::Nodes(nodes), "nodes", 0)
+        }
+        other => panic!("unknown capture variant: {other}"),
+    }
+}
+
+#[rstest]
+#[case::single_node("single_node")]
+#[case::multiple_nodes("multiple_nodes")]
+#[case::empty_nodes("empty_nodes")]
+fn capture_value_serde_round_trip(sample_span: Span, #[case] variant: &str) {
+    let (value, expected_kind, expected_count) = build_capture_value(variant, sample_span);
+    let json = serde_json::to_string(&value).expect("serialize");
+
+    let kind_tag = format!("\"kind\":\"{expected_kind}\"");
+    assert!(
+        json.contains(&kind_tag),
+        "expected JSON to contain {kind_tag}, got: {json}"
     );
-    let value = CaptureValue::Node(node);
-    let json = serde_json::to_string(&value).expect("serialize");
-
-    // Verify the tagged format includes "kind" field
-    assert!(json.contains("\"kind\":\"node\""));
 
     let deserialized: CaptureValue = serde_json::from_str(&json).expect("deserialize");
-    assert!(matches!(deserialized, CaptureValue::Node(_)));
-}
-
-#[test]
-fn capture_value_nodes_serde_round_trip() {
-    let nodes = vec![
-        CapturedNode::new(
-            sample_span(),
-            String::from("identifier"),
-            Some(String::from("a")),
-        ),
-        CapturedNode::new(
-            Span::new(10, 15, LineCol::new(1, 0), LineCol::new(1, 5)),
-            String::from("identifier"),
-            Some(String::from("b")),
-        ),
-    ];
-    let value = CaptureValue::Nodes(nodes);
-    let json = serde_json::to_string(&value).expect("serialize");
-
-    assert!(json.contains("\"kind\":\"nodes\""));
-
-    let deserialized: CaptureValue = serde_json::from_str(&json).expect("deserialize");
-    assert!(matches!(deserialized, CaptureValue::Nodes(ref v) if v.len() == 2));
-}
-
-#[test]
-fn capture_value_empty_nodes_serde_round_trip() {
-    let nodes: Vec<CapturedNode> = Vec::new();
-    let value = CaptureValue::Nodes(nodes);
-    let json = serde_json::to_string(&value).expect("serialize");
-
-    assert!(json.contains("\"kind\":\"nodes\""));
-
-    let deserialized: CaptureValue = serde_json::from_str(&json).expect("deserialize");
-    assert!(matches!(deserialized, CaptureValue::Nodes(ref v) if v.is_empty()));
+    match deserialized {
+        CaptureValue::Node(_) => assert_eq!(expected_kind, "node"),
+        CaptureValue::Nodes(ref v) => {
+            assert_eq!(expected_kind, "nodes");
+            assert_eq!(v.len(), expected_count);
+        }
+    }
 }

--- a/crates/sempai-core/src/tests/config_tests.rs
+++ b/crates/sempai-core/src/tests/config_tests.rs
@@ -1,0 +1,35 @@
+//! Tests for [`EngineConfig`].
+
+use crate::EngineConfig;
+
+#[test]
+fn default_config_has_expected_values() {
+    let config = EngineConfig::default();
+    assert_eq!(config.max_matches_per_rule(), 10_000);
+    assert_eq!(config.max_capture_text_bytes(), 1_048_576);
+    assert_eq!(config.max_deep_search_nodes(), 100_000);
+    assert!(!config.enable_hcl());
+}
+
+#[test]
+fn custom_config_construction() {
+    let config = EngineConfig::new(500, 4096, 1000, true);
+    assert_eq!(config.max_matches_per_rule(), 500);
+    assert_eq!(config.max_capture_text_bytes(), 4096);
+    assert_eq!(config.max_deep_search_nodes(), 1000);
+    assert!(config.enable_hcl());
+}
+
+#[test]
+fn config_equality() {
+    let a = EngineConfig::default();
+    let b = EngineConfig::default();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn config_clone() {
+    let original = EngineConfig::new(100, 200, 300, true);
+    let cloned = original.clone();
+    assert_eq!(original, cloned);
+}

--- a/crates/sempai-core/src/tests/config_tests.rs
+++ b/crates/sempai-core/src/tests/config_tests.rs
@@ -1,6 +1,6 @@
-//! Tests for [`EngineConfig`].
+//! Tests for [`EngineConfig`] and [`EngineLimits`].
 
-use crate::EngineConfig;
+use crate::{EngineConfig, EngineLimits};
 
 #[test]
 fn default_config_has_expected_values() {
@@ -13,7 +13,8 @@ fn default_config_has_expected_values() {
 
 #[test]
 fn custom_config_construction() {
-    let config = EngineConfig::new(500, 4096, 1000, true);
+    let limits = EngineLimits::new(500, 4096, 1000);
+    let config = EngineConfig::new(limits, true);
     assert_eq!(config.max_matches_per_rule(), 500);
     assert_eq!(config.max_capture_text_bytes(), 4096);
     assert_eq!(config.max_deep_search_nodes(), 1000);
@@ -29,7 +30,17 @@ fn config_equality() {
 
 #[test]
 fn config_clone() {
-    let original = EngineConfig::new(100, 200, 300, true);
+    let limits = EngineLimits::new(100, 200, 300);
+    let original = EngineConfig::new(limits, true);
     let cloned = original.clone();
     assert_eq!(original, cloned);
+}
+
+#[test]
+fn limits_accessor() {
+    let limits = EngineLimits::new(42, 84, 168);
+    let config = EngineConfig::new(limits, false);
+    assert_eq!(config.limits().max_matches_per_rule(), 42);
+    assert_eq!(config.limits().max_capture_text_bytes(), 84);
+    assert_eq!(config.limits().max_deep_search_nodes(), 168);
 }

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -1,0 +1,148 @@
+//! Tests for diagnostic types.
+
+use rstest::rstest;
+
+use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
+
+#[rstest]
+#[case::yaml_parse(DiagnosticCode::ESempaiYamlParse, "E_SEMPAI_YAML_PARSE")]
+#[case::dsl_parse(DiagnosticCode::ESempaiDslParse, "E_SEMPAI_DSL_PARSE")]
+#[case::schema_invalid(DiagnosticCode::ESempaiSchemaInvalid, "E_SEMPAI_SCHEMA_INVALID")]
+#[case::unsupported_mode(DiagnosticCode::ESempaiUnsupportedMode, "E_SEMPAI_UNSUPPORTED_MODE")]
+#[case::invalid_not_in_or(DiagnosticCode::ESempaiInvalidNotInOr, "E_SEMPAI_INVALID_NOT_IN_OR")]
+#[case::missing_positive(
+    DiagnosticCode::ESempaiMissingPositiveTermInAnd,
+    "E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND"
+)]
+#[case::snippet_failed(
+    DiagnosticCode::ESempaiPatternSnippetParseFailed,
+    "E_SEMPAI_PATTERN_SNIPPET_PARSE_FAILED"
+)]
+#[case::unsupported_constraint(
+    DiagnosticCode::ESempaiUnsupportedConstraint,
+    "E_SEMPAI_UNSUPPORTED_CONSTRAINT"
+)]
+#[case::ts_query_invalid(DiagnosticCode::ESempaiTsQueryInvalid, "E_SEMPAI_TS_QUERY_INVALID")]
+#[case::not_implemented(DiagnosticCode::NotImplemented, "NOT_IMPLEMENTED")]
+fn diagnostic_code_display(#[case] code: DiagnosticCode, #[case] expected: &str) {
+    assert_eq!(format!("{code}"), expected);
+}
+
+#[test]
+fn diagnostic_code_serde_round_trip() {
+    let code = DiagnosticCode::ESempaiYamlParse;
+    let json = serde_json::to_string(&code).expect("serialize");
+    let deserialized: DiagnosticCode = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized, code);
+}
+
+#[test]
+fn source_span_construction_and_accessors() {
+    let span = SourceSpan::new(10, 42, Some(String::from("file:///rule.yml")));
+    assert_eq!(span.start(), 10);
+    assert_eq!(span.end(), 42);
+    assert_eq!(span.uri(), Some("file:///rule.yml"));
+}
+
+#[test]
+fn source_span_without_uri() {
+    let span = SourceSpan::new(0, 100, None);
+    assert!(span.uri().is_none());
+}
+
+#[test]
+fn source_span_serde_round_trip() {
+    let span = SourceSpan::new(5, 15, Some(String::from("test.yml")));
+    let json = serde_json::to_string(&span).expect("serialize");
+    let deserialized: SourceSpan = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized, span);
+}
+
+#[test]
+fn diagnostic_construction_and_accessors() {
+    let diag = Diagnostic::new(
+        DiagnosticCode::ESempaiYamlParse,
+        String::from("unexpected key 'patterns'"),
+        Some(SourceSpan::new(10, 20, None)),
+        vec![String::from("did you mean 'pattern'?")],
+    );
+    assert_eq!(diag.code(), DiagnosticCode::ESempaiYamlParse);
+    assert_eq!(diag.message(), "unexpected key 'patterns'");
+    assert!(diag.span().is_some());
+    assert_eq!(diag.notes().len(), 1);
+}
+
+#[test]
+fn diagnostic_serde_round_trip() {
+    let diag = Diagnostic::new(
+        DiagnosticCode::ESempaiDslParse,
+        String::from("unexpected token"),
+        None,
+        vec![],
+    );
+    let json = serde_json::to_string(&diag).expect("serialize");
+    let deserialized: Diagnostic = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized.code(), DiagnosticCode::ESempaiDslParse);
+    assert_eq!(deserialized.message(), "unexpected token");
+}
+
+#[test]
+fn diagnostic_report_not_implemented() {
+    let report = DiagnosticReport::not_implemented("compile_yaml");
+    assert_eq!(report.len(), 1);
+    assert!(!report.is_empty());
+
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::NotImplemented);
+    assert!(first.message().contains("compile_yaml"));
+    assert!(first.message().contains("not yet implemented"));
+}
+
+#[test]
+fn diagnostic_report_display_contains_code_and_message() {
+    let report = DiagnosticReport::not_implemented("execute");
+    let display = format!("{report}");
+    assert!(display.contains("NOT_IMPLEMENTED"));
+    assert!(display.contains("execute"));
+}
+
+#[test]
+fn diagnostic_report_is_std_error() {
+    let report = DiagnosticReport::not_implemented("test");
+    let err: &dyn std::error::Error = &report;
+    let display = format!("{err}");
+    assert!(display.contains("NOT_IMPLEMENTED"));
+}
+
+#[test]
+fn diagnostic_report_serde_round_trip() {
+    let report = DiagnosticReport::new(vec![
+        Diagnostic::new(
+            DiagnosticCode::ESempaiYamlParse,
+            String::from("bad yaml"),
+            None,
+            vec![],
+        ),
+        Diagnostic::new(
+            DiagnosticCode::ESempaiSchemaInvalid,
+            String::from("missing id"),
+            Some(SourceSpan::new(0, 10, None)),
+            vec![String::from("add an 'id' field")],
+        ),
+    ]);
+    let json = serde_json::to_string(&report).expect("serialize");
+    let deserialized: DiagnosticReport = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized.len(), 2);
+}
+
+#[test]
+fn empty_diagnostic_report() {
+    let report = DiagnosticReport::new(vec![]);
+    assert!(report.is_empty());
+    assert_eq!(report.len(), 0);
+    let display = format!("{report}");
+    assert_eq!(display, "empty diagnostic report");
+}

--- a/crates/sempai-core/src/tests/language_tests.rs
+++ b/crates/sempai-core/src/tests/language_tests.rs
@@ -1,0 +1,46 @@
+//! Tests for the [`Language`] enum.
+
+use rstest::rstest;
+
+use crate::Language;
+
+#[rstest]
+#[case::rust(Language::Rust, "rust")]
+#[case::python(Language::Python, "python")]
+#[case::typescript(Language::TypeScript, "type_script")]
+#[case::go(Language::Go, "go")]
+#[case::hcl(Language::Hcl, "hcl")]
+fn language_display(#[case] lang: Language, #[case] expected: &str) {
+    assert_eq!(format!("{lang}"), expected);
+}
+
+#[rstest]
+#[case::rust(Language::Rust, "\"rust\"")]
+#[case::python(Language::Python, "\"python\"")]
+#[case::typescript(Language::TypeScript, "\"type_script\"")]
+#[case::go(Language::Go, "\"go\"")]
+#[case::hcl(Language::Hcl, "\"hcl\"")]
+fn language_serde_round_trip(#[case] lang: Language, #[case] expected_json: &str) {
+    let json = serde_json::to_string(&lang).expect("serialize");
+    assert_eq!(json, expected_json);
+
+    let deserialized: Language = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized, lang);
+}
+
+#[test]
+fn language_copy_and_eq() {
+    let a = Language::Rust;
+    let b = a;
+    assert_eq!(a, b);
+}
+
+#[test]
+fn language_hash_is_consistent() {
+    use std::collections::HashSet;
+
+    let mut set = HashSet::new();
+    set.insert(Language::Python);
+    set.insert(Language::Python);
+    assert_eq!(set.len(), 1);
+}

--- a/crates/sempai-core/src/tests/language_tests.rs
+++ b/crates/sempai-core/src/tests/language_tests.rs
@@ -28,6 +28,28 @@ fn language_serde_round_trip(#[case] lang: Language, #[case] expected_json: &str
     assert_eq!(deserialized, lang);
 }
 
+#[rstest]
+#[case::rust("rust", Language::Rust)]
+#[case::python("python", Language::Python)]
+#[case::typescript("typescript", Language::TypeScript)]
+#[case::go("go", Language::Go)]
+#[case::hcl("hcl", Language::Hcl)]
+fn language_from_str(#[case] input: &str, #[case] expected: Language) {
+    let parsed: Language = input.parse().expect("valid language name");
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn language_from_str_unknown_returns_error() {
+    let result: Result<Language, _> = "javascript".parse();
+    assert!(result.is_err());
+    let err = result.expect_err("should be error");
+    assert!(
+        err.to_string().contains("javascript"),
+        "error should contain the unknown name"
+    );
+}
+
 #[test]
 fn language_copy_and_eq() {
     let a = Language::Rust;

--- a/crates/sempai-core/src/tests/language_tests.rs
+++ b/crates/sempai-core/src/tests/language_tests.rs
@@ -7,7 +7,7 @@ use crate::Language;
 #[rstest]
 #[case::rust(Language::Rust, "rust")]
 #[case::python(Language::Python, "python")]
-#[case::typescript(Language::TypeScript, "type_script")]
+#[case::typescript(Language::TypeScript, "typescript")]
 #[case::go(Language::Go, "go")]
 #[case::hcl(Language::Hcl, "hcl")]
 fn language_display(#[case] lang: Language, #[case] expected: &str) {
@@ -17,7 +17,7 @@ fn language_display(#[case] lang: Language, #[case] expected: &str) {
 #[rstest]
 #[case::rust(Language::Rust, "\"rust\"")]
 #[case::python(Language::Python, "\"python\"")]
-#[case::typescript(Language::TypeScript, "\"type_script\"")]
+#[case::typescript(Language::TypeScript, "\"typescript\"")]
 #[case::go(Language::Go, "\"go\"")]
 #[case::hcl(Language::Hcl, "\"hcl\"")]
 fn language_serde_round_trip(#[case] lang: Language, #[case] expected_json: &str) {

--- a/crates/sempai-core/src/tests/match_tests.rs
+++ b/crates/sempai-core/src/tests/match_tests.rs
@@ -1,0 +1,99 @@
+//! Tests for the [`Match`] type.
+
+use std::collections::BTreeMap;
+
+use crate::{CaptureValue, CapturedNode, LineCol, Match, Span};
+
+fn sample_span() -> Span {
+    Span::new(12, 42, LineCol::new(2, 0), LineCol::new(4, 0))
+}
+
+#[test]
+fn match_construction_with_empty_captures() {
+    let m = Match::new(
+        String::from("my-rule"),
+        String::from("file:///app.py"),
+        sample_span(),
+        None,
+        BTreeMap::new(),
+    );
+    assert_eq!(m.rule_id(), "my-rule");
+    assert_eq!(m.uri(), "file:///app.py");
+    assert_eq!(m.span().start_byte(), 12);
+    assert!(m.focus().is_none());
+    assert!(m.captures().is_empty());
+}
+
+#[test]
+fn match_construction_with_focus_and_captures() {
+    let focus = Span::new(18, 26, LineCol::new(3, 6), LineCol::new(3, 14));
+    let node = CapturedNode::new(
+        focus.clone(),
+        String::from("identifier"),
+        Some(String::from("MyClass")),
+    );
+    let mut captures = BTreeMap::new();
+    captures.insert(String::from("$C"), CaptureValue::Node(node));
+
+    let m = Match::new(
+        String::from("rule-2"),
+        String::from("file:///lib.rs"),
+        sample_span(),
+        Some(focus),
+        captures,
+    );
+    assert!(m.focus().is_some());
+    assert_eq!(m.captures().len(), 1);
+    assert!(m.captures().contains_key("$C"));
+}
+
+#[test]
+fn match_serde_round_trip() {
+    let m = Match::new(
+        String::from("test-rule"),
+        String::from("file:///test.py"),
+        sample_span(),
+        None,
+        BTreeMap::new(),
+    );
+    let json = serde_json::to_string(&m).expect("serialize");
+    let deserialized: Match = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized.rule_id(), "test-rule");
+    assert_eq!(deserialized.uri(), "file:///test.py");
+}
+
+#[test]
+fn match_captures_preserve_btreemap_ordering() {
+    let span = sample_span();
+    let mut captures = BTreeMap::new();
+    captures.insert(
+        String::from("$Z"),
+        CaptureValue::Node(CapturedNode::new(
+            span.clone(),
+            String::from("identifier"),
+            None,
+        )),
+    );
+    captures.insert(
+        String::from("$A"),
+        CaptureValue::Node(CapturedNode::new(
+            span.clone(),
+            String::from("identifier"),
+            None,
+        )),
+    );
+
+    let m = Match::new(
+        String::from("order-test"),
+        String::from("file:///test.rs"),
+        span,
+        None,
+        captures,
+    );
+    let json = serde_json::to_string(&m).expect("serialize");
+
+    // $A should appear before $Z in JSON due to BTreeMap ordering
+    let pos_a = json.find("$A").expect("$A present");
+    let pos_z = json.find("$Z").expect("$Z present");
+    assert!(pos_a < pos_z, "$A should appear before $Z in JSON");
+}

--- a/crates/sempai-core/src/tests/match_tests.rs
+++ b/crates/sempai-core/src/tests/match_tests.rs
@@ -62,6 +62,80 @@ fn match_serde_round_trip() {
     assert_eq!(deserialized.uri(), "file:///test.py");
 }
 
+/// Builds a [`Match`] with both `Node` and `Nodes` captures, serializes it
+/// to JSON, and deserializes it back.  Returns the deserialized instance for
+/// per-field assertions in individual tests.
+fn round_trip_match_with_captures() -> Match {
+    let span = sample_span();
+    let node = CapturedNode::new(
+        span.clone(),
+        String::from("identifier"),
+        Some(String::from("MyClass")),
+    );
+    let nodes = vec![
+        CapturedNode::new(
+            span.clone(),
+            String::from("identifier"),
+            Some(String::from("a")),
+        ),
+        CapturedNode::new(
+            Span::new(50, 60, LineCol::new(5, 0), LineCol::new(5, 10)),
+            String::from("string_literal"),
+            Some(String::from("b")),
+        ),
+    ];
+
+    let mut captures = BTreeMap::new();
+    captures.insert(String::from("$node"), CaptureValue::Node(node));
+    captures.insert(String::from("$nodes"), CaptureValue::Nodes(nodes));
+
+    let m = Match::new(
+        String::from("test-rule"),
+        String::from("file:///test.py"),
+        span,
+        None,
+        captures,
+    );
+
+    let json = serde_json::to_string(&m).expect("serialize with captures");
+    serde_json::from_str(&json).expect("deserialize with captures")
+}
+
+#[test]
+fn match_serde_round_trip_preserves_node_capture() {
+    let deserialized = round_trip_match_with_captures();
+
+    assert_eq!(deserialized.rule_id(), "test-rule");
+    assert_eq!(deserialized.uri(), "file:///test.py");
+    assert_eq!(deserialized.captures().len(), 2);
+
+    match deserialized.captures().get("$node") {
+        Some(CaptureValue::Node(n)) => {
+            assert_eq!(n.kind(), "identifier");
+            assert_eq!(n.text(), Some("MyClass"));
+        }
+        other => panic!("expected CaptureValue::Node for `$node`, got {other:?}"),
+    }
+}
+
+#[test]
+fn match_serde_round_trip_preserves_nodes_capture() {
+    let deserialized = round_trip_match_with_captures();
+
+    match deserialized.captures().get("$nodes") {
+        Some(CaptureValue::Nodes(ns)) => {
+            assert_eq!(ns.len(), 2);
+            let first = ns.first().expect("first node");
+            assert_eq!(first.kind(), "identifier");
+            assert_eq!(first.text(), Some("a"));
+            let second = ns.get(1).expect("second node");
+            assert_eq!(second.kind(), "string_literal");
+            assert_eq!(second.text(), Some("b"));
+        }
+        other => panic!("expected CaptureValue::Nodes for `$nodes`, got {other:?}"),
+    }
+}
+
 #[test]
 fn match_captures_preserve_btreemap_ordering() {
     let span = sample_span();

--- a/crates/sempai-core/src/tests/mod.rs
+++ b/crates/sempai-core/src/tests/mod.rs
@@ -1,0 +1,10 @@
+//! Unit tests for `sempai_core` types.
+
+mod capture_tests;
+mod config_tests;
+mod diagnostic_tests;
+mod language_tests;
+mod match_tests;
+mod span_tests;
+
+mod behaviour;

--- a/crates/sempai-core/src/tests/span_tests.rs
+++ b/crates/sempai-core/src/tests/span_tests.rs
@@ -1,0 +1,45 @@
+//! Tests for [`LineCol`] and [`Span`].
+
+use crate::{LineCol, Span};
+
+#[test]
+fn linecol_construction_and_accessors() {
+    let pos = LineCol::new(5, 10);
+    assert_eq!(pos.line(), 5);
+    assert_eq!(pos.column(), 10);
+}
+
+#[test]
+fn linecol_serde_round_trip() {
+    let pos = LineCol::new(3, 7);
+    let json = serde_json::to_string(&pos).expect("serialize");
+    let deserialized: LineCol = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized, pos);
+}
+
+#[test]
+fn span_construction_and_accessors() {
+    let span = Span::new(10, 42, LineCol::new(2, 0), LineCol::new(4, 0));
+    assert_eq!(span.start_byte(), 10);
+    assert_eq!(span.end_byte(), 42);
+    assert_eq!(span.start().line(), 2);
+    assert_eq!(span.start().column(), 0);
+    assert_eq!(span.end().line(), 4);
+    assert_eq!(span.end().column(), 0);
+}
+
+#[test]
+fn span_serde_round_trip() {
+    let span = Span::new(0, 100, LineCol::new(0, 0), LineCol::new(5, 20));
+    let json = serde_json::to_string(&span).expect("serialize");
+    let deserialized: Span = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(deserialized, span);
+}
+
+#[test]
+fn span_json_contains_expected_fields() {
+    let span = Span::new(12, 42, LineCol::new(2, 0), LineCol::new(4, 0));
+    let json = serde_json::to_string(&span).expect("serialize");
+    assert!(json.contains("\"start_byte\":12"));
+    assert!(json.contains("\"end_byte\":42"));
+}

--- a/crates/sempai-core/tests/features/sempai_core.feature
+++ b/crates/sempai-core/tests/features/sempai_core.feature
@@ -1,7 +1,7 @@
 Feature: Sempai core type construction and serialization
 
   Scenario: Span serializes to JSON with byte and line/column fields
-    Given a span from byte 10 to byte 42 on lines 2:0 to 4:0
+    Given a span from bytes "10..42" at lines "2:0..4:0"
     When the span is serialized to JSON
     Then the JSON contains key "start_byte" with value "10"
     And the JSON contains key "end_byte" with value "42"

--- a/crates/sempai-core/tests/features/sempai_core.feature
+++ b/crates/sempai-core/tests/features/sempai_core.feature
@@ -1,0 +1,24 @@
+Feature: Sempai core type construction and serialization
+
+  Scenario: Span serializes to JSON with byte and line/column fields
+    Given a span from byte 10 to byte 42 on lines 2:0 to 4:0
+    When the span is serialized to JSON
+    Then the JSON contains key "start_byte" with value "10"
+    And the JSON contains key "end_byte" with value "42"
+
+  Scenario: Language enum round-trips through serde
+    Given language "rust"
+    When the language is serialized and deserialized
+    Then the round-tripped language equals the original
+
+  Scenario: DiagnosticReport formats with code and message
+    Given a diagnostic with code "E_SEMPAI_YAML_PARSE" and message "invalid YAML"
+    When the diagnostic report is formatted
+    Then the formatted output contains "E_SEMPAI_YAML_PARSE"
+    And the formatted output contains "invalid YAML"
+
+  Scenario: DiagnosticReport not_implemented includes feature name
+    Given a not-implemented report for feature "compile_yaml"
+    When the diagnostic report is formatted
+    Then the formatted output contains "NOT_IMPLEMENTED"
+    And the formatted output contains "compile_yaml"

--- a/crates/sempai/Cargo.toml
+++ b/crates/sempai/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sempai"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+sempai_core = { path = "../sempai-core" }
+
+[dev-dependencies]
+rstest = { workspace = true }
+rstest-bdd = { workspace = true }
+rstest-bdd-macros = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sempai/Cargo.toml
+++ b/crates/sempai/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 sempai_core = { path = "../sempai-core" }
 
 [dev-dependencies]
+sempai_core = { path = "../sempai-core", features = ["test-support"] }
 rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -1,0 +1,138 @@
+//! Engine and query plan types for the Sempai facade.
+//!
+//! The [`Engine`] compiles Semgrep-compatible queries from YAML rule files
+//! or one-liner DSL expressions and executes them against source snapshots.
+//! Compilation and execution are separate phases, allowing a compiled
+//! [`QueryPlan`] to be reused across multiple source files.
+
+use sempai_core::{DiagnosticReport, EngineConfig, Language, Match};
+
+/// A compiled query plan for one rule and one language.
+///
+/// Query plans are produced by [`Engine::compile_yaml`] or
+/// [`Engine::compile_dsl`] and can be executed against source snapshots
+/// via [`Engine::execute`].
+///
+/// # Example
+///
+/// ```
+/// use sempai::{Engine, EngineConfig, Language};
+///
+/// let engine = Engine::new(EngineConfig::default());
+/// // compile_dsl currently returns an error (not yet implemented)
+/// let result = engine.compile_dsl("rule-1", Language::Rust, "pattern(\"fn $F\")");
+/// assert!(result.is_err());
+/// ```
+#[derive(Debug, Clone)]
+pub struct QueryPlan {
+    rule_id: String,
+    language: Language,
+    /// Placeholder for the internal plan representation.  Will be replaced
+    /// by `sempai_core::PlanNode` once the normalisation layer is built.
+    _plan: (),
+}
+
+impl QueryPlan {
+    /// Creates a new query plan (crate-internal).
+    #[expect(
+        dead_code,
+        reason = "constructor will be used once compile_yaml and compile_dsl are implemented"
+    )]
+    #[must_use]
+    pub(crate) const fn new(rule_id: String, language: Language) -> Self {
+        Self {
+            rule_id,
+            language,
+            _plan: (),
+        }
+    }
+
+    /// Returns the rule identifier.
+    #[must_use]
+    pub fn rule_id(&self) -> &str {
+        &self.rule_id
+    }
+
+    /// Returns the target language.
+    #[must_use]
+    pub const fn language(&self) -> Language {
+        self.language
+    }
+}
+
+/// Compiles and executes Semgrep-compatible queries on Tree-sitter syntax
+/// trees.
+///
+/// The engine is the primary entrypoint for the Sempai query pipeline.  It
+/// accepts YAML rule files or one-liner DSL expressions, compiles them into
+/// [`QueryPlan`] objects, and executes those plans against source snapshots
+/// to produce [`Match`] results.
+///
+/// # Example
+///
+/// ```
+/// use sempai::{Engine, EngineConfig};
+///
+/// let engine = Engine::new(EngineConfig::default());
+/// let result = engine.compile_yaml("rules: []");
+/// // Currently returns a "not implemented" diagnostic
+/// assert!(result.is_err());
+/// ```
+#[derive(Debug)]
+pub struct Engine {
+    config: EngineConfig,
+}
+
+impl Engine {
+    /// Creates a new engine with the given configuration.
+    #[must_use]
+    pub const fn new(config: EngineConfig) -> Self {
+        Self { config }
+    }
+
+    /// Returns the engine configuration.
+    #[must_use]
+    pub const fn config(&self) -> &EngineConfig {
+        &self.config
+    }
+
+    /// Compiles a YAML rule file into query plans.
+    ///
+    /// # Errors
+    ///
+    /// Returns a diagnostic report if parsing or validation fails.
+    /// Currently returns a "not implemented" diagnostic for all inputs.
+    pub fn compile_yaml(&self, _yaml: &str) -> Result<Vec<QueryPlan>, DiagnosticReport> {
+        Err(DiagnosticReport::not_implemented("compile_yaml"))
+    }
+
+    /// Compiles a one-liner query DSL expression into a query plan.
+    ///
+    /// # Errors
+    ///
+    /// Returns a diagnostic report if parsing or validation fails.
+    /// Currently returns a "not implemented" diagnostic for all inputs.
+    pub fn compile_dsl(
+        &self,
+        _rule_id: &str,
+        _language: Language,
+        _dsl: &str,
+    ) -> Result<QueryPlan, DiagnosticReport> {
+        Err(DiagnosticReport::not_implemented("compile_dsl"))
+    }
+
+    /// Executes a compiled query plan against a source snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns a diagnostic report if execution fails.
+    /// Currently returns a "not implemented" diagnostic for all inputs.
+    pub fn execute(
+        &self,
+        _plan: &QueryPlan,
+        _uri: &str,
+        _source: &str,
+    ) -> Result<Vec<Match>, DiagnosticReport> {
+        Err(DiagnosticReport::not_implemented("execute"))
+    }
+}

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -38,7 +38,11 @@ impl QueryPlan {
     // real plans — https://github.com/leynos/weaver/issues/67
     #[cfg(test)]
     #[must_use]
-    pub(crate) const fn new(rule_id: String, language: Language) -> Self {
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "heap types cannot be used in const contexts"
+    )]
+    pub(crate) fn new(rule_id: String, language: Language) -> Self {
         Self {
             rule_id,
             language,

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -34,10 +34,9 @@ pub struct QueryPlan {
 
 impl QueryPlan {
     /// Creates a new query plan (crate-internal).
-    #[expect(
-        dead_code,
-        reason = "constructor will be used once compile_yaml and compile_dsl are implemented"
-    )]
+    // FIXME: remove `#[cfg(test)]` when `compile_yaml` / `compile_dsl` produce
+    // real plans — https://github.com/leynos/weaver/issues/67
+    #[cfg(test)]
     #[must_use]
     pub(crate) const fn new(rule_id: String, language: Language) -> Self {
         Self {

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -1,0 +1,49 @@
+//! Sempai: a Semgrep-compatible query engine backed by Tree-sitter.
+//!
+//! This facade crate re-exports stable types from [`sempai_core`] and
+//! provides the top-level [`Engine`] entrypoint for compiling and executing
+//! Semgrep-compatible queries against source code.
+//!
+//! # Stability
+//!
+//! The `sempai` crate is the only semver-stable entrypoint.  Internal crates
+//! (`sempai_core`, `sempai_yaml`, `sempai_dsl`, `sempai_ts`) may evolve, but
+//! this facade preserves type names, serialisation formats, and method
+//! behaviour within documented constraints.
+//!
+//! # Core types
+//!
+//! - [`Language`] — supported host language identifiers
+//! - [`Span`] and [`LineCol`] — byte and line/column source positions
+//! - [`Match`] — a successful rule binding with captures
+//! - [`CaptureValue`] and [`CapturedNode`] — metavariable bindings
+//! - [`DiagnosticReport`] and [`Diagnostic`] — structured error reporting
+//! - [`EngineConfig`] — performance and safety limits
+//! - [`Engine`] — the query compilation and execution entrypoint
+//! - [`QueryPlan`] — a compiled query plan
+//!
+//! # Example
+//!
+//! ```
+//! use sempai::{Engine, EngineConfig, Language};
+//!
+//! let config = EngineConfig::default();
+//! let engine = Engine::new(config);
+//! // Engine methods are stubbed and will return diagnostic errors
+//! // until the backend implementation is complete.
+//! let result = engine.compile_dsl("rule-1", Language::Rust, "pattern(\"fn $F\")");
+//! assert!(result.is_err());
+//! ```
+
+mod engine;
+
+// Re-export all stable types from sempai_core.
+pub use sempai_core::{
+    CaptureValue, CapturedNode, Diagnostic, DiagnosticCode, DiagnosticReport, EngineConfig,
+    Language, LineCol, Match, SourceSpan, Span,
+};
+
+pub use engine::{Engine, QueryPlan};
+
+#[cfg(test)]
+mod tests;

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! # Core types
 //!
-//! - [`Language`] — supported host language identifiers
+//! - [`Language`] and [`LanguageParseError`] — supported host language identifiers
 //! - [`Span`] and [`LineCol`] — byte and line/column source positions
 //! - [`Match`] — a successful rule binding with captures
 //! - [`CaptureValue`] and [`CapturedNode`] — metavariable bindings
@@ -40,7 +40,7 @@ mod engine;
 // Re-export all stable types from sempai_core.
 pub use sempai_core::{
     CaptureValue, CapturedNode, Diagnostic, DiagnosticCode, DiagnosticReport, EngineConfig,
-    EngineLimits, Language, LineCol, Match, SourceSpan, Span,
+    EngineLimits, Language, LanguageParseError, LineCol, Match, SourceSpan, Span,
 };
 
 pub use engine::{Engine, QueryPlan};

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -18,7 +18,7 @@
 //! - [`Match`] — a successful rule binding with captures
 //! - [`CaptureValue`] and [`CapturedNode`] — metavariable bindings
 //! - [`DiagnosticReport`] and [`Diagnostic`] — structured error reporting
-//! - [`EngineConfig`] — performance and safety limits
+//! - [`EngineConfig`] and [`EngineLimits`] — performance and safety limits
 //! - [`Engine`] — the query compilation and execution entrypoint
 //! - [`QueryPlan`] — a compiled query plan
 //!
@@ -40,7 +40,7 @@ mod engine;
 // Re-export all stable types from sempai_core.
 pub use sempai_core::{
     CaptureValue, CapturedNode, Diagnostic, DiagnosticCode, DiagnosticReport, EngineConfig,
-    Language, LineCol, Match, SourceSpan, Span,
+    EngineLimits, Language, LineCol, Match, SourceSpan, Span,
 };
 
 pub use engine::{Engine, QueryPlan};

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! The `sempai` crate is the only semver-stable entrypoint.  Internal crates
 //! (`sempai_core`, `sempai_yaml`, `sempai_dsl`, `sempai_ts`) may evolve, but
-//! this facade preserves type names, serialisation formats, and method
+//! this facade preserves type names, serialization formats, and method
 //! behaviour within documented constraints.
 //!
 //! # Core types

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -1,0 +1,121 @@
+//! Behaviour-driven tests for the `sempai` engine facade.
+
+use std::str::FromStr;
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+
+use crate::{DiagnosticReport, Engine, EngineConfig, Language};
+
+// ---------------------------------------------------------------------------
+// Typed wrappers for Gherkin step parameters
+// ---------------------------------------------------------------------------
+
+/// A quoted string value from a Gherkin feature file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QuotedString(String);
+
+impl FromStr for QuotedString {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.trim_matches('"').to_owned()))
+    }
+}
+
+impl QuotedString {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test world
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct TestWorld {
+    engine: Option<Engine>,
+    compile_result: Option<Result<(), DiagnosticReport>>,
+}
+
+#[fixture]
+fn world() -> TestWorld {
+    TestWorld::default()
+}
+
+// ---------------------------------------------------------------------------
+// Given steps
+// ---------------------------------------------------------------------------
+
+#[given("an engine with default configuration")]
+fn given_default_engine(world: &mut TestWorld) {
+    world.engine = Some(Engine::new(EngineConfig::default()));
+}
+
+// ---------------------------------------------------------------------------
+// When steps
+// ---------------------------------------------------------------------------
+
+#[when("YAML {yaml} is compiled")]
+fn when_compile_yaml(world: &mut TestWorld, yaml: QuotedString) {
+    let engine = world.engine.as_ref().expect("engine should be set");
+    world.compile_result = Some(engine.compile_yaml(yaml.as_str()).map(|_| ()));
+}
+
+#[when("DSL {dsl} is compiled for language {lang}")]
+fn when_compile_dsl(world: &mut TestWorld, dsl: QuotedString, lang: QuotedString) {
+    let engine = world.engine.as_ref().expect("engine should be set");
+    let language = match lang.as_str() {
+        "rust" => Language::Rust,
+        "python" => Language::Python,
+        "type_script" => Language::TypeScript,
+        "go" => Language::Go,
+        "hcl" => Language::Hcl,
+        other => panic!("unknown language: {other}"),
+    };
+    world.compile_result = Some(
+        engine
+            .compile_dsl("interactive", language, dsl.as_str())
+            .map(|_| ()),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Then steps
+// ---------------------------------------------------------------------------
+
+#[then("the engine has max matches per rule of {count}")]
+fn then_engine_max_matches(world: &mut TestWorld, count: usize) {
+    let engine = world.engine.as_ref().expect("engine should be set");
+    assert_eq!(engine.config().max_matches_per_rule(), count);
+}
+
+#[then("compilation fails with code {code}")]
+fn then_compilation_fails(world: &mut TestWorld, code: QuotedString) {
+    let result = world
+        .compile_result
+        .as_ref()
+        .expect("compile result should be set");
+    let report = result.as_ref().expect_err("expected compilation failure");
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    let actual_code = format!("{}", first.code());
+    assert_eq!(
+        actual_code,
+        code.as_str(),
+        "expected code '{}', got '{actual_code}'",
+        code.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario registration
+// ---------------------------------------------------------------------------
+
+#[scenario(path = "tests/features/sempai_engine.feature")]
+fn sempai_engine_behaviour(world: TestWorld) {
+    let _ = world;
+}

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
+use crate::engine::QueryPlan;
 use crate::{DiagnosticReport, Engine, EngineConfig, Language};
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,22 @@ impl QuotedString {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parses a language name string into a [`Language`] variant.
+fn parse_language(name: &str) -> Language {
+    match name {
+        "rust" => Language::Rust,
+        "python" => Language::Python,
+        "typescript" => Language::TypeScript,
+        "go" => Language::Go,
+        "hcl" => Language::Hcl,
+        other => panic!("unknown language: {other}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Test world
 // ---------------------------------------------------------------------------
 
@@ -37,6 +54,7 @@ impl QuotedString {
 struct TestWorld {
     engine: Option<Engine>,
     compile_result: Option<Result<(), DiagnosticReport>>,
+    execute_result: Option<Result<(), DiagnosticReport>>,
 }
 
 #[fixture]
@@ -66,17 +84,21 @@ fn when_compile_yaml(world: &mut TestWorld, yaml: QuotedString) {
 #[when("DSL {dsl} is compiled for language {lang}")]
 fn when_compile_dsl(world: &mut TestWorld, dsl: QuotedString, lang: QuotedString) {
     let engine = world.engine.as_ref().expect("engine should be set");
-    let language = match lang.as_str() {
-        "rust" => Language::Rust,
-        "python" => Language::Python,
-        "type_script" => Language::TypeScript,
-        "go" => Language::Go,
-        "hcl" => Language::Hcl,
-        other => panic!("unknown language: {other}"),
-    };
+    let language = parse_language(lang.as_str());
     world.compile_result = Some(
         engine
             .compile_dsl("interactive", language, dsl.as_str())
+            .map(|_| ()),
+    );
+}
+
+#[when("a query plan is executed")]
+fn when_execute(world: &mut TestWorld) {
+    let engine = world.engine.as_ref().expect("engine should be set");
+    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust);
+    world.execute_result = Some(
+        engine
+            .execute(&plan, "file:///t.rs", "fn main() {}")
             .map(|_| ()),
     );
 }
@@ -98,6 +120,26 @@ fn then_compilation_fails(world: &mut TestWorld, code: QuotedString) {
         .as_ref()
         .expect("compile result should be set");
     let report = result.as_ref().expect_err("expected compilation failure");
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    let actual_code = format!("{}", first.code());
+    assert_eq!(
+        actual_code,
+        code.as_str(),
+        "expected code '{}', got '{actual_code}'",
+        code.as_str()
+    );
+}
+
+#[then("execution fails with code {code}")]
+fn then_execution_fails(world: &mut TestWorld, code: QuotedString) {
+    let result = world
+        .execute_result
+        .as_ref()
+        .expect("execute result should be set");
+    let report = result.as_ref().expect_err("expected execution failure");
     let first = report
         .diagnostics()
         .first()

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -1,50 +1,11 @@
 //! Behaviour-driven tests for the `sempai` engine facade.
 
-use std::str::FromStr;
-
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
+use sempai_core::test_support::QuotedString;
 
 use crate::engine::QueryPlan;
 use crate::{DiagnosticReport, Engine, EngineConfig, Language};
-
-// ---------------------------------------------------------------------------
-// Typed wrappers for Gherkin step parameters
-// ---------------------------------------------------------------------------
-
-/// A quoted string value from a Gherkin feature file.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct QuotedString(String);
-
-impl FromStr for QuotedString {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.trim_matches('"').to_owned()))
-    }
-}
-
-impl QuotedString {
-    fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parses a language name string into a [`Language`] variant.
-fn parse_language(name: &str) -> Language {
-    match name {
-        "rust" => Language::Rust,
-        "python" => Language::Python,
-        "typescript" => Language::TypeScript,
-        "go" => Language::Go,
-        "hcl" => Language::Hcl,
-        other => panic!("unknown language: {other}"),
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Test world
@@ -84,7 +45,7 @@ fn when_compile_yaml(world: &mut TestWorld, yaml: QuotedString) {
 #[when("DSL {dsl} is compiled for language {lang}")]
 fn when_compile_dsl(world: &mut TestWorld, dsl: QuotedString, lang: QuotedString) {
     let engine = world.engine.as_ref().expect("engine should be set");
-    let language = parse_language(lang.as_str());
+    let language: Language = lang.as_str().parse().expect("valid language name");
     world.compile_result = Some(
         engine
             .compile_dsl("interactive", language, dsl.as_str())
@@ -104,6 +65,32 @@ fn when_execute(world: &mut TestWorld) {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Asserts that a diagnostic result contains a specific error code.
+fn assert_diagnostic_code(
+    result: Option<&Result<(), DiagnosticReport>>,
+    expected_code: &str,
+    result_name: &str,
+    failure_kind: &str,
+) {
+    let inner = result.unwrap_or_else(|| panic!("{result_name} should be set"));
+    let report = inner
+        .as_ref()
+        .expect_err(&format!("expected {failure_kind}"));
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    let actual_code = format!("{}", first.code());
+    assert_eq!(
+        actual_code, expected_code,
+        "expected code '{expected_code}', got '{actual_code}'"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Then steps
 // ---------------------------------------------------------------------------
 
@@ -115,41 +102,21 @@ fn then_engine_max_matches(world: &mut TestWorld, count: usize) {
 
 #[then("compilation fails with code {code}")]
 fn then_compilation_fails(world: &mut TestWorld, code: QuotedString) {
-    let result = world
-        .compile_result
-        .as_ref()
-        .expect("compile result should be set");
-    let report = result.as_ref().expect_err("expected compilation failure");
-    let first = report
-        .diagnostics()
-        .first()
-        .expect("at least one diagnostic");
-    let actual_code = format!("{}", first.code());
-    assert_eq!(
-        actual_code,
+    assert_diagnostic_code(
+        world.compile_result.as_ref(),
         code.as_str(),
-        "expected code '{}', got '{actual_code}'",
-        code.as_str()
+        "compile result",
+        "compilation failure",
     );
 }
 
 #[then("execution fails with code {code}")]
 fn then_execution_fails(world: &mut TestWorld, code: QuotedString) {
-    let result = world
-        .execute_result
-        .as_ref()
-        .expect("execute result should be set");
-    let report = result.as_ref().expect_err("expected execution failure");
-    let first = report
-        .diagnostics()
-        .first()
-        .expect("at least one diagnostic");
-    let actual_code = format!("{}", first.code());
-    assert_eq!(
-        actual_code,
+    assert_diagnostic_code(
+        world.execute_result.as_ref(),
         code.as_str(),
-        "expected code '{}', got '{actual_code}'",
-        code.as_str()
+        "execute result",
+        "execution failure",
     );
 }
 

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -1,0 +1,48 @@
+//! Tests for the `Engine` and `QueryPlan` types.
+
+use crate::{DiagnosticCode, Engine, EngineConfig, Language};
+
+#[test]
+fn engine_new_with_default_config() {
+    let engine = Engine::new(EngineConfig::default());
+    assert_eq!(engine.config().max_matches_per_rule(), 10_000);
+}
+
+#[test]
+fn engine_new_with_custom_config() {
+    let config = EngineConfig::new(100, 200, 300, true);
+    let engine = Engine::new(config);
+    assert!(engine.config().enable_hcl());
+}
+
+#[test]
+fn compile_yaml_returns_not_implemented() {
+    let engine = Engine::new(EngineConfig::default());
+    let result = engine.compile_yaml("rules: []");
+    assert!(result.is_err());
+
+    let report = result.expect_err("should be error");
+    assert_eq!(report.diagnostics().len(), 1);
+
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::NotImplemented);
+    assert!(first.message().contains("compile_yaml"));
+}
+
+#[test]
+fn compile_dsl_returns_not_implemented() {
+    let engine = Engine::new(EngineConfig::default());
+    let result = engine.compile_dsl("test-rule", Language::Python, "pattern(\"def $F\")");
+    assert!(result.is_err());
+
+    let report = result.expect_err("should be error");
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::NotImplemented);
+    assert!(first.message().contains("compile_dsl"));
+}

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the `Engine` and `QueryPlan` types.
 
-use crate::{DiagnosticCode, Engine, EngineConfig, Language};
+use crate::engine::QueryPlan;
+use crate::{DiagnosticCode, Engine, EngineConfig, EngineLimits, Language};
 
 #[test]
 fn engine_new_with_default_config() {
@@ -10,7 +11,8 @@ fn engine_new_with_default_config() {
 
 #[test]
 fn engine_new_with_custom_config() {
-    let config = EngineConfig::new(100, 200, 300, true);
+    let limits = EngineLimits::new(100, 200, 300);
+    let config = EngineConfig::new(limits, true);
     let engine = Engine::new(config);
     assert!(engine.config().enable_hcl());
 }
@@ -45,4 +47,20 @@ fn compile_dsl_returns_not_implemented() {
         .expect("at least one diagnostic");
     assert_eq!(first.code(), DiagnosticCode::NotImplemented);
     assert!(first.message().contains("compile_dsl"));
+}
+
+#[test]
+fn execute_returns_not_implemented() {
+    let engine = Engine::new(EngineConfig::default());
+    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust);
+    let result = engine.execute(&plan, "file:///test.rs", "fn main() {}");
+    assert!(result.is_err());
+
+    let report = result.expect_err("should be error");
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::NotImplemented);
+    assert!(first.message().contains("execute"));
 }

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -1,0 +1,6 @@
+//! Unit tests for the `sempai` facade crate.
+
+mod engine_tests;
+mod reexport_tests;
+
+mod behaviour;

--- a/crates/sempai/src/tests/reexport_tests.rs
+++ b/crates/sempai/src/tests/reexport_tests.rs
@@ -1,0 +1,64 @@
+//! Tests verifying that all stable types are accessible via the `sempai`
+//! facade.
+//!
+//! These are primarily compile-time checks — if the re-exports are missing,
+//! the test module will fail to compile.
+
+use std::collections::BTreeMap;
+
+use crate::{
+    CaptureValue, CapturedNode, Diagnostic, DiagnosticCode, DiagnosticReport, EngineConfig,
+    Language, LineCol, Match, SourceSpan, Span,
+};
+
+#[test]
+fn language_is_accessible() {
+    let lang = Language::Rust;
+    assert_eq!(format!("{lang}"), "rust");
+}
+
+#[test]
+fn span_types_are_accessible() {
+    let start = LineCol::new(0, 0);
+    let finish = LineCol::new(0, 10);
+    let span = Span::new(0, 10, start, finish);
+    assert_eq!(span.start_byte(), 0);
+}
+
+#[test]
+fn capture_types_are_accessible() {
+    let node = CapturedNode::new(
+        Span::new(0, 1, LineCol::new(0, 0), LineCol::new(0, 1)),
+        String::from("identifier"),
+        None,
+    );
+    let value = CaptureValue::Node(node);
+    assert!(matches!(value, CaptureValue::Node(_)));
+}
+
+#[test]
+fn match_type_is_accessible() {
+    let m = Match::new(
+        String::from("r"),
+        String::from("u"),
+        Span::new(0, 1, LineCol::new(0, 0), LineCol::new(0, 1)),
+        None,
+        BTreeMap::new(),
+    );
+    assert_eq!(m.rule_id(), "r");
+}
+
+#[test]
+fn diagnostic_types_are_accessible() {
+    let code = DiagnosticCode::ESempaiYamlParse;
+    let span = SourceSpan::new(0, 10, None);
+    let diag = Diagnostic::new(code, String::from("test"), Some(span), vec![]);
+    let report = DiagnosticReport::new(vec![diag]);
+    assert_eq!(report.len(), 1);
+}
+
+#[test]
+fn engine_config_is_accessible() {
+    let config = EngineConfig::default();
+    assert_eq!(config.max_matches_per_rule(), 10_000);
+}

--- a/crates/sempai/tests/features/sempai_engine.feature
+++ b/crates/sempai/tests/features/sempai_engine.feature
@@ -1,0 +1,15 @@
+Feature: Sempai engine stub behaviour
+
+  Scenario: Engine is constructible with default configuration
+    Given an engine with default configuration
+    Then the engine has max matches per rule of 10000
+
+  Scenario: Engine compile_yaml returns not-implemented error
+    Given an engine with default configuration
+    When YAML "rules: []" is compiled
+    Then compilation fails with code "NOT_IMPLEMENTED"
+
+  Scenario: Engine compile_dsl returns not-implemented error
+    Given an engine with default configuration
+    When DSL "pattern(\"fn $F\")" is compiled for language "rust"
+    Then compilation fails with code "NOT_IMPLEMENTED"

--- a/crates/sempai/tests/features/sempai_engine.feature
+++ b/crates/sempai/tests/features/sempai_engine.feature
@@ -13,3 +13,8 @@ Feature: Sempai engine stub behaviour
     Given an engine with default configuration
     When DSL "pattern(\"fn $F\")" is compiled for language "rust"
     Then compilation fails with code "NOT_IMPLEMENTED"
+
+  Scenario: Engine execute returns not-implemented error
+    Given an engine with default configuration
+    When a query plan is executed
+    Then execution fails with code "NOT_IMPLEMENTED"

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -1,0 +1,864 @@
+# 4.1.1 Scaffold `sempai_core` and `sempai` with stable public types and facade entrypoints
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DONE
+
+## Purpose / big picture
+
+After this change, a downstream crate author can depend on the `sempai` facade
+crate and access a stable set of public types for representing languages,
+source spans, match results, capture bindings, diagnostics, and engine
+configuration. The `sempai_core` crate provides the canonical definitions; the
+`sempai` facade re-exports them and exposes a stub `Engine` struct whose
+methods return structured "not yet implemented" diagnostics (never panics).
+
+Running `cargo doc -p sempai --no-deps` produces complete, warning-free public
+API documentation. Unit tests validate type construction, serde round-trips,
+and diagnostic formatting. BDD scenarios exercise the public API surface from a
+consumer's perspective.
+
+Observable outcome: after all stages complete, the following commands succeed:
+
+```plaintext
+make check-fmt   # exits 0
+make lint         # exits 0 (includes cargo doc --workspace --no-deps -D warnings)
+make test         # exits 0, including all new sempai_core and sempai tests
+cargo doc -p sempai --no-deps   # exits 0 with zero warnings
+```
+
+This satisfies roadmap task 4.1.1 from `docs/roadmap.md` (lines 347-350).
+
+## Constraints
+
+- `make check-fmt`, `make lint`, and `make test` must pass after all changes.
+  These are defined in `Makefile` (lines 19-28, 34-35).
+- The workspace uses edition 2024 and `rust-version = "1.85"`
+  (`Cargo.toml` lines 18-21). Both new crates must inherit these.
+- Both new crates must include `[lints] workspace = true` to inherit the strict
+  lint configuration (`Cargo.toml` lines 51-125). This means over 60 denied
+  Clippy lints including `unwrap_used`, `expect_used`, `indexing_slicing`,
+  `string_slice`, `missing_docs`, `cognitive_complexity`, `allow_attributes`,
+  `panic_in_result_fn`, `print_stdout`, and `print_stderr`.
+- No panicking in library code. Because `unwrap_used`, `expect_used`, and
+  `panic_in_result_fn` are all denied, Engine stub methods must return
+  `Err(DiagnosticReport)` with a "not implemented" diagnostic — not `todo!()`,
+  `unimplemented!()`, or `panic!()`.
+- No single source file may exceed 400 lines (`AGENTS.md` line 31).
+- Every module must begin with a `//!` doc comment explaining its purpose
+  (`AGENTS.md` line 154).
+- All public items must have `///` rustdoc comments (`AGENTS.md` line 156).
+- Comments and documentation must use en-GB-oxendict spelling
+  ("-ize" / "-yse" / "-our") (`AGENTS.md` line 24).
+- `#[non_exhaustive]` must be used on public enums
+  (`docs/sempai-query-language-design.md` line 191).
+- Library crates use `thiserror`-derived error enums — no `eyre` or `anyhow`
+  (`AGENTS.md` lines 220-227).
+- All dependency versions use SemVer-compatible caret requirements
+  (`AGENTS.md` lines 206-216).
+- `rstest-bdd` v0.5.0 must be used for BDD tests
+  (workspace `Cargo.toml` line 36).
+- Use `str_to_string = "deny"` — use `String::from(...)` or `.into()` instead
+  of `.to_string()` on `&str` values.
+- Existing crate public APIs must not change.
+- The ExecPlan file must also be written to
+  `docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md`.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than 30 files (net), stop
+  and escalate.
+- Interface: if any existing `pub` API signature in any existing crate must
+  change, stop and escalate. This plan only adds new crates.
+- Dependencies: no new external dependencies beyond those already in
+  `[workspace.dependencies]` are required. If one becomes necessary, stop and
+  escalate.
+- Iterations: if tests still fail after 5 attempts at fixing a given issue,
+  stop and escalate.
+- Ambiguity: if the design document is ambiguous on a type definition and the
+  choice materially affects the public API, stop and present options.
+
+## Risks
+
+- Risk: The `result_large_err = "deny"` lint may fire on
+  `Result<T, DiagnosticReport>` if `DiagnosticReport` exceeds 128 bytes.
+  Severity: medium. Likelihood: medium. Mitigation: Box the inner
+  `Vec<Diagnostic>` or wrap the entire report in `Box<DiagnosticReport>` in the
+  `Result` position. The existing `weaver-graph/src/error.rs` uses
+  `Arc<std::io::Error>` for a similar reason.
+
+- Risk: The `missing_const_for_fn = "deny"` lint may require `const fn` on
+  trivial constructors and accessors where serde-derived types make `const`
+  non-trivial. Severity: low. Likelihood: medium. Mitigation: Mark simple
+  constructors as `const` where possible. For methods that return references to
+  `String` or `Vec` fields, the lint typically does not fire because they are
+  not `const`-eligible. If infeasible, use
+  `#[expect(clippy::missing_const_for_fn, reason = "...")]`.
+
+- Risk: The `shadow_reuse`, `shadow_same`, and `shadow_unrelated` lints are
+  denied. Variable naming in tests must avoid shadowing. Severity: low.
+  Likelihood: medium. Mitigation: Use distinct variable names in test functions.
+
+- Risk: The `str_to_string = "deny"` lint prohibits `.to_string()` on `&str`.
+  Severity: low. Likelihood: high. Mitigation: Use `String::from(...)` or
+  `.into()` on string literals.
+
+- Risk: `CaptureValue` uses `#[serde(tag = "kind")]` which requires
+  struct-like variants (`Node { .. }` not `Node(..)`), or an adjacently-tagged
+  approach. The design doc shows tuple variants. Severity: low. Likelihood:
+  medium. Mitigation: Use `#[serde(tag = "kind", content = "value")]`
+  (adjacently tagged) instead of internally tagged, which supports tuple
+  variants. Or convert to a custom `Serialize`/`Deserialize` implementation.
+  Evaluate during implementation.
+
+## Progress
+
+- [x] Stage A: Write ExecPlan file and register workspace members.
+- [x] Stage B: Implement `sempai_core` types and diagnostics.
+- [x] Stage C: Implement `sempai` facade with Engine stub and re-exports.
+- [x] Stage D: Write unit tests for both crates.
+- [x] Stage E: Write BDD tests with feature files.
+- [x] Stage F: Documentation and roadmap updates.
+- [x] Stage G: Final validation and commit gating.
+
+## Surprises & discoveries
+
+- The `result_large_err` risk did not materialise.
+  `DiagnosticReport` is small enough (a single `Vec` pointer)
+  that Clippy does not fire the lint.
+- `missing_const_for_fn` fired on nearly every constructor and
+  accessor in `sempai_core`. All simple constructors were made
+  `const fn` without issue.
+- `doc_markdown` lint fired on "HashiCorp" in doc comments.
+  Rewrote to avoid the proper noun where possible, or used
+  backtick-escaped forms.
+- `option_if_let_else` fired on `match diagnostics.first()` in
+  the `diagnostic_summary` helper. Refactored to
+  `first().map_or_else(...)`.
+- `too_many_arguments` fired on `Match::new` (5 params). Used
+  `#[expect]` with a reason since the constructor mirrors the
+  struct's five fields.
+- `dead_code` fired on `QueryPlan::new` because it is only used
+  `pub(crate)` and no internal callers exist yet. Used
+  `#[expect]` with a reason explaining future use.
+
+## Decision log
+
+- **CaptureValue serde strategy**: Used adjacently tagged serde
+  (`#[serde(tag = "kind", content = "value")]`) instead of
+  internally tagged, because `CaptureValue` has tuple variants
+  (`Node(CapturedNode)`, `Nodes(Vec<CapturedNode>)`). Internally
+  tagged serde does not support tuple variants. This was
+  identified as a risk in the plan and the adjacently tagged
+  approach was chosen during implementation.
+- **EngineConfig fields**: Made all fields private with `const`
+  accessors to preserve encapsulation. A `const fn new()`
+  constructor accepts all four fields.
+- **QueryPlan `_plan` field**: Used `_plan: ()` as a private
+  placeholder to prevent external construction via struct literal
+  syntax. The `pub(crate) new()` constructor is the only way to
+  create instances.
+
+## Outcomes & retrospective
+
+All acceptance criteria met:
+
+1. `RUSTDOCFLAGS="-D warnings" cargo doc -p sempai --no-deps` exits 0
+   with zero warnings.
+2. All twelve public types are defined in `sempai_core` and re-exported
+   by the `sempai` facade: `Language`, `LineCol`, `Span`,
+   `CapturedNode`, `CaptureValue`, `Match`, `EngineConfig`,
+   `DiagnosticCode`, `SourceSpan`, `Diagnostic`, `DiagnosticReport`,
+   plus `Engine` and `QueryPlan` in the facade.
+3. 63+ tests pass across both crates (unit, BDD, and doc tests) using
+   `rstest-bdd` v0.5.0 with happy and unhappy path scenarios.
+4. `make check-fmt`, `make lint`, and `make test` all exit 0.
+5. `docs/users-guide.md` updated with Sempai query engine section.
+6. Roadmap task 4.1.1 marked as done in `docs/roadmap.md`.
+
+Net new files: 28 (two crates with source, tests, and features).
+No existing crate APIs were modified.
+
+## Context and orientation
+
+The Weaver project is a Rust workspace with 12 crates under
+`/home/user/project/crates/`. The workspace root `Cargo.toml` at
+`/home/user/project/Cargo.toml` defines shared edition (2024), version (0.1.0),
+rust-version (1.85), dependencies, and lint configuration. No `sempai` crates
+currently exist.
+
+The design document at `docs/sempai-query-language-design.md` specifies six
+Sempai crates (Table 1, lines 67-74). This task scaffolds only the first two:
+
+- `crates/sempai-core` (`sempai_core`): Data model, diagnostics, planning IR.
+- `crates/sempai` (`sempai`): Facade crate, stable API. Re-exports from
+  `sempai_core` and provides the `Engine` struct.
+
+The remaining four crates (`sempai-yaml`, `sempai-dsl`, `sempai-ts`,
+`sempai-fixtures`) are out of scope for task 4.1.1.
+
+### Existing crate patterns (references)
+
+`crates/weaver-graph/` demonstrates the standard module pattern:
+
+- `Cargo.toml`: inherits workspace edition/version/lints, declares deps and
+  dev-deps using workspace references (`crates/weaver-graph/Cargo.toml`).
+- `src/lib.rs`: crate-level `//!` doc with examples, private `mod`
+  declarations, selective `pub use` re-exports, `#[cfg(test)] mod tests;`
+  (`crates/weaver-graph/src/lib.rs`).
+- `src/error.rs`: `thiserror`-derived error enum with `#[must_use]`
+  constructors (`crates/weaver-graph/src/error.rs`).
+- `src/tests/mod.rs`: test root with inline unit tests and `mod behaviour;`
+  declaration (`crates/weaver-graph/src/tests/mod.rs`).
+
+`crates/weaver-plugins/` demonstrates the BDD testing pattern:
+
+- `src/tests/behaviour.rs`: `TestWorld` struct with `#[fixture]`, step
+  definitions via `#[given]`, `#[when]`, `#[then]` macros, `QuotedString`
+  parameter type, and `#[scenario(path = "...")]` registration
+  (`crates/weaver-plugins/src/tests/behaviour.rs`).
+- `tests/features/plugin_execution.feature`: Gherkin feature file with
+  happy and unhappy path scenarios
+  (`crates/weaver-plugins/tests/features/plugin_execution.feature`).
+
+### Key types from the design document
+
+The design document (`docs/sempai-query-language-design.md` lines 197-298)
+specifies the following public types:
+
+1. `Language` enum: `Rust`, `Python`, `TypeScript`, `Go`, `Hcl` — with
+   `#[non_exhaustive]`, `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `Hash`,
+   `Serialize`, `Deserialize`.
+
+2. `LineCol` struct: `line: u32`, `column: u32` — with `Serialize`,
+   `Deserialize`.
+
+3. `Span` struct: `start_byte: u32`, `end_byte: u32`, `start: LineCol`,
+   `end: LineCol` — with `Serialize`, `Deserialize`.
+
+4. `CapturedNode` struct: `span: Span`, `kind: String`,
+   `text: Option<String>` — with `Serialize`, `Deserialize`.
+
+5. `CaptureValue` enum: `Node(CapturedNode)`,
+   `Nodes(Vec<CapturedNode>)` — with `#[non_exhaustive]`, tagged serde,
+   `Serialize`, `Deserialize`.
+
+6. `Match` struct: `rule_id: String`, `uri: String`, `span: Span`,
+   `focus: Option<Span>`, `captures: BTreeMap<String, CaptureValue>` — with
+   `Serialize`, `Deserialize`.
+
+7. `EngineConfig` struct: `max_matches_per_rule: usize`,
+   `max_capture_text_bytes: usize`, `max_deep_search_nodes: usize`,
+   `enable_hcl: bool` — with `Default`.
+
+8. `DiagnosticCode` enum: nine `E_SEMPAI_*` codes plus `NotImplemented` for
+   stubs — with `#[non_exhaustive]`, `Display`, `Serialize`, `Deserialize`
+   (design doc lines 969-981).
+
+9. `SourceSpan` struct: `start: u32`, `end: u32`,
+   `uri: Option<String>` — for diagnostic locations.
+
+10. `Diagnostic` struct: `code: DiagnosticCode`, `message: String`,
+    `span: Option<SourceSpan>`, `notes: Vec<String>`.
+
+11. `DiagnosticReport` struct: wraps `Vec<Diagnostic>`, implements
+    `std::error::Error` via `thiserror`.
+
+12. `Engine` struct (in `sempai` facade): holds `EngineConfig`, exposes
+    `compile_yaml`, `compile_dsl`, `execute` — all returning
+    `Result<T, DiagnosticReport>`.
+
+13. `QueryPlan` struct (in `sempai` facade): `rule_id: String`,
+    `language: Language`, private placeholder plan field.
+
+## Plan of work
+
+### Stage A: Crate skeletons and workspace registration
+
+This stage creates the directory structure, registers both crates in the
+workspace, and verifies that the workspace compiles.
+
+**A1.** Write the ExecPlan to
+`docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md`.
+
+**A2.** Create directory trees for both crates:
+
+```plaintext
+crates/sempai-core/src/
+crates/sempai-core/tests/features/
+crates/sempai/src/
+crates/sempai/tests/features/
+```
+
+**A3.** Add `"crates/sempai-core"` and `"crates/sempai"` to the `members` array
+in `Cargo.toml` (after `"crates/weaver-syntax"` on line 14).
+
+**A4.** Create `crates/sempai-core/Cargo.toml`:
+
+```toml
+[package]
+name = "sempai_core"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+rstest-bdd = { workspace = true }
+rstest-bdd-macros = { workspace = true }
+insta = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+**A5.** Create `crates/sempai/Cargo.toml`:
+
+```toml
+[package]
+name = "sempai"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+sempai_core = { path = "../sempai-core" }
+
+[dev-dependencies]
+rstest = { workspace = true }
+rstest-bdd = { workspace = true }
+rstest-bdd-macros = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+**A6.** Create minimal `lib.rs` stubs so compilation succeeds. For
+`crates/sempai-core/src/lib.rs`, a crate-level doc comment only. For
+`crates/sempai/src/lib.rs`, a crate-level doc comment with a
+`pub use sempai_core;` placeholder.
+
+**A7.** Verify: `cargo check --workspace` exits 0.
+
+### Stage B: Implement `sempai_core` types and diagnostics
+
+Each type lives in a focused module to stay within the 400-line file limit. All
+modules follow the weaver-graph pattern: private `mod` in `lib.rs`, selective
+`pub use` re-exports.
+
+**B1.** Create `crates/sempai-core/src/language.rs` containing the `Language`
+enum with `#[non_exhaustive]`, all required derives,
+`serde(rename_all = "snake_case")`, and a `Display` impl that produces
+lowercase names matching the serde output (e.g. `"rust"`, `"python"`,
+`"type_script"`, `"go"`, `"hcl"`).
+
+**B2.** Create `crates/sempai-core/src/span.rs` containing `LineCol` and `Span`
+structs with serde derives, `new()` constructors, and accessor methods.
+
+**B3.** Create `crates/sempai-core/src/capture.rs` containing `CapturedNode`
+and `CaptureValue`. `CaptureValue` uses `#[non_exhaustive]` and a serde tagging
+strategy compatible with its tuple variants. Include `new()` and accessor
+methods.
+
+**B4.** Create `crates/sempai-core/src/match_result.rs` containing the `Match`
+struct (named `match_result` because `match` is a Rust keyword). Include a
+`new()` constructor and accessors.
+
+**B5.** Create `crates/sempai-core/src/config.rs` containing `EngineConfig`
+with a `Default` impl providing sensible defaults:
+`max_matches_per_rule: 10_000`, `max_capture_text_bytes: 1_048_576` (1 MiB),
+`max_deep_search_nodes: 100_000`, `enable_hcl: false`.
+
+**B6.** Create `crates/sempai-core/src/diagnostic.rs` containing
+`DiagnosticCode`, `SourceSpan`, `Diagnostic`, and `DiagnosticReport`.
+
+`DiagnosticCode` is `#[non_exhaustive]` with ten variants: nine `E_SEMPAI_*`
+codes from the design doc (lines 973-981) plus `NotImplemented` for stubs. Each
+variant has a `Display` impl producing the string code (e.g.
+`"E_SEMPAI_YAML_PARSE"`). Include `Serialize`, `Deserialize`.
+
+`DiagnosticReport` wraps `Vec<Diagnostic>` and implements `std::error::Error`
+via `thiserror`. Include a `not_implemented(feature: &str)` constructor that
+creates a single-diagnostic report with `DiagnosticCode::NotImplemented`.
+
+If the `result_large_err` lint fires on `DiagnosticReport`, box the
+`diagnostics` field or provide a `Box<DiagnosticReport>` alias for use in
+`Result` types.
+
+**B7.** Wire up `crates/sempai-core/src/lib.rs` with module declarations and
+`pub use` re-exports for all public types.
+
+**B8.** Verify: `cargo check -p sempai_core` and
+`cargo clippy -p sempai_core --all-targets -- -D warnings` both exit 0.
+
+### Stage C: Implement `sempai` facade
+
+**C1.** Create `crates/sempai/src/engine.rs` containing:
+
+- `QueryPlan` struct with `rule_id: String`, `language: Language`, and a
+  private `_plan: ()` placeholder field (prevents external construction).
+  Public accessors for `rule_id()` and `language()`. A `pub(crate)` or `pub`
+  `new()` constructor.
+
+- `Engine` struct holding `EngineConfig`. Three stub methods:
+  - `compile_yaml` — returns
+    `Result<Vec<QueryPlan>, DiagnosticReport>`
+  - `compile_dsl` — returns
+    `Result<QueryPlan, DiagnosticReport>`
+  - `execute` — returns
+    `Result<Vec<Match>, DiagnosticReport>`
+
+  Each returns `Err(DiagnosticReport::not_implemented("feature_name"))`.
+
+**C2.** Wire up `crates/sempai/src/lib.rs` with re-exports from `sempai_core`
+and the `engine` module:
+
+```rust
+pub use sempai_core::{
+    CaptureValue, CapturedNode, Diagnostic, DiagnosticCode,
+    DiagnosticReport, EngineConfig, Language, LineCol, Match,
+    SourceSpan, Span,
+};
+pub use engine::{Engine, QueryPlan};
+```
+
+**C3.** Verify: `cargo check -p sempai` and
+`RUSTDOCFLAGS="-D warnings" cargo doc -p sempai --no-deps` both exit 0.
+
+### Stage D: Unit tests
+
+Tests follow the weaver-graph pattern: `src/tests/mod.rs` as test root with
+sub-modules for each concern.
+
+**D1.** Create `crates/sempai-core/src/tests/mod.rs` importing sub-modules:
+
+```rust
+//! Unit tests for sempai_core types.
+
+mod capture_tests;
+mod config_tests;
+mod diagnostic_tests;
+mod language_tests;
+mod match_tests;
+mod span_tests;
+```
+
+**D2.** Create test files for `sempai_core`:
+
+- `language_tests.rs`: `rstest` parameterised tests for `Display` output on
+  each variant, serde JSON round-trip for each variant.
+- `span_tests.rs`: `LineCol` and `Span` construction, serde round-trip.
+- `capture_tests.rs`: `CapturedNode` and `CaptureValue` construction, serde
+  round-trip, verify tagged `"kind"` field in JSON output.
+- `match_tests.rs`: `Match` construction with empty and populated captures,
+  serde round-trip, verify `BTreeMap` ordering preserved.
+- `config_tests.rs`: `EngineConfig::default()` returns expected defaults,
+  custom construction.
+- `diagnostic_tests.rs`: `DiagnosticCode` Display for each variant,
+  `DiagnosticReport::not_implemented` constructor, `DiagnosticReport` as
+  `std::error::Error` (Display output), serde round-trip for `Diagnostic` and
+  `DiagnosticReport`, `SourceSpan` construction and serde round-trip.
+
+**D3.** Create `crates/sempai/src/tests/mod.rs` with sub-modules:
+
+```rust
+//! Unit tests for the sempai facade crate.
+
+mod engine_tests;
+mod reexport_tests;
+```
+
+- `engine_tests.rs`: `Engine::new` with default config, `compile_yaml` returns
+  `Err` with `NotImplemented`, `compile_dsl` returns `Err` with
+  `NotImplemented`, `execute` returns `Err` with `NotImplemented`, `QueryPlan`
+  accessors.
+- `reexport_tests.rs`: verify all re-exported types are accessible via
+  `crate::` paths (compile-time check with simple construction).
+
+**D4.** Verify: `cargo test -p sempai_core -p sempai` exits 0.
+
+### Stage E: BDD tests
+
+BDD tests follow the weaver-plugins pattern: `.feature` files in
+`tests/features/`, step definitions in `src/tests/behaviour.rs`, scenario
+registration via `#[scenario]` macro.
+
+**E1.** Create `crates/sempai-core/tests/features/sempai_core.feature` with
+scenarios covering:
+
+- Happy path: Span serializes to JSON with byte and line/column fields.
+- Happy path: Language enum round-trips through serde for each variant.
+- Happy path: DiagnosticReport formats with code and message.
+- Unhappy path: DiagnosticReport with NotImplemented code displays the
+  feature name.
+
+**E2.** Create `crates/sempai-core/src/tests/behaviour.rs` with a `TestWorld`
+struct, fixtures, given/when/then steps, and scenario registration.
+
+**E3.** Create `crates/sempai/tests/features/sempai_engine.feature` with
+scenarios covering:
+
+- Unhappy path: Engine `compile_yaml` returns not-implemented error.
+- Unhappy path: Engine `compile_dsl` returns not-implemented error.
+- Unhappy path: Engine `execute` returns not-implemented error.
+- Happy path: Engine is constructible with default configuration.
+
+**E4.** Create `crates/sempai/src/tests/behaviour.rs` with corresponding step
+definitions.
+
+**E5.** Verify: `cargo test -p sempai_core -p sempai` exits 0.
+
+### Stage F: Documentation and roadmap updates
+
+**F1.** Update `docs/users-guide.md` with a "Sempai query engine" subsection
+documenting the existence of the `sempai` and `sempai_core` crates, the
+available public types, and a note that engine methods are stubbed pending
+backend implementation.
+
+**F2.** Mark roadmap task 4.1.1 as done in `docs/roadmap.md` (line 347): change
+`- [ ] 4.1.1.` to `- [x] 4.1.1.`.
+
+**F3.** Record design decisions taken in the design document
+`docs/sempai-query-language-design.md` if any type definitions diverge from the
+design (e.g. serde tagging strategy for `CaptureValue`).
+
+**F4.** Run `make fmt` to format all changed files.
+
+### Stage G: Final validation and commit gating
+
+**G1.** Run the full commit gating suite:
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt.log
+make lint 2>&1 | tee /tmp/lint.log
+make test 2>&1 | tee /tmp/test.log
+```
+
+All three must exit 0.
+
+**G2.** Verify cargo doc specifically for sempai:
+
+```bash
+RUSTDOCFLAGS="-D warnings" cargo doc -p sempai --no-deps 2>&1 | tee /tmp/sempai-doc.log
+```
+
+Must exit 0.
+
+## Concrete steps
+
+All commands run from the workspace root `/home/user/project`.
+
+### Stage A
+
+1. Create directory trees:
+
+   ```bash
+   mkdir -p crates/sempai-core/src crates/sempai-core/tests/features
+   mkdir -p crates/sempai/src crates/sempai/tests/features
+   ```
+
+2. Edit `Cargo.toml`: add `"crates/sempai-core"` and `"crates/sempai"` to
+   `members`.
+
+3. Create `crates/sempai-core/Cargo.toml` and `crates/sempai/Cargo.toml` (see
+   Stage A plan above).
+
+4. Create minimal `lib.rs` stubs.
+
+5. Verify: `cargo check --workspace` — expect exit 0.
+
+### Stage B
+
+1. Create six module files under `crates/sempai-core/src/`.
+
+2. Wire modules and re-exports in `crates/sempai-core/src/lib.rs`.
+
+3. Verify: `cargo clippy -p sempai_core --all-targets -- -D warnings` —
+   expect exit 0.
+
+### Stage C
+
+1. Create `crates/sempai/src/engine.rs`.
+
+2. Wire re-exports in `crates/sempai/src/lib.rs`.
+
+3. Verify: `RUSTDOCFLAGS="-D warnings" cargo doc -p sempai --no-deps` —
+   expect exit 0.
+
+### Stage D
+
+1. Create `crates/sempai-core/src/tests/mod.rs` and six test sub-modules.
+
+2. Create `crates/sempai/src/tests/mod.rs` and two test sub-modules.
+
+3. Verify: `cargo test -p sempai_core -p sempai` — expect all tests pass.
+
+### Stage E
+
+1. Create `.feature` files and behaviour step definitions.
+
+2. Verify: `cargo test -p sempai_core -p sempai` — expect all tests pass.
+
+### Stage F
+
+1. Update `docs/users-guide.md`, `docs/roadmap.md`.
+
+2. Run `make fmt`.
+
+### Stage G
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt.log
+make lint 2>&1 | tee /tmp/lint.log
+make test 2>&1 | tee /tmp/test.log
+```
+
+Expected: all exit 0.
+
+## Validation and acceptance
+
+**Acceptance criteria** (from roadmap task 4.1.1):
+
+1. Public API documentation builds for `sempai` — verified by
+   `RUSTDOCFLAGS="-D warnings" cargo doc -p sempai --no-deps` exiting 0.
+2. Stable types cover language, span, match, capture, and diagnostics models —
+   verified by unit tests constructing and round-tripping every type.
+3. Unit tests and BDD tests using rstest-bdd v0.5.0 covering happy and unhappy
+   paths — verified by `make test` passing.
+4. `make check-fmt`, `make lint`, `make test` all succeed — verified by
+   Stage G.
+5. `docs/users-guide.md` updated — verified by Stage F.
+6. Roadmap entry marked as done — verified by Stage F.
+
+**Quality criteria:**
+
+- Tests: `make test` passes with zero exit code including all new tests.
+  Expected: approximately 30-40 new tests across both crates.
+- Lint: `make lint` passes (Clippy pedantic with warnings denied, rustdoc
+  with warnings denied).
+- Format: `make check-fmt` reports no violations.
+- Documentation: `cargo doc -p sempai --no-deps` with `-D warnings` produces
+  no warnings.
+
+**Quality method:**
+
+```bash
+make check-fmt && make lint && make test
+```
+
+## Idempotence and recovery
+
+All steps are file creations or edits and can be re-applied. If any step fails
+partway through, the working tree can be reset with `git checkout -- .` and the
+steps re-executed from the beginning. No external state is modified. The crate
+creation steps use `mkdir -p` (no failure on existing directory).
+
+To roll back entirely: remove `crates/sempai-core/` and `crates/sempai/` from
+the filesystem and their entries from the workspace `members` list.
+
+## Artifacts and notes
+
+N/A (to be populated during implementation).
+
+## Interfaces and dependencies
+
+### New crate: `sempai_core`
+
+Dependencies: `serde` 1.0 (workspace, with `derive`), `thiserror` 2.0
+(workspace).
+
+Dev-dependencies: `rstest` 0.26.1, `rstest-bdd` 0.5.0, `rstest-bdd-macros`
+0.5.0, `insta` 1.41, `serde_json` 1.0 (all workspace).
+
+### New crate: `sempai`
+
+Dependencies: `sempai_core` (path `"../sempai-core"`).
+
+Dev-dependencies: `rstest`, `rstest-bdd`, `rstest-bdd-macros`, `serde_json`
+(all workspace).
+
+### Types defined by `sempai_core`
+
+In `crates/sempai-core/src/language.rs`:
+
+```rust
+/// A supported host language identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Language {
+    /// The Rust programming language.
+    Rust,
+    /// The Python programming language.
+    Python,
+    /// The TypeScript programming language.
+    TypeScript,
+    /// The Go programming language.
+    Go,
+    /// HashiCorp Configuration Language.
+    Hcl,
+}
+```
+
+In `crates/sempai-core/src/span.rs`:
+
+```rust
+/// A line and column position within a source file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineCol {
+    /// Zero-indexed line number.
+    pub line: u32,
+    /// Zero-indexed column number (byte offset within the line).
+    pub column: u32,
+}
+
+/// A byte and line/column span in a UTF-8 source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Span {
+    /// Start byte offset (inclusive).
+    pub start_byte: u32,
+    /// End byte offset (exclusive).
+    pub end_byte: u32,
+    /// Start position as line and column.
+    pub start: LineCol,
+    /// End position as line and column.
+    pub end: LineCol,
+}
+```
+
+In `crates/sempai-core/src/diagnostic.rs`:
+
+```rust
+/// Stable error codes for Sempai diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum DiagnosticCode {
+    /// YAML rule file parse failure.
+    ESempaiYamlParse,
+    /// One-liner DSL parse failure.
+    ESempaiDslParse,
+    /// Schema validation failure.
+    ESempaiSchemaInvalid,
+    /// Unsupported execution mode.
+    ESempaiUnsupportedMode,
+    /// Negated branch inside pattern-either/any.
+    ESempaiInvalidNotInOr,
+    /// Conjunction with no positive match-producing term.
+    ESempaiMissingPositiveTermInAnd,
+    /// Pattern snippet failed to parse as host language.
+    ESempaiPatternSnippetParseFailed,
+    /// Unsupported constraint in current context.
+    ESempaiUnsupportedConstraint,
+    /// Invalid Tree-sitter query syntax.
+    ESempaiTsQueryInvalid,
+    /// Feature not yet implemented (used by stub methods).
+    NotImplemented,
+}
+
+/// A collection of diagnostics produced during compilation or execution.
+#[derive(Debug, Clone, thiserror::Error, Serialize, Deserialize)]
+#[error("{}", diagnostic_summary(&self.diagnostics))]
+pub struct DiagnosticReport {
+    diagnostics: Vec<Diagnostic>,
+}
+```
+
+### Types defined by `sempai` facade
+
+In `crates/sempai/src/engine.rs`:
+
+```rust
+/// A compiled query plan for one rule and one language.
+#[derive(Debug, Clone)]
+pub struct QueryPlan {
+    rule_id: String,
+    language: Language,
+    _plan: (),
+}
+
+/// Compiles and executes Semgrep-compatible queries on Tree-sitter syntax
+/// trees.
+pub struct Engine {
+    config: EngineConfig,
+}
+
+impl Engine {
+    /// Creates a new engine with the given configuration.
+    pub const fn new(config: EngineConfig) -> Self;
+
+    /// Returns the engine configuration.
+    pub const fn config(&self) -> &EngineConfig;
+
+    /// Compiles a YAML rule file into query plans.
+    ///
+    /// # Errors
+    /// Returns a diagnostic report. Currently returns a "not implemented"
+    /// diagnostic for all inputs.
+    pub fn compile_yaml(
+        &self, yaml: &str,
+    ) -> Result<Vec<QueryPlan>, DiagnosticReport>;
+
+    /// Compiles a one-liner query DSL expression into a query plan.
+    ///
+    /// # Errors
+    /// Returns a diagnostic report. Currently returns a "not implemented"
+    /// diagnostic for all inputs.
+    pub fn compile_dsl(
+        &self, rule_id: &str, language: Language, dsl: &str,
+    ) -> Result<QueryPlan, DiagnosticReport>;
+
+    /// Executes a compiled query plan against a source snapshot.
+    ///
+    /// # Errors
+    /// Returns a diagnostic report. Currently returns a "not implemented"
+    /// diagnostic for all inputs.
+    pub fn execute(
+        &self, plan: &QueryPlan, uri: &str, source: &str,
+    ) -> Result<Vec<Match>, DiagnosticReport>;
+}
+```
+
+## Files created and modified (summary)
+
+| File                                                      | Change |
+| --------------------------------------------------------- | ------ |
+| `Cargo.toml`                                              | Edit   |
+| `crates/sempai-core/Cargo.toml`                           | New    |
+| `crates/sempai-core/src/lib.rs`                           | New    |
+| `crates/sempai-core/src/language.rs`                      | New    |
+| `crates/sempai-core/src/span.rs`                          | New    |
+| `crates/sempai-core/src/capture.rs`                       | New    |
+| `crates/sempai-core/src/match_result.rs`                  | New    |
+| `crates/sempai-core/src/config.rs`                        | New    |
+| `crates/sempai-core/src/diagnostic.rs`                    | New    |
+| `crates/sempai-core/src/tests/mod.rs`                     | New    |
+| `crates/sempai-core/src/tests/language_tests.rs`          | New    |
+| `crates/sempai-core/src/tests/span_tests.rs`              | New    |
+| `crates/sempai-core/src/tests/capture_tests.rs`           | New    |
+| `crates/sempai-core/src/tests/match_tests.rs`             | New    |
+| `crates/sempai-core/src/tests/config_tests.rs`            | New    |
+| `crates/sempai-core/src/tests/diagnostic_tests.rs`        | New    |
+| `crates/sempai-core/src/tests/behaviour.rs`               | New    |
+| `crates/sempai-core/tests/features/sempai_core.feature`   | New    |
+| `crates/sempai/Cargo.toml`                                | New    |
+| `crates/sempai/src/lib.rs`                                | New    |
+| `crates/sempai/src/engine.rs`                             | New    |
+| `crates/sempai/src/tests/mod.rs`                          | New    |
+| `crates/sempai/src/tests/engine_tests.rs`                 | New    |
+| `crates/sempai/src/tests/reexport_tests.rs`               | New    |
+| `crates/sempai/src/tests/behaviour.rs`                    | New    |
+| `crates/sempai/tests/features/sempai_engine.feature`      | New    |
+| `docs/users-guide.md`                                     | Edit   |
+| `docs/roadmap.md`                                         | Edit   |
+| `docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md` | New    |

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -18,7 +18,8 @@ methods return structured "not yet implemented" diagnostics (never panics).
 
 Running `cargo doc -p sempai --no-deps` produces complete, warning-free public
 API documentation. Unit tests validate type construction, serde round-trips,
-and diagnostic formatting. BDD scenarios exercise the public API surface from a
+and diagnostic formatting. Behaviour-driven development (BDD) scenarios
+exercise the public API surface from a
 consumer's perspective.
 
 Observable outcome: after all stages complete, the following commands succeed:
@@ -57,9 +58,11 @@ This satisfies roadmap task 4.1.1 from `docs/roadmap.md` (lines 347-350).
   (`docs/sempai-query-language-design.md` line 191).
 - Library crates use `thiserror`-derived error enums — no `eyre` or `anyhow`
   (`AGENTS.md` lines 220-227).
-- All dependency versions use SemVer-compatible caret requirements
+- All dependency versions use Semantic Versioning (SemVer)-compatible caret
+  requirements
   (`AGENTS.md` lines 206-216).
-- `rstest-bdd` v0.5.0 must be used for BDD tests
+- `rstest-bdd` v0.5.0 must be used for BDD tests (see above for
+  expansion)
   (workspace `Cargo.toml` line 36).
 - Use `str_to_string = "deny"` — use `String::from(...)` or `.into()` instead
   of `.to_string()` on `&str` values.
@@ -126,7 +129,7 @@ This satisfies roadmap task 4.1.1 from `docs/roadmap.md` (lines 347-350).
 
 ## Surprises & discoveries
 
-- The `result_large_err` risk did not materialise.
+- The `result_large_err` risk did not materialize.
   `DiagnosticReport` is small enough (a single `Vec` pointer)
   that Clippy does not fire the lint.
 - `missing_const_for_fn` fired on nearly every constructor and
@@ -454,7 +457,7 @@ mod span_tests;
 
 **D2.** Create test files for `sempai_core`:
 
-- `language_tests.rs`: `rstest` parameterised tests for `Display` output on
+- `language_tests.rs`: `rstest` parameterized tests for `Display` output on
   each variant, serde JSON round-trip for each variant.
 - `span_tests.rs`: `LineCol` and `Span` construction, serde round-trip.
 - `capture_tests.rs`: `CapturedNode` and `CaptureValue` construction, serde

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -171,11 +171,11 @@ All acceptance criteria met:
 
 1. `RUSTDOCFLAGS="-D warnings" cargo doc -p sempai --no-deps` exits 0
    with zero warnings.
-2. All twelve public types are defined in `sempai_core` and re-exported
-   by the `sempai` facade: `Language`, `LineCol`, `Span`,
-   `CapturedNode`, `CaptureValue`, `Match`, `EngineConfig`,
-   `DiagnosticCode`, `SourceSpan`, `Diagnostic`, `DiagnosticReport`,
-   plus `Engine` and `QueryPlan` in the facade.
+2. All fourteen public types are defined in `sempai_core` and re-exported
+   by the `sempai` facade: `Language`, `LanguageParseError`, `LineCol`,
+   `Span`, `CapturedNode`, `CaptureValue`, `Match`, `EngineConfig`,
+   `EngineLimits`, `DiagnosticCode`, `SourceSpan`, `Diagnostic`,
+   `DiagnosticReport`, plus `Engine` and `QueryPlan` in the facade.
 3. 63+ tests pass across both crates (unit, BDD, and doc tests) using
    `rstest-bdd` v0.5.0 with happy and unhappy path scenarios.
 4. `make check-fmt`, `make lint`, and `make test` all exit 0.
@@ -428,8 +428,8 @@ and the `engine` module:
 ```rust
 pub use sempai_core::{
     CaptureValue, CapturedNode, Diagnostic, DiagnosticCode,
-    DiagnosticReport, EngineConfig, Language, LineCol, Match,
-    SourceSpan, Span,
+    DiagnosticReport, EngineConfig, EngineLimits, Language,
+    LanguageParseError, LineCol, Match, SourceSpan, Span,
 };
 pub use engine::{Engine, QueryPlan};
 ```

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -188,8 +188,8 @@ No existing crate APIs were modified.
 ## Context and orientation
 
 The Weaver project is a Rust workspace with 12 crates under
-`/home/user/project/crates/`. The workspace root `Cargo.toml` at
-`/home/user/project/Cargo.toml` defines shared edition (2024), version (0.1.0),
+`crates/`. The workspace root `Cargo.toml` defines shared edition (2024),
+version (0.1.0),
 rust-version (1.85), dependencies, and lint configuration. No `sempai` crates
 currently exist.
 
@@ -559,7 +559,7 @@ Must exit 0.
 
 ## Concrete steps
 
-All commands run from the workspace root `/home/user/project`.
+All commands run from the workspace root.
 
 ### Stage A
 
@@ -833,6 +833,8 @@ impl Engine {
 ```
 
 ## Files created and modified (summary)
+
+Summary of files added or modified in this change.
 
 | File                                                      | Change |
 | --------------------------------------------------------- | ------ |

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -144,9 +144,11 @@ This satisfies roadmap task 4.1.1 from `docs/roadmap.md` (lines 347-350).
 - `too_many_arguments` fired on `Match::new` (5 params). Used
   `#[expect]` with a reason since the constructor mirrors the
   struct's five fields.
-- `dead_code` fired on `QueryPlan::new` because it is only used
-  `pub(crate)` and no internal callers exist yet. Used
-  `#[expect]` with a reason explaining future use.
+- `dead_code` fired on `QueryPlan::new` because no internal callers
+  exist yet. Gated the constructor behind `#[cfg(test)]` so it
+  compiles only for test targets. A `FIXME` comment with an issue
+  link marks it for removal when `compile_yaml`/`compile_dsl`
+  produce real plans.
 
 ## Decision log
 
@@ -171,11 +173,13 @@ All acceptance criteria met:
 
 1. `RUSTDOCFLAGS="-D warnings" cargo doc -p sempai --no-deps` exits 0
    with zero warnings.
-2. All fourteen public types are defined in `sempai_core` and re-exported
+2. Thirteen public types are defined in `sempai_core` and re-exported
    by the `sempai` facade: `Language`, `LanguageParseError`, `LineCol`,
    `Span`, `CapturedNode`, `CaptureValue`, `Match`, `EngineConfig`,
-   `EngineLimits`, `DiagnosticCode`, `SourceSpan`, `Diagnostic`,
-   `DiagnosticReport`, plus `Engine` and `QueryPlan` in the facade.
+   `EngineLimits`, `DiagnosticCode`, `SourceSpan`, `Diagnostic`, and
+   `DiagnosticReport`. Two additional types, `Engine` and `QueryPlan`,
+   are defined in the `sempai` facade itself, giving fifteen public
+   types in total.
 3. 63+ tests pass across both crates (unit, BDD, and doc tests) using
    `rstest-bdd` v0.5.0 with happy and unhappy path scenarios.
 4. `make check-fmt`, `make lint`, and `make test` all exit 0.
@@ -534,7 +538,8 @@ backend implementation.
 `docs/sempai-query-language-design.md` if any type definitions diverge from the
 design (e.g. serde tagging strategy for `CaptureValue`).
 
-**F4.** Run `make fmt` to format all changed files.
+**F4.** Run `make fmt` to format all changed files, and `make markdownlint`
+to lint any modified Markdown.
 
 ### Stage G: Final validation and commit gating
 
@@ -545,9 +550,10 @@ set -o pipefail
 make check-fmt 2>&1 | tee /tmp/check-fmt.log
 make lint 2>&1 | tee /tmp/lint.log
 make test 2>&1 | tee /tmp/test.log
+make markdownlint 2>&1 | tee /tmp/markdownlint.log
 ```
 
-All three must exit 0.
+All four must exit 0.
 
 **G2.** Verify cargo doc specifically for sempai:
 

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -200,7 +200,8 @@ currently exist.
 The design document at `docs/sempai-query-language-design.md` specifies six
 Sempai crates (Table 1, lines 67-74). This task scaffolds only the first two:
 
-- `crates/sempai-core` (`sempai_core`): Data model, diagnostics, planning IR.
+- `crates/sempai-core` (`sempai_core`): Data model, diagnostics, planning
+  intermediate representation (IR).
 - `crates/sempai` (`sempai`): Facade crate, stable API. Re-exports from
   `sempai_core` and provides the `Engine` struct.
 

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -362,7 +362,7 @@ modules follow the weaver-graph pattern: private `mod` in `lib.rs`, selective
 enum with `#[non_exhaustive]`, all required derives,
 `serde(rename_all = "snake_case")`, and a `Display` impl that produces
 lowercase names matching the serde output (e.g. `"rust"`, `"python"`,
-`"type_script"`, `"go"`, `"hcl"`).
+`"typescript"`, `"go"`, `"hcl"`).
 
 **B2.** Create `crates/sempai-core/src/span.rs` containing `LineCol` and `Span`
 structs with serde derives, `new()` constructors, and accessor methods.

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -188,12 +188,12 @@ satisfies roadmap task 5.1.1 in `../roadmap.md`.
   Rationale: This means the English text is always available even when the
   Fluent pipeline fails (via `NoOpLocalizer`), while genuine translations
   override it cleanly. The function composes the help block from individual
-  Fluent messages so translators can work on each line independently.
-  The English fallback values are centralised in a `bare_help` constants
-  module in `localizer.rs` so each string appears exactly once in the Rust
-  source; the `.ftl` file remains the canonical Fluent resource.  The
-  `fluent_and_fallback_outputs_are_identical` test guards against drift
-  between the two. Date/Author: 2026-02-26, updated 2026-02-28
+  Fluent messages so translators can work on each line independently. The
+  English fallback values are centralised in a `bare_help` constants module in
+  `localizer.rs` so each string appears exactly once in the Rust source; the
+  `.ftl` file remains the canonical Fluent resource.  The
+  `fluent_and_fallback_outputs_are_identical` test guards against drift between
+  the two. Date/Author: 2026-02-26, updated 2026-02-28
 
 - Decision: Construct `FluentLocalizer` once at the start of
   `CliRunner::run()`, falling back to `NoOpLocalizer` on error. Rationale: The

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -189,9 +189,9 @@ satisfies roadmap task 5.1.1 in `../roadmap.md`.
   Fluent pipeline fails (via `NoOpLocalizer`), while genuine translations
   override it cleanly. The function composes the help block from individual
   Fluent messages so translators can work on each line independently. The
-  English fallback values are centralised in a `bare_help` constants module in
+  English fallback values are centralized in a `bare_help` constants module in
   `localizer.rs` so each string appears exactly once in the Rust source; the
-  `.ftl` file remains the canonical Fluent resource.  The
+  `.ftl` file remains the canonical Fluent resource. The
   `fluent_and_fallback_outputs_are_identical` test guards against drift between
   the two. Date/Author: 2026-02-26, updated 2026-02-28
 

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -188,7 +188,7 @@ satisfies roadmap task 5.1.1 in `../roadmap.md`.
   Rationale: This means the English text is always available even when the
   Fluent pipeline fails (via `NoOpLocalizer`), while genuine translations
   override it cleanly. The function composes the help block from individual
-  Fluent messages so translators can work on each line independently. The
+  Fluent messages, so translators can work on each line independently. The
   English fallback values are centralized in a `bare_help` constants module in
   `localizer.rs` so each string appears exactly once in the Rust source; the
   `.ftl` file remains the canonical Fluent resource. The

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -40,7 +40,9 @@ In this document, Language Server Protocol (LSP) and Continuous Integration
 │   ├── weaver-plugins/
 │   ├── weaver-sandbox/
 │   ├── weaver-syntax/
-│   └── weaverd/
+│   ├── weaverd/
+│   ├── sempai-core/
+│   └── sempai/
 ├── docs/
 ├── test_expect/
 ├── .github/workflows/
@@ -70,6 +72,8 @@ In this document, Language Server Protocol (LSP) and Continuous Integration
 | `weaver-plugin-rust-analyzer` | Rust specialist plugin integration                                                                   | Implemented |
 | `weaver-build-util`           | Shared build-time utilities used across crates                                                       | Implemented |
 | `weaver-e2e`                  | End-to-end test support crate and integration scaffolding                                            | Implemented |
+| `sempai-core`                 | Sempai data model, diagnostics, and planning intermediate representation (IR) types                  | Implemented |
+| `sempai`                      | Sempai facade crate with stable public API, re-exports from `sempai-core`, and stub `Engine`         | Implemented |
 
 _Table 1: Implemented crate boundaries and responsibilities._
 
@@ -93,7 +97,7 @@ implemented in this repository snapshot.
 | Rust `extricate-symbol` actuator flow                      | `crates/weaver-plugin-rust-analyzer/` and `crates/weaverd/`                                                   | Proposed in Rust extricate actuator technical design |
 | Rust extricate plugin overlay and RA orchestration modules | `crates/weaver-plugin-rust-analyzer/src/lsp/` and related plugin modules                                      | Proposed in Rust extricate actuator technical design |
 | Plugin capability metadata for extrication                 | `crates/weaver-plugins/src/manifest/mod.rs`                                                                   | Proposed in Rust extricate actuator technical design |
-| Sempai Semgrep-compatible query engine crates              | `crates/sempai/`, `crates/sempai-core/`, `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/` | Proposed in Sempai query language technical design   |
+| Sempai YAML, DSL, and Tree-sitter backend crates           | `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/`                                          | Proposed in Sempai query language technical design   |
 | Sempai integration command surface (`observe`)             | `crates/weaver-cli/` and `crates/weaverd/`                                                                    | Proposed in Sempai query language technical design   |
 | `srgn` specialist plugin                                   | `crates/weaver-plugin-srgn/` (expected new crate)                                                             | Phase 3, specialist actuator plugins                 |
 | `jedi` specialist plugin                                   | `crates/weaver-plugin-jedi/` (expected new crate)                                                             | Phase 3, specialist sensor plugins                   |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -344,7 +344,7 @@ phase* *with explicit parser, backend, and Weaver-integration milestones.*
 *domain-specific language (DSL) parsing, semantic validation, and stable*
 *diagnostic contracts.*
 
-- [ ] 4.1.1. Scaffold `sempai_core` and `sempai` with stable public types and
+- [x] 4.1.1. Scaffold `sempai_core` and `sempai` with stable public types and
       facade entrypoints.
   - Acceptance criteria: public API documentation builds for `sempai`, and
     stable types cover language, span, match, capture, and diagnostics models.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -854,3 +854,33 @@ inspired by ast-grep. Patterns use metavariables (`$VAR` for single captures,
 enables the future `observe grep` and `act apply-rewrite` commands to perform
 precise, AST-aware search and transformation across the codebase. The engine
 currently supports Rust, Python, and TypeScript.
+
+## Sempai query engine
+
+The `sempai` crate provides a Semgrep-compatible query engine backed by
+Tree-sitter for semantics-aware code pattern matching. It is organized as two
+workspace crates:
+
+- **`sempai_core`** — canonical data model including language identifiers
+  (`Language`), source spans (`Span`, `LineCol`), match results (`Match`),
+  capture bindings (`CaptureValue`, `CapturedNode`), structured diagnostics
+  (`DiagnosticReport`, `Diagnostic`, `DiagnosticCode`), and engine
+  configuration (`EngineConfig`).
+- **`sempai`** — stable facade crate that re-exports all public types from
+  `sempai_core` and provides the `Engine` entrypoint.
+
+The `Engine` struct exposes three methods for query compilation and execution:
+
+- `compile_yaml(yaml)` — compiles a YAML rule file into query plans.
+- `compile_dsl(rule_id, language, dsl)` — compiles a one-liner DSL expression.
+- `execute(plan, uri, source)` — executes a compiled plan against a source
+  snapshot.
+
+All three methods currently return "not implemented" diagnostics. They will be
+wired to the YAML parser, DSL parser, and Tree-sitter backend as those
+components are delivered in subsequent roadmap phases.
+
+All error conditions are reported through `DiagnosticReport`, which carries
+stable `E_SEMPAI_*` error codes suitable for programmatic consumption.
+Diagnostics include a code, message, optional source span, and supplementary
+notes.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -881,6 +881,8 @@ wired to the YAML parser, DSL parser, and Tree-sitter backend as those
 components are delivered in subsequent roadmap phases.
 
 All error conditions are reported through `DiagnosticReport`, which carries
-stable `E_SEMPAI_*` error codes suitable for programmatic consumption.
+stable diagnostic codes suitable for programmatic consumption. Stub methods
+currently return the `NOT_IMPLEMENTED` code; real `E_SEMPAI_*` codes will be
+used once the corresponding backends are implemented.
 Diagnostics include a code, message, optional source span, and supplementary
 notes.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -872,7 +872,8 @@ workspace crates:
 The `Engine` struct exposes three methods for query compilation and execution:
 
 - `compile_yaml(yaml)` — compiles a YAML rule file into query plans.
-- `compile_dsl(rule_id, language, dsl)` — compiles a one-liner DSL expression.
+- `compile_dsl(rule_id, language, dsl)` — compiles a one-liner domain-specific
+  language (DSL) expression.
 - `execute(plan, uri, source)` — executes a compiled plan against a source
   snapshot.
 


### PR DESCRIPTION
## Summary
- Scaffold the Sempai core infrastructure by introducing two new crates (sempai-core and sempai), wiring them into the workspace, and laying the groundwork for a stable public API and future backend integration.

## Changes
- Add two new crates and wire them into the workspace:
  - crate: sempai-core
  - crate: sempai
  - Update workspace members to include both crates.
- Core data model (sempai-core):
  - Language enum (Rust, Python, TypeScript, Go, Hcl) with serde support and non_exhaustive.
  - Span and LineCol types for source location tracking with serde derives.
  - CapturedNode and CaptureValue (Node, Nodes) for query bindings with adjacently tagged serde.
  - Match type holding rule_id, uri, span, optional focus, and captures.
  - EngineConfig with defaults and accessors; Default impl provided.
  - Diagnostic system: DiagnosticCode, SourceSpan, Diagnostic, DiagnosticReport with serialization and display implementations.
  - Diagnostic utilities: not_implemented feature constructor for common stub errors.
  - Tests: unit tests for language, span, capture, match, config, and diagnostics; behaviour tests for BDD style steps; feature files for core diagnostics and serialization.
- Facade engine (sempai):
  - QueryPlan struct with rule_id, language, and private placeholder plan field; accessors provided.
  - Engine struct with EngineConfig and stubbed methods:
    - compile_yaml(yaml) -> Err(DiagnosticReport::not_implemented("compile_yaml"))
    - compile_dsl(rule_id, language, dsl) -> Err(DiagnosticReport::not_implemented("compile_dsl"))
    - execute(plan, uri, source) -> Err(DiagnosticReport::not_implemented("execute"))
  - Re-exports in sempai::pub use to surface core types as stable public API.
- Documentation and planning artefacts:
  - docs/users-guide.md updated with Sempai query engine description and scope.
  - docs/roadmap.md updated to mark 4.1.1 as done.
  - docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md added with implementation plan summary.
- Testing and examples:
  - Unit tests for all new core types and engine façade behaviors.
  - Behaviour-driven test scaffolding for core and engine surface using rstest-bdd.
  - Feature files for sempai-core and sempai-engine scenarios added.

## Why this design
- Establishes a stable public API surface via sempai-core and the facade sempai, enabling progressive backend integration in subsequent tasks.
- Uses non_exhaustive enums and const fn constructors to improve extensibility and performance while keeping a strict public API surface.
- Serialization patterns (serde with adjacently tagged CaptureValue) chosen to accommodate tuple variants safely.
- Stubbed Engine methods provide clear, structured diagnostics (NotImplemented) without panicking or using unwraps, aligning with lint expectations.

## Testing plan
- Run cargo test for the workspace to validate core types, serialization round-trips, and diagnostic formatting.
- Run cargo doc -p sempai --no-deps with RUSTDOCFLAGS="-D warnings" to ensure documentation builds without warnings.
- Ensure unit tests cover:
  - Language display and serde round-trips
  - LineCol and Span serialization/deserialization
  - CapturedNode and CaptureValue serde behavior (including kind tag)
  - Match serialization and capture ordering via BTreeMap
  - EngineConfig defaults and custom construction
  - DiagnosticCode formatting and Diagnostic/DiagnosticReport behavior
- Validate BDD tests and feature files compile and the scenarios are wired to the step definitions.

## Notes
- All new APIs are designed to be extended in future iterations; existing public items are stable and ready for downstream usage.
- The engine methods are intentionally stubs returning NotImplemented diagnostics to satisfy lint rules and to provide a realistic surface area for downstream integration work.
- This PR introduces a substantial amount of new test scaffolding and docs to support the staged roadmap work.

📎 **Task**: https://www.devboxer.com/task/1868db31-b7d2-466a-8250-4d3148ddbe6b

## Summary by Sourcery

Introduce Sempai core and facade crates providing a stable query engine API surface, structured diagnostics, and engine configuration, and document their role in the workspace.

New Features:
- Add `sempai_core` crate defining core Sempai data model types for languages, spans, captures, matches, engine limits, and diagnostics.
- Add `sempai` facade crate that re-exports core types and exposes an `Engine` and `QueryPlan` entrypoint API for compiling and executing queries (currently stubbed).

Enhancements:
- Document the Sempai query engine architecture and crates in the user guide and repository layout, and mark the corresponding roadmap task as complete.

Documentation:
- Add an execution plan document for scaffolding `sempai_core` and `sempai`, detailing design, constraints, and validation steps.

Tests:
- Add unit and BDD-style tests for new core types, diagnostics, configuration, and the facade engine behaviour, including feature files for core and engine scenarios.
