### PR TITLE
Update rope plugin and weaverd for rename-symbol capability

### DIFF
--- a/crates/weaver-plugin-rope/src/arguments.rs
+++ b/crates/weaver-plugin-rope/src/arguments.rs
@@ -1,0 +1,93 @@
+//! Argument parsing for `rename-symbol` plugin requests.
+//!
+//! Validates and extracts the `uri`, `position`, and `new_name` fields from a
+//! rename-symbol plugin request, converting the `position` string to the byte
+//! offset required by the rope adapter.
+
+use std::collections::HashMap;
+
+/// Validated rename-symbol arguments extracted from a plugin request.
+pub(crate) struct RenameSymbolArgs {
+    offset: usize,
+    new_name: String,
+}
+
+impl RenameSymbolArgs {
+    /// Returns the byte offset parsed from the `position` field.
+    pub(crate) const fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the new symbol name.
+    pub(crate) fn new_name(&self) -> &str {
+        &self.new_name
+    }
+}
+
+/// Parses and validates rename-symbol arguments from the request map.
+///
+/// Expects `uri` (non-empty string), `position` (parseable as `usize`), and
+/// `new_name` (non-empty string). The `uri` is validated for presence but the
+/// file payload in the request is authoritative for content.
+///
+/// # Errors
+///
+/// Returns a human-readable error message if any required field is missing,
+/// has the wrong type, or is empty.
+pub(crate) fn parse_rename_symbol_arguments(
+    arguments: &HashMap<String, serde_json::Value>,
+) -> Result<RenameSymbolArgs, String> {
+    validate_uri(arguments)?;
+    let offset = parse_position(arguments)?;
+    let new_name = parse_new_name(arguments)?;
+    Ok(RenameSymbolArgs { offset, new_name })
+}
+
+/// Validates that `uri` is present and non-empty.
+fn validate_uri(arguments: &HashMap<String, serde_json::Value>) -> Result<(), String> {
+    let uri_value = arguments
+        .get("uri")
+        .ok_or_else(|| String::from("rename-symbol operation requires 'uri' argument"))?;
+    let uri = uri_value
+        .as_str()
+        .ok_or_else(|| String::from("uri argument must be a string"))?;
+    if uri.trim().is_empty() {
+        return Err(String::from("uri argument must not be empty"));
+    }
+    Ok(())
+}
+
+/// Parses `position` as a byte offset.
+fn parse_position(arguments: &HashMap<String, serde_json::Value>) -> Result<usize, String> {
+    let position_value = arguments
+        .get("position")
+        .ok_or_else(|| String::from("rename-symbol operation requires 'position' argument"))?;
+    let position_string = json_value_to_string(position_value)
+        .ok_or_else(|| String::from("position argument must be a string or number"))?;
+    position_string
+        .parse::<usize>()
+        .map_err(|error| format!("position must be a non-negative integer: {error}"))
+}
+
+/// Parses and validates `new_name`.
+fn parse_new_name(arguments: &HashMap<String, serde_json::Value>) -> Result<String, String> {
+    let new_name_value = arguments
+        .get("new_name")
+        .ok_or_else(|| String::from("rename-symbol operation requires 'new_name' argument"))?;
+    let new_name = new_name_value
+        .as_str()
+        .ok_or_else(|| String::from("new_name argument must be a string"))?;
+    if new_name.trim().is_empty() {
+        return Err(String::from("new_name argument must not be empty"));
+    }
+    Ok(String::from(new_name))
+}
+
+/// Converts a JSON value to a string representation for numeric parsing.
+fn json_value_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => Some(text.to_owned()),
+        serde_json::Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}

--- a/crates/weaver-plugin-rope/src/lib.rs
+++ b/crates/weaver-plugin-rope/src/lib.rs
@@ -292,8 +292,11 @@ fn execute_rename<R: RopeAdapter>(
 
     let modified = adapter
         .rename(file, args.offset(), args.new_name())
-        .map_err(|error| {
-            PluginFailure::with_reason(error.to_string(), ReasonCode::SymbolNotFound)
+        .map_err(|error| match &error {
+            RopeAdapterError::EngineFailed { .. } => {
+                PluginFailure::with_reason(error.to_string(), ReasonCode::SymbolNotFound)
+            }
+            _ => PluginFailure::plain(error.to_string()),
         })?;
 
     if modified == file.content() {
@@ -338,19 +341,12 @@ fn validate_relative_path(path: &Path) -> Result<(), RopeAdapterError> {
         });
     }
 
-    let has_parent_traversal = path
-        .components()
-        .any(|component| matches!(component, Component::ParentDir));
-    if has_parent_traversal {
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
         return Err(RopeAdapterError::InvalidPath {
             message: String::from("path traversal is not allowed"),
         });
     }
-
-    let has_windows_prefix = path
-        .components()
-        .any(|component| matches!(component, Component::Prefix(_)));
-    if has_windows_prefix {
+    if path.components().any(|c| matches!(c, Component::Prefix(_))) {
         return Err(RopeAdapterError::InvalidPath {
             message: String::from("windows path prefixes are not allowed"),
         });

--- a/crates/weaver-plugin-rope/src/lib.rs
+++ b/crates/weaver-plugin-rope/src/lib.rs
@@ -4,19 +4,24 @@
 //! `weaver-plugins`. The plugin reads exactly one JSONL request from stdin,
 //! executes a refactoring operation, and writes one JSONL response to stdout.
 
+mod arguments;
+
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashMap;
+use std::fmt;
 use std::io::{BufRead, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use tempfile::TempDir;
 use thiserror::Error;
+use weaver_plugins::capability::ReasonCode;
 use weaver_plugins::protocol::{
     DiagnosticSeverity, FilePayload, PluginDiagnostic, PluginOutput, PluginRequest, PluginResponse,
 };
+
+use crate::arguments::parse_rename_symbol_arguments;
 
 const PYTHON_BINARY: &str = "python3";
 const PYTHON_RENAME_SCRIPT: &str = concat!(
@@ -164,6 +169,37 @@ pub enum RopeAdapterError {
     },
 }
 
+/// Structured failure carrying an optional reason code for diagnostics.
+#[derive(Debug)]
+pub(crate) struct PluginFailure {
+    message: String,
+    reason_code: Option<ReasonCode>,
+}
+
+impl PluginFailure {
+    /// Creates a failure without a reason code.
+    pub(crate) fn plain(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            reason_code: None,
+        }
+    }
+
+    /// Creates a failure with a stable reason code.
+    pub(crate) fn with_reason(message: impl Into<String>, reason: ReasonCode) -> Self {
+        Self {
+            message: message.into(),
+            reason_code: Some(reason),
+        }
+    }
+}
+
+impl fmt::Display for PluginFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 /// Executes one plugin request from `stdin` and writes one response to `stdout`.
 ///
 /// # Errors
@@ -177,7 +213,7 @@ pub fn run_with_adapter<R: RopeAdapter>(
     let response = match read_request(stdin).and_then(|request| execute_request(adapter, &request))
     {
         Ok(resp) => resp,
-        Err(message) => failure_response(message),
+        Err(failure) => failure_response(failure),
     };
 
     let payload = serde_json::to_string(&response)
@@ -202,95 +238,75 @@ pub fn run(stdin: &mut impl BufRead, stdout: &mut impl Write) -> Result<(), Plug
     run_with_adapter(stdin, stdout, &PythonRopeAdapter)
 }
 
-fn read_request(stdin: &mut impl BufRead) -> Result<PluginRequest, String> {
+fn read_request(stdin: &mut impl BufRead) -> Result<PluginRequest, PluginFailure> {
     let mut line = String::new();
     let bytes_read = stdin
         .read_line(&mut line)
-        .map_err(|error| format!("failed to read request: {error}"))?;
+        .map_err(|error| PluginFailure::plain(format!("failed to read request: {error}")))?;
 
     if bytes_read == 0 {
-        return Err(String::from("plugin request was empty"));
+        return Err(PluginFailure::plain("plugin request was empty"));
     }
 
     serde_json::from_str(line.trim())
-        .map_err(|error| format!("invalid plugin request JSON: {error}"))
+        .map_err(|error| PluginFailure::plain(format!("invalid plugin request JSON: {error}")))
 }
 
 fn execute_request<R: RopeAdapter>(
     adapter: &R,
     request: &PluginRequest,
-) -> Result<PluginResponse, String> {
+) -> Result<PluginResponse, PluginFailure> {
     match request.operation() {
-        "rename" => execute_rename(adapter, request),
-        other => Err(format!("unsupported refactoring operation '{other}'")),
+        "rename-symbol" => execute_rename(adapter, request),
+        other => Err(PluginFailure::with_reason(
+            format!("unsupported refactoring operation '{other}'"),
+            ReasonCode::OperationNotSupported,
+        )),
     }
 }
 
 fn execute_rename<R: RopeAdapter>(
     adapter: &R,
     request: &PluginRequest,
-) -> Result<PluginResponse, String> {
-    let (offset, new_name) = parse_rename_arguments(request.arguments())?;
+) -> Result<PluginResponse, PluginFailure> {
+    let args = parse_rename_symbol_arguments(request.arguments())
+        .map_err(|msg| PluginFailure::with_reason(msg, ReasonCode::IncompletePayload))?;
 
     let files = request.files();
     let file = match files {
         [single] => single,
         other => {
-            return Err(format!(
-                "rename operation requires exactly one file payload, got {}",
-                other.len()
+            return Err(PluginFailure::with_reason(
+                format!(
+                    "rename-symbol operation requires exactly one file payload, got {}",
+                    other.len()
+                ),
+                ReasonCode::IncompletePayload,
             ));
         }
     };
 
-    validate_relative_path(file.path()).map_err(|error| error.to_string())?;
+    validate_relative_path(file.path()).map_err(|error| {
+        PluginFailure::with_reason(error.to_string(), ReasonCode::IncompletePayload)
+    })?;
 
     let modified = adapter
-        .rename(file, offset, &new_name)
-        .map_err(|error| error.to_string())?;
+        .rename(file, args.offset(), args.new_name())
+        .map_err(|error| {
+            PluginFailure::with_reason(error.to_string(), ReasonCode::SymbolNotFound)
+        })?;
 
     if modified == file.content() {
-        return Err(String::from("rename operation produced no content changes"));
+        return Err(PluginFailure::with_reason(
+            String::from("rename operation produced no content changes"),
+            ReasonCode::SymbolNotFound,
+        ));
     }
 
     let patch = build_search_replace_patch(file.path(), file.content(), &modified);
     Ok(PluginResponse::success(PluginOutput::Diff {
         content: patch,
     }))
-}
-
-fn parse_rename_arguments(
-    arguments: &HashMap<String, serde_json::Value>,
-) -> Result<(usize, String), String> {
-    let offset_value = arguments
-        .get("offset")
-        .ok_or_else(|| String::from("rename operation requires 'offset' argument"))?;
-    let new_name_value = arguments
-        .get("new_name")
-        .ok_or_else(|| String::from("rename operation requires 'new_name' argument"))?;
-
-    let offset_string = json_value_to_string(offset_value)
-        .ok_or_else(|| String::from("offset argument must be a string or number"))?;
-    let offset = offset_string
-        .parse::<usize>()
-        .map_err(|error| format!("offset must be a non-negative integer: {error}"))?;
-
-    let new_name = new_name_value
-        .as_str()
-        .ok_or_else(|| String::from("new_name argument must be a string"))?;
-    if new_name.trim().is_empty() {
-        return Err(String::from("new_name argument must not be empty"));
-    }
-
-    Ok((offset, String::from(new_name)))
-}
-
-fn json_value_to_string(value: &serde_json::Value) -> Option<String> {
-    match value {
-        serde_json::Value::String(text) => Some(text.to_owned()),
-        serde_json::Value::Number(number) => Some(number.to_string()),
-        _ => None,
-    }
 }
 
 fn write_workspace_file(
@@ -375,9 +391,10 @@ fn path_to_slash(path: &Path) -> String {
         .join("/")
 }
 
-pub(crate) fn failure_response(message: String) -> PluginResponse {
-    PluginResponse::failure(vec![PluginDiagnostic::new(
-        DiagnosticSeverity::Error,
-        message,
-    )])
+pub(crate) fn failure_response(failure: PluginFailure) -> PluginResponse {
+    let mut diagnostic = PluginDiagnostic::new(DiagnosticSeverity::Error, failure.message);
+    if let Some(code) = failure.reason_code {
+        diagnostic = diagnostic.with_reason_code(code);
+    }
+    PluginResponse::failure(vec![diagnostic])
 }

--- a/crates/weaver-plugin-rope/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rope/src/tests/behaviour.rs
@@ -15,7 +15,7 @@ use crate::{RopeAdapter, RopeAdapterError, execute_request, failure_response};
 #[derive(Default)]
 struct World {
     request: Option<PluginRequest>,
-    execute_result: Option<Result<PluginResponse, String>>,
+    execute_result: Option<Result<PluginResponse, crate::PluginFailure>>,
     adapter_mode: AdapterMode,
 }
 
@@ -45,10 +45,11 @@ mock! {
 }
 
 fn should_invoke_rename(request: &PluginRequest) -> bool {
-    request.operation() == "rename"
+    request.operation() == "rename-symbol"
         && !request.files().is_empty()
-        && request.arguments().contains_key("offset")
+        && request.arguments().contains_key("position")
         && request.arguments().contains_key("new_name")
+        && request.arguments().contains_key("uri")
 }
 
 fn configure_adapter_for_mode(adapter: &mut MockBehaviourAdapter, mode: AdapterMode) {
@@ -63,11 +64,15 @@ fn configure_adapter_for_mode(adapter: &mut MockBehaviourAdapter, mode: AdapterM
     );
 }
 
-fn build_request(operation: &str, with_offset: bool, with_new_name: bool) -> PluginRequest {
+fn build_request(operation: &str, with_position: bool, with_new_name: bool) -> PluginRequest {
     let mut arguments = HashMap::new();
-    if with_offset {
+    arguments.insert(
+        String::from("uri"),
+        serde_json::Value::String(String::from("src/main.py")),
+    );
+    if with_position {
         arguments.insert(
-            String::from("offset"),
+            String::from("position"),
             serde_json::Value::String(String::from("4")),
         );
     }
@@ -88,14 +93,14 @@ fn build_request(operation: &str, with_offset: bool, with_new_name: bool) -> Plu
     )
 }
 
-#[given("a rename request with required arguments")]
+#[given("a rename-symbol request with required arguments")]
 fn given_valid_rename(world: &mut World) {
-    world.request = Some(build_request("rename", true, true));
+    world.request = Some(build_request("rename-symbol", true, true));
 }
 
-#[given("a rename request missing offset")]
-fn given_missing_offset(world: &mut World) {
-    world.request = Some(build_request("rename", false, true));
+#[given("a rename-symbol request missing position")]
+fn given_missing_position(world: &mut World) {
+    world.request = Some(build_request("rename-symbol", false, true));
 }
 
 #[given("an unsupported extract method request")]
@@ -132,7 +137,10 @@ fn resolved_response(world: &World) -> PluginResponse {
         .expect("execute result should be present")
     {
         Ok(resp) => resp.clone(),
-        Err(msg) => failure_response(msg.clone()),
+        Err(failure) => failure_response(crate::PluginFailure {
+            message: failure.message.clone(),
+            reason_code: failure.reason_code,
+        }),
     }
 }
 
@@ -166,6 +174,19 @@ fn then_failure_contains(world: &mut World, text: String) {
             .iter()
             .any(|diagnostic| diagnostic.message().contains(needle)),
         "expected diagnostics to contain '{needle}', got: {diagnostics:?}",
+    );
+}
+
+#[then("the failure has reason code {code}")]
+fn then_failure_has_reason_code(world: &mut World, code: String) {
+    let needle = code.trim_matches('"');
+    let response = resolved_response(world);
+    let diagnostics = response.diagnostics();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.reason_code().is_some_and(|rc| rc.as_str() == needle)),
+        "expected reason code '{needle}' in diagnostics: {diagnostics:?}",
     );
 }
 

--- a/crates/weaver-plugin-rope/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rope/src/tests/behaviour.rs
@@ -164,29 +164,43 @@ fn then_failure_diagnostics(world: &mut World) {
     );
 }
 
-#[then("the failure message contains {text}")]
-fn then_failure_contains(world: &mut World, text: String) {
-    let needle = text.trim_matches('"');
+fn assert_any_diagnostic(
+    world: &mut World,
+    raw_needle: &str,
+    predicate: impl Fn(&weaver_plugins::protocol::PluginDiagnostic) -> bool,
+    fail_prefix: &str,
+) {
+    let needle = raw_needle.trim_matches('"');
     let response = resolved_response(world);
     let diagnostics = response.diagnostics();
     assert!(
-        diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.message().contains(needle)),
-        "expected diagnostics to contain '{needle}', got: {diagnostics:?}",
+        diagnostics.iter().any(&predicate),
+        "{fail_prefix} '{needle}' in diagnostics: {diagnostics:?}",
+    );
+}
+
+#[then("the failure message contains {text}")]
+fn then_failure_contains(world: &mut World, text: String) {
+    let needle = text.trim_matches('"').to_owned();
+    assert_any_diagnostic(
+        world,
+        &needle,
+        |d| d.message().contains(needle.as_str()),
+        "expected diagnostics to contain",
     );
 }
 
 #[then("the failure has reason code {code}")]
 fn then_failure_has_reason_code(world: &mut World, code: String) {
-    let needle = code.trim_matches('"');
-    let response = resolved_response(world);
-    let diagnostics = response.diagnostics();
-    assert!(
-        diagnostics
-            .iter()
-            .any(|d| d.reason_code().is_some_and(|rc| rc.as_str() == needle)),
-        "expected reason code '{needle}' in diagnostics: {diagnostics:?}",
+    let needle = code.trim_matches('"').to_owned();
+    assert_any_diagnostic(
+        world,
+        &needle,
+        |d| {
+            d.reason_code()
+                .is_some_and(|rc| rc.as_str() == needle.as_str())
+        },
+        "expected reason code",
     );
 }
 

--- a/crates/weaver-plugin-rope/src/tests/mod.rs
+++ b/crates/weaver-plugin-rope/src/tests/mod.rs
@@ -82,6 +82,17 @@ fn remove_uri(arguments: &mut HashMap<String, serde_json::Value>) {
     arguments.remove("uri");
 }
 
+fn set_boolean_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(String::from("uri"), serde_json::Value::Bool(true));
+}
+
+fn set_empty_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("uri"),
+        serde_json::Value::String(String::new()),
+    );
+}
+
 fn remove_position(arguments: &mut HashMap<String, serde_json::Value>) {
     arguments.remove("position");
 }
@@ -132,6 +143,8 @@ fn assert_failure_contains(
 
 #[rstest]
 #[case::missing_uri(remove_uri as fn(&mut _), Some("uri"))]
+#[case::boolean_uri(set_boolean_uri as fn(&mut _), Some("uri argument must be a string"))]
+#[case::empty_uri(set_empty_uri as fn(&mut _), Some("uri argument must not be empty"))]
 #[case::missing_position(remove_position as fn(&mut _), Some("position"))]
 #[case::boolean_position(set_boolean_position as fn(&mut _), Some("position"))]
 #[case::negative_position(set_negative_position as fn(&mut _), Some("non-negative integer"))]

--- a/crates/weaver-plugin-rope/src/tests/mod.rs
+++ b/crates/weaver-plugin-rope/src/tests/mod.rs
@@ -7,9 +7,10 @@ use std::path::PathBuf;
 
 use mockall::mock;
 use rstest::{fixture, rstest};
+use weaver_plugins::capability::ReasonCode;
 use weaver_plugins::protocol::{FilePayload, PluginOutput, PluginRequest};
 
-use crate::{RopeAdapter, RopeAdapterError, execute_request, run_with_adapter};
+use crate::{PluginFailure, RopeAdapter, RopeAdapterError, execute_request, run_with_adapter};
 
 mock! {
     Adapter {}
@@ -42,7 +43,11 @@ fn adapter_unused() -> MockAdapter {
 fn rename_arguments() -> HashMap<String, serde_json::Value> {
     let mut arguments = HashMap::new();
     arguments.insert(
-        String::from("offset"),
+        String::from("uri"),
+        serde_json::Value::String(String::from("src/main.py")),
+    );
+    arguments.insert(
+        String::from("position"),
         serde_json::Value::String(String::from("4")),
     );
     arguments.insert(
@@ -54,7 +59,7 @@ fn rename_arguments() -> HashMap<String, serde_json::Value> {
 
 fn request_with_args(arguments: HashMap<String, serde_json::Value>) -> PluginRequest {
     PluginRequest::with_arguments(
-        "rename",
+        "rename-symbol",
         vec![FilePayload::new(
             PathBuf::from("src/main.py"),
             "def old_name():\n    return 1\n",
@@ -73,24 +78,28 @@ fn rename_success_returns_diff_output(rename_arguments: HashMap<String, serde_js
     assert!(matches!(response.output(), PluginOutput::Diff { .. }));
 }
 
-fn remove_offset(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.remove("offset");
+fn remove_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("uri");
 }
 
-fn set_boolean_offset(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(String::from("offset"), serde_json::Value::Bool(true));
+fn remove_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("position");
 }
 
-fn set_negative_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+fn set_boolean_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(String::from("position"), serde_json::Value::Bool(true));
+}
+
+fn set_negative_position(arguments: &mut HashMap<String, serde_json::Value>) {
     arguments.insert(
-        String::from("offset"),
+        String::from("position"),
         serde_json::Value::String(String::from("-1")),
     );
 }
 
-fn set_numeric_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+fn set_numeric_position(arguments: &mut HashMap<String, serde_json::Value>) {
     arguments.insert(
-        String::from("offset"),
+        String::from("position"),
         serde_json::Value::Number(serde_json::Number::from(4)),
     );
 }
@@ -109,11 +118,24 @@ fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
     );
 }
 
+/// Asserts that a `PluginFailure` error message contains the expected needle.
+fn assert_failure_contains(
+    result: Result<weaver_plugins::PluginResponse, PluginFailure>,
+    needle: &str,
+) {
+    let failure = result.expect_err("invalid arguments should fail");
+    assert!(
+        failure.to_string().contains(needle),
+        "expected error mentioning '{needle}', got: {failure}"
+    );
+}
+
 #[rstest]
-#[case::missing_offset(remove_offset as fn(&mut _), Some("offset"))]
-#[case::boolean_offset(set_boolean_offset as fn(&mut _), Some("offset"))]
-#[case::negative_offset(set_negative_offset as fn(&mut _), Some("non-negative integer"))]
-#[case::numeric_offset_succeeds(set_numeric_offset as fn(&mut _), None)]
+#[case::missing_uri(remove_uri as fn(&mut _), Some("uri"))]
+#[case::missing_position(remove_position as fn(&mut _), Some("position"))]
+#[case::boolean_position(set_boolean_position as fn(&mut _), Some("position"))]
+#[case::negative_position(set_negative_position as fn(&mut _), Some("non-negative integer"))]
+#[case::numeric_position_succeeds(set_numeric_position as fn(&mut _), None)]
 #[case::numeric_new_name(set_numeric_new_name as fn(&mut _), Some("new_name argument must be a string"))]
 #[case::empty_new_name(set_empty_new_name as fn(&mut _), Some("new_name"))]
 fn rename_argument_validation(
@@ -125,11 +147,9 @@ fn rename_argument_validation(
 
     if let Some(needle) = expected_error {
         let adapter = adapter_unused();
-        let err = execute_request(&adapter, &request_with_args(rename_arguments))
-            .expect_err("invalid arguments should fail");
-        assert!(
-            err.contains(needle),
-            "expected error mentioning '{needle}', got: {err}"
+        assert_failure_contains(
+            execute_request(&adapter, &request_with_args(rename_arguments)),
+            needle,
         );
     } else {
         let adapter = adapter_returning(Ok(String::from("def new_name():\n    return 1\n")));
@@ -140,15 +160,31 @@ fn rename_argument_validation(
 }
 
 #[test]
-fn unsupported_operation_returns_error() {
+fn unsupported_operation_returns_error_with_reason_code() {
     let adapter = adapter_unused();
     let request = PluginRequest::new("extract_method", Vec::new());
 
-    let err = execute_request(&adapter, &request).expect_err("unsupported operation should fail");
+    let failure =
+        execute_request(&adapter, &request).expect_err("unsupported operation should fail");
     assert!(
-        err.contains("unsupported"),
-        "expected error mentioning 'unsupported', got: {err}"
+        failure.to_string().contains("unsupported"),
+        "expected error mentioning 'unsupported', got: {failure}"
     );
+    assert_eq!(failure.reason_code, Some(ReasonCode::OperationNotSupported));
+}
+
+#[test]
+fn old_rename_operation_rejected_with_operation_not_supported() {
+    let adapter = adapter_unused();
+    let request = PluginRequest::new("rename", Vec::new());
+
+    let failure =
+        execute_request(&adapter, &request).expect_err("old rename operation should fail");
+    assert!(
+        failure.to_string().contains("unsupported"),
+        "expected error mentioning 'unsupported', got: {failure}"
+    );
+    assert_eq!(failure.reason_code, Some(ReasonCode::OperationNotSupported));
 }
 
 enum FailureScenario {
@@ -157,10 +193,11 @@ enum FailureScenario {
 }
 
 #[rstest]
-#[case::no_change(FailureScenario::NoChange)]
-#[case::adapter_error(FailureScenario::AdapterError)]
-fn rename_non_mutating_or_error_returns_failure(
+#[case::no_change(FailureScenario::NoChange, ReasonCode::SymbolNotFound)]
+#[case::adapter_error(FailureScenario::AdapterError, ReasonCode::SymbolNotFound)]
+fn rename_failure_includes_reason_code(
     #[case] scenario: FailureScenario,
+    #[case] expected_reason: ReasonCode,
     rename_arguments: HashMap<String, serde_json::Value>,
 ) {
     let adapter = match &scenario {
@@ -172,19 +209,29 @@ fn rename_non_mutating_or_error_returns_failure(
         }
     };
 
-    let err = execute_request(&adapter, &request_with_args(rename_arguments))
+    let failure = execute_request(&adapter, &request_with_args(rename_arguments))
         .expect_err("failure scenario should return Err");
+    assert_eq!(failure.reason_code, Some(expected_reason));
 
     match scenario {
         FailureScenario::NoChange => assert!(
-            err.contains("no content changes"),
-            "expected no-change diagnostic, got: {err}"
+            failure.to_string().contains("no content changes"),
+            "expected no-change diagnostic, got: {failure}"
         ),
         FailureScenario::AdapterError => assert!(
-            err.contains("rope failed"),
-            "expected adapter error message, got: {err}"
+            failure.to_string().contains("rope failed"),
+            "expected adapter error message, got: {failure}"
         ),
     }
+}
+
+#[rstest]
+fn missing_arguments_include_incomplete_payload_reason_code() {
+    let adapter = adapter_unused();
+    let arguments = HashMap::new();
+    let failure = execute_request(&adapter, &request_with_args(arguments))
+        .expect_err("empty arguments should fail");
+    assert_eq!(failure.reason_code, Some(ReasonCode::IncompletePayload));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/weaver-plugin-rope/src/tests/mod.rs
+++ b/crates/weaver-plugin-rope/src/tests/mod.rs
@@ -159,27 +159,15 @@ fn rename_argument_validation(
     }
 }
 
-#[test]
-fn unsupported_operation_returns_error_with_reason_code() {
+#[rstest]
+#[case::unsupported_operation("extract_method")]
+#[case::old_rename_rejected("rename")]
+fn unsupported_operations_rejected_with_operation_not_supported(#[case] operation: &str) {
     let adapter = adapter_unused();
-    let request = PluginRequest::new("extract_method", Vec::new());
+    let request = PluginRequest::new(operation, Vec::new());
 
     let failure =
         execute_request(&adapter, &request).expect_err("unsupported operation should fail");
-    assert!(
-        failure.to_string().contains("unsupported"),
-        "expected error mentioning 'unsupported', got: {failure}"
-    );
-    assert_eq!(failure.reason_code, Some(ReasonCode::OperationNotSupported));
-}
-
-#[test]
-fn old_rename_operation_rejected_with_operation_not_supported() {
-    let adapter = adapter_unused();
-    let request = PluginRequest::new("rename", Vec::new());
-
-    let failure =
-        execute_request(&adapter, &request).expect_err("old rename operation should fail");
     assert!(
         failure.to_string().contains("unsupported"),
         "expected error mentioning 'unsupported', got: {failure}"

--- a/crates/weaver-plugin-rope/tests/features/rope_plugin.feature
+++ b/crates/weaver-plugin-rope/tests/features/rope_plugin.feature
@@ -1,15 +1,15 @@
 Feature: Rope actuator plugin
 
-  Scenario: Rename succeeds with diff output
-    Given a rename request with required arguments
+  Scenario: Rename-symbol succeeds with diff output
+    Given a rename-symbol request with required arguments
     When the plugin executes the request
     Then the plugin returns successful diff output
 
-  Scenario: Rename fails when offset is missing
-    Given a rename request missing offset
+  Scenario: Rename-symbol fails when position is missing
+    Given a rename-symbol request missing position
     When the plugin executes the request
     Then the plugin returns failure diagnostics
-    And the failure message contains "offset"
+    And the failure message contains "position"
 
   Scenario: Unsupported operation fails with diagnostics
     Given an unsupported extract method request
@@ -17,15 +17,16 @@ Feature: Rope actuator plugin
     Then the plugin returns failure diagnostics
     And the failure message contains "unsupported"
 
-  Scenario: Adapter failures are surfaced
-    Given a rename request with required arguments
+  Scenario: Adapter failures are surfaced with reason code
+    Given a rename-symbol request with required arguments
     And a rope adapter that fails
     When the plugin executes the request
     Then the plugin returns failure diagnostics
     And the failure message contains "rope engine failed"
+    And the failure has reason code "symbol_not_found"
 
   Scenario: Unchanged output is treated as failure
-    Given a rename request with required arguments
+    Given a rename-symbol request with required arguments
     And a rope adapter that returns unchanged content
     When the plugin executes the request
     Then the plugin returns failure diagnostics

--- a/crates/weaverd/src/dispatch/act/refactor/mod.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/mod.rs
@@ -333,13 +333,12 @@ fn apply_rename_symbol_mapping(
     plugin_args: &mut std::collections::HashMap<String, serde_json::Value>,
     file: &str,
 ) {
-    plugin_args
-        .entry(String::from("uri"))
-        .or_insert_with(|| serde_json::Value::String(file.to_owned()));
+    plugin_args.insert(
+        String::from("uri"),
+        serde_json::Value::String(file.to_owned()),
+    );
     if let Some(offset_val) = plugin_args.remove("offset") {
-        plugin_args
-            .entry(String::from("position"))
-            .or_insert(offset_val);
+        plugin_args.insert(String::from("position"), offset_val);
     }
 }
 

--- a/crates/weaverd/src/dispatch/act/refactor/mod.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/mod.rs
@@ -21,7 +21,9 @@ use weaver_plugins::manifest::{PluginKind, PluginManifest, PluginMetadata};
 use weaver_plugins::process::SandboxExecutor;
 use weaver_plugins::protocol::FilePayload;
 use weaver_plugins::runner::PluginRunner;
-use weaver_plugins::{PluginError, PluginOutput, PluginRegistry, PluginRequest, PluginResponse};
+use weaver_plugins::{
+    CapabilityId, PluginError, PluginOutput, PluginRegistry, PluginRequest, PluginResponse,
+};
 
 use crate::backends::{BackendKind, FusionBackends};
 use crate::dispatch::act::apply_patch;
@@ -65,7 +67,8 @@ impl SandboxRefactorRuntime {
         let rope_metadata =
             PluginMetadata::new(ROPE_PLUGIN_NAME, ROPE_PLUGIN_VERSION, PluginKind::Actuator);
         let rope_manifest =
-            PluginManifest::new(rope_metadata, vec![String::from("python")], rope_executable);
+            PluginManifest::new(rope_metadata, vec![String::from("python")], rope_executable)
+                .with_capabilities(vec![CapabilityId::RenameSymbol]);
         registry
             .register(rope_manifest)
             .map_err(|error| format!("failed to initialize refactor runtime: {error}"))?;
@@ -189,8 +192,26 @@ pub fn handle<W: Write>(
         }
     }
 
+    // Map rename operations to the rename-symbol capability contract.
+    // The CLI still accepts `--refactoring rename`; the handler translates
+    // to the contract operation name and argument schema.
+    let effective_operation = match args.refactoring.as_str() {
+        "rename" => {
+            plugin_args
+                .entry(String::from("uri"))
+                .or_insert_with(|| serde_json::Value::String(args.file.clone()));
+            if let Some(offset_val) = plugin_args.remove("offset") {
+                plugin_args
+                    .entry(String::from("position"))
+                    .or_insert(offset_val);
+            }
+            String::from("rename-symbol")
+        }
+        _ => args.refactoring.clone(),
+    };
+
     let plugin_request = PluginRequest::with_arguments(
-        &args.refactoring,
+        &effective_operation,
         vec![FilePayload::new(PathBuf::from(&args.file), file_content)],
         plugin_args,
     );

--- a/crates/weaverd/src/dispatch/act/refactor/mod.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/mod.rs
@@ -5,14 +5,12 @@
 //! through the Double-Lock safety harness before any filesystem change is
 //! committed.
 //!
-//! The handler validates the request arguments, resolves the target file, and
-//! builds a [`PluginRequest`]. Successful plugin responses with diff output are
-//! forwarded to the existing `act apply-patch` pipeline so syntactic and
-//! semantic locks are reused without duplicating safety-critical logic.
+//! The handler validates arguments, resolves the target file, and builds a
+//! [`PluginRequest`]. Diff output is forwarded to `act apply-patch` so
+//! syntactic and semantic locks are reused without duplicating safety logic.
 
 use std::io::Write;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tracing::debug;
@@ -192,19 +190,10 @@ pub fn handle<W: Write>(
         }
     }
 
-    // Map rename operations to the rename-symbol capability contract.
-    // The CLI still accepts `--refactoring rename`; the handler translates
-    // to the contract operation name and argument schema.
+    // Map `--refactoring rename` to the `rename-symbol` capability contract.
     let effective_operation = match args.refactoring.as_str() {
         "rename" => {
-            plugin_args
-                .entry(String::from("uri"))
-                .or_insert_with(|| serde_json::Value::String(args.file.clone()));
-            if let Some(offset_val) = plugin_args.remove("offset") {
-                plugin_args
-                    .entry(String::from("position"))
-                    .or_insert(offset_val);
-            }
+            apply_rename_symbol_mapping(&mut plugin_args, &args.file);
             String::from("rename-symbol")
         }
         _ => args.refactoring.clone(),
@@ -336,6 +325,22 @@ fn resolve_file(workspace_root: &Path, file: &str) -> Result<std::path::PathBuf,
         ));
     }
     Ok(resolved)
+}
+
+/// Rewrites `plugin_args` to conform with the `rename-symbol` contract:
+/// injects `uri` from `file` and renames `offset` to `position`.
+fn apply_rename_symbol_mapping(
+    plugin_args: &mut std::collections::HashMap<String, serde_json::Value>,
+    file: &str,
+) {
+    plugin_args
+        .entry(String::from("uri"))
+        .or_insert_with(|| serde_json::Value::String(file.to_owned()));
+    if let Some(offset_val) = plugin_args.remove("offset") {
+        plugin_args
+            .entry(String::from("position"))
+            .or_insert(offset_val);
+    }
 }
 
 fn handle_plugin_response<W: Write>(

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -246,3 +246,100 @@ fn default_runtime_returns_shared_trait_object() {
     let result = runtime.execute("rope", &request);
     assert!(result.is_err());
 }
+
+/// Captures the `PluginRequest` sent to the runtime for inspection.
+struct InspectingRuntime {
+    captured: std::sync::Mutex<Option<PluginRequest>>,
+    response: PluginResponse,
+}
+
+impl RefactorPluginRuntime for InspectingRuntime {
+    fn execute(
+        &self,
+        _provider: &str,
+        request: &PluginRequest,
+    ) -> Result<PluginResponse, PluginError> {
+        *self.captured.lock().expect("lock") = Some(request.clone());
+        Ok(self.response.clone())
+    }
+}
+
+#[rstest]
+fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) {
+    let workspace = TempDir::new().expect("workspace");
+    let file_path = workspace.path().join("notes.txt");
+    std::fs::write(&file_path, "hello world\n").expect("write");
+
+    let diff = concat!(
+        "diff --git a/notes.txt b/notes.txt\n",
+        "<<<<<<< SEARCH\n",
+        "hello world\n",
+        "=======\n",
+        "hello woven\n",
+        ">>>>>>> REPLACE\n",
+    );
+    let runtime = InspectingRuntime {
+        captured: std::sync::Mutex::new(None),
+        response: PluginResponse::success(PluginOutput::Diff {
+            content: String::from(diff),
+        }),
+    };
+    let request = command_request(vec![
+        String::from("--provider"),
+        String::from("rope"),
+        String::from("--refactoring"),
+        String::from("rename"),
+        String::from("--file"),
+        String::from("notes.txt"),
+        String::from("offset=4"),
+        String::from("new_name=woven"),
+    ]);
+    let socket_path = socket_dir.path().join("socket.sock");
+    let mut backends = build_backends(&socket_path);
+    let mut output = Vec::new();
+    let mut writer = ResponseWriter::new(&mut output);
+
+    let result = handle(
+        &request,
+        &mut writer,
+        RefactorContext {
+            backends: &mut backends,
+            workspace_root: workspace.path(),
+            runtime: &runtime,
+        },
+    )
+    .expect("dispatch result");
+    assert_eq!(result.status, 0);
+
+    let captured = runtime.captured.lock().expect("lock");
+    let plugin_request = captured.as_ref().expect("request should be captured");
+
+    // The handler must translate "rename" to "rename-symbol".
+    assert_eq!(plugin_request.operation(), "rename-symbol");
+
+    // The handler must inject "uri" from --file when not already present.
+    let args = plugin_request.arguments();
+    assert_eq!(
+        args.get("uri").and_then(|v| v.as_str()),
+        Some("notes.txt"),
+        "uri should be injected from --file"
+    );
+
+    // The handler must map "offset" to "position".
+    assert_eq!(
+        args.get("position").and_then(|v| v.as_str()),
+        Some("4"),
+        "offset should be mapped to position"
+    );
+    assert!(
+        !args.contains_key("offset"),
+        "offset key should be removed after mapping to position"
+    );
+
+    // new_name should be forwarded as-is.
+    assert_eq!(
+        args.get("new_name").and_then(|v| v.as_str()),
+        Some("woven"),
+        "new_name should be forwarded"
+    );
+}

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -264,42 +264,41 @@ impl RefactorPluginRuntime for InspectingRuntime {
     }
 }
 
-#[rstest]
-fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) {
-    let workspace = TempDir::new().expect("workspace");
-    let file_path = workspace.path().join("notes.txt");
-    std::fs::write(&file_path, "hello world\n").expect("write");
+const NOTES_DIFF: &str = concat!(
+    "diff --git a/notes.txt b/notes.txt\n",
+    "<<<<<<< SEARCH\n",
+    "hello world\n",
+    "=======\n",
+    "hello woven\n",
+    ">>>>>>> REPLACE\n",
+);
 
-    let diff = concat!(
-        "diff --git a/notes.txt b/notes.txt\n",
-        "<<<<<<< SEARCH\n",
-        "hello world\n",
-        "=======\n",
-        "hello woven\n",
-        ">>>>>>> REPLACE\n",
-    );
+/// Dispatches a rename request through the handler and returns the captured
+/// `PluginRequest` for inspection.
+fn dispatch_inspecting_rename(extra_args: Vec<String>, socket_dir: &TempDir) -> PluginRequest {
+    let workspace = TempDir::new().expect("workspace");
+    std::fs::write(workspace.path().join("notes.txt"), "hello world\n").expect("write");
     let runtime = InspectingRuntime {
         captured: std::sync::Mutex::new(None),
         response: PluginResponse::success(PluginOutput::Diff {
-            content: String::from(diff),
+            content: String::from(NOTES_DIFF),
         }),
     };
-    let request = command_request(vec![
+    let mut args = vec![
         String::from("--provider"),
         String::from("rope"),
         String::from("--refactoring"),
         String::from("rename"),
         String::from("--file"),
         String::from("notes.txt"),
-        String::from("offset=4"),
-        String::from("new_name=woven"),
-    ]);
+    ];
+    args.extend(extra_args);
+    let request = command_request(args);
     let socket_path = socket_dir.path().join("socket.sock");
     let mut backends = build_backends(&socket_path);
     let mut output = Vec::new();
     let mut writer = ResponseWriter::new(&mut output);
-
-    let result = handle(
+    let _result = handle(
         &request,
         &mut writer,
         RefactorContext {
@@ -309,23 +308,27 @@ fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) 
         },
     )
     .expect("dispatch result");
-    assert_eq!(result.status, 0);
+    runtime
+        .captured
+        .into_inner()
+        .expect("lock")
+        .expect("request should be captured")
+}
 
-    let captured = runtime.captured.lock().expect("lock");
-    let plugin_request = captured.as_ref().expect("request should be captured");
+#[rstest]
+fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) {
+    let plugin_request = dispatch_inspecting_rename(
+        vec![String::from("offset=4"), String::from("new_name=woven")],
+        &socket_dir,
+    );
 
-    // The handler must translate "rename" to "rename-symbol".
     assert_eq!(plugin_request.operation(), "rename-symbol");
-
-    // The handler must inject "uri" from --file when not already present.
     let args = plugin_request.arguments();
     assert_eq!(
         args.get("uri").and_then(|v| v.as_str()),
         Some("notes.txt"),
         "uri should be injected from --file"
     );
-
-    // The handler must map "offset" to "position".
     assert_eq!(
         args.get("position").and_then(|v| v.as_str()),
         Some("4"),
@@ -335,11 +338,41 @@ fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) 
         !args.contains_key("offset"),
         "offset key should be removed after mapping to position"
     );
-
-    // new_name should be forwarded as-is.
     assert_eq!(
         args.get("new_name").and_then(|v| v.as_str()),
         Some("woven"),
         "new_name should be forwarded"
+    );
+}
+
+#[rstest]
+fn handler_overwrites_pre_existing_uri_with_file_path(socket_dir: TempDir) {
+    let plugin_request = dispatch_inspecting_rename(
+        vec![
+            String::from("uri=stale_value"),
+            String::from("offset=4"),
+            String::from("new_name=woven"),
+        ],
+        &socket_dir,
+    );
+
+    assert_eq!(
+        plugin_request
+            .arguments()
+            .get("uri")
+            .and_then(|v| v.as_str()),
+        Some("notes.txt"),
+        "uri should be overwritten with --file value, not pre-existing extra"
+    );
+}
+
+#[rstest]
+fn handler_omits_position_when_offset_not_provided(socket_dir: TempDir) {
+    let plugin_request =
+        dispatch_inspecting_rename(vec![String::from("new_name=woven")], &socket_dir);
+
+    assert!(
+        !plugin_request.arguments().contains_key("position"),
+        "position should not be injected when offset is absent"
     );
 }

--- a/docs/execplans/5-2-1-define-the-rename-symbol-capability-contract.md
+++ b/docs/execplans/5-2-1-define-the-rename-symbol-capability-contract.md
@@ -139,28 +139,26 @@ Observable behaviour after this change:
 
 - Observation: The workspace Clippy configuration denies `string_slice`, which
   prevents string indexing even in test code. The initial BDD key-value parser
-  used byte-offset indexing into strings.
-  Evidence: `make lint` failed with 6 `string_slice` errors.
-  Impact: Rewrote the parser to use `split_whitespace` + `split_once` instead
-  of positional indexing. No functional change, but a reminder that the strict
-  lints apply uniformly to test code.
+  used byte-offset indexing into strings. Evidence: `make lint` failed with 6
+  `string_slice` errors. Impact: Rewrote the parser to use `split_whitespace` +
+  `split_once` instead of positional indexing. No functional change, but a
+  reminder that the strict lints apply uniformly to test code.
 
 - Observation: The `doc_markdown` Clippy lint requires backticks around
-  identifiers like `snake_case` in doc comments.
-  Evidence: `make lint` flagged two lines in `reason_code.rs`.
-  Impact: Trivial fix; wrapped `snake_case` in backticks.
+  identifiers like `snake_case` in doc comments. Evidence: `make lint` flagged
+  two lines in `reason_code.rs`. Impact: Trivial fix; wrapped `snake_case` in
+  backticks.
 
 ## Decision log
 
 - Decision: Use an enum for `CapabilityId` rather than a string-backed
   newtype. Rationale: Architecture Decision Record (ADR) 001 defines exactly
-  five first-party capability IDs
-  (`rename-symbol`, `extricate-symbol`, `extract-method`, `replace-body`,
-  `extract-predicate`). An enum provides compile-time exhaustiveness checking,
-  reliable `match` coverage, and prevents typos. Third-party extensibility is a
-  non-goal at this stage. The enum follows the precedent set by
-  `CapabilityKind` in `crates/weaver-lsp-host/src/capability.rs`. Date:
-  2026-02-28.
+  five first-party capability IDs (`rename-symbol`, `extricate-symbol`,
+  `extract-method`, `replace-body`, `extract-predicate`). An enum provides
+  compile-time exhaustiveness checking, reliable `match` coverage, and prevents
+  typos. Third-party extensibility is a non-goal at this stage. The enum
+  follows the precedent set by `CapabilityKind` in
+  `crates/weaver-lsp-host/src/capability.rs`. Date: 2026-02-28.
 
 - Decision: Create a new `capability/` module directory rather than adding
   to existing protocol or manifest modules. Rationale: The capability contract
@@ -213,8 +211,8 @@ All acceptance criteria are met:
    variants is serialized as `snake_case` strings. The optional `reason_code`
    field on `PluginDiagnostic` is backwards-compatible via `serde(default)`.
 
-Deliverables: 4 new files in `capability/` module, 3 extended existing types,
-1 BDD feature file with 10 scenarios, 1 BDD step definitions file, user guide
+Deliverables: 4 new files in `capability/` module, 3 extended existing types, 1
+BDD feature file with 10 scenarios, 1 BDD step definitions file, user guide
 documentation, and roadmap update. All 124 `weaver-plugins` tests pass. Full
 workspace `check-fmt`, `lint`, and `test` gates pass.
 
@@ -353,8 +351,8 @@ capability IDs, the rename-symbol request schema, and refusal reason codes.
 Update `lib.rs` re-exports and ensure all rustdoc examples compile. Run full
 quality gates. Mark roadmap entry as done.
 
-Validation: `make check-fmt && make lint && make test && make markdownlint`
-all pass.
+Validation: `make check-fmt && make lint && make test && make markdownlint` all
+pass.
 
 ## Validation and acceptance
 

--- a/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
+++ b/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
@@ -38,8 +38,8 @@ Observable behaviour after this change:
   failures).
 - The `weaverd` handler maps the user-facing `--refactoring rename` to the
   contract operation `"rename-symbol"` and translates `offset` to `position`
-  internally, preserving CLI backward compatibility.
-- BDD scenarios cover happy path, missing arguments, unsupported operation,
+  internally, preserving command-line interface (CLI) backward compatibility.
+- Behaviour-driven development (BDD) scenarios cover happy path, missing arguments, unsupported operation,
   adapter failure, unchanged output, and reason code verification.
 
 ## Constraints
@@ -148,7 +148,7 @@ Observable behaviour after this change:
 ## Decision log
 
 - Decision: Retire the `"rename"` operation name in the plugin entirely, not
-  keep dual support. Rationale: The acceptance criteria says "Legacy provider
+  keep dual support. Rationale: The acceptance criteria say "Legacy provider
   routing is not required for Python rename flows." Adding dual operation
   support increases complexity and line count, and the `"rename"` name was
   never part of a stable public contract. The weaverd handler maps the
@@ -220,8 +220,8 @@ code analysis and modification. The key crates for this task are:
   updated in roadmap item 5.2.1 and must NOT be modified in 5.2.2.
 
 - `crates/weaver-plugin-rope/` — The Python rope-backed actuator plugin. A
-  standalone binary crate that reads one JSONL request from stdin and writes
-  one JSONL response to stdout. Main logic is in `src/lib.rs` (384 lines).
+  standalone binary crate that reads one JSON Lines (JSONL) request from stdin
+  and writes one JSONL response to stdout. Main logic is in `src/lib.rs` (384 lines).
   Tests are in `src/tests/mod.rs` (224 lines) and `src/tests/behaviour.rs` (176
   lines). BDD feature file is at `tests/features/rope_plugin.feature` (33
   lines).
@@ -482,7 +482,7 @@ All stages are re-runnable. If a stage fails partway, fix the issue and re-run
 from the beginning of that stage. No destructive operations are involved. The
 new `arguments.rs` file is additive; existing files are edited in place.
 
-## Artifacts and notes
+## Artefacts and notes
 
 ### Line budget analysis
 

--- a/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
+++ b/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
@@ -39,8 +39,9 @@ Observable behaviour after this change:
 - The `weaverd` handler maps the user-facing `--refactoring rename` to the
   contract operation `"rename-symbol"` and translates `offset` to `position`
   internally, preserving command-line interface (CLI) backward compatibility.
-- Behaviour-driven development (BDD) scenarios cover happy path, missing arguments, unsupported operation,
-  adapter failure, unchanged output, and reason code verification.
+- Behaviour-driven development (BDD) scenarios cover happy path,
+  missing arguments, unsupported operation, adapter failure,
+  unchanged output, and reason code verification.
 
 ## Constraints
 
@@ -332,7 +333,7 @@ Update `crates/weaver-plugin-rope/src/tests/mod.rs`:
 1. Update `rename_arguments()` fixture: add `"uri"` key, rename `"offset"` to
    `"position"`.
 2. Update `request_with_args()`: operation `"rename"` → `"rename-symbol"`.
-3. Update parameterised `rename_argument_validation` test cases for new
+3. Update parameterized `rename_argument_validation` test cases for new
    argument names (`position`, `uri`) and `PluginFailure` error type.
 4. Update `unsupported_operation_returns_error` for new return type.
 5. Update `rename_non_mutating_or_error_returns_failure` for new return type.

--- a/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
+++ b/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
@@ -1,0 +1,552 @@
+# Update weaver-plugin-rope manifest and runtime handshake for rename-symbol
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: COMPLETE
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root.
+
+## Purpose / big picture
+
+After this change, the `weaver-plugin-rope` actuator plugin declares
+`rename-symbol` in its manifest capabilities and serves rename requests through
+the capability contract interface defined in roadmap item 5.2.1. The daemon
+handler constructs contract-conforming requests, and the plugin returns
+structured failure diagnostics with stable reason codes. Legacy provider
+routing through the old `"rename"` operation name is retired for Python rename
+flows.
+
+Observable behaviour after this change:
+
+- Running `make check-fmt && make lint && make test` passes with no
+  regressions.
+- The rope plugin manifest includes `CapabilityId::RenameSymbol` in its
+  capabilities. The registry method
+  `find_for_language_and_capability("python", CapabilityId::RenameSymbol)`
+  returns the rope manifest.
+- The rope plugin accepts `"rename-symbol"` operation requests with `uri`,
+  `position`, and `new_name` arguments conforming to the `RenameSymbolContract`
+  schema.
+- The rope plugin rejects the old `"rename"` operation name with
+  `ReasonCode::OperationNotSupported`.
+- Failure diagnostics include stable `ReasonCode` values (e.g.,
+  `IncompletePayload` for missing arguments, `SymbolNotFound` for adapter
+  failures).
+- The `weaverd` handler maps the user-facing `--refactoring rename` to the
+  contract operation `"rename-symbol"` and translates `offset` to `position`
+  internally, preserving CLI backward compatibility.
+- BDD scenarios cover happy path, missing arguments, unsupported operation,
+  adapter failure, unchanged output, and reason code verification.
+
+## Constraints
+
+1. **No async runtime.** The entire project uses synchronous blocking I/O.
+2. **Edition 2024, Rust 1.85+.** The workspace uses `edition = "2024"`.
+3. **Strict Clippy.** Over 60 denied lint categories including `unwrap_used`,
+   `expect_used`, `indexing_slicing`, `string_slice`, `missing_docs`,
+   `cognitive_complexity`, and `allow_attributes`. Both `weaver-plugin-rope`
+   and `weaverd` opt into workspace lints. All code must pass
+   `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
+4. **400-line file limit.** No single source file may exceed 400 lines.
+   `crates/weaver-plugin-rope/src/lib.rs` starts at 384 lines (16 lines of
+   headroom). `crates/weaverd/src/dispatch/act/refactor/mod.rs` starts at 375
+   lines (25 lines of headroom).
+5. **Error handling.** Library crates use `thiserror`-derived error enums.
+6. **Documentation.** Every module begins with `//!` doc comments. All public
+   items have `///` rustdoc comments.
+7. **en-GB-oxendict spelling.** Comments and documentation use British English
+   with Oxford "-ize" / "-yse" / "-our" spelling.
+8. **rstest-bdd v0.5.0.** BDD tests use v0.5.0 with mutable world fixtures
+   (`&mut`). The fixture parameter must be named exactly `world` (not
+   `_world`). Use `let _ = world;` to suppress unused warnings.
+9. **Lint suppressions must use `#[expect]` with reason**, not `#[allow]`.
+10. **Do not modify `crates/weaver-plugins/`.** The capability contract types
+    from roadmap item 5.2.1 are complete and must not be changed.
+11. **CLI backward compatibility.** Users still pass `--refactoring rename`,
+    `offset=N`, and `new_name=X`. The handler does the translation internally.
+12. **`str_to_string` denied.** Use `String::from()` or `.into()`, not
+    `.to_string()` on `&str`.
+
+## Tolerances (exception triggers)
+
+- **Scope:** If implementation requires changes to more than 12 files or more
+  than 400 net lines of code, stop and escalate.
+- **Interface:** If the `RopeAdapter` trait's public `rename()` method
+  signature must change in a way that breaks the `PythonRopeAdapter`, stop and
+  escalate.
+- **Dependencies:** If a new external crate dependency is required, stop and
+  escalate.
+- **Iterations:** If tests still fail after 5 attempts at fixing, stop and
+  escalate.
+- **Line budget:** If any file cannot fit within 400 lines without extracting a
+  new submodule, proceed with the extraction, but if it requires more than 2
+  new files, stop and escalate.
+- **Ambiguity:** The acceptance criteria states "Legacy provider routing is not
+  required for Python rename flows." If this interpretation (retire `"rename"`
+  operation name in the plugin, update the `weaverd` handler to send
+  `"rename-symbol"` with contract arguments) is wrong, stop and escalate.
+
+## Risks
+
+- Risk: `lib.rs` at 384 lines has only 16 lines of headroom; adding imports
+  and modifying the dispatch logic could push it over 400. Severity: medium
+  Likelihood: high Mitigation: Extract `parse_rename_arguments()` and
+  `json_value_to_string()` into a new
+  `crates/weaver-plugin-rope/src/arguments.rs` submodule. This frees
+  approximately 30 lines of budget.
+
+- Risk: The `weaverd` refactor handler at 375 lines needs argument
+  translation logic that could push it over 400. Severity: low Likelihood:
+  medium Mitigation: The change replaces existing argument-forwarding code with
+  slightly longer translation code. Net delta is approximately +12 lines,
+  arriving at ~387 lines, within budget.
+
+- Risk: BDD step definitions reference the old operation name `"rename"` and
+  argument keys (`offset`, `new_name`). Updating them could introduce
+  regressions. Severity: medium Likelihood: low Mitigation: Update all step
+  definitions and feature files atomically. Run `make test` after every change.
+
+- Risk: Changing `execute_request` return semantics from `Err(String)` to
+  `Err(PluginFailure)` requires updating all test assertions. Severity: medium
+  Likelihood: certain Mitigation: The `PluginFailure` type provides `Display`
+  and `message()` accessor, so test assertions need minimal rewording. Update
+  tests in the same stage as the type change.
+
+## Progress
+
+- [x] (2026-03-05) Write execution plan.
+- [x] (2026-03-05) Create `crates/weaver-plugin-rope/src/arguments.rs` with
+  `parse_rename_symbol_arguments()`.
+- [x] (2026-03-05) Refactor `crates/weaver-plugin-rope/src/lib.rs`: add
+  `PluginFailure` type, update dispatch to `"rename-symbol"`, integrate reason
+  codes, remove extracted functions.
+- [x] (2026-03-05) Update `crates/weaverd/src/dispatch/act/refactor/mod.rs`:
+  add `.with_capabilities()` to rope manifest, translate arguments in handler.
+- [x] (2026-03-05) Update rope plugin unit tests in `src/tests/mod.rs`.
+- [x] (2026-03-05) Update rope plugin BDD step definitions in
+  `src/tests/behaviour.rs`.
+- [x] (2026-03-05) Update rope plugin feature file
+  `tests/features/rope_plugin.feature`.
+- [x] (2026-03-05) Add weaverd contract conformance test in
+  `src/dispatch/act/refactor/tests.rs`.
+- [x] (2026-03-05) Update `docs/users-guide.md`.
+- [x] (2026-03-05) Mark `docs/roadmap.md` entry 5.2.2 as done.
+- [x] (2026-03-05) Run `make check-fmt`, `make lint`, `make test` — all pass
+  (152 tests, 0 failures).
+
+## Surprises & discoveries
+
+- Observation: `PluginFailure` needed `#[derive(Debug)]` because tests use
+  `.expect()` on `Result<_, PluginFailure>`, which requires `Debug`.
+  Evidence: Clippy error `E0277: PluginFailure doesn't implement Debug`.
+  Impact: Added one derive line; file stayed within 400-line budget.
+
+## Decision log
+
+- Decision: Retire the `"rename"` operation name in the plugin entirely, not
+  keep dual support. Rationale: The acceptance criteria says "Legacy provider
+  routing is not required for Python rename flows." Adding dual operation
+  support increases complexity and line count, and the `"rename"` name was
+  never part of a stable public contract. The weaverd handler maps the
+  user-facing `--refactoring rename` to `"rename-symbol"` before sending to the
+  plugin. Date: 2026-03-05.
+
+- Decision: Extract an `arguments.rs` submodule from `lib.rs` to create line
+  budget. Rationale: `lib.rs` is at 384/400 lines. Moving argument parsing into
+  a dedicated module frees ~30 lines of budget for the new imports and
+  `PluginFailure` type. This follows the project pattern of small, focused
+  modules. Date: 2026-03-05.
+
+- Decision: Map `position` as a byte offset string.
+  Rationale: The rope adapter needs a `usize` byte offset. The contract's
+  `position` field is a string. The handler passes the user's `offset=N` value
+  as the `position` string. The plugin parses it back to `usize`. This is the
+  simplest conforming implementation. Date: 2026-03-05.
+
+- Decision: Introduce `PluginFailure` struct to carry
+  `(message, Option<ReasonCode>)`. Rationale: `execute_request()` currently
+  returns `Result<PluginResponse, String>`. To attach reason codes to failures,
+  the error type must carry an optional `ReasonCode`. A small struct is cleaner
+  than a tuple and provides `Display` for backward-compatible test assertions.
+  The `Err` path is for business-logic failures; infrastructure failures
+  (stdin/JSON parse errors) also use `PluginFailure` but without a reason code.
+  Date: 2026-03-05.
+
+- Decision: Map reason codes as follows: unsupported operation →
+  `OperationNotSupported`; missing/invalid arguments → `IncompletePayload`;
+  adapter engine failure → `SymbolNotFound`; no content changes →
+  `SymbolNotFound`; invalid file path → `IncompletePayload`. Rationale: These
+  mappings align with the `ReasonCode` semantics defined in
+  `crates/weaver-plugins/src/capability/reason_code.rs`. Engine failures and
+  unchanged output both indicate the symbol could not be effectively renamed.
+  Date: 2026-03-05.
+
+## Outcomes & retrospective
+
+All deliverables are complete. The rope plugin now declares `rename-symbol` in
+its manifest, accepts contract-conforming requests with `uri`/`position`/
+`new_name` arguments, and returns structured failure diagnostics with stable
+`ReasonCode` values. The weaverd handler maps the user-facing
+`--refactoring rename` to the internal `rename-symbol` operation and translates
+`offset` to `position`, maintaining CLI backward compatibility.
+
+Files created: `crates/weaver-plugin-rope/src/arguments.rs` (98 lines).
+Files modified: `crates/weaver-plugin-rope/src/lib.rs` (400 lines, exactly at
+budget), `crates/weaverd/src/dispatch/act/refactor/mod.rs` (396 lines),
+`crates/weaver-plugin-rope/src/tests/mod.rs`,
+`crates/weaver-plugin-rope/src/tests/behaviour.rs`,
+`crates/weaver-plugin-rope/tests/features/rope_plugin.feature`,
+`crates/weaverd/src/dispatch/act/refactor/tests.rs`,
+`docs/users-guide.md`, `docs/roadmap.md`.
+
+Lessons: Always derive `Debug` on error types that might be used with
+`.expect()` in tests. The 400-line budget required careful extraction of the
+arguments module to make room for the `PluginFailure` struct.
+
+## Context and orientation
+
+### Repository structure
+
+The Weaver project is a Rust workspace implementing a client-daemon tool for
+code analysis and modification. The key crates for this task are:
+
+- `crates/weaver-plugins/` — Plugin framework. Defines `PluginRequest`,
+  `PluginResponse`, `PluginManifest`, `PluginRegistry`, `CapabilityId`,
+  `ReasonCode`, `RenameSymbolRequest`, `RenameSymbolContract`. This crate was
+  updated in roadmap item 5.2.1 and must NOT be modified in 5.2.2.
+
+- `crates/weaver-plugin-rope/` — The Python rope-backed actuator plugin. A
+  standalone binary crate that reads one JSONL request from stdin and writes
+  one JSONL response to stdout. Main logic is in `src/lib.rs` (384 lines).
+  Tests are in `src/tests/mod.rs` (224 lines) and `src/tests/behaviour.rs` (176
+  lines). BDD feature file is at `tests/features/rope_plugin.feature` (33
+  lines).
+
+- `crates/weaverd/` — The Weaver daemon. The refactor handler at
+  `src/dispatch/act/refactor/mod.rs` (375 lines) registers the rope plugin
+  manifest and constructs `PluginRequest` payloads for plugin execution.
+
+### Current rope plugin protocol
+
+The rope plugin currently:
+
+1. Accepts operation `"rename"` (not `"rename-symbol"`).
+2. Expects arguments: `offset` (string or number, parsed to `usize`) and
+   `new_name` (string).
+3. Returns `PluginOutput::Diff` on success.
+4. Returns failure via `PluginResponse::failure` with a single
+   `PluginDiagnostic` that has no `reason_code`.
+5. The function `failure_response(message: String)` constructs failures.
+
+### Current manifest registration
+
+In `crates/weaverd/src/dispatch/act/refactor/mod.rs` lines 67–68, the rope
+manifest is constructed without capability declarations:
+
+```rust
+let rope_manifest =
+    PluginManifest::new(rope_metadata, vec![String::from("python")], rope_executable);
+```
+
+### Rename-symbol contract (from 5.2.1)
+
+The contract (defined in
+`crates/weaver-plugins/src/capability/rename_symbol.rs`) requires:
+
+- Operation: `"rename-symbol"`
+- Arguments: `uri` (non-empty string), `position` (non-empty string),
+  `new_name` (non-empty string)
+- Success response: `PluginOutput::Diff`
+- Failure response: diagnostics with optional `ReasonCode`
+
+### Reason codes
+
+Defined in `crates/weaver-plugins/src/capability/reason_code.rs` as a 7-
+variant enum: `SymbolNotFound`, `MacroGenerated`, `AmbiguousReferences`,
+`UnsupportedLanguage`, `IncompletePayload`, `NameConflict`,
+`OperationNotSupported`. Serialized as `snake_case` strings.
+
+## Plan of work
+
+### Stage A: Extract arguments module (create line budget)
+
+Create `crates/weaver-plugin-rope/src/arguments.rs` containing:
+
+- `RenameSymbolArgs` struct with `offset: usize` and `new_name: String`, plus
+  accessor methods.
+- `parse_rename_symbol_arguments()` function that validates `uri` (present,
+  non-empty string), `position` (parseable as `usize`), and `new_name`
+  (non-empty string) from the arguments `HashMap`. Returns
+  `Result<RenameSymbolArgs, String>`.
+- `json_value_to_string()` helper (moved from `lib.rs`).
+
+In `lib.rs`, add `mod arguments;`, replace the inline
+`parse_rename_arguments()` and `json_value_to_string()` with the new module's
+function, and remove the old implementations.
+
+Validation: `cargo check -p weaver-plugin-rope` compiles.
+
+### Stage B: Update rope plugin dispatch and failure responses
+
+In `crates/weaver-plugin-rope/src/lib.rs`:
+
+1. Add import for `ReasonCode` from `weaver_plugins`.
+2. Define `PluginFailure` struct carrying `message: String` and
+   `reason_code: Option<ReasonCode>`, with `Display` impl and constructors.
+3. Change `execute_request()` match arm from `"rename"` to
+   `"rename-symbol"`. The `Err` case for unsupported operations uses
+   `PluginFailure::with_reason(message, ReasonCode::OperationNotSupported)`.
+4. Update `execute_rename()` to use `parse_rename_symbol_arguments()` and
+   return `PluginFailure` errors with appropriate reason codes.
+5. Update `failure_response()` to accept `PluginFailure` and attach the
+   reason code to the diagnostic when present.
+6. Update `run_with_adapter()` and `read_request()` to use `PluginFailure`
+   instead of `String`.
+
+Validation: `cargo check -p weaver-plugin-rope` compiles.
+
+### Stage C: Update weaverd manifest and handler
+
+In `crates/weaverd/src/dispatch/act/refactor/mod.rs`:
+
+1. Add `use weaver_plugins::CapabilityId;` import.
+2. Add `.with_capabilities(vec![CapabilityId::RenameSymbol])` to the rope
+   manifest construction.
+3. In `handle()`, after building `plugin_args` from the extras loop:
+   - If the refactoring is `"rename"`, set the effective operation to
+     `"rename-symbol"`.
+   - Inject `uri` from `args.file` if not already present.
+   - Map `offset` to `position` if `offset` is present and `position` is not.
+4. Use the effective operation name when constructing the `PluginRequest`.
+
+Validation: `cargo check -p weaverd` compiles.
+
+### Stage D: Update rope plugin tests
+
+Update `crates/weaver-plugin-rope/src/tests/mod.rs`:
+
+1. Update `rename_arguments()` fixture: add `"uri"` key, rename `"offset"` to
+   `"position"`.
+2. Update `request_with_args()`: operation `"rename"` → `"rename-symbol"`.
+3. Update parameterised `rename_argument_validation` test cases for new
+   argument names (`position`, `uri`) and `PluginFailure` error type.
+4. Update `unsupported_operation_returns_error` for new return type.
+5. Update `rename_non_mutating_or_error_returns_failure` for new return type.
+6. Update `run_with_adapter_dispatch_layer` for new request JSON.
+7. Add test verifying `ReasonCode` on failure diagnostics.
+
+Update `crates/weaver-plugin-rope/src/tests/behaviour.rs`:
+
+1. Update `build_request()`: operation `"rename-symbol"`, add `uri` argument,
+   rename `offset` to `position`.
+2. Update `should_invoke_rename()`: check `"rename-symbol"`, `"position"`,
+   `"uri"`.
+3. Update `#[given]` step annotations to match new feature file text.
+4. Add `#[then("the failure has reason code {code}")]` step for reason code
+   assertion.
+
+Update `crates/weaver-plugin-rope/tests/features/rope_plugin.feature`:
+
+1. Rename scenarios to reference "Rename-symbol".
+2. Update step text: "offset" → "position".
+3. Add reason code assertion step to adapter failure scenario.
+
+Validation: `cargo test -p weaver-plugin-rope` passes.
+
+### Stage E: Update weaverd tests
+
+In `crates/weaverd/src/dispatch/act/refactor/tests.rs`, add a test that
+verifies the `PluginRequest` sent to the plugin uses `"rename-symbol"` as the
+operation and contains `uri`, `position`, and `new_name` in the arguments map.
+
+Validation: `cargo test -p weaverd` passes.
+
+### Stage F: Documentation and cleanup
+
+1. Update `docs/users-guide.md` in the "act refactor" section to note that
+   the handler maps `--refactoring rename` to the capability contract operation
+   `"rename-symbol"` internally. Update the parameter table to note that
+   `offset` is mapped to `position` in the plugin protocol. Add a note that the
+   rope plugin now declares the `rename-symbol` capability.
+2. Mark `docs/roadmap.md` entry 5.2.2 as done (`[x]`).
+3. Run `make fmt` to format all changed files.
+4. Run `make markdownlint` to validate Markdown.
+
+Validation: `make check-fmt && make lint && make test` all pass.
+
+## Concrete steps
+
+All commands are run from the workspace root `/home/user/project`.
+
+### Step 1: Verify baseline
+
+```sh
+set -o pipefail && make test 2>&1 | tee /tmp/test-baseline.log
+```
+
+Expected: all tests pass (29 test suites, 0 failures).
+
+### Step 2: Create arguments module
+
+Create `crates/weaver-plugin-rope/src/arguments.rs` and update `lib.rs`.
+
+```sh
+cargo check -p weaver-plugin-rope
+```
+
+Expected: compiles with no errors.
+
+### Step 3: Update dispatch and failure responses
+
+Edit `lib.rs` as described in Stage B.
+
+```sh
+cargo check -p weaver-plugin-rope
+```
+
+Expected: compiles (tests may fail until Stage D).
+
+### Step 4: Update weaverd manifest and handler
+
+Edit `crates/weaverd/src/dispatch/act/refactor/mod.rs` as described in Stage C.
+
+```sh
+cargo check -p weaverd
+```
+
+Expected: compiles.
+
+### Step 5: Update all tests
+
+Apply changes from Stages D and E.
+
+```sh
+set -o pipefail && make test 2>&1 | tee /tmp/test-after.log
+```
+
+Expected: all tests pass.
+
+### Step 6: Update documentation
+
+Apply changes from Stage F.
+
+```sh
+make fmt && make markdownlint
+```
+
+Expected: no errors.
+
+### Step 7: Final validation
+
+```sh
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/fmt.log
+set -o pipefail && make lint 2>&1 | tee /tmp/lint.log
+set -o pipefail && make test 2>&1 | tee /tmp/test-final.log
+```
+
+Expected: all three pass with zero warnings and zero failures.
+
+## Validation and acceptance
+
+Quality criteria (what "done" means):
+
+- Tests: `make test` passes. All 29 pre-existing test suites pass. New unit
+  tests verify reason codes on failure diagnostics. New BDD scenarios cover
+  rename-symbol happy path, missing arguments, adapter failure with reason
+  code, and unsupported operation.
+- Lint: `make lint` passes with zero warnings.
+- Format: `make check-fmt` passes.
+- Markdown: `make markdownlint` passes.
+
+Acceptance criteria from the roadmap:
+
+1. **Plugin advertises `rename-symbol` in capability probes.** The rope
+   manifest includes `CapabilityId::RenameSymbol`. Verified by a weaverd unit
+   test that inspects the `PluginRequest` operation name.
+2. **Request payloads conform to schema.** The rope plugin accepts
+   `"rename-symbol"` with `uri`, `position`, `new_name`. Unit tests send
+   conforming requests and receive `PluginOutput::Diff`.
+3. **Response payloads conform to schema.** Failure responses include
+   `ReasonCode` values. BDD scenario checks `reason_code` field.
+4. **Legacy provider routing is not required.** The old `"rename"` operation
+   is rejected with `ReasonCode::OperationNotSupported`. A unit test verifies
+   this.
+
+## Idempotence and recovery
+
+All stages are re-runnable. If a stage fails partway, fix the issue and re-run
+from the beginning of that stage. No destructive operations are involved. The
+new `arguments.rs` file is additive; existing files are edited in place.
+
+## Artifacts and notes
+
+### Line budget analysis
+
+Table: Line-budget projection for files modified by this plan.
+
+| File                                                    | Current | Delta                               | Projected |
+| ------------------------------------------------------- | ------- | ----------------------------------- | --------- |
+| `weaver-plugin-rope/src/lib.rs`                         | 384     | -30 (extract) +15 (new logic) = -15 | 369       |
+| `weaver-plugin-rope/src/arguments.rs`                   | 0 (new) | +70                                 | 70        |
+| `weaverd/dispatch/act/refactor/mod.rs`                  | 375     | +12                                 | 387       |
+| `weaver-plugin-rope/src/tests/mod.rs`                   | 224     | +30                                 | 254       |
+| `weaver-plugin-rope/src/tests/behaviour.rs`             | 176     | +20                                 | 196       |
+| `weaver-plugin-rope/tests/features/rope_plugin.feature` | 33      | +5                                  | 38        |
+| `weaverd/dispatch/act/refactor/tests.rs`                | 249     | +30                                 | 279       |
+
+All files remain within the 400-line limit.
+
+### Dependency analysis
+
+No new external crate dependencies are required. All types come from
+`weaver-plugins` which is already a dependency of both `weaver-plugin-rope` and
+`weaverd`.
+
+## Interfaces and dependencies
+
+### New internal types
+
+In `crates/weaver-plugin-rope/src/arguments.rs`:
+
+```rust
+/// Validated rename-symbol arguments extracted from a plugin request.
+pub(crate) struct RenameSymbolArgs {
+    offset: usize,
+    new_name: String,
+}
+
+/// Parses and validates rename-symbol arguments from the request map.
+pub(crate) fn parse_rename_symbol_arguments(
+    arguments: &HashMap<String, serde_json::Value>,
+) -> Result<RenameSymbolArgs, String>
+```
+
+In `crates/weaver-plugin-rope/src/lib.rs`:
+
+```rust
+/// Structured failure carrying an optional reason code for diagnostics.
+pub(crate) struct PluginFailure {
+    message: String,
+    reason_code: Option<ReasonCode>,
+}
+```
+
+### Modified registrations
+
+In `crates/weaverd/src/dispatch/act/refactor/mod.rs`:
+
+```rust
+let rope_manifest =
+    PluginManifest::new(rope_metadata, vec![String::from("python")], rope_executable)
+        .with_capabilities(vec![CapabilityId::RenameSymbol]);
+```
+
+### Imported types (from weaver-plugins, read-only)
+
+- `CapabilityId::RenameSymbol` — capability identifier
+- `ReasonCode` — 7-variant enum for failure diagnostics
+- `PluginDiagnostic::with_reason_code()` — builder method

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -508,7 +508,7 @@ new* *capabilities and specialist providers.*
       diagnostics. Requires 5.1.1.
   - Acceptance criteria: capability contract is versioned, broker validation
     enforces schema shape, and refusal diagnostics use stable reason codes.
-- [ ] 5.2.2. Update `weaver-plugin-rope` manifest and runtime handshake to
+- [x] 5.2.2. Update `weaver-plugin-rope` manifest and runtime handshake to
       declare and serve `rename-symbol` through the capability interface.
       Requires 5.2.1.
   - Acceptance criteria: plugin advertises `rename-symbol` in capability probes,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -551,12 +551,12 @@ weaver act refactor --provider <PLUGIN> --refactoring <OP> --file <PATH> [KEY=VA
 
 Arguments:
 
-| Flag            | Description                                                   |
-| --------------- | ------------------------------------------------------------- |
-| `--provider`    | Name of the registered plugin (e.g. `rope`, `rust-analyzer`). |
-| `--refactoring` | Refactoring operation to request (currently `rename`).        |
-| `--file`        | Path to the target file (relative to workspace root).         |
-| `KEY=VALUE`     | Extra key-value arguments forwarded to the plugin.            |
+| Flag            | Description                                                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `--provider`    | Name of the registered plugin (e.g. `rope`, `rust-analyzer`).                                                                           |
+| `--refactoring` | Refactoring operation to request (currently `rename`). The handler maps `rename` to the `rename-symbol` capability contract internally. |
+| `--file`        | Path to the target file (relative to workspace root).                                                                                   |
+| `KEY=VALUE`     | Extra key-value arguments forwarded to the plugin.                                                                                      |
 
 The plugin receives the file content in-band as part of the JSONL request and
 does not need filesystem access. The daemon validates the resulting diff
@@ -571,12 +571,12 @@ For the built-in actuators, `rename` requires `offset=<BYTE_OFFSET>` and
 The `act refactor` handler accepts the three required flags and forwards any
 additional `KEY=VALUE` pairs to the selected plugin.
 
-| Parameter       | Meaning                                                           | Valid values                                                                             | Failure conditions                                                                          |
-| --------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `--refactoring` | Refactoring operation requested from the plugin.                  | Currently only `rename` is implemented by built-in `rope` and `rust-analyzer` plugins.   | Missing value, or unsupported operation name (for example `extract_method`) causes failure. |
-| `--file`        | Target file to load and refactor.                                 | Workspace-relative path to an existing readable file (for example `src/main.py`).        | Absolute paths, parent traversal (`..`), or unreadable/missing files cause failure.         |
-| `new_name`      | New symbol name used by `rename`.                                 | Non-empty string value.                                                                  | Missing key, non-string value, or empty/whitespace-only value causes failure.               |
-| `offset`        | UTF-8 byte offset of the symbol occurrence used as rename anchor. | Non-negative integer, provided as a number or numeric string (for example `4` or `"4"`). | Missing key, non-numeric value, or negative value causes failure.                           |
+| Parameter       | Meaning                                                                                                                                                | Valid values                                                                             | Failure conditions                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `--refactoring` | Refactoring operation requested from the plugin. The handler maps `rename` to the `rename-symbol` capability contract before forwarding to the plugin. | Currently only `rename` is implemented by built-in `rope` and `rust-analyzer` plugins.   | Missing value, or unsupported operation name (for example `extract_method`) causes failure. |
+| `--file`        | Target file to load and refactor.                                                                                                                      | Workspace-relative path to an existing readable file (for example `src/main.py`).        | Absolute paths, parent traversal (`..`), or unreadable/missing files cause failure.         |
+| `new_name`      | New symbol name used by `rename`.                                                                                                                      | Non-empty string value.                                                                  | Missing key, non-string value, or empty/whitespace-only value causes failure.               |
+| `offset`        | UTF-8 byte offset of the symbol occurrence used as rename anchor. The handler maps `offset` to the contract `position` field internally.               | Non-negative integer, provided as a number or numeric string (for example `4` or `"4"`). | Missing key, non-numeric value, or negative value causes failure.                           |
 
 For `offset`, count bytes from the start of the file (`0`-based), not line and
 column pairs. This matters when multibyte UTF-8 characters appear before the
@@ -709,6 +709,7 @@ For the current actuator rollout, `weaverd` registers:
 - `rope`
   - kind: `actuator`
   - language: `python`
+  - capabilities: `rename-symbol`
   - executable: `/usr/bin/weaver-plugin-rope` (or `WEAVER_ROPE_PLUGIN_PATH`)
   - timeout: `30s`
 - `rust-analyzer`

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -588,7 +588,7 @@ Both examples follow the same execution pipeline:
 
 1. `weaverd` parses `--provider`, `--refactoring`, and `--file`.
 2. The file content is read from the workspace and sent to the plugin in-band.
-3. The plugin executes `rename` using `offset` and `new_name`.
+3. The plugin executes `rename-symbol` using `position` and `new_name`.
 4. The plugin returns a unified diff for the modified file.
 5. Weaver validates the diff via the Double-Lock safety harness (syntax then
    semantic checks).
@@ -750,7 +750,7 @@ Table: Required fields for `rename-symbol` requests.
 | Field      | Type   | Description                                      |
 | ---------- | ------ | ------------------------------------------------ |
 | `uri`      | string | File URI of the symbol to rename.                |
-| `position` | string | Position of the symbol (e.g. `10:5`).            |
+| `position` | string | Position of the symbol as a UTF-8 byte offset.   |
 | `new_name` | string | The new name for the symbol (must be non-empty). |
 
 Successful responses must contain a `Diff` output with a unified diff patch.


### PR DESCRIPTION
## Summary
- Introduces the rename-symbol capability across rope plugin and weaverd workflow; legacy rename pathway is deprecated in favor of rename-symbol.
- Adds contract-conforming request handling with stable ReasonCode diagnostics.

## Changes
### Core changes
- Added new module crates/weaver-plugin-rope/src/arguments.rs with RenameSymbolArgs and parse_rename_symbol_arguments.
- Introduced PluginFailure struct carrying a message and an optional ReasonCode, with Display impl and constructors; updated error handling and failure_response to propagate reason codes as diagnostics.
- Updated plugin request execution to accept operation "rename-symbol" and to parse arguments via parse_rename_symbol_arguments; map errors to PluginFailure with appropriate ReasonCode (IncompletePayload, SymbolNotFound, OperationNotSupported).
- Refined rope adapter invocation to pass offset via args.offset() using the new RenameSymbolArgs type.

### Refactor handshake and messaging
- In weaverd, manifest updated to include CapabilityId::RenameSymbol; the handler translates legacy "rename" to "rename-symbol", injects uri from --file, and maps offset to position.
- PluginRequest construction now uses "rename-symbol" with uri/position/new_name.

### Tests
- rope plugin tests updated to reflect new argument keys (uri, position) and operation name; added tests for incomplete payloads and reason code presence.
- Behavior tests updated; new test to verify reason codes.
- Weaverd tests updated to verify the plugin request uses rename-symbol and argument mapping; new contract conformance test added.
- Feature text updated from "Rename" to "Rename-symbol" in rope_plugin.feature.

### Documentation and roadmap
- docs/roadmap.md: 5.2.2 marked done.
- docs/users-guide.md: add note that the weaverd handler maps --refactoring rename to rename-symbol and position-mapping; rope-manifest exposes RenameSymbol capability.

## Validation plan
- Build and tests: run cargo check and cargo test across crates:
  - cargo check -p weaver-plugin-rope
  - cargo test -p weaver-plugin-rope
  - cargo test -p weaverd
  - cargo test (workspace)
- Lint/format: make check-fmt; make lint; make markdownlint (if docs touched).

## Acceptance criteria mapping
- Plugin advertises rename-symbol in capability probes: manifest updated with CapabilityId::RenameSymbol; tests inspect operation name.
- Request payloads conform to schema: rope plugin now accepts rename-symbol with uri, position, and new_name.
- Response payloads conform to schema: failure diagnostics carry stable ReasonCode values (IncompletePayload, SymbolNotFound, OperationNotSupported).
- Legacy provider routing retired: old operation name "rename" is rejected with OperationNotSupported; tests verify this behavior.
- Weaverd maps user-facing CLI to contract: --refactoring rename maps to rename-symbol; offset -> position mapping is performed in handler.

## Quick notes
- The changes are structured to preserve a 400-line budget by extracting argument parsing into a new arguments module and by centralizing failure diagnostics through PluginFailure.
- All updated tests exercise reason codes and contract-conformance behavior to ensure robust error reporting.


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/c3aa7b37-2ae5-4c67-a142-80785dc9c47b

## Summary by Sourcery

Adopt the new rename-symbol capability end-to-end for the rope plugin and weaverd refactor handler, including contract-conforming arguments, capability metadata, and reason-coded diagnostics, while updating tests and documentation accordingly.

New Features:
- Add rename-symbol argument parsing module for the rope plugin and switch the plugin operation from rename to rename-symbol with contract-conforming uri/position/new_name arguments.
- Expose the rope actuator’s rename-symbol capability via the weaverd plugin manifest and translate CLI rename requests to the rename-symbol contract in the daemon handler.

Bug Fixes:
- Return structured failure diagnostics from the rope plugin with stable ReasonCode values for unsupported operations, incomplete payloads, and symbol-not-found scenarios.

Enhancements:
- Introduce a PluginFailure error type in the rope plugin to carry messages and optional reason codes through the request/response pipeline.
- Improve weaverd refactor tests to capture and assert on the exact PluginRequest sent to the runtime for contract conformance.
- Tidy several markdown documents for formatting consistency and clarity.

Documentation:
- Document the mapping from --refactoring rename and offset arguments to the rename-symbol capability and position field in the user guide, and mark roadmap item 5.2.2 as complete.
- Add an execution plan documenting the design, risks, and validation steps for updating the rope plugin manifest and handshake to use rename-symbol.