### PR TITLE
Declare rename-symbol capability for rust-analyzer plugin

### DIFF
--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -41,7 +41,7 @@ use localizer::{build_localizer, write_bare_help};
 pub use output::{OutputContext, ResolvedOutputFormat, render_human_output};
 use runtime_utils::emit_capabilities;
 pub(crate) use runtime_utils::exit_code_from_status;
-use transport::connect;
+use transport::{connect, connect_with_retry};
 /// CLI flags recognised by the configuration loader.
 ///
 /// MAINTENANCE: This list must be kept in sync with the configuration flags
@@ -294,8 +294,11 @@ where
                 let _ = writeln!(io.stderr, "{start_error}");
                 return ExitCode::FAILURE;
             }
-            // Retry connection after daemon started successfully.
-            match connect(context.config.daemon_socket()) {
+            // Retry briefly after daemon startup to tolerate socket-bind lag.
+            match connect_with_retry(
+                context.config.daemon_socket(),
+                transport::CONNECTION_TIMEOUT,
+            ) {
                 Ok(connection) => connection,
                 Err(retry_error) => {
                     let _ = writeln!(io.stderr, "{retry_error}");

--- a/crates/weaver-cli/src/tests/unit/auto_start.rs
+++ b/crates/weaver-cli/src/tests/unit/auto_start.rs
@@ -92,44 +92,20 @@ fn write_health_snapshot(path: &std::path::Path, status: &str, pid: u32, timesta
     fs::write(path, json).expect("write health snapshot");
 }
 
-/// Success path: daemon starts, becomes ready, and CLI proceeds with command.
+/// Binds a Unix socket shortly after the test starts so the first connect fails
+/// but the retry succeeds once auto-start wait handling completes.
 ///
-/// This test exercises the complete auto-start success flow:
-/// 1. Initial connection fails (Unix socket not yet bound)
-/// 2. CLI spawns daemon binary (/bin/true exits immediately, simulating daemonization)
-/// 3. Health snapshot indicates ready status (pre-written with recent timestamp)
-/// 4. CLI retries connection to the now-listening socket
-/// 5. Daemon responds with valid messages
+/// The 100 ms delay is longer than the initial connection attempt but shorter
+/// than `AUTO_START_TIMEOUT`. The CLI's probe path takes much longer to fail,
+/// so the socket bind reliably happens before the retry without needing precise
+/// cross-thread synchronisation.
 #[cfg(unix)]
-#[test]
-fn auto_start_succeeds_and_proceeds() {
-    let dir = TempDir::new().expect("tempdir");
-    let socket_path = dir.path().join("daemon.sock");
-    let health_path = dir.path().join("weaverd.health");
-    let socket_str = socket_path.to_string_lossy().into_owned();
-
-    // Pre-write health snapshot with ready status and recent timestamp.
-    // The PID check is skipped when daemonized=true (child exits with 0).
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time")
-        .as_secs();
-    write_health_snapshot(&health_path, "ready", 12345, timestamp);
-
-    // Spawn a thread that binds the Unix socket after a brief delay.
-    // This ensures the initial connect fails (triggering auto-start) but the
-    // retry succeeds after wait_for_ready completes.
-    //
-    // Timing coordination: The 100ms delay is chosen to be longer than the
-    // initial connection attempt but shorter than AUTO_START_TIMEOUT. The CLI's
-    // connection attempt takes ~5 seconds (SOCKET_PROBE_TIMEOUT) before failing,
-    // so the socket bind reliably happens before the CLI retries. This is not a
-    // precise synchronisation mechanism, but the wide timing margins make it
-    // robust under typical test loads.
-    let socket_path_for_thread = socket_path.clone();
-    let listener_handle = thread::spawn(move || -> Result<(), String> {
+fn spawn_delayed_unix_listener(
+    socket_path: std::path::PathBuf,
+) -> thread::JoinHandle<Result<(), String>> {
+    thread::spawn(move || -> Result<(), String> {
         thread::sleep(Duration::from_millis(100));
-        let listener = UnixListener::bind(&socket_path_for_thread)
+        let listener = UnixListener::bind(&socket_path)
             .map_err(|error| format!("bind unix socket: {error}"))?;
         listener
             .set_nonblocking(true)
@@ -159,7 +135,62 @@ fn auto_start_succeeds_and_proceeds() {
                 Err(error) => return Err(format!("accept connection: {error}")),
             }
         }
-    });
+    })
+}
+
+#[cfg(unix)]
+fn assert_auto_start_success(exit: ExitCode, stderr_text: &str, stdout_text: &str) {
+    assert_eq!(
+        exit,
+        ExitCode::from(17),
+        "expected exit code 17, got {exit:?}; stderr: {stderr_text:?}"
+    );
+    assert!(
+        stderr_text.contains("Waiting for daemon start..."),
+        "auto-start should write waiting message: {stderr_text:?}"
+    );
+    assert!(
+        !stderr_text.contains("failed to spawn"),
+        "should not contain spawn failure: {stderr_text:?}"
+    );
+    assert!(
+        !stderr_text.contains("exited before"),
+        "should not contain startup failure: {stderr_text:?}"
+    );
+    assert!(
+        stdout_text.contains("daemon says hello"),
+        "should receive daemon stdout: {stdout_text:?}"
+    );
+}
+
+/// Success path: daemon starts, becomes ready, and CLI proceeds with command.
+///
+/// This test exercises the complete auto-start success flow:
+/// 1. Initial connection fails (Unix socket not yet bound)
+/// 2. CLI spawns daemon binary (/bin/true exits immediately, simulating daemonization)
+/// 3. Health snapshot indicates ready status (pre-written with recent timestamp)
+/// 4. CLI retries connection to the now-listening socket
+/// 5. Daemon responds with valid messages
+#[cfg(unix)]
+#[test]
+fn auto_start_succeeds_and_proceeds() {
+    let dir = TempDir::new().expect("tempdir");
+    let socket_path = dir.path().join("daemon.sock");
+    let health_path = dir.path().join("weaverd.health");
+    let socket_str = socket_path.to_string_lossy().into_owned();
+
+    // Pre-write health snapshot with ready status and recent timestamp.
+    // The PID check is skipped when daemonized=true (child exits with 0).
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    write_health_snapshot(&health_path, "ready", 12345, timestamp);
+
+    // Bind the socket on a short delay so the first connect fails and the retry
+    // succeeds once auto-start wait handling completes. See
+    // `spawn_delayed_unix_listener` for the timing rationale.
+    let listener_handle = spawn_delayed_unix_listener(socket_path);
 
     let config = Config {
         daemon_socket: SocketEndpoint::unix(socket_str),
@@ -186,29 +217,7 @@ fn auto_start_succeeds_and_proceeds() {
     let stderr_text = decode_utf8(stderr, "stderr").expect("stderr utf8");
     let stdout_text = decode_utf8(stdout, "stdout").expect("stdout utf8");
 
-    // Daemon responded with exit code 17 (from default_daemon_lines).
-    assert_eq!(
-        exit,
-        ExitCode::from(17),
-        "expected exit code 17, got {exit:?}; stderr: {stderr_text:?}"
-    );
-    assert!(
-        stderr_text.contains("Waiting for daemon start..."),
-        "auto-start should write waiting message: {stderr_text:?}"
-    );
-    assert!(
-        !stderr_text.contains("failed to spawn"),
-        "should not contain spawn failure: {stderr_text:?}"
-    );
-    assert!(
-        !stderr_text.contains("exited before"),
-        "should not contain startup failure: {stderr_text:?}"
-    );
-    // Verify daemon output was received.
-    assert!(
-        stdout_text.contains("daemon says hello"),
-        "should receive daemon stdout: {stdout_text:?}"
-    );
+    assert_auto_start_success(exit, &stderr_text, &stdout_text);
 }
 
 /// Timeout path: daemon spawns but never becomes ready within AUTO_START_TIMEOUT.

--- a/crates/weaver-cli/src/tests/unit/auto_start.rs
+++ b/crates/weaver-cli/src/tests/unit/auto_start.rs
@@ -19,7 +19,7 @@ use std::os::unix::net::UnixListener;
 #[cfg(unix)]
 use std::thread;
 #[cfg(unix)]
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 #[cfg(unix)]
 use tempfile::TempDir;
 
@@ -127,11 +127,38 @@ fn auto_start_succeeds_and_proceeds() {
     // precise synchronisation mechanism, but the wide timing margins make it
     // robust under typical test loads.
     let socket_path_for_thread = socket_path.clone();
-    let listener_handle = thread::spawn(move || {
+    let listener_handle = thread::spawn(move || -> Result<(), String> {
         thread::sleep(Duration::from_millis(100));
-        let listener = UnixListener::bind(&socket_path_for_thread).expect("bind unix socket");
-        let (stream, _) = listener.accept().expect("accept connection");
-        respond_to_request(stream, &default_daemon_lines()).expect("respond to request");
+        let listener = UnixListener::bind(&socket_path_for_thread)
+            .map_err(|error| format!("bind unix socket: {error}"))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| format!("set nonblocking: {error}"))?;
+        let deadline = Instant::now()
+            .checked_add(Duration::from_secs(5))
+            .ok_or_else(|| String::from("listener deadline overflow"))?;
+
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    respond_to_request(stream, &default_daemon_lines())
+                        .map_err(|error| format!("respond to request: {error}"))?;
+                    return Ok(());
+                }
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+                        && Instant::now() < deadline =>
+                {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    return Err(String::from(
+                        "timed out waiting for CLI retry connection on Unix socket",
+                    ));
+                }
+                Err(error) => return Err(format!("accept connection: {error}")),
+            }
+        }
     });
 
     let config = Config {
@@ -152,7 +179,10 @@ fn auto_start_succeeds_and_proceeds() {
 
     let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
 
-    listener_handle.join().expect("listener thread");
+    listener_handle
+        .join()
+        .expect("listener thread")
+        .expect("listener should accept connection");
     let stderr_text = decode_utf8(stderr, "stderr").expect("stderr utf8");
     let stdout_text = decode_utf8(stdout, "stdout").expect("stdout utf8");
 

--- a/crates/weaver-cli/src/transport.rs
+++ b/crates/weaver-cli/src/transport.rs
@@ -6,7 +6,9 @@
 
 use std::io::{self, Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::thread;
 use std::time::Duration;
+use std::time::Instant;
 
 use weaver_config::SocketEndpoint;
 
@@ -19,9 +21,10 @@ use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
 #[cfg(unix)]
 use socket2::{Domain, SockAddr, Socket, Type};
 
-use super::AppError;
+use super::{AppError, is_daemon_not_running};
 
 pub(super) const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+const RETRY_INTERVAL: Duration = Duration::from_millis(25);
 
 pub(super) enum Connection {
     Tcp(TcpStream),
@@ -86,6 +89,28 @@ pub(super) fn connect(endpoint: &SocketEndpoint) -> Result<Connection, AppError>
             {
                 Err(AppError::UnsupportedUnixTransport(endpoint.to_string()))
             }
+        }
+    }
+}
+
+pub(super) fn connect_with_retry(
+    endpoint: &SocketEndpoint,
+    retry_window: Duration,
+) -> Result<Connection, AppError> {
+    let deadline = Instant::now().checked_add(retry_window);
+    loop {
+        match connect(endpoint) {
+            Ok(connection) => return Ok(connection),
+            Err(error)
+                if is_daemon_not_running(&error)
+                    && deadline.is_some_and(|limit| Instant::now() < limit) =>
+            {
+                let sleep_duration = deadline
+                    .and_then(|limit| limit.checked_duration_since(Instant::now()))
+                    .map_or(RETRY_INTERVAL, |remaining| remaining.min(RETRY_INTERVAL));
+                thread::sleep(sleep_duration);
+            }
+            Err(error) => return Err(error),
         }
     }
 }

--- a/crates/weaver-plugin-rust-analyzer/src/arguments.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/arguments.rs
@@ -1,0 +1,94 @@
+//! Argument parsing for `rename-symbol` plugin requests.
+//!
+//! Validates and extracts the `uri`, `position`, and `new_name` fields from a
+//! rename-symbol plugin request.
+
+use std::collections::HashMap;
+
+/// Validated rename-symbol arguments extracted from a plugin request.
+pub(crate) struct RenameSymbolArgs {
+    uri: String,
+    offset: usize,
+    new_name: String,
+}
+
+impl RenameSymbolArgs {
+    /// Returns the request URI.
+    pub(crate) fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    /// Returns the byte offset parsed from the `position` field.
+    pub(crate) const fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the new symbol name.
+    pub(crate) fn new_name(&self) -> &str {
+        &self.new_name
+    }
+}
+
+/// Parses and validates rename-symbol arguments from the request map.
+///
+/// # Errors
+///
+/// Returns a human-readable error message if any required field is missing,
+/// has the wrong type, or is empty.
+pub(crate) fn parse_rename_symbol_arguments(
+    arguments: &HashMap<String, serde_json::Value>,
+) -> Result<RenameSymbolArgs, String> {
+    let uri = parse_uri(arguments)?;
+    let offset = parse_position(arguments)?;
+    let new_name = parse_new_name(arguments)?;
+    Ok(RenameSymbolArgs {
+        uri,
+        offset,
+        new_name,
+    })
+}
+
+fn parse_uri(arguments: &HashMap<String, serde_json::Value>) -> Result<String, String> {
+    let uri_value = arguments
+        .get("uri")
+        .ok_or_else(|| String::from("rename-symbol operation requires 'uri' argument"))?;
+    let uri = uri_value
+        .as_str()
+        .ok_or_else(|| String::from("uri argument must be a string"))?;
+    if uri.trim().is_empty() {
+        return Err(String::from("uri argument must not be empty"));
+    }
+    Ok(String::from(uri))
+}
+
+fn parse_position(arguments: &HashMap<String, serde_json::Value>) -> Result<usize, String> {
+    let position_value = arguments
+        .get("position")
+        .ok_or_else(|| String::from("rename-symbol operation requires 'position' argument"))?;
+    let position_string = json_value_to_string(position_value)
+        .ok_or_else(|| String::from("position argument must be a string or number"))?;
+    position_string
+        .parse::<usize>()
+        .map_err(|error| format!("position must be a non-negative integer: {error}"))
+}
+
+fn parse_new_name(arguments: &HashMap<String, serde_json::Value>) -> Result<String, String> {
+    let new_name_value = arguments
+        .get("new_name")
+        .ok_or_else(|| String::from("rename-symbol operation requires 'new_name' argument"))?;
+    let new_name = new_name_value
+        .as_str()
+        .ok_or_else(|| String::from("new_name argument must be a string"))?;
+    if new_name.trim().is_empty() {
+        return Err(String::from("new_name argument must not be empty"));
+    }
+    Ok(String::from(new_name))
+}
+
+fn json_value_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => Some(text.to_owned()),
+        serde_json::Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}

--- a/crates/weaver-plugin-rust-analyzer/src/lib.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lib.rs
@@ -4,19 +4,24 @@
 //! `weaver-plugins`. The plugin reads exactly one JSONL request from stdin,
 //! executes a refactoring operation, and writes one JSONL response to stdout.
 
+mod arguments;
+
 #[cfg(test)]
 mod tests;
 
 mod lsp;
 
-use std::collections::HashMap;
+use std::fmt;
 use std::io::{BufRead, Write};
 use std::path::{Component, Path, PathBuf};
 
 use thiserror::Error;
+use weaver_plugins::capability::ReasonCode;
 use weaver_plugins::protocol::{
     DiagnosticSeverity, FilePayload, PluginDiagnostic, PluginOutput, PluginRequest, PluginResponse,
 };
+
+use crate::arguments::parse_rename_symbol_arguments;
 
 pub use lsp::RustAnalyzerLspAdapter;
 
@@ -70,6 +75,50 @@ pub enum PluginDispatchError {
         #[source]
         source: serde_json::Error,
     },
+}
+
+/// Structured failure carrying an optional reason code for diagnostics.
+#[derive(Debug)]
+pub(crate) struct PluginFailure {
+    message: String,
+    reason_code: Option<ReasonCode>,
+}
+
+impl PluginFailure {
+    /// Creates a failure without a reason code.
+    pub(crate) fn plain(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            reason_code: None,
+        }
+    }
+
+    /// Creates a failure with a stable reason code.
+    pub(crate) fn with_reason(message: impl Into<String>, reason: ReasonCode) -> Self {
+        Self {
+            message: message.into(),
+            reason_code: Some(reason),
+        }
+    }
+}
+
+#[cfg(test)]
+impl PluginFailure {
+    /// Returns the failure message.
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the failure reason code, if present.
+    pub(crate) const fn reason_code(&self) -> Option<ReasonCode> {
+        self.reason_code
+    }
+}
+
+impl fmt::Display for PluginFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
 }
 
 /// Errors raised by rust-analyzer adapter implementations.
@@ -137,7 +186,7 @@ pub fn run_with_adapter<R: RustAnalyzerAdapter>(
     let response = match read_request(stdin).and_then(|request| execute_request(adapter, &request))
     {
         Ok(resp) => resp,
-        Err(message) => failure_response(message),
+        Err(failure) => failure_response(failure),
     };
 
     let payload = serde_json::to_string(&response)
@@ -162,95 +211,91 @@ pub fn run(stdin: &mut impl BufRead, stdout: &mut impl Write) -> Result<(), Plug
     run_with_adapter(stdin, stdout, &RustAnalyzerLspAdapter)
 }
 
-fn read_request(stdin: &mut impl BufRead) -> Result<PluginRequest, String> {
+fn read_request(stdin: &mut impl BufRead) -> Result<PluginRequest, PluginFailure> {
     let mut line = String::new();
     let bytes_read = stdin
         .read_line(&mut line)
-        .map_err(|error| format!("failed to read request: {error}"))?;
+        .map_err(|error| PluginFailure::plain(format!("failed to read request: {error}")))?;
 
     if bytes_read == 0 {
-        return Err(String::from("plugin request was empty"));
+        return Err(PluginFailure::plain("plugin request was empty"));
     }
 
     serde_json::from_str(line.trim())
-        .map_err(|error| format!("invalid plugin request JSON: {error}"))
+        .map_err(|error| PluginFailure::plain(format!("invalid plugin request JSON: {error}")))
 }
 
 fn execute_request<R: RustAnalyzerAdapter>(
     adapter: &R,
     request: &PluginRequest,
-) -> Result<PluginResponse, String> {
+) -> Result<PluginResponse, PluginFailure> {
     match request.operation() {
-        "rename" => execute_rename(adapter, request),
-        other => Err(format!("unsupported refactoring operation '{other}'")),
+        "rename-symbol" => execute_rename(adapter, request),
+        other => Err(PluginFailure::with_reason(
+            format!("unsupported refactoring operation '{other}'"),
+            ReasonCode::OperationNotSupported,
+        )),
     }
 }
 
 fn execute_rename<R: RustAnalyzerAdapter>(
     adapter: &R,
     request: &PluginRequest,
-) -> Result<PluginResponse, String> {
-    let (offset, new_name) = parse_rename_arguments(request.arguments())?;
+) -> Result<PluginResponse, PluginFailure> {
+    let arguments = parse_rename_symbol_arguments(request.arguments())
+        .map_err(|message| PluginFailure::with_reason(message, ReasonCode::IncompletePayload))?;
 
     let files = request.files();
     let file = match files {
         [single] => single,
         other => {
-            return Err(format!(
-                "rename operation requires exactly one file payload, got {}",
-                other.len()
+            return Err(PluginFailure::with_reason(
+                format!(
+                    "rename-symbol operation requires exactly one file payload, got {}",
+                    other.len()
+                ),
+                ReasonCode::IncompletePayload,
             ));
         }
     };
 
-    validate_relative_path(file.path()).map_err(|error| error.to_string())?;
+    validate_relative_path(file.path()).map_err(|error| {
+        PluginFailure::with_reason(error.to_string(), ReasonCode::IncompletePayload)
+    })?;
+
+    let request_path = path_to_slash(file.path());
+    if arguments.uri() != request_path {
+        return Err(PluginFailure::with_reason(
+            format!(
+                "uri argument '{}' does not match file payload '{}'",
+                arguments.uri(),
+                request_path,
+            ),
+            ReasonCode::IncompletePayload,
+        ));
+    }
 
     let modified = adapter
-        .rename(file, offset, &new_name)
-        .map_err(|error| error.to_string())?;
+        .rename(
+            file,
+            ByteOffset::new(arguments.offset()),
+            arguments.new_name(),
+        )
+        .map_err(|error| {
+            PluginFailure::with_reason(error.to_string(), ReasonCode::SymbolNotFound)
+        })?;
 
     if modified == file.content() {
-        return Err(String::from("rename operation produced no content changes"));
+        return Err(PluginFailure::with_reason(
+            "rename-symbol operation produced no content changes",
+            ReasonCode::SymbolNotFound,
+        ));
     }
 
     let patch = build_search_replace_patch(file.path(), file.content(), &modified);
     Ok(PluginResponse::success(PluginOutput::Diff {
         content: patch,
     }))
-}
-
-fn parse_rename_arguments(
-    arguments: &HashMap<String, serde_json::Value>,
-) -> Result<(ByteOffset, String), String> {
-    let offset_value = arguments
-        .get("offset")
-        .ok_or_else(|| String::from("rename operation requires 'offset' argument"))?;
-    let new_name_value = arguments
-        .get("new_name")
-        .ok_or_else(|| String::from("rename operation requires 'new_name' argument"))?;
-
-    let offset_string = json_value_to_string(offset_value)
-        .ok_or_else(|| String::from("offset argument must be a string or number"))?;
-    let offset = offset_string
-        .parse::<usize>()
-        .map_err(|error| format!("offset must be a non-negative integer: {error}"))?;
-
-    let new_name = new_name_value
-        .as_str()
-        .ok_or_else(|| String::from("new_name argument must be a string"))?;
-    if new_name.trim().is_empty() {
-        return Err(String::from("new_name argument must not be empty"));
-    }
-
-    Ok((ByteOffset::new(offset), String::from(new_name)))
-}
-
-fn json_value_to_string(value: &serde_json::Value) -> Option<String> {
-    match value {
-        serde_json::Value::String(text) => Some(text.to_owned()),
-        serde_json::Value::Number(number) => Some(number.to_string()),
-        _ => None,
-    }
 }
 
 pub(crate) fn write_workspace_file(
@@ -350,9 +395,10 @@ fn path_to_slash(path: &Path) -> String {
         .join("/")
 }
 
-pub(crate) fn failure_response(message: String) -> PluginResponse {
-    PluginResponse::failure(vec![PluginDiagnostic::new(
-        DiagnosticSeverity::Error,
-        message,
-    )])
+pub(crate) fn failure_response(failure: PluginFailure) -> PluginResponse {
+    let mut diagnostic = PluginDiagnostic::new(DiagnosticSeverity::Error, failure.message);
+    if let Some(reason_code) = failure.reason_code {
+        diagnostic = diagnostic.with_reason_code(reason_code);
+    }
+    PluginResponse::failure(vec![diagnostic])
 }

--- a/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use mockall::mock;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
+use weaver_plugins::capability::ReasonCode;
 use weaver_plugins::protocol::{
     DiagnosticSeverity, FilePayload, PluginOutput, PluginRequest, PluginResponse,
 };
@@ -17,7 +18,7 @@ use crate::{
 #[derive(Default)]
 struct World {
     request: Option<PluginRequest>,
-    execute_result: Option<Result<PluginResponse, String>>,
+    execute_result: Option<Result<PluginResponse, crate::PluginFailure>>,
     adapter_mode: AdapterMode,
 }
 
@@ -47,9 +48,10 @@ mock! {
 }
 
 fn should_invoke_rename(request: &PluginRequest) -> bool {
-    request.operation() == "rename"
+    request.operation() == "rename-symbol"
         && !request.files().is_empty()
-        && request.arguments().contains_key("offset")
+        && request.arguments().contains_key("uri")
+        && request.arguments().contains_key("position")
         && request.arguments().contains_key("new_name")
 }
 
@@ -65,11 +67,22 @@ fn configure_adapter_for_mode(adapter: &mut MockBehaviourAdapter, mode: AdapterM
     );
 }
 
-fn build_request(operation: &str, with_offset: bool, with_new_name: bool) -> PluginRequest {
+fn build_request(
+    operation: &str,
+    with_uri: bool,
+    with_position: bool,
+    with_new_name: bool,
+) -> PluginRequest {
     let mut arguments = HashMap::new();
-    if with_offset {
+    if with_uri {
         arguments.insert(
-            String::from("offset"),
+            String::from("uri"),
+            serde_json::Value::String(String::from("src/main.rs")),
+        );
+    }
+    if with_position {
+        arguments.insert(
+            String::from("position"),
             serde_json::Value::String(String::from("3")),
         );
     }
@@ -90,19 +103,24 @@ fn build_request(operation: &str, with_offset: bool, with_new_name: bool) -> Plu
     )
 }
 
-#[given("a rename request with required arguments")]
+#[given("a rename-symbol request with required arguments")]
 fn given_valid_rename(world: &mut World) {
-    world.request = Some(build_request("rename", true, true));
+    world.request = Some(build_request("rename-symbol", true, true, true));
 }
 
-#[given("a rename request missing offset")]
-fn given_missing_offset(world: &mut World) {
-    world.request = Some(build_request("rename", false, true));
+#[given("a rename-symbol request missing position")]
+fn given_missing_position(world: &mut World) {
+    world.request = Some(build_request("rename-symbol", true, false, true));
+}
+
+#[given("a rename-symbol request missing uri")]
+fn given_missing_uri(world: &mut World) {
+    world.request = Some(build_request("rename-symbol", false, true, true));
 }
 
 #[given("an unsupported extract method request")]
 fn given_unsupported_operation(world: &mut World) {
-    world.request = Some(build_request("extract_method", true, true));
+    world.request = Some(build_request("extract_method", true, true, true));
 }
 
 #[given("a rust analyzer adapter that fails")]
@@ -134,7 +152,12 @@ fn resolved_response(world: &World) -> PluginResponse {
         .expect("execute result should be present")
     {
         Ok(resp) => resp.clone(),
-        Err(msg) => failure_response(msg.clone()),
+        Err(failure) => failure_response(crate::PluginFailure::with_reason(
+            failure.message().to_owned(),
+            failure
+                .reason_code()
+                .expect("behaviour failures should carry a reason code"),
+        )),
     }
 }
 
@@ -168,6 +191,24 @@ fn then_failure_contains(world: &mut World, text: String) {
             .iter()
             .any(|diagnostic| diagnostic.message().contains(needle)),
         "expected diagnostics to contain '{needle}', got: {diagnostics:?}",
+    );
+}
+
+#[then("the failure reason code is {text}")]
+fn then_failure_reason_code(world: &mut World, text: String) {
+    let expected = match text.trim_matches('"') {
+        "incomplete_payload" => ReasonCode::IncompletePayload,
+        "operation_not_supported" => ReasonCode::OperationNotSupported,
+        other => panic!("unsupported reason code in feature: {other}"),
+    };
+    let response = resolved_response(world);
+    assert!(
+        response
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.reason_code() == Some(expected)),
+        "expected reason code {expected:?}, got: {:?}",
+        response.diagnostics(),
     );
 }
 

--- a/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use mockall::mock;
 use rstest::{fixture, rstest};
+use weaver_plugins::capability::ReasonCode;
 use weaver_plugins::protocol::{
     DiagnosticSeverity, FilePayload, PluginOutput, PluginRequest, PluginResponse,
 };
@@ -46,7 +47,11 @@ fn adapter_unused() -> MockAdapter {
 fn rename_arguments() -> HashMap<String, serde_json::Value> {
     let mut arguments = HashMap::new();
     arguments.insert(
-        String::from("offset"),
+        String::from("uri"),
+        serde_json::Value::String(String::from("src/main.rs")),
+    );
+    arguments.insert(
+        String::from("position"),
         serde_json::Value::String(String::from("3")),
     );
     arguments.insert(
@@ -58,7 +63,7 @@ fn rename_arguments() -> HashMap<String, serde_json::Value> {
 
 fn request_with_args(arguments: HashMap<String, serde_json::Value>) -> PluginRequest {
     PluginRequest::with_arguments(
-        "rename",
+        "rename-symbol",
         vec![FilePayload::new(
             PathBuf::from("src/main.rs"),
             "fn old_name() -> i32 {\n    1\n}\n",
@@ -77,24 +82,42 @@ fn rename_success_returns_diff_output(rename_arguments: HashMap<String, serde_js
     assert!(matches!(response.output(), PluginOutput::Diff { .. }));
 }
 
-fn remove_offset(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.remove("offset");
+fn remove_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("uri");
 }
 
-fn set_boolean_offset(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(String::from("offset"), serde_json::Value::Bool(true));
-}
-
-fn set_negative_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+fn set_empty_uri(arguments: &mut HashMap<String, serde_json::Value>) {
     arguments.insert(
-        String::from("offset"),
+        String::from("uri"),
+        serde_json::Value::String(String::from("  ")),
+    );
+}
+
+fn set_numeric_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("uri"),
+        serde_json::Value::Number(serde_json::Number::from(4)),
+    );
+}
+
+fn remove_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("position");
+}
+
+fn set_boolean_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(String::from("position"), serde_json::Value::Bool(true));
+}
+
+fn set_negative_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("position"),
         serde_json::Value::String(String::from("-1")),
     );
 }
 
-fn set_numeric_offset(arguments: &mut HashMap<String, serde_json::Value>) {
+fn set_numeric_position(arguments: &mut HashMap<String, serde_json::Value>) {
     arguments.insert(
-        String::from("offset"),
+        String::from("position"),
         serde_json::Value::Number(serde_json::Number::from(3)),
     );
 }
@@ -114,10 +137,13 @@ fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
 }
 
 #[rstest]
-#[case::missing_offset(remove_offset as fn(&mut _), Some("offset"))]
-#[case::boolean_offset(set_boolean_offset as fn(&mut _), Some("offset"))]
-#[case::negative_offset(set_negative_offset as fn(&mut _), Some("non-negative integer"))]
-#[case::numeric_offset_succeeds(set_numeric_offset as fn(&mut _), None)]
+#[case::missing_uri(remove_uri as fn(&mut _), Some("uri"))]
+#[case::empty_uri(set_empty_uri as fn(&mut _), Some("uri"))]
+#[case::numeric_uri(set_numeric_uri as fn(&mut _), Some("uri argument must be a string"))]
+#[case::missing_position(remove_position as fn(&mut _), Some("position"))]
+#[case::boolean_position(set_boolean_position as fn(&mut _), Some("position"))]
+#[case::negative_position(set_negative_position as fn(&mut _), Some("non-negative integer"))]
+#[case::numeric_position_succeeds(set_numeric_position as fn(&mut _), None)]
 #[case::numeric_new_name(set_numeric_new_name as fn(&mut _), Some("new_name argument must be a string"))]
 #[case::empty_new_name(set_empty_new_name as fn(&mut _), Some("new_name"))]
 fn rename_argument_validation(
@@ -132,9 +158,10 @@ fn rename_argument_validation(
         let err = execute_request(&adapter, &request_with_args(rename_arguments))
             .expect_err("invalid arguments should fail");
         assert!(
-            err.contains(needle),
+            err.message().contains(needle),
             "expected error mentioning '{needle}', got: {err}"
         );
+        assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
     } else {
         let adapter = adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")));
         let response = execute_request(&adapter, &request_with_args(rename_arguments))
@@ -150,29 +177,39 @@ fn unsupported_operation_returns_error() {
 
     let err = execute_request(&adapter, &request).expect_err("unsupported operation should fail");
     assert!(
-        err.contains("unsupported"),
+        err.message().contains("unsupported"),
         "expected error mentioning 'unsupported', got: {err}"
     );
+    assert_eq!(err.reason_code(), Some(ReasonCode::OperationNotSupported));
 }
 
 enum FailureScenario {
     NoChange,
     AdapterError,
+    UriMismatch,
 }
 
 #[rstest]
 #[case::no_change(FailureScenario::NoChange)]
 #[case::adapter_error(FailureScenario::AdapterError)]
+#[case::uri_mismatch(FailureScenario::UriMismatch)]
 fn rename_non_mutating_or_error_returns_failure(
     #[case] scenario: FailureScenario,
-    rename_arguments: HashMap<String, serde_json::Value>,
+    mut rename_arguments: HashMap<String, serde_json::Value>,
 ) {
+    if matches!(scenario, FailureScenario::UriMismatch) {
+        rename_arguments.insert(
+            String::from("uri"),
+            serde_json::Value::String(String::from("src/other.rs")),
+        );
+    }
     let adapter = match &scenario {
         FailureScenario::AdapterError => {
             adapter_returning(Err(RustAnalyzerAdapterError::EngineFailed {
                 message: String::from("rust-analyzer adapter failed"),
             }))
         }
+        FailureScenario::UriMismatch => adapter_unused(),
         FailureScenario::NoChange => {
             adapter_returning(Ok(String::from("fn old_name() -> i32 {\n    1\n}\n")))
         }
@@ -183,12 +220,16 @@ fn rename_non_mutating_or_error_returns_failure(
 
     match scenario {
         FailureScenario::NoChange => assert!(
-            err.contains("no content changes"),
+            err.message().contains("no content changes"),
             "expected no-change diagnostic, got: {err}"
         ),
         FailureScenario::AdapterError => assert!(
-            err.contains("rust-analyzer adapter failed"),
+            err.message().contains("rust-analyzer adapter failed"),
             "expected adapter error message, got: {err}"
+        ),
+        FailureScenario::UriMismatch => assert!(
+            err.message().contains("does not match file payload"),
+            "expected uri mismatch diagnostic, got: {err}"
         ),
     }
 }
@@ -254,9 +295,43 @@ fn run_with_adapter_dispatch_layer(
     }
 }
 
+#[rstest]
+#[case::missing_position(
+    {
+        let mut arguments = rename_arguments();
+        arguments.remove("position");
+        request_with_args(arguments)
+    },
+    ReasonCode::IncompletePayload
+)]
+#[case::unsupported_operation(
+    PluginRequest::new("extract_method", Vec::new()),
+    ReasonCode::OperationNotSupported
+)]
+fn failure_responses_include_reason_codes(
+    #[case] request: PluginRequest,
+    #[case] expected_reason: ReasonCode,
+) {
+    let input = format!(
+        "{}\n",
+        serde_json::to_string(&request).expect("serialize request")
+    );
+    let response = dispatch_stdin(input.as_bytes(), &adapter_unused());
+
+    assert!(!response.is_success());
+    assert!(
+        response
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.reason_code() == Some(expected_reason)),
+        "expected reason code {expected_reason:?}, got: {:?}",
+        response.diagnostics(),
+    );
+}
+
 fn request_with_path(path: &str) -> PluginRequest {
     PluginRequest::with_arguments(
-        "rename",
+        "rename-symbol",
         vec![FilePayload::new(
             PathBuf::from(path),
             "fn old_name() -> i32 {\n    1\n}\n",
@@ -273,7 +348,10 @@ fn rename_rejects_empty_or_curdir_path(#[case] path: &str) {
     let error = execute_request(&adapter, &request_with_path(path))
         .expect_err("invalid path should fail before adapter invocation");
     assert!(
-        error.contains("path must not be empty or only '.'"),
+        error
+            .message()
+            .contains("path must not be empty or only '.'"),
         "expected empty-path error, got: {error}",
     );
+    assert_eq!(error.reason_code(), Some(ReasonCode::IncompletePayload));
 }

--- a/crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature
+++ b/crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature
@@ -1,31 +1,40 @@
 Feature: rust-analyzer actuator plugin
 
-  Scenario: Rename succeeds with diff output
-    Given a rename request with required arguments
+  Scenario: rename-symbol succeeds with diff output
+    Given a rename-symbol request with required arguments
     When the plugin executes the request
     Then the plugin returns successful diff output
 
-  Scenario: Rename fails when offset is missing
-    Given a rename request missing offset
+  Scenario: rename-symbol fails when position is missing
+    Given a rename-symbol request missing position
     When the plugin executes the request
     Then the plugin returns failure diagnostics
-    And the failure message contains "offset"
+    And the failure message contains "position"
+    And the failure reason code is "incomplete_payload"
+
+  Scenario: rename-symbol fails when uri is missing
+    Given a rename-symbol request missing uri
+    When the plugin executes the request
+    Then the plugin returns failure diagnostics
+    And the failure message contains "uri"
+    And the failure reason code is "incomplete_payload"
 
   Scenario: Unsupported operation fails with diagnostics
     Given an unsupported extract method request
     When the plugin executes the request
     Then the plugin returns failure diagnostics
     And the failure message contains "unsupported"
+    And the failure reason code is "operation_not_supported"
 
   Scenario: Adapter failures are surfaced
-    Given a rename request with required arguments
+    Given a rename-symbol request with required arguments
     And a rust analyzer adapter that fails
     When the plugin executes the request
     Then the plugin returns failure diagnostics
     And the failure message contains "rust-analyzer adapter failed"
 
   Scenario: Unchanged output is treated as failure
-    Given a rename request with required arguments
+    Given a rename-symbol request with required arguments
     And a rust analyzer adapter that returns unchanged content
     When the plugin executes the request
     Then the plugin returns failure diagnostics

--- a/crates/weaverd/src/dispatch/act/refactor/manifests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/manifests.rs
@@ -1,0 +1,34 @@
+//! Manifest builders for refactor plugins.
+//!
+//! Keeping manifest construction here prevents the main refactor handler from
+//! overflowing the repository's 400-line limit while still exposing a small
+//! test seam for capability declarations.
+
+use std::path::PathBuf;
+
+use weaver_plugins::CapabilityId;
+use weaver_plugins::manifest::{PluginKind, PluginManifest, PluginMetadata};
+
+use super::plugin_paths::{
+    ROPE_PLUGIN_NAME, ROPE_PLUGIN_VERSION, RUST_ANALYZER_PLUGIN_NAME,
+    RUST_ANALYZER_PLUGIN_TIMEOUT_SECS, RUST_ANALYZER_PLUGIN_VERSION,
+};
+
+/// Builds the default rope plugin manifest.
+pub(crate) fn rope_manifest(executable: PathBuf) -> PluginManifest {
+    let metadata = PluginMetadata::new(ROPE_PLUGIN_NAME, ROPE_PLUGIN_VERSION, PluginKind::Actuator);
+    PluginManifest::new(metadata, vec![String::from("python")], executable)
+        .with_capabilities(vec![CapabilityId::RenameSymbol])
+}
+
+/// Builds the default rust-analyzer plugin manifest.
+pub(crate) fn rust_analyzer_manifest(executable: PathBuf) -> PluginManifest {
+    let metadata = PluginMetadata::new(
+        RUST_ANALYZER_PLUGIN_NAME,
+        RUST_ANALYZER_PLUGIN_VERSION,
+        PluginKind::Actuator,
+    );
+    PluginManifest::new(metadata, vec![String::from("rust")], executable)
+        .with_capabilities(vec![CapabilityId::RenameSymbol])
+        .with_timeout_secs(RUST_ANALYZER_PLUGIN_TIMEOUT_SECS)
+}

--- a/crates/weaverd/src/dispatch/act/refactor/mod.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/mod.rs
@@ -15,13 +15,10 @@ use std::sync::Arc;
 
 use tracing::debug;
 
-use weaver_plugins::manifest::{PluginKind, PluginManifest, PluginMetadata};
 use weaver_plugins::process::SandboxExecutor;
 use weaver_plugins::protocol::FilePayload;
 use weaver_plugins::runner::PluginRunner;
-use weaver_plugins::{
-    CapabilityId, PluginError, PluginOutput, PluginRegistry, PluginRequest, PluginResponse,
-};
+use weaver_plugins::{PluginError, PluginOutput, PluginRegistry, PluginRequest, PluginResponse};
 
 use crate::backends::{BackendKind, FusionBackends};
 use crate::dispatch::act::apply_patch;
@@ -30,12 +27,13 @@ use crate::dispatch::request::{CommandDescriptor, CommandRequest};
 use crate::dispatch::response::ResponseWriter;
 use crate::dispatch::router::{DISPATCH_TARGET, DispatchResult};
 use crate::semantic_provider::SemanticBackendProvider;
+use manifests::{rope_manifest, rust_analyzer_manifest};
 use plugin_paths::{
-    ROPE_PLUGIN_NAME, ROPE_PLUGIN_PATH_ENV, ROPE_PLUGIN_VERSION, RUST_ANALYZER_PLUGIN_NAME,
-    RUST_ANALYZER_PLUGIN_PATH_ENV, RUST_ANALYZER_PLUGIN_TIMEOUT_SECS, RUST_ANALYZER_PLUGIN_VERSION,
-    resolve_rope_plugin_path, resolve_rust_analyzer_plugin_path,
+    ROPE_PLUGIN_PATH_ENV, RUST_ANALYZER_PLUGIN_PATH_ENV, resolve_rope_plugin_path,
+    resolve_rust_analyzer_plugin_path,
 };
 
+mod manifests;
 mod plugin_paths;
 
 /// Runtime abstraction for executing refactor plugins.
@@ -62,30 +60,14 @@ impl SandboxRefactorRuntime {
     pub fn from_environment() -> Result<Self, String> {
         let mut registry = PluginRegistry::new();
         let rope_executable = resolve_rope_plugin_path(std::env::var_os(ROPE_PLUGIN_PATH_ENV));
-        let rope_metadata =
-            PluginMetadata::new(ROPE_PLUGIN_NAME, ROPE_PLUGIN_VERSION, PluginKind::Actuator);
-        let rope_manifest =
-            PluginManifest::new(rope_metadata, vec![String::from("python")], rope_executable)
-                .with_capabilities(vec![CapabilityId::RenameSymbol]);
         registry
-            .register(rope_manifest)
+            .register(rope_manifest(rope_executable))
             .map_err(|error| format!("failed to initialize refactor runtime: {error}"))?;
 
         let rust_analyzer_executable =
             resolve_rust_analyzer_plugin_path(std::env::var_os(RUST_ANALYZER_PLUGIN_PATH_ENV));
-        let rust_analyzer_metadata = PluginMetadata::new(
-            RUST_ANALYZER_PLUGIN_NAME,
-            RUST_ANALYZER_PLUGIN_VERSION,
-            PluginKind::Actuator,
-        );
-        let rust_analyzer_manifest = PluginManifest::new(
-            rust_analyzer_metadata,
-            vec![String::from("rust")],
-            rust_analyzer_executable,
-        )
-        .with_timeout_secs(RUST_ANALYZER_PLUGIN_TIMEOUT_SECS);
         registry
-            .register(rust_analyzer_manifest)
+            .register(rust_analyzer_manifest(rust_analyzer_executable))
             .map_err(|error| format!("failed to initialize refactor runtime: {error}"))?;
 
         Ok(Self {

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -5,11 +5,12 @@ use std::path::Path;
 use rstest::{fixture, rstest};
 use tempfile::TempDir;
 use weaver_config::{CapabilityMatrix, Config, SocketEndpoint};
-use weaver_plugins::{PluginError, PluginOutput, PluginRequest, PluginResponse};
+use weaver_plugins::{CapabilityId, PluginError, PluginOutput, PluginRequest, PluginResponse};
 
 use super::{
     DispatchError, FusionBackends, RefactorContext, RefactorPluginRuntime, ResponseWriter,
     default_runtime, handle, resolve_rope_plugin_path, resolve_rust_analyzer_plugin_path,
+    rust_analyzer_manifest,
 };
 use crate::dispatch::request::{CommandDescriptor, CommandRequest};
 use crate::semantic_provider::SemanticBackendProvider;
@@ -275,7 +276,11 @@ const NOTES_DIFF: &str = concat!(
 
 /// Dispatches a rename request through the handler and returns the captured
 /// `PluginRequest` for inspection.
-fn dispatch_inspecting_rename(extra_args: Vec<String>, socket_dir: &TempDir) -> PluginRequest {
+fn dispatch_inspecting_rename(
+    provider: &str,
+    extra_args: Vec<String>,
+    socket_dir: &TempDir,
+) -> PluginRequest {
     let workspace = TempDir::new().expect("workspace");
     std::fs::write(workspace.path().join("notes.txt"), "hello world\n").expect("write");
     let runtime = InspectingRuntime {
@@ -286,7 +291,7 @@ fn dispatch_inspecting_rename(extra_args: Vec<String>, socket_dir: &TempDir) -> 
     };
     let mut args = vec![
         String::from("--provider"),
-        String::from("rope"),
+        String::from(provider),
         String::from("--refactoring"),
         String::from("rename"),
         String::from("--file"),
@@ -318,6 +323,7 @@ fn dispatch_inspecting_rename(extra_args: Vec<String>, socket_dir: &TempDir) -> 
 #[rstest]
 fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) {
     let plugin_request = dispatch_inspecting_rename(
+        "rope",
         vec![String::from("offset=4"), String::from("new_name=woven")],
         &socket_dir,
     );
@@ -348,6 +354,7 @@ fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) 
 #[rstest]
 fn handler_overwrites_pre_existing_uri_with_file_path(socket_dir: TempDir) {
     let plugin_request = dispatch_inspecting_rename(
+        "rope",
         vec![
             String::from("uri=stale_value"),
             String::from("offset=4"),
@@ -369,10 +376,44 @@ fn handler_overwrites_pre_existing_uri_with_file_path(socket_dir: TempDir) {
 #[rstest]
 fn handler_omits_position_when_offset_not_provided(socket_dir: TempDir) {
     let plugin_request =
-        dispatch_inspecting_rename(vec![String::from("new_name=woven")], &socket_dir);
+        dispatch_inspecting_rename("rope", vec![String::from("new_name=woven")], &socket_dir);
 
     assert!(
         !plugin_request.arguments().contains_key("position"),
         "position should not be injected when offset is absent"
     );
+}
+
+#[rstest]
+fn rust_analyzer_provider_uses_rename_symbol_contract(socket_dir: TempDir) {
+    let plugin_request = dispatch_inspecting_rename(
+        "rust-analyzer",
+        vec![String::from("offset=4"), String::from("new_name=woven")],
+        &socket_dir,
+    );
+
+    assert_eq!(plugin_request.operation(), "rename-symbol");
+    assert_eq!(
+        plugin_request
+            .arguments()
+            .get("uri")
+            .and_then(|value| value.as_str()),
+        Some("notes.txt"),
+    );
+    assert_eq!(
+        plugin_request
+            .arguments()
+            .get("position")
+            .and_then(|value| value.as_str()),
+        Some("4"),
+    );
+}
+
+#[test]
+fn rust_analyzer_manifest_declares_rename_symbol_capability() {
+    let manifest = rust_analyzer_manifest(std::path::PathBuf::from(
+        "/usr/bin/weaver-plugin-rust-analyzer",
+    ));
+
+    assert_eq!(manifest.capabilities(), &[CapabilityId::RenameSymbol]);
 }

--- a/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
+++ b/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
@@ -1,0 +1,360 @@
+# Update weaver-plugin-rust-analyzer manifest and handshake for `rename-symbol`
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root.
+
+Implementation must not begin until this draft is explicitly approved.
+
+## Purpose / big picture
+
+Roadmap item 5.2.3 migrates the Rust actuator plugin from its legacy
+provider-specific rename request shape to the shared `rename-symbol` capability
+contract introduced in 5.2.1. After this change, the
+`weaver-plugin-rust-analyzer` manifest declares `CapabilityId::RenameSymbol`,
+the plugin accepts contract-conforming request payloads using `uri`,
+`position`, and `new_name`, and successful responses still return diff output
+that flows through the existing Double-Lock safety harness.
+
+The user-visible command stays the same:
+
+```sh
+weaver act refactor \
+  --provider rust-analyzer \
+  --refactoring rename \
+  --file src/main.rs \
+  offset=3 \
+  new_name=renamed_name
+```
+
+The daemon continues to translate the CLI-facing `rename` request into the
+internal `rename-symbol` capability operation before invoking the plugin. The
+observable difference is that the Rust plugin now matches the same capability
+contract already used by the Python rope plugin.
+
+Observable success for this roadmap item:
+
+- `crates/weaverd/src/dispatch/act/refactor/mod.rs` registers the
+  rust-analyzer manifest with `CapabilityId::RenameSymbol`.
+- `crates/weaver-plugin-rust-analyzer/src/lib.rs` accepts only the
+  `rename-symbol` operation and validates the `uri`, `position`, and `new_name`
+  request arguments defined by
+  `crates/weaver-plugins/src/capability/rename_symbol.rs`.
+- Successful plugin responses still use `PluginOutput::Diff`; failure payloads
+  remain protocol-conforming and carry stable reason codes where the failure
+  class is known.
+- Unit tests and `rstest-bdd` v0.5.0 behavioural tests cover happy paths,
+  unhappy paths, and edge cases for the contract migration.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+  reflect the shipped behaviour.
+- `make fmt`, `make markdownlint`, `make check-fmt`, `make lint`, and
+  `make test` all pass.
+
+## Constraints
+
+1. The `rename-symbol` contract from 5.2.1 is already complete. Do not modify
+   `crates/weaver-plugins/` unless an implementation blocker proves the
+   contract is insufficient. That is an escalation event, not an autonomous
+   change.
+2. Keep the CLI surface stable. Users still invoke
+   `weaver act refactor --provider rust-analyzer --refactoring rename ...`. The
+   daemon performs the internal mapping to `rename-symbol`.
+3. Keep all execution synchronous. Do not introduce async runtimes, async
+   traits, or background tasks.
+4. Preserve the existing Double-Lock path. Successful Rust rename edits must
+   still return unified diff output that is forwarded into `act apply-patch`.
+5. Respect the repository-wide 400-line file limit. Current hotspots:
+   `crates/weaver-plugin-rust-analyzer/src/lib.rs` is 358 lines and
+   `crates/weaverd/src/dispatch/act/refactor/mod.rs` is 399 lines.
+6. All touched Rust modules must retain module-level `//!` documentation, and
+   all public items must remain documented.
+7. Behaviour tests must use `rstest-bdd` v0.5.0 patterns already used in this
+   repository, including a fixture parameter named exactly `world`.
+8. Lint suppressions are a last resort. If unavoidable, use tightly scoped
+   `#[expect(..., reason = "...")]`; do not add `#[allow(...)]`.
+9. Comments and documentation must use en-GB-oxendict spelling.
+10. Use existing workspace dependencies only. Adding a new crate dependency is
+    out of scope for this item.
+11. The plan must record any new design decisions in `docs/weaver-design.md`
+    as part of implementation, not just in this ExecPlan.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than 10 files or more than
+  roughly 500 net lines, stop and escalate.
+- Interface: if any public API in `weaver-plugins` or the CLI argument contract
+  for `act refactor` must change, stop and escalate.
+- Dependencies: if a new workspace or external dependency appears necessary,
+  stop and escalate.
+- Iterations: if `make lint` or `make test` still fail after 5 repair loops,
+  stop and escalate with the failing commands and current hypothesis.
+- Line budget: if `crates/weaverd/src/dispatch/act/refactor/mod.rs` cannot
+  absorb the manifest update and any supporting tests without exceeding 400
+  lines, extract a focused helper module instead of forcing more code into
+  `mod.rs`. If this requires more than 2 new files, stop and escalate.
+- Ambiguity: if “plugin advertises `rename-symbol` in capability probes” turns
+  out to require changes to the top-level `weaver --capabilities` output, stop
+  and escalate. Roadmap item 5.7.5 is the planned place for merged runtime
+  capability probe output.
+
+## Risks
+
+- Risk: The rust-analyzer plugin currently accepts `"rename"` with `offset`
+  rather than `"rename-symbol"` with `position`. This migration can easily
+  leave unit and BDD fixtures half-updated. Severity: high Likelihood: high
+  Mitigation: update plugin request builders, unit tests, and feature steps in
+  the same commit slice before changing dispatch assertions.
+
+- Risk: `crates/weaverd/src/dispatch/act/refactor/mod.rs` is already at 399
+  lines, so even a small registration change could force a split. Severity:
+  medium Likelihood: high Mitigation: extract manifest-construction or
+  request-mapping helpers into a sibling module if the file crosses the cap.
+
+- Risk: Failure reason codes for rust-analyzer errors may not map cleanly from
+  arbitrary LSP error text. Severity: medium Likelihood: medium Mitigation:
+  guarantee reason codes for deterministic classes only: unsupported operation,
+  incomplete payload, and unchanged output. Preserve free-text adapter
+  diagnostics for opaque engine failures unless a stable classification is
+  obvious from existing behaviour.
+
+- Risk: The acceptance criterion says “Rust rename flows are capability-routed”
+  even though full language-aware provider resolution is deferred to 5.2.4.
+  Severity: medium Likelihood: medium Mitigation: treat 5.2.3 as the
+  runtime-handshake half of capability routing: the daemon already maps CLI
+  `rename` to internal `rename-symbol`; this item finishes the Rust plugin side
+  and manifest declaration, while 5.2.4 will handle provider selection policy.
+
+## Progress
+
+- [x] (2026-03-06) Reviewed `AGENTS.md`, the roadmap entry, the execplans
+  skill, the prior 5.2.1 and 5.2.2 ExecPlans, and project memory notes.
+- [x] (2026-03-06) Inspected the current Rust plugin and daemon refactor
+  handler to identify the present contract mismatch and line-budget pressure.
+- [x] (2026-03-06) Drafted this ExecPlan.
+- [ ] Obtain approval for the ExecPlan.
+- [ ] Add failing unit and behavioural tests that assert the
+  `rename-symbol` request/response contract for the rust-analyzer plugin.
+- [ ] Update the rust-analyzer plugin runtime handshake and error mapping.
+- [ ] Update daemon manifest registration and any request-capture tests needed
+  to prove Rust rename requests are capability-routed.
+- [ ] Update `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/roadmap.md`.
+- [ ] Run `make fmt`, `make markdownlint`, `make check-fmt`, `make lint`, and
+  `make test`, each via `tee` with `set -o pipefail`.
+
+## Surprises & Discoveries
+
+- Discovery: `crates/weaverd/src/dispatch/act/refactor/mod.rs` already maps
+  CLI `--refactoring rename` to internal operation `"rename-symbol"` and
+  renames `offset` to `position`. The remaining 5.2.3 gap is that the
+  rust-analyzer plugin itself still expects the old request shape and the
+  rust-analyzer manifest is not yet declared with `CapabilityId::RenameSymbol`.
+
+- Discovery: the rust-analyzer plugin crate currently has no manifest code of
+  its own. In this repository, “manifest and runtime handshake” means the
+  daemon-side registration in `weaverd` plus the plugin’s request/response
+  contract at the JSONL boundary.
+
+## Decision Log
+
+- Decision: treat 5.2.3 as a compatibility migration, not a user-facing CLI
+  redesign. Rationale: the roadmap acceptance criteria require schema
+  conformance and capability routing, while the existing command syntax is
+  already documented and exercised by tests. Date: 2026-03-06.
+
+- Decision: do not plan changes to `weaver --capabilities` for this item.
+  Rationale: the current top-level capability probe covers negotiated daemon
+  and LSP capability state, while roadmap 5.7.x is the explicit home for
+  plugin-capability discoverability. Date: 2026-03-06.
+
+- Decision: prefer small helper extraction over in-place expansion if
+  `weaverd` hits the 400-line limit. Rationale: `mod.rs` has only one line of
+  headroom, so even documenting the manifest registration logic may force a
+  split. Date: 2026-03-06.
+
+## Outcomes & Retrospective
+
+This section remains empty until implementation is complete. It must be updated
+with the shipped behaviour, files changed, gate results, and any lessons that
+would help the next contributor.
+
+## Context and orientation
+
+The current implementation is split across two main areas.
+
+`crates/weaver-plugin-rust-analyzer/` is the one-shot actuator plugin. It reads
+one `PluginRequest` from stdin, executes a rename through the
+`RustAnalyzerAdapter` trait, and writes one `PluginResponse` to stdout. Today
+it still matches only `request.operation() == "rename"` and parses
+`offset`/`new_name` from the request arguments. That behaviour lives primarily
+in `crates/weaver-plugin-rust-analyzer/src/lib.rs`, with unit coverage in
+`crates/weaver-plugin-rust-analyzer/src/tests/mod.rs` and behavioural coverage
+in `crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs` plus
+`crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature`.
+
+`crates/weaverd/src/dispatch/act/refactor/mod.rs` is the daemon-side
+registration and request-building layer. It already maps CLI
+`--refactoring rename` to the internal operation `"rename-symbol"`, injects
+`uri` from `--file`, and maps `offset` to `position`. It already declares
+`CapabilityId::RenameSymbol` for the rope plugin, but not for the rust-analyzer
+manifest. Tests for the request-building path live in
+`crates/weaverd/src/dispatch/act/refactor/tests.rs`.
+
+The shared contract defined by 5.2.1 lives in
+`crates/weaver-plugins/src/capability/rename_symbol.rs`. The important parts
+for this plan are:
+
+- operation name: `"rename-symbol"`
+- required arguments: `uri`, `position`, `new_name`
+- successful response: `PluginOutput::Diff`
+- failure response: ordinary plugin failure payload with optional stable
+  `reason_code`
+
+Roadmap 5.2.2 already applied the same migration to the rope plugin. Use that
+implementation and its ExecPlan at
+`docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md` as the local
+precedent for test style, reason-code treatment, and documentation updates.
+
+## Implementation plan
+
+### Stage 1: lock in failing tests for the contract mismatch
+
+Start with red tests in the rust-analyzer plugin crate. Update the request
+builders in `crates/weaver-plugin-rust-analyzer/src/tests/mod.rs` so the happy
+path constructs a `PluginRequest` using operation `"rename-symbol"` and the
+contract keys `uri`, `position`, and `new_name`. Change the unhappy-path cases
+to validate missing `position`, non-numeric `position`, empty `new_name`,
+unsupported operation, unchanged output, and adapter failure under the new
+contract vocabulary.
+
+Update the behavioural tests in
+`crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs` and
+`crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature`
+ to describe the capability contract explicitly. The scenarios should prove:
+
+1. the plugin accepts a valid `rename-symbol` request and returns diff output;
+2. the plugin rejects missing required arguments with failure diagnostics;
+3. the plugin rejects unsupported operations with a stable failure shape;
+4. adapter failures are surfaced without crashing the dispatcher;
+5. unchanged content is treated as failure.
+
+If line pressure grows in `src/tests/mod.rs`, extract request-building helpers
+into a small test-only support submodule rather than making the file sprawl.
+
+### Stage 2: update the rust-analyzer plugin dispatcher to the capability contract
+
+Modify `crates/weaver-plugin-rust-analyzer/src/lib.rs` so `execute_request()`
+recognizes `"rename-symbol"` instead of `"rename"`. Update argument parsing to
+require `uri`, `position`, and `new_name`, with `position` parsed as the UTF-8
+byte offset used by the existing adapter. The in-band file payload remains
+authoritative for file content; `uri` is used to satisfy the contract and
+should be checked against the single file payload path so the request cannot
+silently describe one file while carrying another.
+
+Introduce a small failure carrier if needed, similar to the 5.2.2 rope
+migration, so deterministic failures can attach `ReasonCode` values without
+changing the outer protocol shape. At minimum:
+
+- unsupported operation -> `ReasonCode::OperationNotSupported`
+- missing or malformed required fields -> `ReasonCode::IncompletePayload`
+- unchanged output -> `ReasonCode::SymbolNotFound`
+
+Opaque adapter errors may continue to surface as human-readable messages if no
+stable reason code is justified. Keep the final success path as
+`PluginResponse::success(PluginOutput::Diff { ... })`.
+
+If `src/lib.rs` approaches 400 lines, extract the contract argument parsing
+into a dedicated `arguments.rs` helper module with its own `//!` comment and
+unit tests, mirroring the rope migration.
+
+### Stage 3: declare the capability in daemon registration and prove handshake coverage
+
+Update `crates/weaverd/src/dispatch/act/refactor/mod.rs` so the registered
+rust-analyzer manifest uses
+`.with_capabilities(vec![CapabilityId::RenameSymbol])` just like the rope
+manifest. Preserve the existing timeout and executable-path behaviour.
+
+Add or update tests in `crates/weaverd/src/dispatch/act/refactor/tests.rs` to
+prove the Rust path is capability-routed in the sense expected by 5.2.3:
+
+- a captured request for `--provider rust-analyzer --refactoring rename`
+  reaches the runtime as operation `"rename-symbol"`;
+- the runtime request carries `uri`, `position`, and `new_name`;
+- the rust-analyzer manifest constructor includes
+  `CapabilityId::RenameSymbol`.
+
+Because `mod.rs` is already 399 lines, assume a helper extraction may be
+necessary here. The cleanest split is a small sibling module for manifest
+construction or request mapping, leaving `handle()` readable and within the
+line budget.
+
+### Stage 4: update design and user documentation
+
+Record the migration decisions in `docs/weaver-design.md`. The most natural
+place is the rust-analyzer actuator implementation decisions section, adding a
+short note that the plugin now participates in the shared `rename-symbol`
+capability contract, that the daemon translates CLI `rename` requests to the
+capability operation internally, and that the rust-analyzer manifest now
+declares `rename-symbol`.
+
+Update `docs/users-guide.md` anywhere it still implies that only rope declares
+the capability. The plugin inventory and `act refactor` sections should make
+clear that both built-in rename providers now implement the same internal
+contract while the CLI remains `--refactoring rename`.
+
+After implementation passes the gates, mark roadmap item 5.2.3 as done in
+`docs/roadmap.md`.
+
+### Stage 5: run the quality gates and capture evidence
+
+Run the required gates from the repository root, always using `tee` and
+`set -o pipefail` so truncated terminal output does not hide failures:
+
+```sh
+set -o pipefail; make fmt 2>&1 | tee /tmp/5-2-3-make-fmt.log
+```
+
+```sh
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/5-2-3-make-markdownlint.log
+```
+
+```sh
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/5-2-3-make-check-fmt.log
+```
+
+```sh
+set -o pipefail; make lint 2>&1 | tee /tmp/5-2-3-make-lint.log
+```
+
+```sh
+set -o pipefail; make test 2>&1 | tee /tmp/5-2-3-make-test.log
+```
+
+If any command fails, inspect the corresponding log, fix the issue, and rerun
+the full failing gate until the workspace is clean again. Do not declare the
+roadmap item complete until all five commands succeed.
+
+## Validation details
+
+The minimal evidence expected from the implementation is:
+
+1. a unit test in the rust-analyzer plugin crate proving a valid
+   `rename-symbol` request succeeds with diff output;
+2. unit tests proving malformed `position`, missing `uri`, missing
+   `new_name`, unsupported operation, and unchanged output fail with the
+   expected diagnostic shape;
+3. `rstest-bdd` scenarios covering happy and unhappy contract paths using the
+   repository’s mutable-world pattern;
+4. a daemon-side test proving the Rust provider path sends the
+   `rename-symbol` operation and contract fields;
+5. passing `make fmt`, `make markdownlint`, `make check-fmt`, `make lint`, and
+   `make test`.
+
+The feature is complete only when those checks pass and the roadmap entry is
+checked off.

--- a/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
+++ b/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
@@ -5,12 +5,12 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root.
 
-Implementation must not begin until this draft is explicitly approved.
+Implementation was approved on 2026-03-07 and is now in progress.
 
 ## Purpose / big picture
 
@@ -137,16 +137,17 @@ Observable success for this roadmap item:
 - [x] (2026-03-06) Inspected the current Rust plugin and daemon refactor
   handler to identify the present contract mismatch and line-budget pressure.
 - [x] (2026-03-06) Drafted this ExecPlan.
-- [ ] Obtain approval for the ExecPlan.
-- [ ] Add failing unit and behavioural tests that assert the
+- [x] (2026-03-07) Obtained approval for the ExecPlan.
+- [x] (2026-03-07) Added unit and behavioural tests that assert the
   `rename-symbol` request/response contract for the rust-analyzer plugin.
-- [ ] Update the rust-analyzer plugin runtime handshake and error mapping.
-- [ ] Update daemon manifest registration and any request-capture tests needed
-  to prove Rust rename requests are capability-routed.
-- [ ] Update `docs/weaver-design.md`, `docs/users-guide.md`, and
-  `docs/roadmap.md`.
-- [ ] Run `make fmt`, `make markdownlint`, `make check-fmt`, `make lint`, and
-  `make test`, each via `tee` with `set -o pipefail`.
+- [x] (2026-03-07) Updated the rust-analyzer plugin runtime handshake and
+  error mapping.
+- [x] (2026-03-07) Updated daemon manifest registration and request-capture
+  tests proving Rust rename requests are capability-routed.
+- [x] (2026-03-07) Updated `docs/weaver-design.md`, `docs/users-guide.md`,
+  and `docs/roadmap.md`.
+- [x] (2026-03-07) Ran `make fmt`, `make markdownlint`, `make check-fmt`,
+  `make lint`, and `make test`, each via `tee` with `set -o pipefail`.
 
 ## Surprises & Discoveries
 
@@ -160,6 +161,19 @@ Observable success for this roadmap item:
   its own. In this repository, “manifest and runtime handshake” means the
   daemon-side registration in `weaverd` plus the plugin’s request/response
   contract at the JSONL boundary.
+
+- Discovery: extracting refactor-plugin manifest builders into a dedicated
+  `manifests.rs` module dropped
+  `crates/weaverd/src/dispatch/act/refactor/mod.rs` from 399 lines to 381
+  lines, creating room for manifest-specific tests without breaking the
+  400-line cap.
+
+- Discovery: the pre-existing workspace test hang in
+  `tests::unit::auto_start::auto_start_succeeds_and_proceeds` was caused by a
+  race between the daemon reporting a healthy auto-start snapshot and the Unix
+  socket becoming connectable. A bounded `connect_with_retry` helper in the CLI
+  transport layer resolved the production race and made `make test`
+  deterministic again.
 
 ## Decision Log
 
@@ -178,11 +192,68 @@ Observable success for this roadmap item:
   headroom, so even documenting the manifest registration logic may force a
   split. Date: 2026-03-06.
 
+- Decision: make `PluginFailure` the rust-analyzer plugin's internal error
+  transport and attach `ReasonCode::OperationNotSupported`,
+  `ReasonCode::IncompletePayload`, and `ReasonCode::SymbolNotFound` for the
+  deterministic failure classes. Rationale: this matches the rope migration,
+  keeps the outer protocol unchanged, and lets tests assert structured
+  diagnostics rather than brittle free-text only. Date: 2026-03-07.
+
+- Decision: fix the daemon auto-start race in production rather than only
+  loosening the test. Rationale: the hanging test exposed a genuine gap where
+  the CLI could observe a healthy daemon snapshot before the Unix socket was
+  ready for connection, so a bounded retry in `weaver-cli` was the correct
+  behavioural fix and not merely test scaffolding. Date: 2026-03-07.
+
 ## Outcomes & Retrospective
 
-This section remains empty until implementation is complete. It must be updated
-with the shipped behaviour, files changed, gate results, and any lessons that
-would help the next contributor.
+Roadmap item 5.2.3 is complete. The rust-analyzer actuator plugin now accepts
+only the capability operation `"rename-symbol"`, parses the shared contract
+arguments `uri`, `position`, and `new_name`, and emits protocol-conforming
+failure diagnostics with stable `ReasonCode` values for unsupported operation,
+incomplete payloads, and symbol-not-found style failures. The daemon now
+registers the rust-analyzer provider through a manifest helper that declares
+`CapabilityId::RenameSymbol`, and regression tests prove Rust rename requests
+are routed through the capability contract rather than the legacy provider-
+specific request shape.
+
+Files created:
+
+- `crates/weaver-plugin-rust-analyzer/src/arguments.rs`
+- `crates/weaverd/src/dispatch/act/refactor/manifests.rs`
+
+Files materially changed:
+
+- `crates/weaver-plugin-rust-analyzer/src/lib.rs`
+- `crates/weaver-plugin-rust-analyzer/src/tests/mod.rs`
+- `crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs`
+- `crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature`
+- `crates/weaverd/src/dispatch/act/refactor/mod.rs`
+- `crates/weaverd/src/dispatch/act/refactor/tests.rs`
+- `crates/weaver-cli/src/transport.rs`
+- `crates/weaver-cli/src/lib.rs`
+- `crates/weaver-cli/src/tests/unit/auto_start.rs`
+- `docs/weaver-design.md`
+- `docs/users-guide.md`
+- `docs/roadmap.md`
+
+Validation results:
+
+- `make fmt` passed.
+- `make markdownlint` passed.
+- `make check-fmt` passed.
+- `make lint` passed.
+- `make test` passed.
+
+Lessons:
+
+- The rope migration from 5.2.2 was the right precedent for the Rust plugin as
+  well; keeping request validation and reason-code mapping structurally aligned
+  across plugins reduced review risk.
+- The auto-start test hang was a useful signal, not mere test fragility. When a
+  behavioural test stalls on orchestration, prefer turning the stall into a
+  bounded failure and fixing the underlying race rather than simply increasing
+  timeouts.
 
 ## Context and orientation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -514,7 +514,7 @@ new* *capabilities and specialist providers.*
   - Acceptance criteria: plugin advertises `rename-symbol` in capability probes,
     request payloads conform to schema, and response payloads conform to schema.
     Legacy provider routing is not required for Python rename flows.
-- [ ] 5.2.3. Update `weaver-plugin-rust-analyzer` manifest and runtime
+- [x] 5.2.3. Update `weaver-plugin-rust-analyzer` manifest and runtime
       handshake to declare and serve `rename-symbol` through the capability
       interface. Requires 5.2.1.
   - Acceptance criteria: plugin advertises `rename-symbol` in capability probes,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -785,8 +785,9 @@ Worked examples:
 
 The daemon ships with default actuator registrations:
 
-- `rope` for Python (`timeout_secs = 30`)
-- `rust-analyzer` for Rust (`timeout_secs = 60`)
+- `rope` for Python (`timeout_secs = 30`, `capabilities = rename-symbol`)
+- `rust-analyzer` for Rust (`timeout_secs = 60`,
+  `capabilities = rename-symbol`)
 
 By default, it expects plugin executables at:
 
@@ -803,6 +804,10 @@ WEAVER_RUST_ANALYZER_PLUGIN_PATH=/absolute/path/to/weaver-plugin-rust-analyzer
 The override path is resolved to an absolute path at daemon startup. If the
 plugin executable cannot be launched, `act refactor` returns a structured
 failure and does not modify the filesystem.
+
+The built-in rust-analyzer plugin now declares the same capability contract as
+rope for rename flows, even though the CLI continues to accept
+`--refactoring rename`.
 
 ## Plugin system
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1380,6 +1380,13 @@ following decisions govern this rollout:
   rust-analyzer actuator with a `60` second timeout and executable override via
   `WEAVER_RUST_ANALYZER_PLUGIN_PATH`.
 
+- **Shared `rename-symbol` capability contract.** The rust-analyzer actuator
+  now declares `rename-symbol` in its manifest, accepts `uri`, `position`, and
+  `new_name` in plugin requests, and returns protocol-conforming refusal
+  diagnostics with stable reason codes for unsupported operations and malformed
+  payloads. The user-facing CLI still spells the operation as
+  `--refactoring rename`; `weaverd` performs the contract mapping internally.
+
 - **Shared Double-Lock commit path remains unchanged.** As with rope, successful
   `PluginOutput::Diff` output from rust-analyzer is forwarded to
   `act apply-patch`, reusing the existing syntactic + semantic verification and


### PR DESCRIPTION
## Summary
- Implements the shared rename-symbol capability contract for the rust-analyzer plugin. This includes adding a dedicated argument parser, updating the plugin to accept the rename-symbol operation, validating the shared payload keys (uri, position, new_name), and wiring up the capability declaration in the daemon. The ExecPlan for this work (5-2-3) has been added and aligned with the rope-migration precedent. 
- Broader gating and test coverage have been extended across unit, behaviour, and daemon tests to reflect the new contract and stable reason codes.
- This PR includes related transport changes to improve CLI-daemon startup resilience and updated tests to cover the new contract surface.

## Changes
- New file: crates/weaver-plugin-rust-analyzer/src/arguments.rs
  - Parses and validates rename-symbol arguments: uri, position, new_name.
- Modified: crates/weaver-plugin-rust-analyzer/src/lib.rs
  - Switches to handling the rename-symbol operation, uses new argument parsing, and maps errors to structured failures with reason codes.
- Modified: crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
  - Updated tests to exercise the new rename-symbol contract and argument requirements.
- Modified: crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
  - Updated behaviour tests to reflect the new contract, including missing/malformed payload scenarios and reason-code validation.
- Modified: crates/weaverd/src/dispatch/act/refactor/mod.rs
  - Integrates with the new manifest-based capability wiring and uses the new manifests module for wiring name-capability declarations.
- New file: crates/weaverd/src/dispatch/act/refactor/manifests.rs
  - Provides manifest builders for rope and rust-analyzer plugins, including both declaring RenameSymbol capability and plugin timeouts.
- Modified: docs/roadmap.md
  - Reflects 5.2.3 completion status for the rust-analyzer upgrade.
- Updated: docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
  - Adds and maintains the live ExecPlan for this change, with detailed stages, risks, and validation steps.
- Updated: docs/weaver-design.md
  - Documented the shared rename-symbol capability contract usage by the rust-analyzer actuator and the daemon handshake.
- Updated: docs/users-guide.md
  - Documented that the rust-analyzer plugin now declares the rename-symbol capability and participates in the shared contract routing.
- Updated: crates/weaver-cli/src/transport.rs
  - Introduces retry behavior for CLI-daemon connection to tolerate startup lag; supports connect_with_retry.
- Updated: crates/weaver-cli/src/lib.rs
  - Uses connect_with_retry for daemon connection, improving startup robustness.
- Updated: crates/weaver-cli/src/tests/unit/auto_start.rs
  - Adjusts tests to accommodate the new retry-based connection flow.

## Rationale
- Align the Rust actuator with the shared rename-symbol contract (5.2.1) to enable deterministic routing, standardized request/response payloads, and consistent test coverage across plugins.
- Mirror the rope-plugin migration pattern (5.2.2) to keep design, tests, and documentation aligned and to minimize gating risk.
- Introduce a clean, testable path for future Stage 2–5 work as described in the ExecPlan, while preserving the existing CLI surface.

## Validation plan
- Unit tests for the new arguments parser (uri, position, new_name).
- Behavioural tests covering: happy path (valid rename-symbol request), missing/invalid uri, missing/invalid position, missing new_name, unsupported operation, and unchanged output with appropriate reason codes.
- Daemon/manifest tests ensuring rust-analyzer manifest declares RenameSymbol capability and is exercised by the runtime path.
- End-to-end tests validating the CLI-to-daemon handshake remains robust with the new retry logic.
- Formatting, linting, and full test suite (make fmt, make markdownlint, make check-fmt, make lint, make test).

## Next steps
- Review feedback on the ExecPlan and implementation details.
- Prepare follow-up PRs to complete Stage 2–5 of the ExecPlan (e.g., deeper integration tests, docs, and any minor design adjustments).

## Notes for reviewers
- This PR moves from planning-only to concrete implementation, including tests and daemon/manifest wiring. Please review for correctness in argument validation, error handling (ReasonCode mapping), manifest wiring, and test coverage alignment with the 5.2.3 ExecPlan.
- The task link remains relevant for traceability.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/ec189dd0-0c0f-433b-a913-cccf8a3ce8c7

## Summary by Sourcery

Align the rust-analyzer plugin and daemon with the shared `rename-symbol` capability contract and improve CLI-daemon connection robustness.

New Features:
- Add structured argument parsing for `rename-symbol` requests in the rust-analyzer plugin, validating `uri`, `position`, and `new_name`.
- Have the daemon register rust-analyzer with a manifest that declares the `RenameSymbol` capability, matching the rope plugin.

Bug Fixes:
- Stabilize CLI auto-start flows by retrying daemon connections to tolerate Unix socket bind lag and preventing intermittent test hangs.

Enhancements:
- Standardize rust-analyzer plugin failures around a `PluginFailure` type that surfaces stable `ReasonCode` values for unsupported operations, malformed payloads, and symbol-not-found conditions.
- Extend unit, behaviour, and daemon tests to cover the `rename-symbol` contract semantics and capability wiring for rust-analyzer.
- Refactor refactor-actuator manifest construction into a dedicated module to keep runtime registration concise and within line limits.

Documentation:
- Document the shared `rename-symbol` capability contract for rust-analyzer in the design and user guides, and mark roadmap item 5.2.3 as complete.
- Add an ExecPlan document capturing the implementation plan, risks, and validation steps for updating the rust-analyzer plugin to declare `rename-symbol`.
