### PR TITLE
Upgrade ortho-config to v0.8.0 and add weaver-cards crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,11 +1265,12 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ortho_config"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee9d60c6be312d7c6ce47b7146e3c9b8464c54fc304ef8f7656e29c268faeb1"
+checksum = "9314c7a4be184287f3f9a66fcbcec054ac215d4975152df86b7aadeae8d5e019"
 dependencies = [
  "camino",
+ "cap-std 3.4.5",
  "clap",
  "clap-dispatch",
  "directories",
@@ -1291,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "ortho_config_macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992d8fc0b33823adb993fe8968614ac0df3964d9e3564f7a147fd253e27a3acd"
+checksum = "a3941ab7c592a0b93aadf12ce30e0ef3d01af87b46c8f363d8157dc33273ba83"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 version = "0.1.0"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.dependencies]
 anyhow = "1.0"
@@ -33,7 +33,7 @@ insta = "1.41"
 lsp-types = "0.97"
 mockall = "0.14.0"
 once_cell = "1.19"
-ortho_config = "0.7.0"
+ortho_config = "0.8.0"
 predicates = "3.1"
 rstest = "0.26.1"
 rstest-bdd = { version = "0.5.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ configuration layering, and the complete command reference.
 
 ## Building from source
 
-Weaver requires **Rust 1.85+** (edition 2024). To build:
+Weaver requires **Rust 1.88+** (edition 2024). To build:
 
 ```sh
 cargo build --release

--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -266,13 +266,13 @@ impl DiagnosticReport {
 
     /// Returns `true` if the report contains no diagnostics.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.diagnostics.is_empty()
     }
 
     /// Returns the number of diagnostics in the report.
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.diagnostics.len()
     }
 }

--- a/crates/weaver-build-util/Cargo.toml
+++ b/crates/weaver-build-util/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-build-util"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 time = { version = "0.3", features = ["formatting"] }

--- a/crates/weaver-cli/Cargo.toml
+++ b/crates/weaver-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-cli"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "weaver"

--- a/crates/weaver-config/src/socket.rs
+++ b/crates/weaver-config/src/socket.rs
@@ -70,13 +70,13 @@ impl SocketEndpoint {
             builder.mode(0o700);
         }
 
-        if let Err(source) = builder.create(parent.as_std_path()) {
-            if source.kind() != std::io::ErrorKind::AlreadyExists {
-                return Err(SocketPreparationError::CreateDirectory {
-                    path: parent.to_path_buf(),
-                    source,
-                });
-            }
+        if let Err(source) = builder.create(parent.as_std_path())
+            && source.kind() != std::io::ErrorKind::AlreadyExists
+        {
+            return Err(SocketPreparationError::CreateDirectory {
+                path: parent.to_path_buf(),
+                source,
+            });
         }
 
         #[cfg(unix)]

--- a/crates/weaver-e2e/Cargo.toml
+++ b/crates/weaver-e2e/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-e2e"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 weaver-graph = { path = "../weaver-graph" }

--- a/crates/weaver-graph/Cargo.toml
+++ b/crates/weaver-graph/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-graph"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 weaver-lsp-host = { path = "../weaver-lsp-host" }

--- a/crates/weaver-lsp-host/Cargo.toml
+++ b/crates/weaver-lsp-host/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-lsp-host"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 weaver-config = { path = "../weaver-config" }

--- a/crates/weaver-plugin-rope/Cargo.toml
+++ b/crates/weaver-plugin-rope/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-plugin-rope"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 serde_json.workspace = true

--- a/crates/weaver-plugin-rust-analyzer/Cargo.toml
+++ b/crates/weaver-plugin-rust-analyzer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-plugin-rust-analyzer"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 lsp-types.workspace = true

--- a/crates/weaver-plugins/Cargo.toml
+++ b/crates/weaver-plugins/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-plugins"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/weaver-sandbox/Cargo.toml
+++ b/crates/weaver-sandbox/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaver-sandbox"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 birdcage.workspace = true

--- a/crates/weaver-syntax/src/pattern.rs
+++ b/crates/weaver-syntax/src/pattern.rs
@@ -139,7 +139,7 @@ impl Pattern {
 
     /// Returns whether this pattern has any metavariables.
     #[must_use]
-    pub fn has_metavariables(&self) -> bool {
+    pub const fn has_metavariables(&self) -> bool {
         !self.metavariables.is_empty()
     }
 }

--- a/crates/weaverd/Cargo.toml
+++ b/crates/weaverd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weaverd"
 edition.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "weaverd"

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -20,6 +20,8 @@
     deliverables.
 - [Ortho-config user's guide](ortho-config-users-guide.md)
   - Operational guide for configuration layering and ortho-config usage.
+- [Ortho-config v0.8.0 migration guide](ortho-config-v0-8-0-migration-guide.md)
+  - Weaver-specific adoption notes for the current ortho-config upgrade.
 - [Ortho-config v0.6.0 migration guide](ortho-config-v0-6-0-migration-guide.md)
   - Migration notes and compatibility guidance for ortho-config changes.
 - [Pratt parser design for DDlog expressions](pratt-parser-for-ddlog-expressions.md)

--- a/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
+++ b/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
@@ -143,8 +143,8 @@ Observable behaviour after this change:
 
 - Observation: `PluginFailure` needed `#[derive(Debug)]` because tests use
   `.expect()` on `Result<_, PluginFailure>`, which requires `Debug`. Evidence:
-  Clippy error `E0277: PluginFailure doesn't implement Debug`. Impact: Added
-  one derive line; file stayed within 400-line budget.
+  rustc error `E0277: PluginFailure doesn't implement Debug`. Impact: Added one
+  derive line; file stayed within 400-line budget.
 
 ## Decision log
 
@@ -195,14 +195,15 @@ its manifest, accepts contract-conforming requests with `uri`/`position`/
 `--refactoring rename` to the internal `rename-symbol` operation and translates
 `offset` to `position`, maintaining CLI backward compatibility.
 
-Files created: `crates/weaver-plugin-rope/src/arguments.rs` (98 lines). Files
-modified: `crates/weaver-plugin-rope/src/lib.rs` (400 lines, exactly at
-budget), `crates/weaverd/src/dispatch/act/refactor/mod.rs` (396 lines),
-`crates/weaver-plugin-rope/src/tests/mod.rs`,
+Files created: `crates/weaver-plugin-rope/src/arguments.rs` (98 lines).
+Implementation artefacts: `crates/weaver-plugin-rope/src/lib.rs` (400 lines,
+exactly at budget), `crates/weaverd/src/dispatch/act/refactor/mod.rs` (396
+lines), `crates/weaver-plugin-rope/src/tests/mod.rs`,
 `crates/weaver-plugin-rope/src/tests/behaviour.rs`,
 `crates/weaver-plugin-rope/tests/features/rope_plugin.feature`,
 `crates/weaverd/src/dispatch/act/refactor/tests.rs`, `docs/users-guide.md`,
-`docs/roadmap.md`.
+`docs/roadmap.md`, and this ExecPlan
+(`docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md`).
 
 Lessons: Always derive `Debug` on error types that might be used with
 `.expect()` in tests. The 400-line budget required careful extraction of the
@@ -222,9 +223,9 @@ code analysis and modification. The key crates for this task are:
 
 - `crates/weaver-plugin-rope/` — The Python rope-backed actuator plugin. A
   standalone binary crate that reads one JSON Lines (JSONL) request from stdin
-  and writes one JSONL response to stdout. Main logic is in `src/lib.rs` (384
-  lines). Tests are in `src/tests/mod.rs` (224 lines) and
-  `src/tests/behaviour.rs` (176 lines). BDD feature file is at
+  and writes one JSONL response to stdout. Baseline-only line counts before
+  implementation were: `src/lib.rs` (384 lines), `src/tests/mod.rs` (224
+  lines), `src/tests/behaviour.rs` (176 lines), and
   `tests/features/rope_plugin.feature` (33 lines).
 
 - `crates/weaverd/` — The Weaver daemon. The refactor handler at

--- a/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
+++ b/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
@@ -40,8 +40,8 @@ Observable behaviour after this change:
   contract operation `"rename-symbol"` and translates `offset` to `position`
   internally, preserving command-line interface (CLI) backward compatibility.
 - Behaviour-driven development (BDD) scenarios cover happy path,
-  missing arguments, unsupported operation, adapter failure,
-  unchanged output, and reason code verification.
+  missing arguments, unsupported operation, adapter failure, unchanged output,
+  and reason code verification.
 
 ## Constraints
 
@@ -142,9 +142,9 @@ Observable behaviour after this change:
 ## Surprises & discoveries
 
 - Observation: `PluginFailure` needed `#[derive(Debug)]` because tests use
-  `.expect()` on `Result<_, PluginFailure>`, which requires `Debug`.
-  Evidence: Clippy error `E0277: PluginFailure doesn't implement Debug`.
-  Impact: Added one derive line; file stayed within 400-line budget.
+  `.expect()` on `Result<_, PluginFailure>`, which requires `Debug`. Evidence:
+  Clippy error `E0277: PluginFailure doesn't implement Debug`. Impact: Added
+  one derive line; file stayed within 400-line budget.
 
 ## Decision log
 
@@ -195,14 +195,14 @@ its manifest, accepts contract-conforming requests with `uri`/`position`/
 `--refactoring rename` to the internal `rename-symbol` operation and translates
 `offset` to `position`, maintaining CLI backward compatibility.
 
-Files created: `crates/weaver-plugin-rope/src/arguments.rs` (98 lines).
-Files modified: `crates/weaver-plugin-rope/src/lib.rs` (400 lines, exactly at
+Files created: `crates/weaver-plugin-rope/src/arguments.rs` (98 lines). Files
+modified: `crates/weaver-plugin-rope/src/lib.rs` (400 lines, exactly at
 budget), `crates/weaverd/src/dispatch/act/refactor/mod.rs` (396 lines),
 `crates/weaver-plugin-rope/src/tests/mod.rs`,
 `crates/weaver-plugin-rope/src/tests/behaviour.rs`,
 `crates/weaver-plugin-rope/tests/features/rope_plugin.feature`,
-`crates/weaverd/src/dispatch/act/refactor/tests.rs`,
-`docs/users-guide.md`, `docs/roadmap.md`.
+`crates/weaverd/src/dispatch/act/refactor/tests.rs`, `docs/users-guide.md`,
+`docs/roadmap.md`.
 
 Lessons: Always derive `Debug` on error types that might be used with
 `.expect()` in tests. The 400-line budget required careful extraction of the
@@ -222,10 +222,10 @@ code analysis and modification. The key crates for this task are:
 
 - `crates/weaver-plugin-rope/` — The Python rope-backed actuator plugin. A
   standalone binary crate that reads one JSON Lines (JSONL) request from stdin
-  and writes one JSONL response to stdout. Main logic is in `src/lib.rs` (384 lines).
-  Tests are in `src/tests/mod.rs` (224 lines) and `src/tests/behaviour.rs` (176
-  lines). BDD feature file is at `tests/features/rope_plugin.feature` (33
-  lines).
+  and writes one JSONL response to stdout. Main logic is in `src/lib.rs` (384
+  lines). Tests are in `src/tests/mod.rs` (224 lines) and
+  `src/tests/behaviour.rs` (176 lines). BDD feature file is at
+  `tests/features/rope_plugin.feature` (33 lines).
 
 - `crates/weaverd/` — The Weaver daemon. The refactor handler at
   `src/dispatch/act/refactor/mod.rs` (375 lines) registers the rope plugin

--- a/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
+++ b/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
@@ -341,8 +341,8 @@ Types mapped from the design doc lines 147-170:
 - `SymbolRef` — location-based reference: `uri`, `range`, `language`,
   `kind`, `name`, `container` (Option, skip_serializing_if is_none)
 - `SymbolId` — `{ symbol_id: String }`
-- `SymbolIdentity` — `{ symbol_id: String, #[serde(rename = "ref")] symbol_ref:
-  SymbolRef }`
+- `SymbolIdentity` —
+  `{ symbol_id: String, #[serde(rename = "ref")] symbol_ref: SymbolRef }`
 
 **New file: `crates/weaver-cards/src/detail.rs`** (~55 lines)
 
@@ -364,23 +364,35 @@ Types mapped from design doc lines 176-268:
   String }`
 - `DocInfo` — `{ docstring: String, summary: String, source: String }`
 - `NormalizedAttachments` — `{ decorators: Vec<String> }`
-- `AttachmentsInfo` — `{ doc_comments: Vec<String>, decorators:
-  Vec<String>, normalized: NormalizedAttachments, bundle_rule: String
-  }` (present at `structure` detail and above)
+- `AttachmentsInfo` —
+
+  ```text
+  { doc_comments: Vec<String>, decorators: Vec<String>, normalized: NormalizedAttachments, bundle_rule: String }
+  ```
+
+  Present at `structure` detail and above.
 - `LocalInfo` — `{ name: String, kind: String, decl_line: u32 }`
 - `BranchInfo` — `{ kind: String, line: u32 }`
 - `StructureInfo` — `{ locals: Vec<LocalInfo>, branches: Vec<BranchInfo> }`
 - `LspInfo` — `{ hover: String, #[serde(rename = "type")] type_info:
   String, deprecated: bool, source: String }`
-- `MetricsInfo` — `{ lines: u32, cyclomatic: u32, fan_in: Option<u32>,
-  fan_out: Option<u32>
-  }` (fan metrics are `Option` because they are only populated at `full
-  ` detail from the relational graph layer)
+- `MetricsInfo` —
+
+  ```text
+  { lines: u32, cyclomatic: u32, fan_in: Option<u32>, fan_out: Option<u32> }
+  ```
+
+  Fan metrics are `Option` because they are only populated at `full` detail
+  from the relational graph layer.
 - `DepsInfo` — `{ calls: Vec<String>, imports: Vec<String>, config:
   Vec<String> }`
-- `ImportInterstitialInfo` — `{ raw: String, normalized: Vec<String>,
-  groups: Vec<Vec<String>>, source: String
-  }` (import block data for file/module or interstitial cards)
+- `ImportInterstitialInfo` —
+
+  ```text
+  { raw: String, normalized: Vec<String>, groups: Vec<Vec<String>>, source: String }
+  ```
+
+  Import block data for file/module or interstitial cards.
 - `InterstitialInfo` — `{ imports: ImportInterstitialInfo }` (present on
   file/module and interstitial cards only)
 - `Provenance` — `{ extracted_at: String, sources: Vec<String> }`
@@ -398,10 +410,10 @@ All types derive `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`.
 
 **New file: `crates/weaver-cards/src/request.rs`** (~110 lines)
 
-- `GetCardRequest` — `{ uri: String, line: u32, column: u32, detail:
-  DetailLevel }`. The `parse(arguments: &[String]) -> Result<Self,
-  GetCardError>` method follows the pattern from `
-  crates/weaverd/src/dispatch/observe/arguments.rs`:
+- `GetCardRequest` —
+  `{ uri: String, line: u32, column: u32, detail: DetailLevel }`. The
+  `parse(arguments: &[String]) -> Result<Self, GetCardError>` method follows
+  the pattern from `crates/weaverd/src/dispatch/observe/arguments.rs`:
   - Iterates with a peekable iterator
   - Recognizes `--uri`, `--position`, `--detail`, `--format`
   - `--position` parsed with `split_once(':')` (not indexing)

--- a/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
+++ b/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
@@ -334,21 +334,21 @@ Types mapped from the design doc lines 147-170:
 - `SourcePosition` — `{ line: u32, column: u32 }` (zero-indexed, matching
   Tree-sitter and LSP internal representation)
 - `SourceRange` — `{ start: SourcePosition, end: SourcePosition }`
-- `CardSymbolKind` — `#[non_exhaustive]` enum with `#[serde(rename_all =
-  "snake_case")]`: `Function`, `Method`, `Class`, `Interface`, `Type`, `Variable
-   `, `Module`, `Field`
+- `CardSymbolKind` — `#[non_exhaustive]` enum with
+  `#[serde(rename_all = "snake_case")]`: `Function`, `Method`, `Class`,
+  `Interface`, `Type`, `Variable`, `Module`, `Field`
 - `CardLanguage` — `#[non_exhaustive]` enum: `Rust`, `Python`, `TypeScript`
 - `SymbolRef` — location-based reference: `uri`, `range`, `language`,
   `kind`, `name`, `container` (Option, skip_serializing_if is_none)
 - `SymbolId` — `{ symbol_id: String }`
-- `SymbolIdentity` — `{ symbol_id: String, #[serde(rename = "ref")]
-  symbol_ref: SymbolRef }`
+- `SymbolIdentity` — `{ symbol_id: String, #[serde(rename = "ref")] symbol_ref:
+  SymbolRef }`
 
 **New file: `crates/weaver-cards/src/detail.rs`** (~55 lines)
 
-- `DetailLevel` — `#[non_exhaustive]` enum with `#[serde(rename_all =
-  "snake_case")]`: `Minimal`, `Signature`, `Structure` (default), `Semantic`, `
-  Full`. Implements `Default` returning `Structure`.
+- `DetailLevel` — `#[non_exhaustive]` enum with
+  `#[serde(rename_all = "snake_case")]`: `Minimal`, `Signature`, `Structure`
+  (default), `Semantic`, `Full`. Implements `Default` returning `Structure`.
 
 **Validation:** `cargo check -p weaver-cards` succeeds.
 
@@ -711,10 +711,10 @@ Quality criteria (what "done" means):
 - Documentation: `make markdownlint` and `make nixie` pass.
 - Schema stability: The JSON output for each detail level is deterministic.
   Repeated serialization of the same fixture produces byte-identical output.
-- Refusal payload: Dispatching `observe get-card --uri file:///foo.rs
-  --position
-  10:5` returns a JSONL response containing a `GetCardResponse::Refusal
-  ` with reason `"not_yet_implemented"` and status 1.
+- Refusal payload: Dispatching
+  `observe get-card --uri file:///foo.rs --position 10:5`
+  returns a JSONL response containing a `GetCardResponse::Refusal` with reason
+  `"not_yet_implemented"` and status 1.
 - Field names: JSON field names match the design document
   (`card_version`, `symbol`, `signature`, `doc`, `structure`, `lsp`, `metrics`,
   `deps`, `provenance`, `etag`).

--- a/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
+++ b/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
@@ -199,15 +199,15 @@ This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
 
 ## Outcomes & retrospective
 
-All stages completed successfully. The `weaver-cards` crate exports 25 public
-types covering the full `observe get-card` schema. Six insta snapshots lock the
-JSON shapes for minimal, structure, and full detail cards, plus refusal and
-success response envelopes. Five BDD scenarios validate schema contracts. The
-`weaverd` router recognizes `observe get-card` and dispatches to a handler that
-returns a structured `GetCardResponse::Refusal` with reason
-`not_yet_implemented`. All quality gates (`make check-fmt`, `make lint`,
-`make test`, `make markdownlint`, `make nixie`) pass. Documentation updated in
-`users-guide.md`, `repository-layout.md`, and `roadmap.md`.
+All stages completed successfully. The `weaver-cards` crate exports the full
+public schema surface for `observe get-card`. Six insta snapshots lock the JSON
+shapes for minimal, structure, and full detail cards, plus refusal and success
+response envelopes. Five BDD scenarios validate schema contracts. The `weaverd`
+router recognizes `observe get-card` and dispatches to a handler that returns a
+structured `GetCardResponse::Refusal` with reason `not_yet_implemented`. All
+quality gates (`make check-fmt`, `make lint`, `make test`, `make markdownlint`,
+`make nixie`) pass. Documentation updated in `users-guide.md`,
+`repository-layout.md`, and `roadmap.md`.
 
 Key learnings:
 
@@ -415,9 +415,9 @@ All types derive `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`.
 
 **New file: `crates/weaver-cards/src/response.rs`** (~100 lines)
 
-- `RefusalReason` — `#[non_exhaustive]` enum with `#[serde(rename_all =
-  "snake_case")]`: `NoSymbolAtPosition`, `UnsupportedLanguage`, `
-  NotYetImplemented`, `BackendUnavailable`
+- `RefusalReason` — `#[non_exhaustive]` enum with
+  `#[serde(rename_all = "snake_case")]`: `NoSymbolAtPosition`,
+  `UnsupportedLanguage`, `NotYetImplemented`, `BackendUnavailable`
 - `CardRefusal` — `{ reason: RefusalReason, message: String,
   requested_detail: DetailLevel }`
 - `GetCardResponse` — `#[serde(tag = "status", rename_all = "snake_case")]
@@ -597,8 +597,8 @@ operation is recognized and returns a structured refusal.
 Add an `#### observe get-card` section after the existing
 `observe call-hierarchy` section (around line 440). Content:
 
-- Syntax: `weaver observe get-card --uri <URI> --position <LINE:COL>
-  [--detail <LEVEL>]`
+- Syntax:
+  `weaver observe get-card --uri <URI> --position <LINE:COL> [--detail <LEVEL>]`
 - Arguments: `--uri` (required), `--position` (required, 1-indexed),
   `--detail` (optional, one of `minimal`/`signature`/`structure`
   (default)/`semantic`/`full`)
@@ -712,8 +712,8 @@ Quality criteria (what "done" means):
 - Schema stability: The JSON output for each detail level is deterministic.
   Repeated serialization of the same fixture produces byte-identical output.
 - Refusal payload: Dispatching
-  `observe get-card --uri file:///foo.rs --position 10:5`
-  returns a JSONL response containing a `GetCardResponse::Refusal` with reason
+  `observe get-card --uri file:///foo.rs --position 10:5` returns a JSONL
+  response containing a `GetCardResponse::Refusal` with reason
   `"not_yet_implemented"` and status 1.
 - Field names: JSON field names match the design document
   (`card_version`, `symbol`, `signature`, `doc`, `structure`, `lsp`, `metrics`,
@@ -918,8 +918,8 @@ Modified files (8):
 7. `docs/repository-layout.md` — add crate listing
 8. `docs/users-guide.md` — add `observe get-card` documentation
 
-Total: ~23 file touches (15 new + 8 modified) plus auto-generated snapshot
-files. Within the 25-file tolerance.
+Total: ~23 planned file touches (15 new + 8 modified), excluding the committed
+snapshot outputs from the 25-file tolerance count.
 
 ### Critical reference files
 

--- a/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
+++ b/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
@@ -203,8 +203,8 @@ success response envelopes. Five BDD scenarios validate schema contracts. The
 `weaverd` router recognizes `observe get-card` and dispatches to a handler that
 returns a structured `GetCardResponse::Refusal` with reason
 `not_yet_implemented`. All quality gates (`make check-fmt`, `make lint`,
-`make test`) pass. Documentation updated in `users-guide.md`,
-`repository-layout.md`, and `roadmap.md`.
+`make test`, `make markdownlint`, `make nixie`) pass. Documentation updated in
+`users-guide.md`, `repository-layout.md`, and `roadmap.md`.
 
 Key learnings:
 

--- a/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
+++ b/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
@@ -24,6 +24,8 @@ Observable outcome after all stages complete:
 make check-fmt   # exits 0
 make lint         # exits 0 (includes cargo doc --workspace --no-deps -D warnings)
 make test         # exits 0, including all new weaver-cards and weaverd tests
+make markdownlint # exits 0
+make nixie        # exits 0
 ```
 
 Specifically:
@@ -54,9 +56,10 @@ This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
 
 ## Constraints
 
-- `make check-fmt`, `make lint`, and `make test` must pass after all changes.
-  These are defined in `Makefile` (lines 19-35).
-- The workspace uses `edition = "2024"` and `rust-version = "1.85"`
+- `make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie` must pass after all changes. These are defined in `Makefile`
+  (lines 19-35).
+- The workspace uses `edition = "2024"` and `rust-version = "1.88"`
   (`Cargo.toml` lines 20-23). The new crate must inherit these via
   `edition.workspace = true`, `version.workspace = true`, and
   `rust-version.workspace = true`.
@@ -617,7 +620,8 @@ task and both sub-tasks).
 
 Copy the finalized ExecPlan to the execplans directory.
 
-**Validation:** `make fmt` passes. `make markdownlint` passes.
+**Validation:** `make fmt` passes. `make markdownlint` passes. `make nixie`
+passes.
 
 ### Stage I: Final validation and commit gating
 
@@ -628,9 +632,11 @@ set -o pipefail
 make check-fmt 2>&1 | tee /tmp/check-fmt.log
 make lint 2>&1 | tee /tmp/lint.log
 make test 2>&1 | tee /tmp/test.log
+make markdownlint 2>&1 | tee /tmp/markdownlint.log
+make nixie 2>&1 | tee /tmp/nixie.log
 ```
 
-All three must exit 0. Additionally verify:
+All five must exit 0. Additionally verify:
 
 - `cargo doc -p weaver-cards --no-deps` produces zero warnings.
 - Insta snapshot files exist and are committed.
@@ -687,9 +693,11 @@ set -o pipefail
 make check-fmt 2>&1 | tee /tmp/check-fmt.log
 make lint 2>&1 | tee /tmp/lint.log
 make test 2>&1 | tee /tmp/test.log
+make markdownlint 2>&1 | tee /tmp/markdownlint.log
+make nixie 2>&1 | tee /tmp/nixie.log
 ```
 
-Expected: all three exit 0.
+Expected: all five exit 0.
 
 ## Validation and acceptance
 
@@ -700,6 +708,7 @@ Quality criteria (what "done" means):
 - Lint/typecheck: `make lint` passes. `cargo doc -p weaver-cards --no-deps`
   produces zero warnings.
 - Formatting: `make check-fmt` passes.
+- Documentation: `make markdownlint` and `make nixie` pass.
 - Schema stability: The JSON output for each detail level is deterministic.
   Repeated serialization of the same fixture produces byte-identical output.
 - Refusal payload: Dispatching `observe get-card --uri file:///foo.rs
@@ -716,7 +725,9 @@ Quality criteria (what "done" means):
 
 Quality method (how checks are performed):
 
-- Run `make check-fmt && make lint && make test` and confirm exit 0.
+- Run
+  `make check-fmt && make lint && make test && make markdownlint && make nixie`
+  and confirm exit 0.
 - Inspect snapshot files in `crates/weaver-cards/src/tests/snapshots/` to
   verify JSON shapes match the design document.
 

--- a/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
+++ b/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
@@ -15,8 +15,8 @@ stable, serde-annotated Rust types that describe every field, variant, and
 version marker in the `observe get-card` request and response payloads. These
 types lock down the JSON shapes described in
 `docs/jacquard-card-first-symbol-graph-design.md` so that later tasks (7.1.2
-Tree-sitter extraction, 7.1.3 LSP enrichment) implement against a
-well-defined contract rather than inventing the schema ad hoc.
+Tree-sitter extraction, 7.1.3 LSP enrichment) implement against a well-defined
+contract rather than inventing the schema ad hoc.
 
 Observable outcome after all stages complete:
 
@@ -30,24 +30,22 @@ Specifically:
 
 1. A new crate `weaver-cards` exists in `crates/weaver-cards/` and is
    registered as a workspace member. It exports types for `SymbolCard`,
-   `SymbolRef`, `SymbolId`, `DetailLevel`, `GetCardRequest`,
-   `GetCardResponse` (success and refusal variants), and all nested
-   sub-structures.
+   `SymbolRef`, `SymbolId`, `DetailLevel`, `GetCardRequest`, `GetCardResponse`
+   (success and refusal variants), and all nested sub-structures.
 2. Insta snapshot tests in `weaver-cards` lock the JSON shape of a fully
    populated success card, a minimal card, and a refusal payload. These
    snapshots are byte-identical across runs for unchanged inputs.
 3. Behaviour-driven development (BDD) feature scenarios in
-   `weaver-cards` exercise the request parsing and response
-   construction via `rstest-bdd` v0.5.0.
+   `weaver-cards` exercise the request parsing and response construction via
+   `rstest-bdd` v0.5.0.
 4. `weaverd` adds `"get-card"` to the
    `DomainRoutingContext::OBSERVE.known_operations` list so that
    `observe get-card` is recognized by the router.
 5. Because no Tree-sitter extraction exists yet (that is 7.1.2), the handler
    in `weaverd` returns a structured refusal response (a
-   `GetCardResponse::Refusal` variant) rather than a bare "not yet
-   implemented" string. This exercises the schema types in the dispatch path
-   and produces a JSON payload that tells the caller exactly why no card was
-   produced.
+   `GetCardResponse::Refusal` variant) rather than a bare "not yet implemented"
+   string. This exercises the schema types in the dispatch path and produces a
+   JSON payload that tells the caller exactly why no card was produced.
 6. `docs/users-guide.md` is updated with `observe get-card` command
    documentation including syntax, arguments, and response format.
 7. Roadmap item 7.1.1 in `docs/roadmap.md` is marked complete.
@@ -82,9 +80,9 @@ This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
 - All dependency versions use caret requirements (`AGENTS.md`
   lines 206-216).
 - No new external dependencies beyond those already in
-  `[workspace.dependencies]`. The needed dependencies (`serde`,
-  `serde_json`, `thiserror`, `rstest`, `rstest-bdd`, `rstest-bdd-macros`,
-  `insta`) are all already workspace dependencies.
+  `[workspace.dependencies]`. The needed dependencies (`serde`, `serde_json`,
+  `thiserror`, `rstest`, `rstest-bdd`, `rstest-bdd-macros`, `insta`) are all
+  already workspace dependencies.
 - Existing crate public APIs must not change.
 - Provenance timestamps use `String` (ISO 8601 format) rather than
   introducing `chrono` or `time`, since neither is a workspace dependency.
@@ -95,8 +93,8 @@ This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
   and escalate. (Raised from 15 because new-crate scaffolding creates many
   small files plus insta snapshot files.)
 - Interface: if any existing `pub` API signature in any existing crate must
-  change (beyond adding `"get-card"` to the known operations list and adding
-  a new module in `dispatch/observe/`), stop and escalate.
+  change (beyond adding `"get-card"` to the known operations list and adding a
+  new module in `dispatch/observe/`), stop and escalate.
 - Dependencies: if a new external dependency beyond those already in
   `[workspace.dependencies]` is required, stop and escalate.
 - Iterations: if tests still fail after 5 attempts at fixing a given issue,
@@ -107,22 +105,20 @@ This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
 ## Risks
 
 - Risk: `result_large_err = "deny"` lint may fire if `GetCardResponse` or
-  `SymbolCard` is large as a `Result` error type.
-  Severity: low. Likelihood: low. Mitigation: `GetCardResponse` is not used
-  as an error type; it is serialized directly. The card types themselves are
-  serialized to JSON strings, not returned as `Err(...)`.
+  `SymbolCard` is large as a `Result` error type. Severity: low. Likelihood:
+  low. Mitigation: `GetCardResponse` is not used as an error type; it is
+  serialized directly. The card types themselves are serialized to JSON
+  strings, not returned as `Err(...)`.
 
 - Risk: `missing_const_for_fn = "deny"` fires on constructors taking
-  `String`, `Vec`, or `Option<String>`.
-  Severity: low. Likelihood: high. Mitigation: Use
-  `#[expect(clippy::missing_const_for_fn, reason = "...")]` on such
-  constructors. This is the established pattern from `sempai-core`.
+  `String`, `Vec`, or `Option<String>`. Severity: low. Likelihood: high.
+  Mitigation: Use `#[expect(clippy::missing_const_for_fn, reason = "...")]` on
+  such constructors. This is the established pattern from `sempai-core`.
 
 - Risk: The 400-line file limit may be challenged by the number of struct
-  definitions.
-  Severity: medium. Likelihood: medium. Mitigation: Split the types across
-  multiple modules (`symbol.rs`, `card.rs`, `request.rs`, `response.rs`,
-  `detail.rs`, `error.rs`).
+  definitions. Severity: medium. Likelihood: medium. Mitigation: Split the
+  types across multiple modules (`symbol.rs`, `card.rs`, `request.rs`,
+  `response.rs`, `detail.rs`, `error.rs`).
 
 - Risk: `str_to_string = "deny"` fires on `.to_string()` called on `&str`.
   Severity: low. Likelihood: high. Mitigation: Use `String::from(...)` or
@@ -150,78 +146,74 @@ This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
 
 - `CardLanguage::TypeScript` with `#[serde(rename_all = "snake_case")]`
   serialized as `"type_script"` instead of the design document's
-  `"typescript"`. Fixed by adding an explicit `#[serde(rename =
-  "typescript")]` on the `TypeScript` variant.
+  `"typescript"`. Fixed by adding an explicit `#[serde(rename = "typescript")]`
+  on the `TypeScript` variant.
 
 - `cargo-insta` command-line interface (CLI) was not installed
-  in the environment. Snapshot tests failed on first run because
-  no snapshot files existed. Resolved by running with
-  `INSTA_UPDATE=always` environment variable to auto-accept new
-  snapshots.
+  in the environment. Snapshot tests failed on first run because no snapshot
+  files existed. Resolved by running with `INSTA_UPDATE=always` environment
+  variable to auto-accept new snapshots.
 
 - The `Cargo.toml` edit tool requires a fresh `Read` call before each
-  `Edit`. An initial attempt to edit the workspace `Cargo.toml` failed due
-  to a stale read cache. Re-reading before editing resolved it.
+  `Edit`. An initial attempt to edit the workspace `Cargo.toml` failed due to a
+  stale read cache. Re-reading before editing resolved it.
 
 ## Decision log
 
 - Decision: Place schema types in a new `weaver-cards` crate rather than
-  inside `weaverd`.
-  Rationale: The design document
-  (`docs/jacquard-card-first-symbol-graph-design.md` lines 709-727)
-  recommends Option A (new crates) for better testability and reduced daemon
-  coupling. The workspace already follows this pattern with `weaver-graph`,
-  `weaver-plugins`, `sempai-core`, etc.
+  inside `weaverd`. Rationale: The design document
+  (`docs/jacquard-card-first-symbol-graph-design.md` lines 709-727) recommends
+  Option A (new crates) for better testability and reduced daemon coupling. The
+  workspace already follows this pattern with `weaver-graph`, `weaver-plugins`,
+  `sempai-core`, etc.
 
 - Decision: Use `String` for timestamps rather than `time::OffsetDateTime`.
-  Rationale: Neither `chrono` nor `time` is a workspace dependency. Adding
-  one solely for a schema definition crate is unnecessary. The
-  `extracted_at` field is serialized as an ISO 8601 string.
+  Rationale: Neither `chrono` nor `time` is a workspace dependency. Adding one
+  solely for a schema definition crate is unnecessary. The `extracted_at` field
+  is serialized as an ISO 8601 string.
 
 - Decision: Model progressive detail levels via `Option` fields on a single
-  `SymbolCard` struct rather than separate structs per detail level.
-  Rationale: The design document defines detail levels as additive layers
-  (`minimal` is a subset of `signature` which is a subset of `structure`,
-  etc.). Using `Option` fields with
-  `#[serde(skip_serializing_if = "Option::is_none")]` naturally produces the
-  right JSON shape for each level. A single struct with optional sections is
-  simpler than maintaining five separate structs with overlapping fields.
+  `SymbolCard` struct rather than separate structs per detail level. Rationale:
+  The design document defines detail levels as additive layers (`minimal` is a
+  subset of `signature` which is a subset of `structure`, etc.). Using `Option`
+  fields with `#[serde(skip_serializing_if = "Option::is_none")]` naturally
+  produces the right JSON shape for each level. A single struct with optional
+  sections is simpler than maintaining five separate structs with overlapping
+  fields.
 
 - Decision: Use internally-tagged enum `#[serde(tag = "status")]` for
-  `GetCardResponse`.
-  Rationale: The response has struct-like variants (`Success { card }` and
-  `Refusal { refusal }`), which are compatible with internally-tagged serde.
-  This produces a clean JSON shape where `"status": "success"` or
-  `"status": "refusal"` appears at the top level alongside the payload
-  fields.
+  `GetCardResponse`. Rationale: The response has struct-like variants
+  (`Success { card }` and `Refusal { refusal }`), which are compatible with
+  internally-tagged serde. This produces a clean JSON shape where
+  `"status": "success"` or `"status": "refusal"` appears at the top level
+  alongside the payload fields.
 
 - Decision: The `get-card` handler in `weaverd` returns a structured refusal
   rather than the existing `route_fallback` text-based "not yet implemented"
-  message.
-  Rationale: The acceptance criteria state "schema fixtures lock field names
-  and payload shapes". Returning a typed refusal exercises the schema in the
-  dispatch path and provides a richer signal to callers.
+  message. Rationale: The acceptance criteria state "schema fixtures lock field
+  names and payload shapes". Returning a typed refusal exercises the schema in
+  the dispatch path and provides a richer signal to callers.
 
 ## Outcomes & retrospective
 
-All stages completed successfully. The `weaver-cards` crate exports 25
-public types covering the full `observe get-card` schema. Six insta
-snapshots lock the JSON shapes for minimal, structure, and full detail
-cards, plus refusal and success response envelopes. Five BDD scenarios
-validate schema contracts. The `weaverd` router recognizes `observe
-get-card` and dispatches to a handler that returns a structured
-`GetCardResponse::Refusal` with reason `not_yet_implemented`. All quality
-gates (`make check-fmt`, `make lint`, `make test`) pass. Documentation
-updated in `users-guide.md`, `repository-layout.md`, and `roadmap.md`.
+All stages completed successfully. The `weaver-cards` crate exports 25 public
+types covering the full `observe get-card` schema. Six insta snapshots lock the
+JSON shapes for minimal, structure, and full detail cards, plus refusal and
+success response envelopes. Five BDD scenarios validate schema contracts. The
+`weaverd` router recognizes `observe get-card` and dispatches to a handler that
+returns a structured `GetCardResponse::Refusal` with reason
+`not_yet_implemented`. All quality gates (`make check-fmt`, `make lint`,
+`make test`) pass. Documentation updated in `users-guide.md`,
+`repository-layout.md`, and `roadmap.md`.
 
 Key learnings:
 
 - Serde `rename_all = "snake_case"` splits on camelCase boundaries, so
-  `TypeScript` becomes `type_script`. Use explicit `#[serde(rename = ...)]`
-  for compound words that should not be split.
+  `TypeScript` becomes `type_script`. Use explicit `#[serde(rename = ...)]` for
+  compound words that should not be split.
 - The `INSTA_UPDATE=always` environment variable is a practical alternative
-  to the `cargo-insta` CLI for accepting new snapshots in environments
-  where the CLI is not installed.
+  to the `cargo-insta` CLI for accepting new snapshots in environments where
+  the CLI is not installed.
 - Splitting types across 6 modules kept every file well under the 400-line
   limit (largest was ~230 lines for `card.rs`).
 
@@ -229,15 +221,15 @@ Key learnings:
 
 ### Repository structure
 
-Weaver is a Rust workspace rooted at `./`. The workspace has 14
-crates in `crates/`. The main daemon is `crates/weaverd/`. The CLI is
+Weaver is a Rust workspace rooted at `./`. The workspace has 14 crates in
+`crates/`. The main daemon is `crates/weaverd/`. The CLI is
 `crates/weaver-cli/`. Domain-specific logic lives in separate crates:
 `weaver-graph` (call graphs), `weaver-plugins` (plugin orchestration),
 `weaver-syntax` (Tree-sitter), `weaver-lsp-host` (LSP management),
 `sempai-core` and `sempai` (query engine).
 
-The workspace `Cargo.toml` at `Cargo.toml` lists all members (lines 2-17)
-and defines shared dependencies (lines 25-51) and lint rules (lines 53-127).
+The workspace `Cargo.toml` at `Cargo.toml` lists all members (lines 2-17) and
+defines shared dependencies (lines 25-51) and lint rules (lines 53-127).
 
 ### JSONL dispatch architecture
 
@@ -340,8 +332,8 @@ Types mapped from the design doc lines 147-170:
   Tree-sitter and LSP internal representation)
 - `SourceRange` — `{ start: SourcePosition, end: SourcePosition }`
 - `CardSymbolKind` — `#[non_exhaustive]` enum with `#[serde(rename_all =
-  "snake_case")]`: `Function`, `Method`, `Class`, `Interface`, `Type`,
-  `Variable`, `Module`, `Field`
+  "snake_case")]`: `Function`, `Method`, `Class`, `Interface`, `Type`, `Variable
+   `, `Module`, `Field`
 - `CardLanguage` — `#[non_exhaustive]` enum: `Rust`, `Python`, `TypeScript`
 - `SymbolRef` — location-based reference: `uri`, `range`, `language`,
   `kind`, `name`, `container` (Option, skip_serializing_if is_none)
@@ -352,8 +344,8 @@ Types mapped from the design doc lines 147-170:
 **New file: `crates/weaver-cards/src/detail.rs`** (~55 lines)
 
 - `DetailLevel` — `#[non_exhaustive]` enum with `#[serde(rename_all =
-  "snake_case")]`: `Minimal`, `Signature`, `Structure` (default),
-  `Semantic`, `Full`. Implements `Default` returning `Structure`.
+  "snake_case")]`: `Minimal`, `Signature`, `Structure` (default), `Semantic`, `
+  Full`. Implements `Default` returning `Structure`.
 
 **Validation:** `cargo check -p weaver-cards` succeeds.
 
@@ -370,28 +362,29 @@ Types mapped from design doc lines 176-268:
 - `DocInfo` — `{ docstring: String, summary: String, source: String }`
 - `NormalizedAttachments` — `{ decorators: Vec<String> }`
 - `AttachmentsInfo` — `{ doc_comments: Vec<String>, decorators:
-  Vec<String>, normalized: NormalizedAttachments, bundle_rule: String }`
-  (present at `structure` detail and above)
+  Vec<String>, normalized: NormalizedAttachments, bundle_rule: String
+  }` (present at `structure` detail and above)
 - `LocalInfo` — `{ name: String, kind: String, decl_line: u32 }`
 - `BranchInfo` — `{ kind: String, line: u32 }`
 - `StructureInfo` — `{ locals: Vec<LocalInfo>, branches: Vec<BranchInfo> }`
 - `LspInfo` — `{ hover: String, #[serde(rename = "type")] type_info:
   String, deprecated: bool, source: String }`
 - `MetricsInfo` — `{ lines: u32, cyclomatic: u32, fan_in: Option<u32>,
-  fan_out: Option<u32> }` (fan metrics are `Option` because they are only
-  populated at `full` detail from the relational graph layer)
+  fan_out: Option<u32>
+  }` (fan metrics are `Option` because they are only populated at `full
+  ` detail from the relational graph layer)
 - `DepsInfo` — `{ calls: Vec<String>, imports: Vec<String>, config:
   Vec<String> }`
 - `ImportInterstitialInfo` — `{ raw: String, normalized: Vec<String>,
-  groups: Vec<Vec<String>>, source: String }` (import block data for
-  file/module or interstitial cards)
+  groups: Vec<Vec<String>>, source: String
+  }` (import block data for file/module or interstitial cards)
 - `InterstitialInfo` — `{ imports: ImportInterstitialInfo }` (present on
   file/module and interstitial cards only)
 - `Provenance` — `{ extracted_at: String, sources: Vec<String> }`
-- `SymbolCard` — top-level struct with `card_version: u32`, `symbol:
-  SymbolIdentity`, and all other sections as `Option<T>` with
-  `#[serde(skip_serializing_if = "Option::is_none")]`. The `provenance`
-  field is not optional (always present). The `etag` field is
+- `SymbolCard` — top-level struct with `card_version: u32`,
+  `symbol: SymbolIdentity`, and all other sections as `Option<T>`. Apply
+  `#[serde(skip_serializing_if = "Option::is_none")]` to the optional sections.
+  The `provenance` field is not optional (always present). The `etag` field is
   `Option<String>`.
 
 All types derive `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`.
@@ -404,8 +397,8 @@ All types derive `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`.
 
 - `GetCardRequest` — `{ uri: String, line: u32, column: u32, detail:
   DetailLevel }`. The `parse(arguments: &[String]) -> Result<Self,
-  GetCardError>` method follows the pattern from
-  `crates/weaverd/src/dispatch/observe/arguments.rs`:
+  GetCardError>` method follows the pattern from `
+  crates/weaverd/src/dispatch/observe/arguments.rs`:
   - Iterates with a peekable iterator
   - Recognizes `--uri`, `--position`, `--detail`, `--format`
   - `--position` parsed with `split_once(':')` (not indexing)
@@ -420,8 +413,8 @@ All types derive `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`.
 **New file: `crates/weaver-cards/src/response.rs`** (~100 lines)
 
 - `RefusalReason` — `#[non_exhaustive]` enum with `#[serde(rename_all =
-  "snake_case")]`: `NoSymbolAtPosition`, `UnsupportedLanguage`,
-  `NotYetImplemented`, `BackendUnavailable`
+  "snake_case")]`: `NoSymbolAtPosition`, `UnsupportedLanguage`, `
+  NotYetImplemented`, `BackendUnavailable`
 - `CardRefusal` — `{ reason: RefusalReason, message: String,
   requested_detail: DetailLevel }`
 - `GetCardResponse` — `#[serde(tag = "status", rename_all = "snake_case")]
@@ -433,18 +426,18 @@ All types derive `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`.
 **New file: `crates/weaver-cards/src/error.rs`** (~60 lines)
 
 - `GetCardError` — `#[non_exhaustive] #[derive(thiserror::Error)]`:
-  `MissingArgument { flag: String }`, `InvalidValue { flag: String,
-  message: String }`, `UnknownArgument { argument: String }`
+  `MissingArgument { flag: String }`,
+  `InvalidValue { flag: String, message: String }`,
+  `UnknownArgument { argument: String }`
 
-**Validation:** `cargo check -p weaver-cards` succeeds. Basic serde
-round-trip tests pass.
+**Validation:** `cargo check -p weaver-cards` succeeds. Basic serde round-trip
+tests pass.
 
 ### Stage E: Add insta snapshot tests
 
 **New file: `crates/weaver-cards/src/tests/mod.rs`**
 
-Module declarations for `snapshot_tests`, `round_trip_tests`, and
-`behaviour`.
+Module declarations for `snapshot_tests`, `round_trip_tests`, and `behaviour`.
 
 **New file: `crates/weaver-cards/src/tests/snapshot_tests.rs`** (~180 lines)
 
@@ -464,22 +457,22 @@ Fixture builders construct example payloads and snapshot via
 6. `snapshot_success_response` — `GetCardResponse::Success` wrapping a
    structure-level card.
 
-Each test serializes to JSON via `serde_json::to_string_pretty` and
-snapshots the result. Snapshot files auto-generated in
+Each test serializes to JSON via `serde_json::to_string_pretty` and snapshots
+the result. Snapshot files auto-generated in
 `crates/weaver-cards/src/tests/snapshots/`.
 
 **New file: `crates/weaver-cards/src/tests/round_trip_tests.rs`** (~80 lines)
 
-Tests serialize and deserialize each type to confirm serde compatibility.
-Uses `rstest` parameterization for detail levels. Verifies byte-identical
+Tests serialize and deserialize each type to confirm serde compatibility. Uses
+`rstest` parameterization for detail levels. Verifies byte-identical
 re-serialization.
 
 **Validation:** `cargo test -p weaver-cards` passes. Snapshot files created.
 
 ### Stage F: Add BDD feature file and behaviour tests
 
-**New file: `crates/weaver-cards/tests/features/get_card_schema.feature`**
-(~45 lines)
+**New file: `crates/weaver-cards/tests/features/get_card_schema.feature`** (~45
+lines)
 
 ```gherkin
 Feature: Symbol card schema contracts
@@ -521,8 +514,8 @@ Feature: Symbol card schema contracts
 
 **New file: `crates/weaver-cards/src/tests/behaviour.rs`** (~200 lines)
 
-BDD step implementations using `rstest-bdd-macros`, following the pattern
-from `crates/weaver-plugins/src/tests/behaviour.rs`:
+BDD step implementations using `rstest-bdd-macros`, following the pattern from
+`crates/weaver-plugins/src/tests/behaviour.rs`:
 
 - `TestWorld` struct holding the current card, response, serialized JSON,
   and request.
@@ -532,8 +525,7 @@ from `crates/weaver-plugins/src/tests/behaviour.rs`:
 - `world` parameter named `world` (not `_world`); unused suppressed with
   `let _ = world;`.
 
-**Validation:** `cargo test -p weaver-cards` passes. All BDD scenarios
-green.
+**Validation:** `cargo test -p weaver-cards` passes. All BDD scenarios green.
 
 ### Stage G: Wire `weaverd` dispatch
 
@@ -559,8 +551,8 @@ green.
    "get-card" => observe::get_card::handle(request, writer),
    ```
 
-   The `get-card` handler does NOT take `backends` because it does not
-   start any backend. It returns a structured refusal.
+   The `get-card` handler does NOT take `backends` because it does not start
+   any backend. It returns a structured refusal.
 
 **New file: `crates/weaverd/src/dispatch/observe/get_card.rs`** (~65 lines)
 
@@ -618,8 +610,8 @@ Add `weaver-cards/` to the crate listing in the `crates/` tree (line 31-45).
 
 **Modify: `docs/roadmap.md`**
 
-Mark 7.1.1 as complete: change `- [ ]` to `- [x]` on lines 788-795 (the
-main task and both sub-tasks).
+Mark 7.1.1 as complete: change `- [ ]` to `- [x]` on lines 788-795 (the main
+task and both sub-tasks).
 
 **Write: `docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md`**
 
@@ -711,12 +703,12 @@ Quality criteria (what "done" means):
 - Schema stability: The JSON output for each detail level is deterministic.
   Repeated serialization of the same fixture produces byte-identical output.
 - Refusal payload: Dispatching `observe get-card --uri file:///foo.rs
-  --position 10:5` returns a JSONL response containing a
-  `GetCardResponse::Refusal` with reason `"not_yet_implemented"` and
-  status 1.
+  --position
+  10:5` returns a JSONL response containing a `GetCardResponse::Refusal
+  ` with reason `"not_yet_implemented"` and status 1.
 - Field names: JSON field names match the design document
-  (`card_version`, `symbol`, `signature`, `doc`, `structure`, `lsp`,
-  `metrics`, `deps`, `provenance`, `etag`).
+  (`card_version`, `symbol`, `signature`, `doc`, `structure`, `lsp`, `metrics`,
+  `deps`, `provenance`, `etag`).
 - Provenance: every non-trivial field section includes a `source` field.
 - User guide: `docs/users-guide.md` documents the `observe get-card`
   command.
@@ -921,8 +913,8 @@ files. Within the 25-file tolerance.
 ### Critical reference files
 
 - `docs/jacquard-card-first-symbol-graph-design.md` — source of truth for
-  the `SymbolCard` JSON schema, detail levels, and command surface
-  (lines 138-614)
+  the `SymbolCard` JSON schema, detail levels, and command surface (lines
+  138-614)
 - `crates/weaverd/src/dispatch/router.rs` — router where `"get-card"` must
   be added (lines 89-199)
 - `crates/weaverd/src/dispatch/observe/arguments.rs` — pattern to follow
@@ -930,8 +922,8 @@ files. Within the 25-file tolerance.
 - `crates/sempai-core/src/lib.rs` — pattern to follow for new crate
   scaffolding (module structure, re-exports, lint compliance)
 - `crates/weaverd/src/dispatch/observe/get_definition.rs` — pattern to
-  follow for handler module structure (parse args, serialize response,
-  return `DispatchResult`)
+  follow for handler module structure (parse args, serialize response, return
+  `DispatchResult`)
 - `crates/weaverd/src/dispatch/router/tests.rs` — existing router test
   structure to extend
 

--- a/docs/execplans/adopt-ortho-config-v0-8-0.md
+++ b/docs/execplans/adopt-ortho-config-v0-8-0.md
@@ -252,23 +252,20 @@ Validation completed successfully with captured logs:
 
 The upgrade is concentrated in a small set of files.
 
-- `/home/user/project/Cargo.toml` holds the workspace dependency on
+- `./Cargo.toml` holds the workspace dependency on
   `ortho_config = "0.7.0"` and the current Rust floor `rust-version = "1.85"`.
-- `/home/user/project/crates/weaver-config/src/lib.rs` defines the shared
+- `crates/weaver-config/src/lib.rs` defines the shared
   `Config` struct and the derive-generated loading path used by both binaries.
-- `/home/user/project/crates/weaver-cli/src/localizer.rs` exercises the
+- `crates/weaver-cli/src/localizer.rs` exercises the
   Fluent localisation APIs added in v0.7.0 and must continue to compile after
   the v0.8.0 upgrade.
-- `/home/user/project/crates/weaver-cli/src/config.rs` is a secondary audit
+- `crates/weaver-cli/src/config.rs` is a secondary audit
   point because it forwards CLI flags into `Config::load_from_iter`.
-- `/home/user/project/README.md`,
-  `/home/user/project/docs/users-guide.md`,
-  `/home/user/project/docs/weaver-design.md`,
-  `/home/user/project/docs/ortho-config-users-guide.md`,
-  `/home/user/project/docs/contents.md`, and
-  `/home/user/project/docs/roadmap.md` all describe the current configuration
-  story and will become stale if the migration lands without documentation
-  updates.
+- `./README.md`,
+  `docs/users-guide.md`, `docs/weaver-design.md`,
+  `docs/ortho-config-users-guide.md`, `docs/contents.md`, and `docs/roadmap.md`
+  all describe the current configuration story and will become stale if the
+  migration lands without documentation updates.
 
 The current implementation does not appear to use the migration-note edge
 cases. There is no alias for the `ortho_config` crate, no direct
@@ -317,7 +314,7 @@ the migration and whether any unrelated blockers were already present.
 Make the version and toolchain changes first, then let the compiler and tests
 tell us whether any source edits are needed.
 
-1. In `/home/user/project/Cargo.toml`, change the workspace Rust floor from
+1. In `./Cargo.toml`, change the workspace Rust floor from
    `1.85` to `1.88` and change `ortho_config = "0.7.0"` to
    `ortho_config = "0.8.0"`.
 2. Add `rust-version.workspace = true` to every member manifest that lacks
@@ -378,14 +375,14 @@ non-applicable with concrete evidence.
 
 The code change is small; the documentation clean-up is not optional.
 
-1. Add `/home/user/project/docs/ortho-config-v0-8-0-migration-guide.md`.
+1. Add `docs/ortho-config-v0-8-0-migration-guide.md`.
    This guide should: describe the Weaver-specific move from v0.7.0 to v0.8.0,
    list the upstream migration notes supplied in the user request, call out
    which notes apply here, and record the audit results for the notes that do
    not apply.
-2. Update `/home/user/project/docs/contents.md` to include the new migration
+2. Update `docs/contents.md` to include the new migration
    guide without deleting the v0.6.0 guide.
-3. Replace `/home/user/project/docs/ortho-config-users-guide.md` with the
+3. Replace `docs/ortho-config-users-guide.md` with the
    upstream v0.8.0 guide from:
 
    ```text
@@ -395,15 +392,15 @@ The code change is small; the documentation clean-up is not optional.
    Treat that fetched document as the body of the local file. Only make
    repository-local follow-up edits when they are necessary to keep links,
    formatting, or Markdown tooling valid in this repository.
-4. Update `/home/user/project/docs/users-guide.md` and
-   `/home/user/project/docs/weaver-design.md` so they describe the current
-   Weaver configuration story accurately. These files should say that Weaver
-   now uses `ortho-config` v0.8.0 and Rust 1.88+, and they should not imply
-   that YAML is part of Weaver's runtime config path unless it truly is.
-5. Update `/home/user/project/docs/roadmap.md` item 3.2.5 so it points at
+4. Update `docs/users-guide.md` and
+   `docs/weaver-design.md` so they describe the current Weaver configuration
+   story accurately. These files should say that Weaver now uses `ortho-config`
+   v0.8.0 and Rust 1.88+, and they should not imply that YAML is part of
+   Weaver's runtime config path unless it truly is.
+5. Update `docs/roadmap.md` item 3.2.5 so it points at
    the v0.8.0 guide and no longer asks for already-completed v0.6.0
    documentation work.
-6. Update `/home/user/project/README.md` so the build requirements say
+6. Update `./README.md` so the build requirements say
    Rust 1.88+ instead of Rust 1.85+.
 7. Explicitly record the `orthohelp` conclusion in the new migration guide:
    either it is not applicable because Weaver does not generate ortho-config
@@ -441,8 +438,3 @@ After all edits are in place, run every relevant gate and capture the logs.
 
 Acceptance for Stage 5: all applicable gates pass, or any remaining failure is
 clearly shown to be pre-existing and user-approved for follow-up.
-
-## Approval gate
-
-This document is the draft phase only. Do not start implementing the migration
-until the user explicitly approves this plan or requests changes to it.

--- a/docs/execplans/adopt-ortho-config-v0-8-0.md
+++ b/docs/execplans/adopt-ortho-config-v0-8-0.md
@@ -181,6 +181,14 @@ Observable success after implementation:
   guide is still truthful historical documentation, and versioned file names
   should remain accurate. Date: 2026-03-07.
 
+- Decision: Replace `docs/ortho-config-users-guide.md` with the upstream
+  v0.8.0 guide from
+  `https://raw.githubusercontent.com/leynos/ortho-config/refs/tags/v0.8.0/docs/users-guide.md`
+   instead of hand-editing the in-repo copy. Rationale: the user explicitly
+  requested the upstream guide as the replacement artefact, and the fetched
+  file already captures the v0.8.0 material around layer composition,
+  post-merge hooks, localisation, and dependency aliasing. Date: 2026-03-07.
+
 - Decision: Only implement the `orthohelp` metadata flow if a concrete
   repository consumer is found during implementation. Rationale: the current
   tree has no `orthohelp` wiring, and adding speculative metadata would create
@@ -337,10 +345,16 @@ The code change is small; the documentation clean-up is not optional.
    not apply.
 2. Update `/home/user/project/docs/contents.md` to include the new migration
    guide without deleting the v0.6.0 guide.
-3. Update `/home/user/project/docs/ortho-config-users-guide.md` so it no
-   longer claims the crate targets v0.6.0. Refresh examples to prefer
-   `ortho_config::figment` re-exports where relevant, and update any Rust
-   toolchain or YAML-behaviour discussion to match v0.8.0.
+3. Replace `/home/user/project/docs/ortho-config-users-guide.md` with the
+   upstream v0.8.0 guide from:
+
+   ```text
+   https://raw.githubusercontent.com/leynos/ortho-config/refs/tags/v0.8.0/docs/users-guide.md
+   ```
+
+   Treat that fetched document as the body of the local file. Only make
+   repository-local follow-up edits when they are necessary to keep links,
+   formatting, or Markdown tooling valid in this repository.
 4. Update `/home/user/project/docs/users-guide.md` and
    `/home/user/project/docs/weaver-design.md` so they describe the current
    Weaver configuration story accurately. These files should say that Weaver
@@ -357,8 +371,9 @@ The code change is small; the documentation clean-up is not optional.
    required it.
 
 Acceptance for Stage 4: the active repository documentation matches the new
-dependency/toolchain reality, and the migration guide explains every upstream
-note in Weaver terms.
+dependency/toolchain reality, the in-tree `docs/ortho-config-users-guide.md`
+matches the upstream v0.8.0 guide except for minimal repository-local fixes,
+and the migration guide explains every upstream note in Weaver terms.
 
 ### Stage 5: Validate end to end
 

--- a/docs/execplans/adopt-ortho-config-v0-8-0.md
+++ b/docs/execplans/adopt-ortho-config-v0-8-0.md
@@ -1,0 +1,393 @@
+# Adopt `ortho-config` v0.8.0 Across Weaver
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root.
+
+## Purpose / big picture
+
+After this change, the Weaver workspace builds against `ortho_config` v0.8.0,
+advertises Rust 1.88 or newer consistently, and keeps its configuration
+behaviour unchanged for operators. The shared config loader in
+`crates/weaver-config/` must still discover `weaver.toml`, `.weaver.toml`,
+`config.toml`, `WEAVER_*` environment variables, and the existing CLI flags
+exactly as it does today; the migration is a dependency and tooling upgrade,
+not a feature redesign.
+
+Observable success after implementation:
+
+- `Cargo.toml` declares `ortho_config = "0.8.0"` in
+  `[workspace.dependencies]`.
+- The workspace and member manifests surface Rust 1.88+ rather than the
+  current Rust 1.85 floor.
+- `cargo` resolves both `ortho_config` and `ortho_config_macros` to
+  `0.8.0` in `Cargo.lock`.
+- `make check-fmt`, `make lint`, `make test`, `make markdownlint`,
+  `make fmt`, and `make nixie` all pass when run through `tee` with
+  `set -o pipefail`.
+- Operator-facing documentation no longer claims that Weaver uses
+  `ortho-config` v0.6.0 or Rust 1.85.
+- The migration notes that do not apply to Weaver
+  (`crate =` aliasing, `cli_default_as_absent`, generated `orthohelp` artefacts
+  unless proven otherwise) are documented explicitly so future maintainers do
+  not re-audit the same questions from scratch.
+
+## Constraints
+
+1. Preserve the current configuration contract. `weaver-config::Config`
+   must keep the current discovery rules, precedence order, environment
+   variable names, CLI flag names, and default values unless a migration note
+   requires a source-compatible rewrite.
+2. Keep `ortho_config` and `ortho_config_macros` in lockstep at `0.8.0`.
+   The macro crate is not declared directly today, so lockfile inspection is
+   required after the upgrade.
+3. Raise the Rust floor to 1.88 or newer in a way Cargo will actually
+   surface. Updating only `[workspace.package].rust-version` is insufficient
+   because many member crates currently omit `rust-version.workspace = true`.
+4. Do not introduce direct dependencies on `figment`, `uncased`, or `xdg`
+   unless a source file genuinely needs them for non-generated code.
+   Derive-adjacent imports and examples should prefer the `ortho_config::...`
+   re-exports.
+5. Preserve the existing localisation behaviour in
+   `crates/weaver-cli/src/localizer.rs`. The Fluent-backed localiser and
+   English fallbacks must keep working after the dependency bump.
+6. Treat the `orthohelp` metadata flow as conditional. The current
+   repository generates CLI man pages via build scripts, but the audit found no
+   `OrthoConfigDocs`, `cargo orthohelp`, or `[package.metadata.ortho_config]`
+   wiring. Do not add speculative metadata unless a concrete documentation
+   artefact in this repository needs it.
+7. Historical documents should remain truthful. Do not silently rewrite
+   the versioned v0.6.0 migration guide to pretend it was always about v0.8.0.
+   If new versioned migration guidance is needed, add a new guide.
+8. Use the repository quality gates and the Makefile targets where they
+   exist. Long-running commands must use `tee` and `set -o pipefail`.
+9. Comments and documentation must use en-GB-oxendict spelling and remain
+   wrapped to 80 columns.
+
+## Tolerances
+
+- If the upgrade changes any public CLI flag name, environment variable
+  name, config file name, or precedence rule, stop and escalate before
+  proceeding.
+- If `ortho_config` v0.8.0 requires source edits outside the workspace
+  manifests, `crates/weaver-config/`, `crates/weaver-cli/`, `crates/weaverd/`,
+  `README.md`, and the configuration-related docs, stop and re-evaluate the
+  scope.
+- If a new runtime dependency is required beyond the `ortho_config`
+  version change, stop and escalate.
+- If `cargo orthohelp` is absent and a repository artefact truly depends on
+  it, stop and ask whether installing an additional Cargo subcommand is
+  acceptable.
+- If `make test` reproduces the known pre-existing hang in
+  `weaver_cli::tests::unit::auto_start::auto_start_succeeds_and_proceeds`
+  before the ortho-config-specific diffs are complete, record that as a blocker
+  with log evidence instead of treating it as a migration failure.
+- If five successive fix attempts still leave the workspace failing to
+  compile, lint, or test, stop and escalate with the captured logs.
+
+## Risks
+
+- Risk: Rust-version propagation is incomplete today. The root
+  `Cargo.toml` sets `rust-version = "1.85"`, but these manifests currently do
+  not inherit it: `crates/weaver-build-util/Cargo.toml`,
+  `crates/weaver-cli/Cargo.toml`, `crates/weaver-e2e/Cargo.toml`,
+  `crates/weaver-graph/Cargo.toml`, `crates/weaver-lsp-host/Cargo.toml`,
+  `crates/weaver-plugin-rope/Cargo.toml`,
+  `crates/weaver-plugin-rust-analyzer/Cargo.toml`,
+  `crates/weaver-plugins/Cargo.toml`, `crates/weaver-sandbox/Cargo.toml`, and
+  `crates/weaverd/Cargo.toml`. Severity: medium. Likelihood: certain.
+  Mitigation: normalise every member manifest to
+  `rust-version.workspace = true` as part of the migration.
+
+- Risk: The repository still documents `ortho-config` v0.6.0 in multiple
+  places, and one completed ExecPlan documents the v0.7.0 upgrade. Severity:
+  medium. Likelihood: certain. Mitigation: update active operator/developer
+  docs (`README.md`, `docs/users-guide.md`, `docs/weaver-design.md`,
+  `docs/ortho-config-users-guide.md`, `docs/contents.md`, and
+  `docs/roadmap.md`) while leaving historical execplans untouched.
+
+- Risk: `weaver-config/src/lib.rs` wraps derive-generated loaders and
+  currently carries `#[allow(unfulfilled_lint_expectations)]` around
+  `#[expect(clippy::missing_panics_doc)]`. A newer toolchain or macro expansion
+  could change the lint surface. Severity: medium. Likelihood: medium.
+  Mitigation: re-run `make lint` after the version bump before making unrelated
+  refactors, and only touch the suppression if the new expansion makes it
+  necessary.
+
+- Risk: The migration notes mention `cli_default_as_absent`, crate aliasing,
+  and `SelectedSubcommandMerge`, none of which appear in the current source.
+  Severity: low. Likelihood: low. Mitigation: keep the audit evidence in the
+  migration guide so future maintainers know these notes were considered and
+  found non-applicable.
+
+- Risk: The repository documents YAML behaviour in its ortho-config guides
+  even though Weaver itself currently uses TOML discovery. Severity: low.
+  Likelihood: medium. Mitigation: update the generic documentation to match
+  v0.8.0 semantics while clarifying that Weaver's runtime path still uses TOML
+  by default.
+
+## Progress
+
+- [x] (2026-03-07 00:00 UTC) Audit the current workspace state and draft
+  this ExecPlan.
+- [ ] Record a clean before-state: dependency versions, Rust floor, and the
+  result of the current quality gates.
+- [ ] Update workspace and member manifests for Rust 1.88+ and
+  `ortho_config` v0.8.0.
+- [ ] Regenerate `Cargo.lock` so `ortho_config` and
+  `ortho_config_macros` both resolve to `0.8.0`.
+- [ ] Re-audit source for migration-note applicability and make any required
+  code changes in `weaver-config`, `weaver-cli`, or `weaverd`.
+- [ ] Refresh the configuration and migration documentation.
+- [ ] Run all relevant quality gates and capture the command logs.
+- [ ] Summarise the outcome and update this document's living sections.
+
+## Surprises & Discoveries
+
+- The live workspace is already on `ortho_config` v0.7.0, not v0.6.0.
+  The next migration is therefore incremental, but the surrounding docs have
+  not kept pace.
+- `crates/weaver-config/src/lib.rs` is the primary derive site. It uses
+  `#[derive(OrthoConfig)]` with a `#[ortho_config(discovery(...))]` attribute
+  and does not alias the runtime crate.
+- The CLI localiser in `crates/weaver-cli/src/localizer.rs` uses
+  `FluentLocalizer`, `Localizer`, and `NoOpLocalizer` from `ortho_config`
+  directly. This is the main non-config API surface exercised by the dependency
+  today.
+- The audit found no in-repo use of `SelectedSubcommandMerge`,
+  `cli_default_as_absent`, `#[ortho_config(crate = "...")]`,
+  `[package.metadata.ortho_config]`, `cargo orthohelp`, or `OrthoConfigDocs`.
+- The repository does generate manual pages for `weaver` and `weaverd`
+  during builds, but that mechanism is implemented with `clap_mangen` and a
+  handwritten build script, not ortho-config documentation metadata.
+
+## Decision Log
+
+- Decision: Treat this as a repo-wide migration of dependency version,
+  toolchain floor, and documentation, not as a new feature. Rationale: the user
+  asked to update usage to v0.8.0 using upstream migration notes, and the
+  source audit shows the likely code delta is narrow while the documentation
+  delta is broad. Date: 2026-03-07.
+
+- Decision: Preserve versioned history by adding a new
+  `docs/ortho-config-v0-8-0-migration-guide.md` rather than rewriting
+  `docs/ortho-config-v0-6-0-migration-guide.md`. Rationale: the existing v0.6.0
+  guide is still truthful historical documentation, and versioned file names
+  should remain accurate. Date: 2026-03-07.
+
+- Decision: Only implement the `orthohelp` metadata flow if a concrete
+  repository consumer is found during implementation. Rationale: the current
+  tree has no `orthohelp` wiring, and adding speculative metadata would create
+  maintenance burden without an observable payoff. Date: 2026-03-07.
+
+- Decision: Normalise member manifests to
+  `rust-version.workspace = true` while raising the workspace floor. Rationale:
+  without that change, several crates would continue to omit an explicit Rust
+  floor, undermining the requirement to ensure Rust 1.88 or newer. Date:
+  2026-03-07.
+
+## Outcomes & Retrospective
+
+Not started yet. Success means the workspace resolves `ortho_config` v0.8.0,
+advertises Rust 1.88+, preserves current configuration behaviour, and updates
+the active documentation to match reality. This section must be rewritten after
+implementation with the actual results, command outcomes, and any follow-up
+work.
+
+## Context and orientation
+
+The upgrade is concentrated in a small set of files.
+
+- `/home/user/project/Cargo.toml` holds the workspace dependency on
+  `ortho_config = "0.7.0"` and the current Rust floor `rust-version = "1.85"`.
+- `/home/user/project/crates/weaver-config/src/lib.rs` defines the shared
+  `Config` struct and the derive-generated loading path used by both binaries.
+- `/home/user/project/crates/weaver-cli/src/localizer.rs` exercises the
+  Fluent localisation APIs added in v0.7.0 and must continue to compile after
+  the v0.8.0 upgrade.
+- `/home/user/project/crates/weaver-cli/src/config.rs` is a secondary audit
+  point because it forwards CLI flags into `Config::load_from_iter`.
+- `/home/user/project/README.md`,
+  `/home/user/project/docs/users-guide.md`,
+  `/home/user/project/docs/weaver-design.md`,
+  `/home/user/project/docs/ortho-config-users-guide.md`,
+  `/home/user/project/docs/contents.md`, and
+  `/home/user/project/docs/roadmap.md` all describe the current configuration
+  story and will become stale if the migration lands without documentation
+  updates.
+
+The current implementation does not appear to use the migration-note edge
+cases. There is no alias for the `ortho_config` crate, no direct
+`ortho_config_macros` dependency in workspace manifests, no
+`SelectedSubcommandMerge`, and no `cli_default_as_absent` annotations in the
+source audit. That means the code changes may be as small as a version bump,
+Rust-floor uplift, and any compile fixes required by the new macro output. The
+plan still includes explicit audits so those assumptions are verified rather
+than guessed.
+
+## Implementation plan
+
+### Stage 1: Capture the baseline and prove the starting point
+
+Start by recording the before-state so any later failure can be attributed
+correctly.
+
+1. Confirm the current dependency and toolchain state:
+
+   ```sh
+   rg -n 'ortho_config|rust-version' Cargo.toml crates/*/Cargo.toml
+   rg -n 'name = "ortho_config"|name = "ortho_config_macros"|version = "0\\.(7|8)\\.0"' Cargo.lock
+   migration_audit_pattern='SelectedSubcommandMerge|cli_default_as_absent|\\#\\[ortho_config\\(crate =|package.metadata.ortho_config|OrthoConfigDocs|orthohelp'
+   rg -n "$migration_audit_pattern" crates docs
+   ```
+
+2. Run the current quality gates before any edits, using log capture:
+
+   ```sh
+   set -o pipefail; make check-fmt 2>&1 | tee /tmp/ortho-v0-8-check-fmt.before.log
+   set -o pipefail; make lint 2>&1 | tee /tmp/ortho-v0-8-lint.before.log
+   set -o pipefail; make test 2>&1 | tee /tmp/ortho-v0-8-test.before.log
+   set -o pipefail; make markdownlint 2>&1 | tee /tmp/ortho-v0-8-markdownlint.before.log
+   set -o pipefail; make nixie 2>&1 | tee /tmp/ortho-v0-8-nixie.before.log
+   ```
+
+3. If the known `make test` hang reproduces before any migration edits, do
+   not continue blindly. Capture the tail of the test log in this plan and
+   treat it as a pre-existing blocker that needs user direction.
+
+Acceptance for Stage 1: the plan records whether the workspace was green before
+the migration and whether any unrelated blockers were already present.
+
+### Stage 2: Update manifests and the lockfile
+
+Make the version and toolchain changes first, then let the compiler and tests
+tell us whether any source edits are needed.
+
+1. In `/home/user/project/Cargo.toml`, change the workspace Rust floor from
+   `1.85` to `1.88` and change `ortho_config = "0.7.0"` to
+   `ortho_config = "0.8.0"`.
+2. Add `rust-version.workspace = true` to every member manifest that lacks
+   it today: `crates/weaver-build-util/Cargo.toml`,
+   `crates/weaver-cli/Cargo.toml`, `crates/weaver-e2e/Cargo.toml`,
+   `crates/weaver-graph/Cargo.toml`, `crates/weaver-lsp-host/Cargo.toml`,
+   `crates/weaver-plugin-rope/Cargo.toml`,
+   `crates/weaver-plugin-rust-analyzer/Cargo.toml`,
+   `crates/weaver-plugins/Cargo.toml`, `crates/weaver-sandbox/Cargo.toml`, and
+   `crates/weaverd/Cargo.toml`.
+3. Regenerate the lockfile entries. There is no Makefile target for this, so
+   use Cargo directly:
+
+   ```sh
+   cargo update -p ortho_config --precise 0.8.0
+   cargo update -p ortho_config_macros --precise 0.8.0
+   ```
+
+4. Verify that `Cargo.lock` now resolves both crates to `0.8.0`.
+
+Acceptance for Stage 2: the workspace manifests declare the new Rust floor and
+dependency version, and the lockfile resolves both runtime and macro crates to
+`0.8.0`.
+
+### Stage 3: Re-audit migration-note applicability and fix code
+
+Only make source changes that the upgraded crate or the new Rust floor actually
+require.
+
+1. Re-run the source audit after Stage 2:
+
+   ```sh
+   migration_source_pattern='SelectedSubcommandMerge|cli_default_as_absent|\\#\\[ortho_config\\(crate =|default_value =|default_value_t|default_values_t'
+   rg -n "$migration_source_pattern" crates
+   rg -n 'use figment|use uncased|use xdg|figment::|uncased::|xdg::' crates
+   ```
+
+2. Compile/lint and repair only the affected areas:
+   `crates/weaver-config/src/lib.rs`, `crates/weaver-cli/src/localizer.rs`,
+   `crates/weaver-cli/src/config.rs`, and any directly failing call site
+   surfaced by the compiler.
+3. If an alias for `ortho_config` is introduced during the migration,
+   annotate every relevant derive with `#[ortho_config(crate = "...")]`,
+   including any future `SelectedSubcommandMerge` derives. The audit suggests
+   this should not be necessary in Weaver today.
+4. If any `cli_default_as_absent` usage is discovered, replace stringly
+   `default_value = ...` overrides with typed clap defaults (`default_value_t`
+   or `default_values_t`) before proceeding.
+5. Do not add direct `figment`, `uncased`, or `xdg` dependencies to make
+   derive-generated code happy. Prefer the `ortho_config::...` re-export paths
+   where source imports are needed.
+
+Acceptance for Stage 3: the workspace compiles cleanly against `ortho_config`
+v0.8.0, and every migration note has been either applied or marked
+non-applicable with concrete evidence.
+
+### Stage 4: Refresh documentation and record applicability
+
+The code change is small; the documentation clean-up is not optional.
+
+1. Add `/home/user/project/docs/ortho-config-v0-8-0-migration-guide.md`.
+   This guide should: describe the Weaver-specific move from v0.7.0 to v0.8.0,
+   list the upstream migration notes supplied in the user request, call out
+   which notes apply here, and record the audit results for the notes that do
+   not apply.
+2. Update `/home/user/project/docs/contents.md` to include the new migration
+   guide without deleting the v0.6.0 guide.
+3. Update `/home/user/project/docs/ortho-config-users-guide.md` so it no
+   longer claims the crate targets v0.6.0. Refresh examples to prefer
+   `ortho_config::figment` re-exports where relevant, and update any Rust
+   toolchain or YAML-behaviour discussion to match v0.8.0.
+4. Update `/home/user/project/docs/users-guide.md` and
+   `/home/user/project/docs/weaver-design.md` so they describe the current
+   Weaver configuration story accurately. These files should say that Weaver
+   now uses `ortho-config` v0.8.0 and Rust 1.88+, and they should not imply
+   that YAML is part of Weaver's runtime config path unless it truly is.
+5. Update `/home/user/project/docs/roadmap.md` item 3.2.5 so it points at
+   the v0.8.0 guide and no longer asks for already-completed v0.6.0
+   documentation work.
+6. Update `/home/user/project/README.md` so the build requirements say
+   Rust 1.88+ instead of Rust 1.85+.
+7. Explicitly record the `orthohelp` conclusion in the new migration guide:
+   either it is not applicable because Weaver does not generate ortho-config
+   documentation artefacts today, or it was added because a concrete artefact
+   required it.
+
+Acceptance for Stage 4: the active repository documentation matches the new
+dependency/toolchain reality, and the migration guide explains every upstream
+note in Weaver terms.
+
+### Stage 5: Validate end to end
+
+After all edits are in place, run every relevant gate and capture the logs.
+
+1. Format first:
+
+   ```sh
+   set -o pipefail; make fmt 2>&1 | tee /tmp/ortho-v0-8-fmt.after.log
+   ```
+
+2. Then run the Rust and docs gates:
+
+   ```sh
+   set -o pipefail; make check-fmt 2>&1 | tee /tmp/ortho-v0-8-check-fmt.after.log
+   set -o pipefail; make lint 2>&1 | tee /tmp/ortho-v0-8-lint.after.log
+   set -o pipefail; make test 2>&1 | tee /tmp/ortho-v0-8-test.after.log
+   set -o pipefail; make markdownlint 2>&1 | tee /tmp/ortho-v0-8-markdownlint.after.log
+   set -o pipefail; make nixie 2>&1 | tee /tmp/ortho-v0-8-nixie.after.log
+   ```
+
+3. Record the key evidence in this plan:
+   `Cargo.lock` versions, successful command completion, and any notable
+   warnings or follow-up constraints.
+
+Acceptance for Stage 5: all applicable gates pass, or any remaining failure is
+clearly shown to be pre-existing and user-approved for follow-up.
+
+## Approval gate
+
+This document is the draft phase only. Do not start implementing the migration
+until the user explicitly approves this plan or requests changes to it.

--- a/docs/execplans/adopt-ortho-config-v0-8-0.md
+++ b/docs/execplans/adopt-ortho-config-v0-8-0.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root.
@@ -136,17 +136,22 @@ Observable success after implementation:
 
 - [x] (2026-03-07 00:00 UTC) Audit the current workspace state and draft
   this ExecPlan.
-- [ ] Record a clean before-state: dependency versions, Rust floor, and the
-  result of the current quality gates.
-- [ ] Update workspace and member manifests for Rust 1.88+ and
-  `ortho_config` v0.8.0.
-- [ ] Regenerate `Cargo.lock` so `ortho_config` and
+- [x] (2026-03-07 10:40 UTC) Record the before-state. `make check-fmt`,
+  `make lint`, and `make test` all passed on the pre-migration tree.
+- [x] (2026-03-07 10:42 UTC) Update workspace and member manifests for
+  Rust 1.88+ and `ortho_config` v0.8.0.
+- [x] (2026-03-07 10:42 UTC) Regenerate `Cargo.lock` so `ortho_config` and
   `ortho_config_macros` both resolve to `0.8.0`.
-- [ ] Re-audit source for migration-note applicability and make any required
-  code changes in `weaver-config`, `weaver-cli`, or `weaverd`.
-- [ ] Refresh the configuration and migration documentation.
-- [ ] Run all relevant quality gates and capture the command logs.
-- [ ] Summarise the outcome and update this document's living sections.
+- [x] (2026-03-07 10:44 UTC) Re-audit source for migration-note
+  applicability and make the required code changes surfaced by the Rust 1.88
+  lint set.
+- [x] (2026-03-07 10:43 UTC) Refresh the configuration and migration
+  documentation, including replacing the local ortho-config guide with the
+  upstream v0.8.0 guide.
+- [x] (2026-03-07 10:46 UTC) Run all relevant quality gates and capture the
+  command logs.
+- [x] (2026-03-07 10:46 UTC) Summarise the outcome and update this document's
+  living sections.
 
 ## Surprises & Discoveries
 
@@ -166,6 +171,13 @@ Observable success after implementation:
 - The repository does generate manual pages for `weaver` and `weaverd`
   during builds, but that mechanism is implemented with `clap_mangen` and a
   handwritten build script, not ortho-config documentation metadata.
+- Raising the Rust floor from 1.85 to 1.88 surfaced four pre-existing Clippy
+  findings under the stricter toolchain: three trivial accessors that now need
+  `const fn` and one collapsible nested `if` in
+  `crates/weaver-config/src/socket.rs`.
+- Replacing the local ortho-config guide with the upstream v0.8.0 document
+  required only two repository-local link fixes, both pointing README
+  references at the tagged upstream GitHub URLs.
 
 ## Decision Log
 
@@ -200,13 +212,41 @@ Observable success after implementation:
   floor, undermining the requirement to ensure Rust 1.88 or newer. Date:
   2026-03-07.
 
+- Decision: Accept the minimal Rust 1.88 follow-on fixes in
+  `crates/sempai-core/src/diagnostic.rs`,
+  `crates/weaver-syntax/src/pattern.rs`, and
+  `crates/weaver-config/src/socket.rs` as part of this migration. Rationale:
+  these were pre-existing code paths that only became lint failures after the
+  toolchain uplift, and fixing them keeps the workspace green without changing
+  behaviour. Date: 2026-03-07.
+
 ## Outcomes & Retrospective
 
-Not started yet. Success means the workspace resolves `ortho_config` v0.8.0,
-advertises Rust 1.88+, preserves current configuration behaviour, and updates
-the active documentation to match reality. This section must be rewritten after
-implementation with the actual results, command outcomes, and any follow-up
-work.
+The migration completed successfully. The workspace now resolves `ortho_config`
+and `ortho_config_macros` to `0.8.0`, advertises Rust 1.88 at the workspace
+root, and surfaces that floor consistently across member manifests by using
+`rust-version.workspace = true` where it was previously missing.
+
+The code impact was deliberately small. No aliasing, `SelectedSubcommandMerge`,
+`cli_default_as_absent`, or `orthohelp` wiring was needed in Weaver. The only
+code changes beyond manifests were the four toolchain-driven lint fixes noted
+above. Behaviourally, the configuration contract for `weaver-config::Config`
+and the CLI localiser remained unchanged.
+
+Documentation now matches the upgraded state. The repository gained
+`docs/ortho-config-v0-8-0-migration-guide.md`, the local
+`docs/ortho-config-users-guide.md` was replaced with the upstream v0.8.0 guide
+plus minimal local link fixes, and the active Weaver docs no longer describe
+the project as an `ortho-config` v0.6.0 / Rust 1.85 workspace.
+
+Validation completed successfully with captured logs:
+
+- `make check-fmt`
+- `make lint`
+- `make test`
+- `make fmt`
+- `make markdownlint`
+- `make nixie`
 
 ## Context and orientation
 

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -8,24 +8,10 @@ to minimize boiler‑plate. The library uses `serde` for deserialization and
 management. This guide covers the functionality currently implemented in the
 repository.
 
-## Weaver integration
-
-The `weaver-config` crate targets `ortho-config` v0.6.0. Its `Config` struct
-declares discovery rules inline via `#[ortho_config(discovery(...))]`, listing
-the `weaver.toml` project file, `.weaver.toml` dotfile, and the
-`--config-path`/`WEAVER_CONFIG_PATH` override in one attribute. The CLI calls
-`Config::load_from_iter` while the daemon calls `Config::load`, so both
-binaries share the generated loaders with no manual builders to maintain.
-
-Because v0.6.0 returns an aggregated error whenever every discovered file
-fails, the CLI and daemon now exit immediately when a configuration file exists
-but cannot be parsed. Operators no longer see silent fallbacks to defaults; the
-`OrthoError` reported via `LoadConfiguration` pinpoints each offending file.
-
 ## Core concepts and motivation
 
 Rust projects often wire together `clap` for CLI parsing, `serde` for
-de/serialization, and ad-hoc code for loading `*.toml` files or reading
+de/serialization, and ad‑hoc code for loading `*.toml` files or reading
 environment variables. Mapping between different naming conventions (kebab‑case
 flags, `UPPER_SNAKE_CASE` environment variables, and `snake_case` struct
 fields) can be tedious. `OrthoConfig` addresses these problems by letting
@@ -61,18 +47,21 @@ values from multiple sources. The core features are:
 
 The workspace bundles an executable Hello World example under
 `examples/hello_world`. It layers defaults, environment variables, and CLI
-flags via the derive macro; see its [README](../examples/hello_world/README.md)
-for a step-by-step walkthrough and the Cucumber scenarios that validate
-behaviour end-to-end.
+flags via the derive macro; see its
+[README](https://github.com/leynos/ortho-config/blob/v0.8.0/examples/hello_world/README.md)
+ for a step-by-step walkthrough and the `rstest-bdd` (Behaviour-Driven
+Development) scenarios that validate behaviour end-to-end.
 
 Run `make test` to execute the example’s coverage. The unit suite uses `rstest`
 fixtures to exercise parsing, validation, and command planning across
-parameterised edge-cases (conflicting delivery modes, blank salutations, and
-custom punctuation). Behavioural coverage comes from the `cucumber-rs` runner
-in `tests/cucumber.rs`, which spawns the compiled binary inside a temporary
-working directory, layers `.hello_world.toml` defaults via `cap-std`, and sets
-`HELLO_WORLD_*` environment variables per scenario to demonstrate precedence:
-configuration files < environment variables < CLI arguments.
+parameterized edge-cases (conflicting delivery modes, blank salutations, and
+custom punctuation). Behavioural coverage comes from the `rstest-bdd`
+integration test under `tests/rstest_bdd`, which spawns the compiled binary
+inside a temporary working directory, layers `.hello_world.toml` defaults via
+`cap-std`, and sets `HELLO_WORLD_*` environment variables per scenario to
+demonstrate precedence: configuration files < environment variables < CLI
+arguments. Scenarios tagged `@requires.yaml` are gated by compile-time tag
+filters, so non-`yaml` builds skip them automatically.
 
 `ConfigDiscovery` exposes the same search order used by the example so
 applications can replace bespoke path juggling with a single call. By default
@@ -152,13 +141,140 @@ fixtures for default payloads, then enumerate cases for file, environment, and
 CLI layers. This validates every precedence permutation without copy-pasting
 setup.
 
+Every derived configuration also exposes `compose_layers()` and
+`compose_layers_from_iter(...)`. These helpers discover configuration files,
+serialize environment variables, and capture CLI input as a `LayerComposition`,
+keeping discovery separate from merging. The returned composition includes both
+the ordered layers and any collected errors, letting callers push additional
+layers or aggregate errors before invoking `merge_from_layers`.
+
+### Post-merge hooks
+
+Some configuration structs require custom adjustments after the standard merge
+pipeline completes. The `PostMergeHook` trait provides an opt-in hook that the
+library invokes automatically when the `#[ortho_config(post_merge_hook)]`
+attribute is present.
+
+```rust
+use ortho_config::{OrthoConfig, OrthoResult, PostMergeContext, PostMergeHook};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Deserialize, Serialize, OrthoConfig)]
+#[ortho_config(prefix = "APP_", post_merge_hook)]
+struct GreetArgs {
+    #[ortho_config(default = String::from("!"))]
+    punctuation: String,
+    preamble: Option<String>,
+}
+
+impl PostMergeHook for GreetArgs {
+    fn post_merge(&mut self, _ctx: &PostMergeContext) -> OrthoResult<()> {
+        // Normalize whitespace-only preambles to None
+        if self.preamble.as_ref().is_some_and(|p| p.trim().is_empty()) {
+            self.preamble = None;
+        }
+        Ok(())
+    }
+}
+```
+
+The `PostMergeContext` provides metadata about the merge process:
+
+- `prefix()` – the environment variable prefix used during loading
+- `loaded_files()` – paths of configuration files that contributed to the merge
+- `has_cli_input()` – whether CLI arguments were present in the merge
+
+Use post-merge hooks sparingly. Most configuration needs are satisfied by the
+standard merge pipeline combined with field-level attributes like
+`cli_default_as_absent` and `merge_strategy`. Hooks are best suited for:
+
+- Normalizing values after all layers have been applied
+- Performing validation that depends on multiple fields being merged
+- Conditional transformations based on which sources contributed
+
+The Hello World example demonstrates this pattern with `GreetCommand`, which
+uses a post-merge hook to clean up whitespace-only preambles.
+
+### Localizing CLI copy
+
+`ortho_config` exposes a `Localizer` trait, so applications can swap the text
+`clap` displays without abandoning sensible defaults. Each implementation is
+`Send + Sync` and returns owned `String` instances, making it cheap to cache
+resolved messages or fall back to the stock help text. The helper type
+`LocalizationArgs<'a> = HashMap<&'a str, FluentValue<'a>>` mirrors Fluent’s
+placeholder model, keeping argument-aware lookups ergonomic.
+
+The crate now ships a Fluent-backed implementation. `FluentLocalizer` embeds an
+English catalogue at `locales/en-US/messages.ftl`, layers any consumer bundles
+over those defaults, logs formatting errors with `tracing`, and falls back to
+the next bundle when a lookup fails:
+
+```rust
+use ortho_config::{langid, FluentLocalizer, LocalizationArgs, Localizer};
+
+static APP_EN: &str = include_str!("../locales/en-US/app.ftl");
+
+let localizer = FluentLocalizer::builder(langid!("en-US"))
+    .with_consumer_resources([APP_EN])
+    .try_build()
+    .expect("embedded locales load successfully");
+
+let mut args: LocalizationArgs<'_> = LocalizationArgs::default();
+args.insert("binary", "demo".into());
+assert_eq!(
+localizer
+    .lookup("cli.usage", Some(&args))
+    .expect("usage copy exists"),
+    "Usage: demo [OPTIONS] <COMMAND>"
+);
+```
+
+Applications can inject a custom logger with `with_error_reporter` when they
+need to capture Fluent formatting errors alongside command parsing failures.
+
+The Hello World example ships `hello_world::localizer::DemoLocalizer`, which
+builds a `FluentLocalizer` from `examples/hello_world/locales/en-US` and drives
+`CommandLine::command().localize(&localizer)` and
+`CommandLine::try_parse_localized_env`. If the localization setup ever fails,
+the example falls back to `NoOpLocalizer`, preserving the stock `clap` strings
+until translations are fixed.
+
+Errors surfaced by `clap` can be localized as well. Use
+`localize_clap_error_with_command` to map each `ErrorKind` to a Fluent
+identifier of the form `clap-error-<kebab-case>`, forwarding argument context
+such as the missing flag or the offending value. Supplying the command enables
+the helper to populate missing context (for example, the available subcommands
+when `clap` emits `DisplayHelpOnMissingArgumentOrSubcommand`). When no
+translation exists, the helper returns the original `clap` error unchanged:
+
+```rust
+use clap::CommandFactory;
+use ortho_config::{localize_clap_error_with_command, Localizer};
+
+# #[derive(clap::Parser)]
+# struct Cli {}
+fn parse(localizer: &dyn Localizer) -> Result<Cli, clap::Error> {
+    let mut command = Cli::command().localize(localizer);
+    let mut matches = command
+        .try_get_matches()
+        .map_err(|err| {
+            localize_clap_error_with_command(err, localizer, Some(&command))
+        })?;
+
+    Cli::from_arg_matches_mut(&mut matches).map_err(|err| {
+        let err = err.with_cmd(&command);
+        localize_clap_error_with_command(err, localizer, Some(&command))
+    })
+}
+```
+
 ## Installation and dependencies
 
 Add `ortho_config` as a dependency in `Cargo.toml` along with `serde`:
 
 ```toml
 [dependencies]
-ortho_config = "0.6.0"            # replace with the latest version
+ortho_config = "0.8.0"            # replace with the latest version
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }    # required for CLI support
 ```
@@ -169,7 +285,7 @@ corresponding cargo features:
 
 ```toml
 [dependencies]
-ortho_config = { version = "0.6.0", features = ["json5", "yaml"] }
+ortho_config = { version = "0.8.0", features = ["json5", "yaml"] }
 # Enabling these features expands file formats; precedence stays: defaults < file < env < CLI.
 ```
 
@@ -185,6 +301,62 @@ Redox targets), and the optional parsers (`figment_json5`, `json5`,
 `serde_saphyr`, `toml`) via `ortho_config::` paths. The `serde_json` re-export
 is enabled by default because the crate relies on it internally; disable
 default features only when explicitly opting back into `serde_json`.
+
+### Dependency architecture for derive macro users
+
+The `#[derive(OrthoConfig)]` macro emits fully qualified paths rooted at
+`ortho_config`. For example, generated code references
+`ortho_config::figment::Figment` and `ortho_config::uncased::Uncased` rather
+than `figment::...` or `uncased::...`. Those paths resolve because
+`ortho_config` re-exports these crates.
+
+For screen readers: The following diagram shows that generated code references
+re-exported crates through `ortho_config`, so consumer crates can rely on the
+runtime crate dependency.
+
+```mermaid
+flowchart TD
+    A[Consumer crate] -->|depends on| B[ortho_config]
+    C[derive OrthoConfig] -->|generates| D[ortho_config::figment::...]
+    C -->|generates| E[ortho_config::uncased::...]
+    B -->|re-exports| F[figment]
+    B -->|re-exports| G[uncased]
+    B -->|re-exports on Unix/Redox| H[xdg]
+```
+
+_Figure 1: Derive output resolves parser crates through `ortho_config`._
+
+In the common case, `Cargo.toml` does not need direct `figment`, `uncased`, or
+`xdg` dependencies:
+
+```toml
+[dependencies]
+ortho_config = "0.8.0"
+serde = { version = "1.0", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
+```
+
+### Troubleshooting dependency errors
+
+- If source code imports `figment`, `uncased`, or `xdg` directly, either switch
+  imports to `ortho_config::figment` / `ortho_config::uncased` /
+  `ortho_config::xdg`, or keep explicit dependencies for that direct usage.
+- If derive output fails with unresolved `ortho_config::...` paths, ensure the
+  dependency key is named `ortho_config` in `Cargo.toml` or use the
+  `#[ortho_config(crate = "...")]` attribute to specify the alias.
+- **Dependency aliasing** is supported via the `crate` attribute. When
+  renaming the dependency in `Cargo.toml` (for example,
+  `my_cfg = { package = "ortho_config", ... }`), add
+  `#[ortho_config(crate = "my_cfg")]` to the struct so generated code
+  references the correct crate path.
+- If dependency resolution reports conflicts, inspect duplicates with
+  `cargo tree -d` and prefer the versions selected through `ortho_config`
+  unless direct usage requires something else.
+
+### FAQ: should `figment`, `uncased`, or `xdg` be direct dependencies?
+
+No for derive-generated code. Yes, only when application code directly imports
+those crates without going through the `ortho_config::` re-exports.
 
 YAML parsing is handled by the pure-Rust `serde-saphyr` crate. It adheres to
 the YAML 1.2 specification, so unquoted scalars such as `yes`, `on`, and `off`
@@ -263,12 +435,13 @@ environment variables like `APP_PORT` and file names such as `.app.toml`.
 
 Field attributes modify how a field is sourced or merged:
 
-| Attribute                   | Behaviour                                                                                                                                                                     |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default = expr`            | Supplies a default value when no source provides one. The expression can be a literal or a function path.                                                                     |
-| `cli_long = "name"`         | Overrides the automatically generated long CLI flag (kebab-case).                                                                                                             |
-| `cli_short = 'c'`           | Adds a single-letter short flag for the field.                                                                                                                                |
-| `merge_strategy = "append"` | For `Vec<T>` fields, specifies that values from different sources should be concatenated. This is currently the only supported strategy and is the default for vector fields. |
+| Attribute                   | Behaviour                                                                                                                                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default = expr`            | Supplies a default value when no source provides one. The expression can be a literal or a function path.                                                                                       |
+| `cli_long = "name"`         | Overrides the automatically generated long CLI flag (kebab-case).                                                                                                                               |
+| `cli_short = 'c'`           | Adds a single-letter short flag for the field.                                                                                                                                                  |
+| `merge_strategy = "append"` | For `Vec<T>` fields, specifies that values from different sources should be concatenated. This is currently the only supported strategy and is the default for vector fields.                   |
+| `cli_default_as_absent`     | Treats typed clap defaults (`default_value_t`, `default_values_t`) as absent during configuration merging. File and environment values take precedence, while explicit CLI overrides still win. |
 
 Unrecognized keys are ignored by the derive macro for forwards compatibility.
 Unknown keys will therefore silently do nothing. Developers who require
@@ -660,14 +833,68 @@ Subcommands `pr` and `issue` load their defaults from the `cmds` namespace and
 environment variables. If the `reference` field is missing in the defaults, the
 tool continues using the CLI value instead of exiting with an error.
 
+### Merging a selected subcommand enum
+
+When the root CLI parses into a `Commands` enum, it is possible to derive
+`ortho_config_macros::SelectedSubcommandMerge` and import the
+`SelectedSubcommandMerge` trait from `ortho_config` to merge the selected
+variant in one call, instead of matching only to call `load_and_merge()` per
+branch.
+
+Variants that rely on `cli_default_as_absent` (because they use
+`default_value_t`) should be annotated with `#[ortho_subcommand(with_matches)]`
+so the merge can consult `ArgMatches` and treat clap defaults as absent.
+
+To load the global configuration and merge the selected subcommand in one
+expression, use `load_globals_and_merge_selected_subcommand` and supply a
+global loader as a closure.
+
+```rust
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+use ortho_config::{SelectedSubcommandMerge, load_globals_and_merge_selected_subcommand};
+
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, ortho_config_macros::SelectedSubcommandMerge)]
+enum Commands {
+    #[ortho_subcommand(with_matches)]
+    Greet(GreetArgs),
+    Run(RunArgs),
+}
+
+// Placeholder types for the example; real subcommands define fields and derive
+// `OrthoConfig`.
+struct GreetArgs;
+struct RunArgs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+let mut cmd = Cli::command();
+let matches = cmd.get_matches();
+let cli = Cli::from_arg_matches(&matches)?;
+let (_globals, _merged) = load_globals_and_merge_selected_subcommand(
+    &matches,
+    cli.command,
+    || Ok::<_, std::io::Error>(()),
+)?;
+Ok(())
+}
+```
+
 ### Hello world walkthrough
 
 <https://github.com/leynos/ortho-config/tree/main/examples/hello_world>
 
 The `hello_world` example crate demonstrates these patterns in a compact
-setting. Global options such as `--recipient` or `--salutation` are parsed via
-`load_global_config`, which layers configuration files and environment
-variables beneath any CLI overrides. The `greet` subcommand adds optional
+setting. Global options such as `--recipient` or `--salutation` are resolved by
+`load_global_config`, which now reuses
+`HelloWorldCli::compose_layers_from_iter` to collect defaults, discovered files
+and environment variables before applying CLI overrides. When callers pass
+`-s/--salutation`, the helper clears earlier vector contributions, so CLI input
+replaces file or environment values. The `greet` subcommand adds optional
 behaviour like a preamble (`--preamble "Good morning"`) or custom punctuation
 while reusing the merged global configuration. The `take-leave` subcommand
 combines switches and optional arguments (`--wave`, `--gift`,
@@ -675,7 +902,7 @@ combines switches and optional arguments (`--wave`, `--gift`,
 (`--preamble "Until next time"`, `--punctuation ?`) to describe how the
 farewell should unfold. Each subcommand struct derives `OrthoConfig` so
 defaults from `[cmds.greet]` or `[cmds.take-leave]` merge automatically when
-`load_and_merge()` is called.
+`load_and_merge_selected()` is invoked on the derived `Commands` enum.
 
 Behavioural tests in `examples/hello_world/tests` exercise scenarios such as
 `hello_world greet --preamble "Good morning"` and running
@@ -693,6 +920,63 @@ running `cargo run -p hello_world`, illustrating how file defaults, environment
 variables, and CLI arguments override one another without mutating the working
 tree.
 
+### Treating clap defaults as absent
+
+Non‑`Option` fields annotated with `#[arg(default_value_t = ...)]` normally
+override configuration files and environment variables because `clap` always
+populates them. The `cli_default_as_absent` attribute changes this behaviour:
+when the user does not explicitly provide a value on the command line, the
+field is excluded from the CLI layer so that file and environment values take
+precedence.
+
+Add `cli_default_as_absent` and define the default in clap. The derive macro
+now infers the struct default from clap's default metadata, so the default only
+needs to be declared once:
+
+```rust
+#[derive(Parser, Deserialize, Serialize, OrthoConfig)]
+#[ortho_config(prefix = "APP_")]
+struct GreetArgs {
+    #[arg(long, default_value_t = String::from("!"))]
+    #[ortho_config(cli_default_as_absent)]
+    punctuation: String,
+}
+```
+
+`default_value_t` and `default_values_t` are supported for inferred defaults.
+`default_value` inference is intentionally unsupported for now; use
+`default_value_t` or add an explicit `#[ortho_config(default = ...)]` to avoid
+string-parser mismatches. Parser-faithful `default_value` inference is planned
+as a day-2 follow-up.
+
+If `#[ortho_config(default = ...)]` is still provided, that explicit value
+remains available for generated defaults/documentation metadata.
+
+**Precedence with the attribute (lowest to highest):**
+
+1. Struct default (`#[ortho_config(default = ...)]` or inferred from clap)
+2. Configuration file
+3. Environment variable
+4. Explicit CLI override (e.g. `--punctuation "?"`)
+
+Without `cli_default_as_absent`, the clap default would always beat the file
+and environment layers. With the attribute, calling `greet` without
+`--punctuation` allows a `[cmds.greet] punctuation = "?"` file entry or
+`APP_CMDS_GREET_PUNCTUATION=?` environment variable to win.
+
+When using this attribute, pass the `ArgMatches` so the crate can inspect
+`value_source()`:
+
+```rust
+let matches = GreetArgs::command().get_matches();
+let cli = GreetArgs::from_arg_matches(&matches)?;
+let merged = cli.load_and_merge_with_matches(&matches)?;
+```
+
+Clap's `value_source()` uses argument IDs (the field identifier unless
+`#[arg(id = "...")]` overrides it). This behaviour requires the `serde_json`
+feature (enabled by default).
+
 ### Dispatching with `clap‑dispatch`
 
 The `clap‑dispatch` crate can be combined with `OrthoConfig` to simplify
@@ -700,8 +984,9 @@ subcommand execution. Each subcommand struct implements a trait defining the
 action to perform. An enum of subcommands is annotated with
 `#[clap_dispatch(fn run(...))]`, and the `load_and_merge_subcommand_for`
 function can be called on each variant before dispatching. See the
-`Subcommand Configuration` section of the `OrthoConfig` [README](../README.md)
-for a complete example.
+`Subcommand Configuration` section of the `OrthoConfig`
+[README](https://github.com/leynos/ortho-config/blob/v0.8.0/README.md) for a
+complete example.
 
 ## Error handling
 
@@ -721,6 +1006,37 @@ example:
 Missing required values:
   sample_value (use --sample-value, SAMPLE_VALUE, or file entry)
 ```
+
+### Preserving `clap` display exits
+
+When a user passes `--help` or `--version`, `clap` surfaces specialised
+`ErrorKind::DisplayHelp` / `DisplayVersion` errors so applications can print
+usage text and exit successfully. Deriving `OrthoConfig` often goes hand in
+hand with `Cli::try_parse()` so applications can map errors into their own
+types. Before performing that conversion, call
+`ortho_config::is_display_request` to detect these cases and delegate to
+`err.exit()`:
+
+```rust
+use clap::Parser;
+use ortho_config::{is_display_request, OrthoConfig};
+
+fn parse_cli() -> Result<MyCli, CliError> {
+    match MyCli::try_parse() {
+        Ok(cli) => Ok(cli),
+        Err(mut err) => {
+            if is_display_request(&err) {
+                err.exit();
+            }
+            Err(CliError::ArgumentParsing(err.into()))
+        }
+    }
+}
+```
+
+The `examples/hello_world` crate applies this pattern in `main.rs`. Behavioural
+tests assert that both `--help` and `--version` exit with code 0 so regressions
+are caught automatically.
 
 ### Aggregating multiple errors
 
@@ -746,6 +1062,25 @@ let err = OrthoError::aggregate(vec![
 ]);
 ```
 
+### Gathering vs Merge errors
+
+`OrthoConfig` distinguishes between two phases of configuration loading:
+
+- **Gathering** (`OrthoError::Gathering`): Errors that occur while reading
+  configuration sources (files, environment variables). These indicate problems
+  with the source data itself, such as malformed TOML or invalid JSON.
+
+- **Merge** (`OrthoError::Merge`): Errors that occur while combining layers and
+  deserializing the final configuration. These indicate incompatibilities
+  between the merged data and the target struct, such as type mismatches or
+  invalid field values.
+
+When deserializing the final merged configuration fails (for example, because a
+field has an invalid type after all layers are combined), the error is reported
+as `Merge`. This distinction helps diagnose whether an issue lies with a
+specific source file (Gathering) or with the combined result of all layers
+(Merge).
+
 ### Mapping errors ergonomically
 
 To reduce boiler‑plate when converting between error types, the crate exposes
@@ -755,6 +1090,9 @@ small extension traits:
   `OrthoResult<T>` when `E: Into<OrthoError>` (e.g., `serde_json::Error`).
 - `OrthoMergeExt::into_ortho_merge()` converts `Result<T, figment::Error>`
   into `OrthoResult<T>` as `OrthoError::Merge`.
+- `OrthoJsonMergeExt::into_ortho_merge_json()` converts
+  `Result<T, serde_json::Error>` into `OrthoResult<T>` as `OrthoError::Merge`,
+  preserving location information from the JSON parser.
 - `IntoFigmentError::into_figment()` converts `Arc<OrthoError>` (or
   `&Arc<OrthoError>`) into `figment::Error` for interop in tests or adapters,
   cloning the inner error to preserve structured details where possible.
@@ -779,6 +1117,134 @@ fn interop(r: ortho_config::OrthoResult<MyCfg>) -> Result<MyCfg, figment::Error>
 }
 ```
 
+## Documentation metadata (OrthoConfigDocs)
+
+The derive macro now emits an `OrthoConfigDocs` implementation alongside the
+runtime loader. This lets tooling such as `cargo-orthohelp` serialize a stable,
+clap-agnostic intermediate representation (IR) for man pages and PowerShell
+help.
+
+```rust
+use ortho_config::docs::OrthoConfigDocs;
+
+#[derive(serde::Deserialize, serde::Serialize, ortho_config::OrthoConfig)]
+#[ortho_config(prefix = "APP")]
+struct AppConfig {
+    #[ortho_config(default = 8080)]
+    port: u16,
+}
+
+let ir = AppConfig::get_doc_metadata();
+let json = ortho_config::serde_json::to_string_pretty(&ir)?;
+println!("{json}");
+```
+
+When IDs are not supplied, the macro generates deterministic defaults such as
+`{app}.about` for the CLI overview and `{app}.fields.{field}.help` for field
+descriptions. Field-level metadata can be refined with `help_id`,
+`long_help_id`, `value(type = "...")`, `deprecated(note_id = "...")`,
+`env(name = "...")`, and `file(key_path = "...")`. These documentation
+attributes affect only the emitted IR; they do not change runtime naming or
+loading behaviour.
+
+### Generating IR with cargo-orthohelp
+
+`cargo-orthohelp` compiles a tiny bridge binary that calls
+`OrthoConfigDocs::get_doc_metadata()`, resolves Fluent messages per locale, and
+writes localized IR JSON into the chosen output directory. Add metadata to the
+package `Cargo.toml` so the tool knows which config type to load:
+
+```toml
+[package.metadata.ortho_config]
+root_type = "hello_world::cli::HelloWorldCli"
+locales = ["en-US", "ja"]
+```
+
+Run the tool from the project root:
+
+```bash
+cargo orthohelp --out-dir target/orthohelp --locale en-US
+```
+
+`--cache` reuses any previously generated IR cached under
+`target/orthohelp/<hash>/ir.json`, while `--no-build` skips the bridge build
+and fails if the cache is missing. The generated per-locale JSON lives under
+`<out>/ir/<locale>.json` and is ready for downstream generators.
+
+### Generating man pages
+
+`cargo-orthohelp` can generate roff-formatted man pages from the localized IR.
+Use `--format man` to produce `man/man<N>/<name>.<N>` files suitable for
+installation via `make install` or packaging:
+
+```bash
+cargo orthohelp --format man --out-dir target/man --locale en-US
+```
+
+The generator produces standard man page sections in the canonical order:
+
+1. **NAME** – binary name and one-line description
+2. **SYNOPSIS** – usage pattern with flags
+3. **DESCRIPTION** – expanded about text
+4. **OPTIONS** – CLI flags with types, defaults, and possible values
+5. **ENVIRONMENT** – environment variables mapped to fields
+6. **FILES** – configuration file paths and discovery locations
+7. **PRECEDENCE** – source priority order (defaults → file → env → CLI)
+8. **EXAMPLES** – usage examples from the IR
+9. **SEE ALSO** – related commands and documentation links
+10. **EXIT STATUS** – standard exit codes
+
+Additional options:
+
+- `--man-section <N>` – man page section number (default: 1)
+- `--man-date <DATE>` – override the date shown in the footer
+- `--man-split-subcommands` – generate separate man pages for each subcommand
+
+Text is automatically escaped for roff: backslashes are doubled, and leading
+dashes, periods, and single quotes are escaped to prevent macro interpretation.
+Enum fields list their possible values in the OPTIONS description.
+
+### Generating PowerShell help
+
+`cargo-orthohelp` can generate PowerShell external help in Microsoft Assistance
+Markup Language (MAML) alongside a wrapper module so `Get-Help {BinName} -Full`
+surfaces the same configuration metadata as the man page generator. Use the
+`ps` format to emit the module layout under `powershell/<ModuleName>`:
+
+```bash
+cargo orthohelp --format ps --out-dir target/orthohelp --locale en-US
+```
+
+The generator produces:
+
+- `powershell/<ModuleName>/<ModuleName>.psm1` – wrapper module.
+- `powershell/<ModuleName>/<ModuleName>.psd1` – module manifest.
+- `powershell/<ModuleName>/<culture>/<ModuleName>-help.xml` – MAML help.
+- `powershell/<ModuleName>/<culture>/about_<ModuleName>.help.txt` – about topic.
+
+`en-US` help is always generated. If only other locales are rendered, the
+generator copies the first locale into `en-US` unless fallback generation is
+disabled with `--ensure-en-us false`.
+
+PowerShell options:
+
+- `--ps-module-name <NAME>` – override the module name (defaults to the binary
+  name).
+- `--ps-split-subcommands <BOOL>` – emit wrapper functions for subcommands.
+- `--ps-include-common-parameters <BOOL>` – include CommonParameters in MAML.
+- `--ps-help-info-uri <URI>` – set `HelpInfoUri` for Update-Help payloads.
+- `--ensure-en-us <BOOL>` – control the `en-US` fallback behaviour.
+
+To set defaults in `Cargo.toml`, use the Windows metadata table:
+
+```toml
+[package.metadata.ortho_config.windows]
+module_name = "MyModule"
+include_common_parameters = true
+split_subcommands_into_functions = false
+help_info_uri = "https://example.com/help/MyModule"
+```
+
 ## Additional notes
 
 - **Vector merging** – For `Vec<T>` fields the default merge strategy is
@@ -800,10 +1266,10 @@ fn interop(r: ortho_config::OrthoResult<MyCfg>) -> Result<MyCfg, figment::Error>
   while still requiring the CLI to provide a value when defaults are absent;
   see the `vk` example above.
 
-- **Changing naming conventions** – Currently, only the default
-  snake/hyphenated (underscores → hyphens)/upper snake mappings are supported.
-  Future versions may introduce attributes such as `file_key` or `env` to
-  customize names further.
+- **Changing naming conventions** – Runtime naming continues to use the
+  default snake/hyphenated (underscores → hyphens)/upper snake mappings. For
+  documentation output, use `env(name = "...")` and `file(key_path = "...")` to
+  override IR metadata without altering runtime behaviour.
 
 - **Testing** – Because the CLI and environment variables are merged at
   runtime, integration tests should set environment variables and construct CLI

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -546,10 +546,10 @@ resulting in environment variables such as `APP_DB_URL`. The `features` field
 is a `Vec<String>` and accumulates values from multiple sources rather than
 overwriting them.
 
-### Customising configuration discovery
+### Customizing configuration discovery
 
 Configuration discovery can be tailored per struct using the `discovery(...)`
-attribute. The keys recognised today include:
+attribute. The keys recognized today include:
 
 - `app_name`: directory name used under XDG and application data folders.
 - `env_var`: override for the environment variable consulted before discovery
@@ -618,11 +618,11 @@ following steps:
 
 ### Config path override
 
-The derive macro always recognises a configuration override flag and the
+The derive macro always recognizes a configuration override flag and the
 associated environment variables even when no explicit field is declared. By
 default a hidden `--config-path` flag is accepted alongside
 `<PREFIX>CONFIG_PATH` and the unprefixed `CONFIG_PATH`. Applying the
-struct-level `discovery(...)` attribute customises this behaviour, allowing the
+struct-level `discovery(...)` attribute customizes this behaviour, allowing the
 CLI flag to be renamed or exposed and the filenames searched during discovery
 to be adjusted:
 

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -435,13 +435,13 @@ environment variables like `APP_PORT` and file names such as `.app.toml`.
 
 Field attributes modify how a field is sourced or merged:
 
-| Attribute                   | Behaviour                                                                                                                                                                                       |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default = expr`            | Supplies a default value when no source provides one. The expression can be a literal or a function path.                                                                                       |
-| `cli_long = "name"`         | Overrides the automatically generated long CLI flag (kebab-case).                                                                                                                               |
-| `cli_short = 'c'`           | Adds a single-letter short flag for the field.                                                                                                                                                  |
-| `merge_strategy = "append"` | For `Vec<T>` fields, specifies that values from different sources should be concatenated. This is currently the only supported strategy and is the default for vector fields.                   |
-| `cli_default_as_absent`     | Treats typed clap defaults (`default_value_t`, `default_values_t`) as absent during configuration merging. File and environment values take precedence, while explicit CLI overrides still win. |
+| Attribute                   | Behaviour                                                                                                                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `default = expr`            | Supplies a default value when no source provides one. The expression can be a literal or a function path.                                                                            |
+| `cli_long = "name"`         | Overrides the automatically generated long CLI flag (kebab-case).                                                                                                                    |
+| `cli_short = 'c'`           | Adds a single-letter short flag for the field.                                                                                                                                       |
+| `merge_strategy = "append"` | For `Vec<T>` fields, specifies the merge strategy: `append` (default) concatenates values across layers, whilst `replace` discards earlier layers and uses standard layer semantics. |
+| `cli_default_as_absent`     | Treats typed clap defaults as absent during merging; file and environment values still beat defaults, while explicit CLI overrides still win.                                        |
 
 Unrecognized keys are ignored by the derive macro for forwards compatibility.
 Unknown keys will therefore silently do nothing. Developers who require
@@ -565,9 +565,10 @@ attribute. The keys recognised today include:
 - `config_cli_visible`: when `true`, the generated CLI flag appears in help
   output instead of remaining hidden.
 
-Supplying only the keys you need lets you rename the CLI flag without altering
-file discovery, or vice versa. When the attribute is omitted, the defaults
-described in [Config path override](#config-path-override) continue to apply.
+Supplying only the required keys allows renaming of the CLI flag without
+altering file discovery, or vice versa. When the attribute is omitted, the
+defaults described in [Config path override](#config-path-override) continue to
+apply.
 
 ## Loading configuration and precedence rules
 
@@ -618,12 +619,12 @@ following steps:
 ### Config path override
 
 The derive macro always recognises a configuration override flag and the
-associated environment variables even when you do not declare a field
-explicitly. By default a hidden `--config-path` flag is accepted alongside
+associated environment variables even when no explicit field is declared. By
+default a hidden `--config-path` flag is accepted alongside
 `<PREFIX>CONFIG_PATH` and the unprefixed `CONFIG_PATH`. Applying the
-struct-level `discovery(...)` attribute customises this behaviour, allowing you
-to rename or expose the CLI flag and adjust the filenames searched during
-discovery:
+struct-level `discovery(...)` attribute customises this behaviour, allowing the
+CLI flag to be renamed or exposed and the filenames searched during discovery
+to be adjusted:
 
 ```rust
 #[derive(Debug, Deserialize, ortho_config::OrthoConfig)]

--- a/docs/ortho-config-v0-8-0-migration-guide.md
+++ b/docs/ortho-config-v0-8-0-migration-guide.md
@@ -1,0 +1,138 @@
+# Migration guide: Weaver adoption of `ortho-config` v0.8.0
+
+## Introduction
+
+This guide records how the Weaver workspace adopts `ortho_config` v0.8.0 from
+the previous v0.7.0 baseline. It combines the upstream migration notes with the
+repository-specific audit performed during the upgrade so future maintainers
+can see both what changed and what was intentionally left alone.
+
+The authoritative upstream user guide for v0.8.0 now replaces the local copy at
+`docs/ortho-config-users-guide.md`. Weaver-specific behaviour remains
+documented in `docs/users-guide.md` and `docs/weaver-design.md`.
+
+## Starting point
+
+Before this migration, the workspace state was:
+
+- `[workspace.dependencies]` pinned `ortho_config = "0.7.0"` in
+  `Cargo.toml`.
+- `[workspace.package]` advertised `rust-version = "1.85"`.
+- Several member crates inherited `edition` and `version` from the workspace
+  but did not inherit `rust-version.workspace = true`, so the Rust floor was
+  not surfaced consistently across the workspace.
+- `crates/weaver-config/src/lib.rs` was the primary derive site, using
+  `#[derive(OrthoConfig)]` with a declarative `#[ortho_config(discovery(...))]`
+  attribute.
+- `crates/weaver-cli/src/localizer.rs` consumed the localisation APIs added in
+  v0.7.0 (`FluentLocalizer`, `Localizer`, and `NoOpLocalizer`).
+- The repository still described the configuration stack as
+  `ortho-config` v0.6.0 in several docs.
+
+## Required migration steps
+
+### 1. Update dependency versions and toolchain floor
+
+Change every `ortho_config` and `ortho_config_macros` dependency to `0.8.0` and
+ensure the workspace requires Rust 1.88 or newer.
+
+For Weaver, that means:
+
+- updating `[workspace.package].rust-version` to `1.88`,
+- updating `[workspace.dependencies].ortho_config` to `0.8.0`,
+- regenerating `Cargo.lock` so both `ortho_config` and
+  `ortho_config_macros` resolve to `0.8.0`, and
+- adding `rust-version.workspace = true` to the member manifests that
+  previously omitted it.
+
+### 2. Crate aliasing is not used in Weaver
+
+Upstream v0.8.0 requires `#[ortho_config(crate = "...")]` whenever the runtime
+crate is aliased in `Cargo.toml`, and the same rule applies to
+`SelectedSubcommandMerge`.
+
+The Weaver audit found no aliased `ortho_config` dependency and no in-repo use
+of `SelectedSubcommandMerge`, so this note is currently non-applicable here. If
+either pattern is introduced later, the derive attributes must be updated at
+the same time.
+
+### 3. `cli_default_as_absent` is not used in Weaver
+
+Upstream v0.8.0 now rejects inference from stringly `default_value` metadata
+when `cli_default_as_absent` is active; callers must use typed clap defaults
+such as `default_value_t` or `default_values_t`.
+
+The Weaver audit found no `cli_default_as_absent` attributes in the source, so
+no code changes were required for this note. Future uses of
+`cli_default_as_absent` must follow the typed-default rule from the start.
+
+### 4. YAML semantics changed, even though Weaver runtime config is TOML-first
+
+Upstream YAML parsing now uses `serde-saphyr` with YAML 1.2 behaviour. Legacy
+literals such as `yes`, `on`, and `off` must be quoted when they should remain
+strings, and duplicate mapping keys are rejected.
+
+Weaver's runtime configuration still uses TOML discovery, so no production code
+path changed here. The documentation set still needs this note because the
+local ortho-config user guide discusses optional YAML support in generic
+examples.
+
+### 5. Prefer `ortho_config` re-exports for derive-adjacent imports
+
+Upstream v0.8.0 expects derive-generated code to use dependency re-exports from
+`ortho_config::figment`, `ortho_config::uncased`, and `ortho_config::xdg`
+unless the application imports those crates directly for its own purposes.
+
+Weaver did not have direct source imports from `figment`, `uncased`, or `xdg`
+that needed correction. The main impact was documentation: examples in the
+in-repo ortho-config guide should reflect the re-exported import paths that the
+upstream v0.8.0 guide now uses.
+
+### 6. `cargo orthohelp` is not currently part of the Weaver build
+
+Upstream v0.8.0 adds metadata for generated configuration-documentation
+artefacts via `[package.metadata.ortho_config]` and `cargo orthohelp`.
+
+The Weaver audit found:
+
+- no `OrthoConfigDocs` metadata in the source tree,
+- no `[package.metadata.ortho_config]` in any manifest,
+- no `cargo orthohelp` usage in scripts or docs, and
+- build-time documentation generation that is limited to CLI man pages via
+  `clap_mangen`.
+
+Because no concrete Weaver artefact depends on `orthohelp` today, this note is
+non-applicable for the current migration. Revisit it only if the workspace
+starts emitting ortho-config-specific documentation artefacts.
+
+## Documentation policy for this migration
+
+Weaver keeps two kinds of ortho-config documentation:
+
+- a versioned migration record inside this repository, and
+- the upstream ortho-config user's guide, copied locally for reference.
+
+For v0.8.0, the local policy is:
+
+- keep `docs/ortho-config-v0-6-0-migration-guide.md` as a truthful historical
+  document,
+- add this new v0.8.0 migration guide rather than rewriting the v0.6.0 file,
+  and
+- replace `docs/ortho-config-users-guide.md` with the upstream
+  `docs/users-guide.md` from the `v0.8.0` tag, applying only the minimal local
+  fixes needed for links and Markdown tooling inside Weaver.
+
+## Weaver adoption checklist
+
+After the migration is complete, verify the following:
+
+- `Cargo.toml` advertises `ortho_config = "0.8.0"` and Rust `1.88`.
+- Every member crate surfaces the shared Rust floor through
+  `rust-version.workspace = true` or an explicit `rust-version`.
+- `Cargo.lock` resolves `ortho_config` and `ortho_config_macros` to `0.8.0`.
+- `docs/ortho-config-users-guide.md` matches the upstream v0.8.0 guide except
+  for minimal repository-local fixes.
+- `docs/users-guide.md`, `docs/weaver-design.md`, and `README.md` no longer
+  describe Weaver as an `ortho-config` v0.6.0 / Rust 1.85 workspace.
+- `make check-fmt`, `make lint`, `make test`, `make markdownlint`,
+  `make fmt`, and `make nixie` pass.

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -75,7 +75,7 @@ In this document, Language Server Protocol (LSP) and Continuous Integration
 | `weaver-e2e`                  | End-to-end test support crate and integration scaffolding                                            | Implemented |
 | `sempai-core`                 | Sempai data model, diagnostics, and planning intermediate representation (IR) types                  | Implemented |
 | `sempai`                      | Sempai facade crate with stable public API, re-exports from `sempai-core`, and stub `Engine`         | Implemented |
-| `weaver-cards`                | Stable JSONL schemas for `observe get-card` symbol card requests and responses                        | Implemented |
+| `weaver-cards`                | Stable JSONL schemas for `observe get-card` symbol card requests and responses                       | Implemented |
 
 _Table 1: Implemented crate boundaries and responsibilities._
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -316,18 +316,18 @@ does* *not require source inspection or external runbooks.*
   - [ ] Acceptance criteria: every exposed operation supports
         `weaver <domain> <operation> --help` and each help screen includes
         required flags, argument types, and at least one concrete invocation.
-- [ ] 3.2.5. Document ortho-config v0.6.0 behaviour in 3.2 guidance. See
-      [ortho-config v0.6.0 migration guide](ortho-config-v0-6-0-migration-guide.md).
-  - [ ] Document the new dependency-graph model used by configuration loading
+- [x] 3.2.5. Document ortho-config v0.8.0 behaviour in 3.2 guidance. See
+      [ortho-config v0.8.0 migration guide](ortho-config-v0-8-0-migration-guide.md).
+  - [x] Document the new dependency-graph model used by configuration loading
         and precedence resolution.
-  - [ ] Document fail-fast discovery behaviour when configuration files exist
+  - [x] Document fail-fast discovery behaviour when configuration files exist
         but are invalid.
-  - [ ] Document YAML 2.2 parsing semantics via `SaphyrYaml`, including known
+  - [x] Document YAML 2.2 parsing semantics via `SaphyrYaml`, including known
         compatibility warnings.
-  - [ ] Update internal runbooks and user-facing documentation to reflect
-        `ortho-config` v0.6.0 operational behaviour.
-  - [ ] Validate documentation quality gates and docs tests after updates.
-  - [ ] Acceptance criteria: migration guide, runbooks, and user docs are
+  - [x] Update internal runbooks and user-facing documentation to reflect
+        `ortho-config` v0.8.0 operational behaviour.
+  - [x] Validate documentation quality gates and docs tests after updates.
+  - [x] Acceptance criteria: migration guide, runbooks, and user docs are
         updated with explicit sections for dependency graph, fail-fast
         discovery, and YAML 2.2 semantics; and `make markdownlint`,
         `make fmt`, `make nixie`, and documentation tests pass.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -322,14 +322,14 @@ does* *not require source inspection or external runbooks.*
         and precedence resolution.
   - [x] Document fail-fast discovery behaviour when configuration files exist
         but are invalid.
-  - [x] Document YAML 2.2 parsing semantics via `SaphyrYaml`, including known
+  - [x] Document YAML 1.2 parsing semantics via `SaphyrYaml`, including known
         compatibility warnings.
   - [x] Update internal runbooks and user-facing documentation to reflect
         `ortho-config` v0.8.0 operational behaviour.
   - [x] Validate documentation quality gates and docs tests after updates.
   - [x] Acceptance criteria: migration guide, runbooks, and user docs are
         updated with explicit sections for dependency graph, fail-fast
-        discovery, and YAML 2.2 semantics; and `make markdownlint`,
+        discovery, and YAML 1.2 semantics; and `make markdownlint`,
         `make fmt`, `make nixie`, and documentation tests pass.
 
 ## 4. Query language infrastructure (Sempai)

--- a/docs/rust-extricate-actuator-plugin-technical-design.md
+++ b/docs/rust-extricate-actuator-plugin-technical-design.md
@@ -63,12 +63,12 @@ Because plugin execution is sandboxed, the plugin cannot assume unrestricted
 filesystem access. The daemon must provide all file payloads required for
 analysis and patch generation.
 
-## ortho_config v0.6.0 impacts
+## ortho_config v0.8.0 impacts
 
-The Rust extricate flow inherits Weaver's current `ortho_config` v0.6.0
+The Rust extricate flow inherits Weaver's current `ortho_config` v0.8.0
 behaviour model:
 
-- dependency-graph updates in v0.6.0 align parser features with the runtime and
+- dependency-graph updates in v0.8.0 align parser features with the runtime and
   macro contract,
 - discovery is fail-fast when discovered files are invalid, so configuration
   load errors must stop orchestration immediately,
@@ -85,12 +85,12 @@ These behaviours directly affect payload and transaction handling:
   preconditions, not recoverable warnings.
 
 Authoritative runbook:
-[Migration guide: v0.5.0 to v0.6.0](ortho-config-v0-6-0-migration-guide.md),
-especially sections:
+[Migration guide: Weaver adoption of v0.8.0](ortho-config-v0-8-0-migration-guide.md),
+ especially sections:
 
-- [1](ortho-config-v0-6-0-migration-guide.md#1-update-crate-versions-and-feature-flags)
-- [4](ortho-config-v0-6-0-migration-guide.md#4-handle-stricter-discovery-outcomes)
-- [5](ortho-config-v0-6-0-migration-guide.md#5-switch-to-the-new-stricter-yaml-provider)
+- [Required migration steps](ortho-config-v0-8-0-migration-guide.md#required-migration-steps)
+- [YAML semantics changed, even though Weaver runtime config is TOML-first](ortho-config-v0-8-0-migration-guide.md#4-yaml-semantics-changed-even-though-weaver-runtime-config-is-toml-first)
+- [Documentation policy for this migration](ortho-config-v0-8-0-migration-guide.md#documentation-policy-for-this-migration)
 
 ## Capability and request contract
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -485,16 +485,15 @@ Arguments:
 
 Response:
 
-The response is a discriminated-union JSON envelope keyed on the
-`"status"` field. When `"status"` is `"refusal"`, the envelope
-carries a refusal payload indicating why a card could not be
-produced. When `"status"` is `"success"`, the envelope contains
-the card payload. The overall shape of the envelope therefore
-depends on the `"status"` value.
+The response is a discriminated-union JSON envelope keyed on the `"status"`
+field. When `"status"` is `"refusal"`, the envelope carries a refusal payload
+indicating why a card could not be produced. When `"status"` is `"success"`,
+the envelope contains the card payload. The overall shape of the envelope
+therefore depends on the `"status"` value.
 
 Note: Tree-sitter card extraction is not yet implemented. The operation
-currently returns a structured refusal. See the Jacquard roadmap[^1] for
-the extraction milestone.
+currently returns a structured refusal. See the Jacquard roadmap[^1] for the
+extraction milestone.
 
 When the operation cannot produce a card, the status is `"refusal"`:
 
@@ -562,17 +561,17 @@ object:
 
 Note: the `card.symbol.ref.range` uses 0-based line and column numbers in a
 half-open interval — `start` is inclusive and `end` is exclusive (i.e.
-`[start, end)`). This differs from the `--position` request flag, which
-accepts 1-indexed `LINE:COL` values.
+`[start, end)`). This differs from the `--position` request flag, which accepts
+1-indexed `LINE:COL` values.
 
-Card fields beyond identity are progressively included based on the
-detail level:
+Card fields beyond identity are progressively included based on the detail
+level:
 
 - `minimal` — returns only the `symbol` and `provenance` fields.
 - `signature` — adds the `signature` block (for callable symbols)
   exposing the callable display string, parameters, and return type.
-  Non-callable symbols (classes, variables, constants) may omit
-  `signature` or structure it differently.
+  Non-callable symbols (classes, variables, constants) may omit `signature` or
+  structure it differently.
 - `structure` (default) — further adds `doc`, `structure`, and basic
   `metrics`. May include `attachments`.
 - `semantic` — adds LSP hover/type information.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -67,8 +67,8 @@ directive = "force"
 ### Validation and error reporting
 
 `weaver` now uses `ortho-config` v0.8.0, which treats invalid configuration
-files as fatal. When `--config-path` points at a broken file—or when discovery
-finds a malformed `weaver.toml`/`.weaver.toml`—, both the CLI and daemon abort
+files as fatal. When `--config-path` points at a broken file, or when discovery
+finds a malformed `weaver.toml`/`.weaver.toml`, both the CLI and daemon abort
 with a `LoadConfiguration` error that lists every offending path. Remove or fix
 the reported files before retrying. If no configuration files exist at all the
 loader still falls back to the built-in defaults described below.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -66,7 +66,7 @@ directive = "force"
 
 ### Validation and error reporting
 
-`weaver` now uses `ortho-config` v0.6.0, which treats invalid configuration
+`weaver` now uses `ortho-config` v0.8.0, which treats invalid configuration
 files as fatal. When `--config-path` points at a broken file—or when discovery
 finds a malformed `weaver.toml`/`.weaver.toml`—, both the CLI and daemon abort
 with a `LoadConfiguration` error that lists every offending path. Remove or fix

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -930,16 +930,17 @@ Configuration is layered with `ortho-config`, producing the precedence order
 alongside the standard XDG locations, ensuring the CLI and daemon resolve
 identical results regardless of which component loads the settings.
 
-The workspace now targets `ortho-config` v0.6.0. The switch lets
+The workspace now targets `ortho-config` v0.8.0. The switch lets
 `weaver-config::Config` declare its discovery policy inline through the
 `#[ortho_config(discovery(...))]` attribute. The app name, dotfile, project
 file, and `--config-path` flag are all defined next to the struct, so every
 consumer shares the same generated loader without bespoke builders.
 
-Version 0.6.0 also tightens error handling: if any discovered configuration
-file fails to parse, `ConfigDiscovery::load_first` returns an aggregated
-`OrthoError`. Both the CLI and daemon bubble that error to the user instead of
-quietly falling back to defaults, making misconfigurations immediately visible.
+Version 0.8.0 also preserves the stricter discovery and parsing model adopted
+in earlier releases: if any discovered configuration file fails to parse,
+`ConfigDiscovery::load_first` returns an aggregated `OrthoError`. Both the CLI
+and daemon bubble that error to the user instead of quietly falling back to
+defaults, making misconfigurations immediately visible.
 
 The daemon transport defaults to a Unix domain socket placed under
 `$XDG_RUNTIME_DIR/weaver/weaverd.sock`. When the runtime directory is absent,


### PR DESCRIPTION
## Summary

This PR upgrades ortho-config to v0.8.0 across the Weaver workspace, raises the Rust toolchain floor to 1.88+, regenerates the lockfile, and expands documentation to reflect the migration. The update includes small internal code adjustments to accommodate the new toolchain, the addition of a new ExecPlan document, and the introduction of a new weaver-cards crate for symbol card schemas. While there are no user-facing runtime feature changes, the changes are broader than purely documentation and touch on build, dependency management, and API surface tweaks to stay compatible with ortho-config v0.8.0.

## Changes

### Documentation
- Added docs/execplans/adopt-ortho-config-v0-8-0.md detailing the upgrade plan and rationale.
- Added docs/ortho-config-v0-8-0-migration-guide.md outlining Weaver-specific notes and applicability.
- Replaced docs/ortho-config-users-guide.md with the upstream v0.8.0 content (with minimal repository-local fixes) and updated cross-links.
- Updated docs/contents.md to reference the new migration guide.
- Updated docs/weaver-design.md, docs/users-guide.md, and docs/roadmap.md to reflect the v0.8.0 upgrade and Rust 1.88+ requirements.
- Updated README.md build notes to reflect Rust 1.88+ and the ortho-config upgrade.

### Build and versioning notes
- Updated workspace to use ortho_config = "0.8.0".
- Raised the minimum Rust version (rust-version) to 1.88+ across the workspace (rust-version.workspace = true on member manifests).
- Regenerated Cargo.lock so both ortho_config and ortho_config_macros resolve to 0.8.0.
- Minor textual/formatting refinements in related docs to better reflect the upgrade scope and constraints.

### Code adjustments (internal, non-user-facing)
- Minor internal API refinements to satisfy the Rust 1.88 lint surface (e.g., making some accessors const fn in DiagnosticReport and related areas).
- Propagated rust-version.workspace = true to member crates to ensure uniform 1.88+ surface across the workspace.
- A few small build/util crates were aligned to the new toolchain constraints.

### New components
- New weaver-cards crate introduced to model stable JSONL schemas for observe get-card (including tests and integration within weaverd). This aligns with the expanded symbol-card work described in the migration.

### Testing plan (updated)
- Regenerate lockfile entries:
  - cargo update -p ortho_config --precise 0.8.0
  - cargo update -p ortho_config_macros --precise 0.8.0
- Ensure Cargo.lock resolves both crates to 0.8.0.
- Local checks: make check-fmt, make lint, make test, and make markdownlint if available.
- Documentation review: confirm presence and correctness of docs/execplans/adopt-ortho-config-v0-8-0.md and updated references in other docs.

### Why this change
- Upgrading to ortho-config v0.8.0 aligns Weaver with upstream improvements and raises the Rust floor to match the dependency’s needs. The ExecPlan documents the migration approach, risks, and validation steps to ensure a smooth upgrade path while preserving existing configuration semantics. The change set includes build-time and documentation updates, with minimal code churn necessary to stay compatible with the new version.

### Risks and mitigations
- Risk: Rust-version propagation across all crates may be incomplete.
  Mitigation: apply rust-version.workspace = true across member manifests where missing and re-run the build/tests.
- Risk: Documentation-heavy changes may drift from actual behavior during rollout.
  Mitigation: the ExecPlan outlines explicit steps and rollback paths; CI gates should verify consistency.
- Risk: The repository documents YAML behaviour in its ortho-config guides even though Weaver itself currently uses TOML discovery. Mitigation: update references to reflect the v0.8.0 semantics while clarifying Weaver runtime usage.
- Risk: If new runtime dependencies are required beyond ortho_config, stop and escalate.
  Mitigation: handle via follow-up PRs with targeted scope.

### Acceptance criteria
- OrtHo-config is upgraded to v0.8.0 across the workspace and Rust floor is raised to 1.88+.
- Lockfile reflects 0.8.0 for ortho_config and ortho_config_macros.
- Documentation reflects the upgrade accurately, including the new ExecPlan and updated guidance.
- All standard quality gates pass (formatting, linting, tests).

If reviewers require any code changes beyond documentation (e.g., Rust changes to accommodate new config behavior), we will address them in a follow-up PR with a targeted scope.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/48552f7c-af2e-4c8e-b32d-795ae1a51f2b

## Summary by Sourcery

Upgrade the workspace to ortho-config v0.0.8 across the Weaver workspace? (Note: This line is intentionally identical to the original for brevity in the PR summary.)

Upgrade the workspace to ortho-config v0.8.0, raise the Rust toolchain floor, and align configuration-related documentation with the new version and behaviour.

Enhancements:
- Increase the minimum supported Rust version for the workspace and member crates to 1.88+ and propagate it via rust-version.workspace.
- Adopt the upstream ortho-config v0.8.0 user guide content and extend internal docs to cover new configuration features like layer composition, post-merge hooks, localization, and documentation metadata.
- Refine minor APIs to satisfy the stricter Rust 1.88 lint set, including making simple accessors const and simplifying error-handling control flow.

Build:
- Bump the ortho_config dependency (and underlying lockfile resolution) to v0.8.0 across the workspace.

Documentation:
- Add a new ExecPlan and migration guide documenting Weaver’s adoption of ortho-config v0.8.0 and its non-applicable migration notes.
- Update user guides, design docs, roadmap entries, and contents navigation to reference ortho-config v0.8.0, the new migration guide, and the raised Rust version requirement.
- Clarify and expand documentation around observe get-card schemas, plugin behaviour, and repository structure without changing runtime semantics.
