### PR TITLE
Refactor plugin failures and file URI normalization; update tests

### DIFF
--- a/crates/weaver-plugin-rust-analyzer/src/failure.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/failure.rs
@@ -1,12 +1,12 @@
 //! Structured plugin failures and response conversion helpers.
 
-use std::fmt;
-
+use thiserror::Error;
 use weaver_plugins::capability::ReasonCode;
 use weaver_plugins::protocol::{DiagnosticSeverity, PluginDiagnostic, PluginResponse};
 
 /// Structured failure carrying an optional reason code for diagnostics.
-#[derive(Debug)]
+#[derive(Debug, Error, Clone)]
+#[error("{message}")]
 pub(crate) struct PluginFailure {
     message: String,
     reason_code: Option<ReasonCode>,
@@ -39,12 +39,6 @@ impl PluginFailure {
     #[cfg(test)]
     pub(crate) const fn reason_code(&self) -> Option<ReasonCode> {
         self.reason_code
-    }
-}
-
-impl fmt::Display for PluginFailure {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message)
     }
 }
 

--- a/crates/weaver-plugin-rust-analyzer/src/failure.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/failure.rs
@@ -1,0 +1,58 @@
+//! Structured plugin failures and response conversion helpers.
+
+use std::fmt;
+
+use weaver_plugins::capability::ReasonCode;
+use weaver_plugins::protocol::{DiagnosticSeverity, PluginDiagnostic, PluginResponse};
+
+/// Structured failure carrying an optional reason code for diagnostics.
+#[derive(Debug)]
+pub(crate) struct PluginFailure {
+    message: String,
+    reason_code: Option<ReasonCode>,
+}
+
+impl PluginFailure {
+    /// Creates a failure without a reason code.
+    pub(crate) fn plain(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            reason_code: None,
+        }
+    }
+
+    /// Creates a failure with a stable reason code.
+    pub(crate) fn with_reason(message: impl Into<String>, reason: ReasonCode) -> Self {
+        Self {
+            message: message.into(),
+            reason_code: Some(reason),
+        }
+    }
+
+    /// Returns the failure message.
+    #[cfg(test)]
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the failure reason code, if present.
+    #[cfg(test)]
+    pub(crate) const fn reason_code(&self) -> Option<ReasonCode> {
+        self.reason_code
+    }
+}
+
+impl fmt::Display for PluginFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+/// Converts a structured plugin failure into a protocol failure response.
+pub(crate) fn failure_response(failure: PluginFailure) -> PluginResponse {
+    let mut diagnostic = PluginDiagnostic::new(DiagnosticSeverity::Error, failure.message);
+    if let Some(reason_code) = failure.reason_code {
+        diagnostic = diagnostic.with_reason_code(reason_code);
+    }
+    PluginResponse::failure(vec![diagnostic])
+}

--- a/crates/weaver-plugin-rust-analyzer/src/lib.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lib.rs
@@ -16,6 +16,7 @@ use std::io::{BufRead, Write};
 use std::path::{Component, Path, PathBuf};
 
 use thiserror::Error;
+use url::Url;
 use weaver_plugins::capability::ReasonCode;
 use weaver_plugins::protocol::{FilePayload, PluginOutput, PluginRequest, PluginResponse};
 
@@ -342,14 +343,31 @@ fn build_search_replace_patch(path: &Path, original: &str, modified: &str) -> St
 }
 
 fn normalize_request_uri(uri: &str) -> Result<String, RustAnalyzerAdapterError> {
-    let relative_path =
-        uri.strip_prefix("file://")
-            .ok_or_else(|| RustAnalyzerAdapterError::InvalidPath {
-                message: String::from("uri argument must be a file:// URI"),
-            })?;
-    let path = Path::new(relative_path);
-    validate_relative_path(path)?;
-    Ok(path_to_slash(path))
+    let parsed = Url::parse(uri).map_err(|_| invalid_file_uri_error())?;
+    if parsed.scheme() != "file" || parsed.has_host() {
+        return Err(invalid_file_uri_error());
+    }
+
+    let path = parsed
+        .to_file_path()
+        .map_err(|()| invalid_file_uri_error())?;
+    let relative_path = strip_file_uri_root(&path)?;
+    validate_relative_path(relative_path.as_path())?;
+    Ok(path_to_slash(relative_path.as_path()))
+}
+
+fn invalid_file_uri_error() -> RustAnalyzerAdapterError {
+    RustAnalyzerAdapterError::InvalidPath {
+        message: String::from("uri argument must be a valid file:// URI without an authority"),
+    }
+}
+
+fn strip_file_uri_root(path: &Path) -> Result<PathBuf, RustAnalyzerAdapterError> {
+    let mut components = path.components();
+    if !matches!(components.next(), Some(Component::RootDir)) {
+        return Err(invalid_file_uri_error());
+    }
+    Ok(components.as_path().to_path_buf())
 }
 
 fn path_to_slash(path: &Path) -> String {

--- a/crates/weaver-plugin-rust-analyzer/src/lib.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/lib.rs
@@ -5,23 +5,22 @@
 //! executes a refactoring operation, and writes one JSONL response to stdout.
 
 mod arguments;
+mod failure;
 
 #[cfg(test)]
 mod tests;
 
 mod lsp;
 
-use std::fmt;
 use std::io::{BufRead, Write};
 use std::path::{Component, Path, PathBuf};
 
 use thiserror::Error;
 use weaver_plugins::capability::ReasonCode;
-use weaver_plugins::protocol::{
-    DiagnosticSeverity, FilePayload, PluginDiagnostic, PluginOutput, PluginRequest, PluginResponse,
-};
+use weaver_plugins::protocol::{FilePayload, PluginOutput, PluginRequest, PluginResponse};
 
 use crate::arguments::parse_rename_symbol_arguments;
+use crate::failure::{PluginFailure, failure_response};
 
 pub use lsp::RustAnalyzerLspAdapter;
 
@@ -75,50 +74,6 @@ pub enum PluginDispatchError {
         #[source]
         source: serde_json::Error,
     },
-}
-
-/// Structured failure carrying an optional reason code for diagnostics.
-#[derive(Debug)]
-pub(crate) struct PluginFailure {
-    message: String,
-    reason_code: Option<ReasonCode>,
-}
-
-impl PluginFailure {
-    /// Creates a failure without a reason code.
-    pub(crate) fn plain(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-            reason_code: None,
-        }
-    }
-
-    /// Creates a failure with a stable reason code.
-    pub(crate) fn with_reason(message: impl Into<String>, reason: ReasonCode) -> Self {
-        Self {
-            message: message.into(),
-            reason_code: Some(reason),
-        }
-    }
-}
-
-#[cfg(test)]
-impl PluginFailure {
-    /// Returns the failure message.
-    pub(crate) fn message(&self) -> &str {
-        &self.message
-    }
-
-    /// Returns the failure reason code, if present.
-    pub(crate) const fn reason_code(&self) -> Option<ReasonCode> {
-        self.reason_code
-    }
-}
-
-impl fmt::Display for PluginFailure {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message)
-    }
 }
 
 /// Errors raised by rust-analyzer adapter implementations.
@@ -264,7 +219,10 @@ fn execute_rename<R: RustAnalyzerAdapter>(
     })?;
 
     let request_path = path_to_slash(file.path());
-    if arguments.uri() != request_path {
+    let uri_path = normalize_request_uri(arguments.uri()).map_err(|error| {
+        PluginFailure::with_reason(error.to_string(), ReasonCode::IncompletePayload)
+    })?;
+    if uri_path != request_path {
         return Err(PluginFailure::with_reason(
             format!(
                 "uri argument '{}' does not match file payload '{}'",
@@ -281,9 +239,7 @@ fn execute_rename<R: RustAnalyzerAdapter>(
             ByteOffset::new(arguments.offset()),
             arguments.new_name(),
         )
-        .map_err(|error| {
-            PluginFailure::with_reason(error.to_string(), ReasonCode::SymbolNotFound)
-        })?;
+        .map_err(|error| PluginFailure::plain(error.to_string()))?;
 
     if modified == file.content() {
         return Err(PluginFailure::with_reason(
@@ -385,6 +341,17 @@ fn build_search_replace_patch(path: &Path, original: &str, modified: &str) -> St
     )
 }
 
+fn normalize_request_uri(uri: &str) -> Result<String, RustAnalyzerAdapterError> {
+    let relative_path =
+        uri.strip_prefix("file://")
+            .ok_or_else(|| RustAnalyzerAdapterError::InvalidPath {
+                message: String::from("uri argument must be a file:// URI"),
+            })?;
+    let path = Path::new(relative_path);
+    validate_relative_path(path)?;
+    Ok(path_to_slash(path))
+}
+
 fn path_to_slash(path: &Path) -> String {
     path.components()
         .filter_map(|component| match component {
@@ -393,12 +360,4 @@ fn path_to_slash(path: &Path) -> String {
         })
         .collect::<Vec<String>>()
         .join("/")
-}
-
-pub(crate) fn failure_response(failure: PluginFailure) -> PluginResponse {
-    let mut diagnostic = PluginDiagnostic::new(DiagnosticSeverity::Error, failure.message);
-    if let Some(reason_code) = failure.reason_code {
-        diagnostic = diagnostic.with_reason_code(reason_code);
-    }
-    PluginResponse::failure(vec![diagnostic])
 }

--- a/crates/weaver-plugin-rust-analyzer/src/tests/argument_validation.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/argument_validation.rs
@@ -1,0 +1,97 @@
+//! Argument-validation tests for rust-analyzer plugin requests.
+
+use std::collections::HashMap;
+
+use rstest::rstest;
+use weaver_plugins::capability::ReasonCode;
+
+use super::support::{adapter_returning, adapter_unused, rename_arguments, request_with_args};
+use crate::execute_request;
+
+fn remove_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("uri");
+}
+
+fn set_empty_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("uri"),
+        serde_json::Value::String(String::from("  ")),
+    );
+}
+
+fn set_numeric_uri(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("uri"),
+        serde_json::Value::Number(serde_json::Number::from(4)),
+    );
+}
+
+fn remove_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("position");
+}
+
+fn set_boolean_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(String::from("position"), serde_json::Value::Bool(true));
+}
+
+fn set_negative_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("position"),
+        serde_json::Value::String(String::from("-1")),
+    );
+}
+
+fn set_numeric_position(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("position"),
+        serde_json::Value::Number(serde_json::Number::from(3)),
+    );
+}
+
+fn set_empty_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("  ")),
+    );
+}
+
+fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::Number(serde_json::Number::from(42)),
+    );
+}
+
+#[rstest]
+#[case::missing_uri(remove_uri as fn(&mut _), Some("uri"))]
+#[case::empty_uri(set_empty_uri as fn(&mut _), Some("uri"))]
+#[case::numeric_uri(set_numeric_uri as fn(&mut _), Some("uri argument must be a string"))]
+#[case::missing_position(remove_position as fn(&mut _), Some("position"))]
+#[case::boolean_position(set_boolean_position as fn(&mut _), Some("position"))]
+#[case::negative_position(set_negative_position as fn(&mut _), Some("non-negative integer"))]
+#[case::numeric_position_succeeds(set_numeric_position as fn(&mut _), None)]
+#[case::numeric_new_name(set_numeric_new_name as fn(&mut _), Some("new_name argument must be a string"))]
+#[case::empty_new_name(set_empty_new_name as fn(&mut _), Some("new_name"))]
+fn rename_argument_validation(
+    #[case] mutate: fn(&mut HashMap<String, serde_json::Value>),
+    #[case] expected_error: Option<&str>,
+) {
+    let mut arguments = rename_arguments();
+    mutate(&mut arguments);
+
+    if let Some(needle) = expected_error {
+        let adapter = adapter_unused();
+        let err = execute_request(&adapter, &request_with_args(arguments))
+            .expect_err("invalid arguments should fail");
+        assert!(
+            err.message().contains(needle),
+            "expected error mentioning '{needle}', got: {err}"
+        );
+        assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
+    } else {
+        let adapter = adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")));
+        let response = execute_request(&adapter, &request_with_args(arguments))
+            .expect("valid arguments should succeed");
+        assert!(response.is_success());
+    }
+}

--- a/crates/weaver-plugin-rust-analyzer/src/tests/argument_validation.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/argument_validation.rs
@@ -62,6 +62,10 @@ fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
     );
 }
 
+fn remove_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
+    arguments.remove("new_name");
+}
+
 #[rstest]
 #[case::missing_uri(remove_uri as fn(&mut _), Some("uri"))]
 #[case::empty_uri(set_empty_uri as fn(&mut _), Some("uri"))]
@@ -70,6 +74,7 @@ fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
 #[case::boolean_position(set_boolean_position as fn(&mut _), Some("position"))]
 #[case::negative_position(set_negative_position as fn(&mut _), Some("non-negative integer"))]
 #[case::numeric_position_succeeds(set_numeric_position as fn(&mut _), None)]
+#[case::missing_new_name(remove_new_name as fn(&mut _), Some("new_name"))]
 #[case::numeric_new_name(set_numeric_new_name as fn(&mut _), Some("new_name argument must be a string"))]
 #[case::empty_new_name(set_empty_new_name as fn(&mut _), Some("new_name"))]
 fn rename_argument_validation(

--- a/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
@@ -77,7 +77,7 @@ fn build_request(
     if with_uri {
         arguments.insert(
             String::from("uri"),
-            serde_json::Value::String(String::from("file://src/main.rs")),
+            serde_json::Value::String(String::from("file:///src/main.rs")),
         );
     }
     if with_position {
@@ -152,12 +152,7 @@ fn resolved_response(world: &World) -> PluginResponse {
         .expect("execute result should be present")
     {
         Ok(resp) => resp.clone(),
-        Err(failure) => failure_response(crate::PluginFailure::with_reason(
-            failure.message().to_owned(),
-            failure
-                .reason_code()
-                .expect("behaviour failures should carry a reason code"),
-        )),
+        Err(failure) => failure_response(failure.clone()),
     }
 }
 

--- a/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/behaviour.rs
@@ -77,7 +77,7 @@ fn build_request(
     if with_uri {
         arguments.insert(
             String::from("uri"),
-            serde_json::Value::String(String::from("src/main.rs")),
+            serde_json::Value::String(String::from("file://src/main.rs")),
         );
     }
     if with_position {
@@ -199,6 +199,7 @@ fn then_failure_reason_code(world: &mut World, text: String) {
     let expected = match text.trim_matches('"') {
         "incomplete_payload" => ReasonCode::IncompletePayload,
         "operation_not_supported" => ReasonCode::OperationNotSupported,
+        "symbol_not_found" => ReasonCode::SymbolNotFound,
         other => panic!("unsupported reason code in feature: {other}"),
     };
     let response = resolved_response(world);

--- a/crates/weaver-plugin-rust-analyzer/src/tests/dispatch_layer.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/dispatch_layer.rs
@@ -1,0 +1,101 @@
+//! stdin/stdout dispatch-layer tests for rust-analyzer plugin requests.
+
+use rstest::rstest;
+use weaver_plugins::capability::ReasonCode;
+use weaver_plugins::protocol::{DiagnosticSeverity, PluginResponse};
+
+use super::support::{
+    MockAdapter, adapter_returning, adapter_unused, rename_arguments, request_with_args,
+};
+use crate::run_with_adapter;
+
+fn valid_request_json() -> String {
+    let request = request_with_args(rename_arguments());
+    serde_json::to_string(&request).expect("serialize request")
+}
+
+/// Dispatches `input` through `run_with_adapter` and parses the response.
+fn dispatch_stdin(input: &[u8], adapter: &MockAdapter) -> PluginResponse {
+    let mut stdin = std::io::Cursor::new(input.to_vec());
+    let mut stdout = Vec::new();
+    run_with_adapter(&mut stdin, &mut stdout, adapter).expect("dispatch should succeed");
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    serde_json::from_str(output.trim()).expect("parse response")
+}
+
+#[rstest]
+#[case::success(
+    format!("{}\n", valid_request_json()).into_bytes(),
+    adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n"))),
+    true,
+    None
+)]
+#[case::empty_stdin(Vec::new(), adapter_unused(), false, Some("plugin request was empty"))]
+#[case::invalid_json(
+    b"not valid json\n".to_vec(),
+    adapter_unused(),
+    false,
+    Some("invalid plugin request JSON")
+)]
+fn run_with_adapter_dispatch_layer(
+    #[case] input: Vec<u8>,
+    #[case] adapter: MockAdapter,
+    #[case] expect_success: bool,
+    #[case] expected_message: Option<&str>,
+) {
+    let response = dispatch_stdin(&input, &adapter);
+    assert_eq!(response.is_success(), expect_success);
+
+    if let Some(needle) = expected_message {
+        assert!(
+            response
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.severity() == DiagnosticSeverity::Error),
+            "expected at least one error diagnostic, got: {:?}",
+            response.diagnostics(),
+        );
+        assert!(
+            response
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.message().contains(needle)),
+            "expected diagnostic mentioning '{needle}', got: {:?}",
+            response.diagnostics(),
+        );
+    }
+}
+
+#[rstest]
+#[case::missing_position(
+    {
+        let mut arguments = rename_arguments();
+        arguments.remove("position");
+        request_with_args(arguments)
+    },
+    ReasonCode::IncompletePayload
+)]
+#[case::unsupported_operation(
+    weaver_plugins::protocol::PluginRequest::new("extract_method", Vec::new()),
+    ReasonCode::OperationNotSupported
+)]
+fn failure_responses_include_reason_codes(
+    #[case] request: weaver_plugins::protocol::PluginRequest,
+    #[case] expected_reason: ReasonCode,
+) {
+    let input = format!(
+        "{}\n",
+        serde_json::to_string(&request).expect("serialize request")
+    );
+    let response = dispatch_stdin(input.as_bytes(), &adapter_unused());
+
+    assert!(!response.is_success());
+    assert!(
+        response
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.reason_code() == Some(expected_reason)),
+        "expected reason code {expected_reason:?}, got: {:?}",
+        response.diagnostics(),
+    );
+}

--- a/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
@@ -34,7 +34,11 @@ fn adapter_returning(result: Result<String, RustAnalyzerAdapterError>) -> MockAd
     adapter
         .expect_rename()
         .once()
-        .return_once(move |_file, _offset, _new_name| result);
+        .return_once(move |_file, offset, new_name| {
+            assert_eq!(offset, ByteOffset::new(3));
+            assert_eq!(new_name, "new_name");
+            result
+        });
     adapter
 }
 
@@ -48,7 +52,7 @@ fn rename_arguments() -> HashMap<String, serde_json::Value> {
     let mut arguments = HashMap::new();
     arguments.insert(
         String::from("uri"),
-        serde_json::Value::String(String::from("src/main.rs")),
+        serde_json::Value::String(String::from("file://src/main.rs")),
     );
     arguments.insert(
         String::from("position"),
@@ -187,12 +191,14 @@ enum FailureScenario {
     NoChange,
     AdapterError,
     UriMismatch,
+    RelativeUri,
 }
 
 #[rstest]
 #[case::no_change(FailureScenario::NoChange)]
 #[case::adapter_error(FailureScenario::AdapterError)]
 #[case::uri_mismatch(FailureScenario::UriMismatch)]
+#[case::relative_uri(FailureScenario::RelativeUri)]
 fn rename_non_mutating_or_error_returns_failure(
     #[case] scenario: FailureScenario,
     mut rename_arguments: HashMap<String, serde_json::Value>,
@@ -200,7 +206,13 @@ fn rename_non_mutating_or_error_returns_failure(
     if matches!(scenario, FailureScenario::UriMismatch) {
         rename_arguments.insert(
             String::from("uri"),
-            serde_json::Value::String(String::from("src/other.rs")),
+            serde_json::Value::String(String::from("file://src/other.rs")),
+        );
+    }
+    if matches!(scenario, FailureScenario::RelativeUri) {
+        rename_arguments.insert(
+            String::from("uri"),
+            serde_json::Value::String(String::from("file://./src/main.rs")),
         );
     }
     let adapter = match &scenario {
@@ -210,27 +222,47 @@ fn rename_non_mutating_or_error_returns_failure(
             }))
         }
         FailureScenario::UriMismatch => adapter_unused(),
+        FailureScenario::RelativeUri => {
+            adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")))
+        }
         FailureScenario::NoChange => {
             adapter_returning(Ok(String::from("fn old_name() -> i32 {\n    1\n}\n")))
         }
     };
 
-    let err = execute_request(&adapter, &request_with_args(rename_arguments))
-        .expect_err("failure scenario should return Err");
-
     match scenario {
-        FailureScenario::NoChange => assert!(
-            err.message().contains("no content changes"),
-            "expected no-change diagnostic, got: {err}"
-        ),
-        FailureScenario::AdapterError => assert!(
-            err.message().contains("rust-analyzer adapter failed"),
-            "expected adapter error message, got: {err}"
-        ),
-        FailureScenario::UriMismatch => assert!(
-            err.message().contains("does not match file payload"),
-            "expected uri mismatch diagnostic, got: {err}"
-        ),
+        FailureScenario::RelativeUri => {
+            let response = execute_request(&adapter, &request_with_args(rename_arguments))
+                .expect("equivalent relative file URI should succeed");
+            assert!(response.is_success());
+        }
+        FailureScenario::NoChange => {
+            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+                .expect_err("failure scenario should return Err");
+            assert!(
+                err.message().contains("no content changes"),
+                "expected no-change diagnostic, got: {err}"
+            );
+            assert_eq!(err.reason_code(), Some(ReasonCode::SymbolNotFound));
+        }
+        FailureScenario::AdapterError => {
+            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+                .expect_err("failure scenario should return Err");
+            assert!(
+                err.message().contains("rust-analyzer adapter failed"),
+                "expected adapter error message, got: {err}"
+            );
+            assert_eq!(err.reason_code(), None);
+        }
+        FailureScenario::UriMismatch => {
+            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+                .expect_err("failure scenario should return Err");
+            assert!(
+                err.message().contains("does not match file payload"),
+                "expected uri mismatch diagnostic, got: {err}"
+            );
+            assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
+        }
     }
 }
 

--- a/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
@@ -30,11 +30,23 @@ mock! {
 
 /// Builds a `MockAdapter` that expects a single rename call returning `result`.
 fn adapter_returning(result: Result<String, RustAnalyzerAdapterError>) -> MockAdapter {
+    adapter_returning_with_path(result, None)
+}
+
+/// Builds a `MockAdapter` that can also assert the forwarded payload path.
+fn adapter_returning_with_path(
+    result: Result<String, RustAnalyzerAdapterError>,
+    expected_payload_path: Option<&str>,
+) -> MockAdapter {
+    let expected_path_string = expected_payload_path.map(String::from);
     let mut adapter = MockAdapter::new();
     adapter
         .expect_rename()
         .once()
-        .return_once(move |_file, offset, new_name| {
+        .return_once(move |file, offset, new_name| {
+            if let Some(path) = &expected_path_string {
+                assert_eq!(file.path(), PathBuf::from(path).as_path());
+            }
             assert_eq!(offset, ByteOffset::new(3));
             assert_eq!(new_name, "new_name");
             result
@@ -52,7 +64,7 @@ fn rename_arguments() -> HashMap<String, serde_json::Value> {
     let mut arguments = HashMap::new();
     arguments.insert(
         String::from("uri"),
-        serde_json::Value::String(String::from("file://src/main.rs")),
+        serde_json::Value::String(String::from("file:///src/main.rs")),
     );
     arguments.insert(
         String::from("position"),
@@ -192,6 +204,7 @@ enum FailureScenario {
     AdapterError,
     UriMismatch,
     RelativeUri,
+    InvalidUri,
 }
 
 #[rstest]
@@ -199,6 +212,7 @@ enum FailureScenario {
 #[case::adapter_error(FailureScenario::AdapterError)]
 #[case::uri_mismatch(FailureScenario::UriMismatch)]
 #[case::relative_uri(FailureScenario::RelativeUri)]
+#[case::invalid_uri(FailureScenario::InvalidUri)]
 fn rename_non_mutating_or_error_returns_failure(
     #[case] scenario: FailureScenario,
     mut rename_arguments: HashMap<String, serde_json::Value>,
@@ -206,13 +220,19 @@ fn rename_non_mutating_or_error_returns_failure(
     if matches!(scenario, FailureScenario::UriMismatch) {
         rename_arguments.insert(
             String::from("uri"),
-            serde_json::Value::String(String::from("file://src/other.rs")),
+            serde_json::Value::String(String::from("file:///src/other.rs")),
         );
     }
     if matches!(scenario, FailureScenario::RelativeUri) {
         rename_arguments.insert(
             String::from("uri"),
-            serde_json::Value::String(String::from("file://./src/main.rs")),
+            serde_json::Value::String(String::from("file:///./src/main.rs")),
+        );
+    }
+    if matches!(scenario, FailureScenario::InvalidUri) {
+        rename_arguments.insert(
+            String::from("uri"),
+            serde_json::Value::String(String::from("src/main.rs")),
         );
     }
     let adapter = match &scenario {
@@ -221,10 +241,11 @@ fn rename_non_mutating_or_error_returns_failure(
                 message: String::from("rust-analyzer adapter failed"),
             }))
         }
-        FailureScenario::UriMismatch => adapter_unused(),
-        FailureScenario::RelativeUri => {
-            adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")))
-        }
+        FailureScenario::UriMismatch | FailureScenario::InvalidUri => adapter_unused(),
+        FailureScenario::RelativeUri => adapter_returning_with_path(
+            Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")),
+            Some("src/main.rs"),
+        ),
         FailureScenario::NoChange => {
             adapter_returning(Ok(String::from("fn old_name() -> i32 {\n    1\n}\n")))
         }
@@ -260,6 +281,16 @@ fn rename_non_mutating_or_error_returns_failure(
             assert!(
                 err.message().contains("does not match file payload"),
                 "expected uri mismatch diagnostic, got: {err}"
+            );
+            assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
+        }
+        FailureScenario::InvalidUri => {
+            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+                .expect_err("failure scenario should return Err");
+            assert!(
+                err.message()
+                    .contains("uri argument must be a valid file:// URI"),
+                "expected invalid-URI diagnostic, got: {err}"
             );
             assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
         }

--- a/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/mod.rs
@@ -1,189 +1,28 @@
 //! Unit and behavioural tests for the rust-analyzer actuator plugin.
 
+mod argument_validation;
 mod behaviour;
+mod dispatch_layer;
+mod support;
 
-use std::collections::HashMap;
-use std::path::PathBuf;
-
-use mockall::mock;
-use rstest::{fixture, rstest};
+use rstest::rstest;
 use weaver_plugins::capability::ReasonCode;
-use weaver_plugins::protocol::{
-    DiagnosticSeverity, FilePayload, PluginOutput, PluginRequest, PluginResponse,
+use weaver_plugins::protocol::{PluginOutput, PluginRequest};
+
+use crate::{RustAnalyzerAdapterError, execute_request};
+use support::{
+    adapter_returning, adapter_returning_with_path, adapter_unused, rename_arguments,
+    request_with_args, request_with_path,
 };
 
-use crate::{
-    ByteOffset, RustAnalyzerAdapter, RustAnalyzerAdapterError, execute_request, run_with_adapter,
-};
-
-mock! {
-    Adapter {}
-    impl RustAnalyzerAdapter for Adapter {
-        fn rename(
-            &self,
-            file: &FilePayload,
-            offset: ByteOffset,
-            new_name: &str,
-        ) -> Result<String, RustAnalyzerAdapterError>;
-    }
-}
-
-/// Builds a `MockAdapter` that expects a single rename call returning `result`.
-fn adapter_returning(result: Result<String, RustAnalyzerAdapterError>) -> MockAdapter {
-    adapter_returning_with_path(result, None)
-}
-
-/// Builds a `MockAdapter` that can also assert the forwarded payload path.
-fn adapter_returning_with_path(
-    result: Result<String, RustAnalyzerAdapterError>,
-    expected_payload_path: Option<&str>,
-) -> MockAdapter {
-    let expected_path_string = expected_payload_path.map(String::from);
-    let mut adapter = MockAdapter::new();
-    adapter
-        .expect_rename()
-        .once()
-        .return_once(move |file, offset, new_name| {
-            if let Some(path) = &expected_path_string {
-                assert_eq!(file.path(), PathBuf::from(path).as_path());
-            }
-            assert_eq!(offset, ByteOffset::new(3));
-            assert_eq!(new_name, "new_name");
-            result
-        });
-    adapter
-}
-
-/// Builds a `MockAdapter` where rename is never expected.
-fn adapter_unused() -> MockAdapter {
-    MockAdapter::new()
-}
-
-#[fixture]
-fn rename_arguments() -> HashMap<String, serde_json::Value> {
-    let mut arguments = HashMap::new();
-    arguments.insert(
-        String::from("uri"),
-        serde_json::Value::String(String::from("file:///src/main.rs")),
-    );
-    arguments.insert(
-        String::from("position"),
-        serde_json::Value::String(String::from("3")),
-    );
-    arguments.insert(
-        String::from("new_name"),
-        serde_json::Value::String(String::from("new_name")),
-    );
-    arguments
-}
-
-fn request_with_args(arguments: HashMap<String, serde_json::Value>) -> PluginRequest {
-    PluginRequest::with_arguments(
-        "rename-symbol",
-        vec![FilePayload::new(
-            PathBuf::from("src/main.rs"),
-            "fn old_name() -> i32 {\n    1\n}\n",
-        )],
-        arguments,
-    )
-}
-
-#[rstest]
-fn rename_success_returns_diff_output(rename_arguments: HashMap<String, serde_json::Value>) {
+#[test]
+fn rename_success_returns_diff_output() {
     let adapter = adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")));
 
-    let response = execute_request(&adapter, &request_with_args(rename_arguments))
+    let response = execute_request(&adapter, &request_with_args(rename_arguments()))
         .expect("execute_request should succeed");
     assert!(response.is_success());
     assert!(matches!(response.output(), PluginOutput::Diff { .. }));
-}
-
-fn remove_uri(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.remove("uri");
-}
-
-fn set_empty_uri(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(
-        String::from("uri"),
-        serde_json::Value::String(String::from("  ")),
-    );
-}
-
-fn set_numeric_uri(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(
-        String::from("uri"),
-        serde_json::Value::Number(serde_json::Number::from(4)),
-    );
-}
-
-fn remove_position(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.remove("position");
-}
-
-fn set_boolean_position(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(String::from("position"), serde_json::Value::Bool(true));
-}
-
-fn set_negative_position(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(
-        String::from("position"),
-        serde_json::Value::String(String::from("-1")),
-    );
-}
-
-fn set_numeric_position(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(
-        String::from("position"),
-        serde_json::Value::Number(serde_json::Number::from(3)),
-    );
-}
-
-fn set_empty_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(
-        String::from("new_name"),
-        serde_json::Value::String(String::from("  ")),
-    );
-}
-
-fn set_numeric_new_name(arguments: &mut HashMap<String, serde_json::Value>) {
-    arguments.insert(
-        String::from("new_name"),
-        serde_json::Value::Number(serde_json::Number::from(42)),
-    );
-}
-
-#[rstest]
-#[case::missing_uri(remove_uri as fn(&mut _), Some("uri"))]
-#[case::empty_uri(set_empty_uri as fn(&mut _), Some("uri"))]
-#[case::numeric_uri(set_numeric_uri as fn(&mut _), Some("uri argument must be a string"))]
-#[case::missing_position(remove_position as fn(&mut _), Some("position"))]
-#[case::boolean_position(set_boolean_position as fn(&mut _), Some("position"))]
-#[case::negative_position(set_negative_position as fn(&mut _), Some("non-negative integer"))]
-#[case::numeric_position_succeeds(set_numeric_position as fn(&mut _), None)]
-#[case::numeric_new_name(set_numeric_new_name as fn(&mut _), Some("new_name argument must be a string"))]
-#[case::empty_new_name(set_empty_new_name as fn(&mut _), Some("new_name"))]
-fn rename_argument_validation(
-    #[case] mutate: fn(&mut HashMap<String, serde_json::Value>),
-    #[case] expected_error: Option<&str>,
-    mut rename_arguments: HashMap<String, serde_json::Value>,
-) {
-    mutate(&mut rename_arguments);
-
-    if let Some(needle) = expected_error {
-        let adapter = adapter_unused();
-        let err = execute_request(&adapter, &request_with_args(rename_arguments))
-            .expect_err("invalid arguments should fail");
-        assert!(
-            err.message().contains(needle),
-            "expected error mentioning '{needle}', got: {err}"
-        );
-        assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
-    } else {
-        let adapter = adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n")));
-        let response = execute_request(&adapter, &request_with_args(rename_arguments))
-            .expect("valid arguments should succeed");
-        assert!(response.is_success());
-    }
 }
 
 #[test]
@@ -213,24 +52,22 @@ enum FailureScenario {
 #[case::uri_mismatch(FailureScenario::UriMismatch)]
 #[case::relative_uri(FailureScenario::RelativeUri)]
 #[case::invalid_uri(FailureScenario::InvalidUri)]
-fn rename_non_mutating_or_error_returns_failure(
-    #[case] scenario: FailureScenario,
-    mut rename_arguments: HashMap<String, serde_json::Value>,
-) {
+fn rename_non_mutating_or_error_returns_failure(#[case] scenario: FailureScenario) {
+    let mut arguments = rename_arguments();
     if matches!(scenario, FailureScenario::UriMismatch) {
-        rename_arguments.insert(
+        arguments.insert(
             String::from("uri"),
             serde_json::Value::String(String::from("file:///src/other.rs")),
         );
     }
     if matches!(scenario, FailureScenario::RelativeUri) {
-        rename_arguments.insert(
+        arguments.insert(
             String::from("uri"),
             serde_json::Value::String(String::from("file:///./src/main.rs")),
         );
     }
     if matches!(scenario, FailureScenario::InvalidUri) {
-        rename_arguments.insert(
+        arguments.insert(
             String::from("uri"),
             serde_json::Value::String(String::from("src/main.rs")),
         );
@@ -253,12 +90,12 @@ fn rename_non_mutating_or_error_returns_failure(
 
     match scenario {
         FailureScenario::RelativeUri => {
-            let response = execute_request(&adapter, &request_with_args(rename_arguments))
+            let response = execute_request(&adapter, &request_with_args(arguments))
                 .expect("equivalent relative file URI should succeed");
             assert!(response.is_success());
         }
         FailureScenario::NoChange => {
-            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+            let err = execute_request(&adapter, &request_with_args(arguments))
                 .expect_err("failure scenario should return Err");
             assert!(
                 err.message().contains("no content changes"),
@@ -267,7 +104,7 @@ fn rename_non_mutating_or_error_returns_failure(
             assert_eq!(err.reason_code(), Some(ReasonCode::SymbolNotFound));
         }
         FailureScenario::AdapterError => {
-            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+            let err = execute_request(&adapter, &request_with_args(arguments))
                 .expect_err("failure scenario should return Err");
             assert!(
                 err.message().contains("rust-analyzer adapter failed"),
@@ -276,7 +113,7 @@ fn rename_non_mutating_or_error_returns_failure(
             assert_eq!(err.reason_code(), None);
         }
         FailureScenario::UriMismatch => {
-            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+            let err = execute_request(&adapter, &request_with_args(arguments))
                 .expect_err("failure scenario should return Err");
             assert!(
                 err.message().contains("does not match file payload"),
@@ -285,7 +122,7 @@ fn rename_non_mutating_or_error_returns_failure(
             assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
         }
         FailureScenario::InvalidUri => {
-            let err = execute_request(&adapter, &request_with_args(rename_arguments))
+            let err = execute_request(&adapter, &request_with_args(arguments))
                 .expect_err("failure scenario should return Err");
             assert!(
                 err.message()
@@ -295,112 +132,6 @@ fn rename_non_mutating_or_error_returns_failure(
             assert_eq!(err.reason_code(), Some(ReasonCode::IncompletePayload));
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// stdin/stdout dispatch layer tests (run_with_adapter)
-// ---------------------------------------------------------------------------
-
-fn valid_request_json() -> String {
-    let request = request_with_args(rename_arguments());
-    serde_json::to_string(&request).expect("serialize request")
-}
-
-/// Dispatches `input` through `run_with_adapter` and parses the response.
-fn dispatch_stdin(input: &[u8], adapter: &MockAdapter) -> PluginResponse {
-    let mut stdin = std::io::Cursor::new(input.to_vec());
-    let mut stdout = Vec::new();
-    run_with_adapter(&mut stdin, &mut stdout, adapter).expect("dispatch should succeed");
-    let output = String::from_utf8(stdout).expect("utf8 stdout");
-    serde_json::from_str(output.trim()).expect("parse response")
-}
-
-#[rstest]
-#[case::success(
-    format!("{}\n", valid_request_json()).into_bytes(),
-    adapter_returning(Ok(String::from("fn new_name() -> i32 {\n    1\n}\n"))),
-    true,
-    None
-)]
-#[case::empty_stdin(Vec::new(), adapter_unused(), false, Some("plugin request was empty"))]
-#[case::invalid_json(
-    b"not valid json\n".to_vec(),
-    adapter_unused(),
-    false,
-    Some("invalid plugin request JSON")
-)]
-fn run_with_adapter_dispatch_layer(
-    #[case] input: Vec<u8>,
-    #[case] adapter: MockAdapter,
-    #[case] expect_success: bool,
-    #[case] expected_message: Option<&str>,
-) {
-    let response = dispatch_stdin(&input, &adapter);
-    assert_eq!(response.is_success(), expect_success);
-
-    if let Some(needle) = expected_message {
-        assert!(
-            response
-                .diagnostics()
-                .iter()
-                .any(|diagnostic| diagnostic.severity() == DiagnosticSeverity::Error),
-            "expected at least one error diagnostic, got: {:?}",
-            response.diagnostics(),
-        );
-        assert!(
-            response
-                .diagnostics()
-                .iter()
-                .any(|diagnostic| diagnostic.message().contains(needle)),
-            "expected diagnostic mentioning '{needle}', got: {:?}",
-            response.diagnostics(),
-        );
-    }
-}
-
-#[rstest]
-#[case::missing_position(
-    {
-        let mut arguments = rename_arguments();
-        arguments.remove("position");
-        request_with_args(arguments)
-    },
-    ReasonCode::IncompletePayload
-)]
-#[case::unsupported_operation(
-    PluginRequest::new("extract_method", Vec::new()),
-    ReasonCode::OperationNotSupported
-)]
-fn failure_responses_include_reason_codes(
-    #[case] request: PluginRequest,
-    #[case] expected_reason: ReasonCode,
-) {
-    let input = format!(
-        "{}\n",
-        serde_json::to_string(&request).expect("serialize request")
-    );
-    let response = dispatch_stdin(input.as_bytes(), &adapter_unused());
-
-    assert!(!response.is_success());
-    assert!(
-        response
-            .diagnostics()
-            .iter()
-            .any(|diagnostic| diagnostic.reason_code() == Some(expected_reason)),
-        "expected reason code {expected_reason:?}, got: {:?}",
-        response.diagnostics(),
-    );
-}
-
-fn request_with_path(path: &str) -> PluginRequest {
-    PluginRequest::with_arguments(
-        "rename-symbol",
-        vec![FilePayload::new(
-            PathBuf::from(path),
-            "fn old_name() -> i32 {\n    1\n}\n",
-        )],
-        rename_arguments(),
-    )
 }
 
 #[rstest]

--- a/crates/weaver-plugin-rust-analyzer/src/tests/support.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/support.rs
@@ -1,0 +1,94 @@
+//! Shared test helpers for rust-analyzer plugin unit tests.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use mockall::mock;
+use weaver_plugins::protocol::{FilePayload, PluginRequest};
+
+use crate::{ByteOffset, RustAnalyzerAdapter, RustAnalyzerAdapterError};
+
+mock! {
+    pub(crate) Adapter {}
+    impl RustAnalyzerAdapter for Adapter {
+        fn rename(
+            &self,
+            file: &FilePayload,
+            offset: ByteOffset,
+            new_name: &str,
+        ) -> Result<String, RustAnalyzerAdapterError>;
+    }
+}
+
+/// Builds a `MockAdapter` that expects a single rename call returning `result`.
+pub(crate) fn adapter_returning(result: Result<String, RustAnalyzerAdapterError>) -> MockAdapter {
+    adapter_returning_with_path(result, None)
+}
+
+/// Builds a `MockAdapter` that can also assert the forwarded payload path.
+pub(crate) fn adapter_returning_with_path(
+    result: Result<String, RustAnalyzerAdapterError>,
+    expected_payload_path: Option<&str>,
+) -> MockAdapter {
+    let expected_path_string = expected_payload_path.map(String::from);
+    let mut adapter = MockAdapter::new();
+    adapter
+        .expect_rename()
+        .once()
+        .return_once(move |file, offset, new_name| {
+            if let Some(path) = &expected_path_string {
+                assert_eq!(file.path(), PathBuf::from(path).as_path());
+            }
+            assert_eq!(offset, ByteOffset::new(3));
+            assert_eq!(new_name, "new_name");
+            result
+        });
+    adapter
+}
+
+/// Builds a `MockAdapter` where rename is never expected.
+pub(crate) fn adapter_unused() -> MockAdapter {
+    MockAdapter::new()
+}
+
+/// Returns a valid `rename-symbol` argument map.
+pub(crate) fn rename_arguments() -> HashMap<String, serde_json::Value> {
+    let mut arguments = HashMap::new();
+    arguments.insert(
+        String::from("uri"),
+        serde_json::Value::String(String::from("file:///src/main.rs")),
+    );
+    arguments.insert(
+        String::from("position"),
+        serde_json::Value::String(String::from("3")),
+    );
+    arguments.insert(
+        String::from("new_name"),
+        serde_json::Value::String(String::from("new_name")),
+    );
+    arguments
+}
+
+/// Builds a request with a single Rust file payload.
+pub(crate) fn request_with_args(arguments: HashMap<String, serde_json::Value>) -> PluginRequest {
+    PluginRequest::with_arguments(
+        "rename-symbol",
+        vec![FilePayload::new(
+            PathBuf::from("src/main.rs"),
+            "fn old_name() -> i32 {\n    1\n}\n",
+        )],
+        arguments,
+    )
+}
+
+/// Builds a request using the provided file payload path.
+pub(crate) fn request_with_path(path: &str) -> PluginRequest {
+    PluginRequest::with_arguments(
+        "rename-symbol",
+        vec![FilePayload::new(
+            PathBuf::from(path),
+            "fn old_name() -> i32 {\n    1\n}\n",
+        )],
+        rename_arguments(),
+    )
+}

--- a/crates/weaver-plugin-rust-analyzer/src/tests/support.rs
+++ b/crates/weaver-plugin-rust-analyzer/src/tests/support.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use mockall::mock;
+use url::Url;
 use weaver_plugins::protocol::{FilePayload, PluginRequest};
 
 use crate::{ByteOffset, RustAnalyzerAdapter, RustAnalyzerAdapterError};
@@ -83,12 +84,29 @@ pub(crate) fn request_with_args(arguments: HashMap<String, serde_json::Value>) -
 
 /// Builds a request using the provided file payload path.
 pub(crate) fn request_with_path(path: &str) -> PluginRequest {
+    let mut arguments = rename_arguments();
+    arguments.insert(
+        String::from("uri"),
+        serde_json::Value::String(file_uri_for_path(path)),
+    );
+
     PluginRequest::with_arguments(
         "rename-symbol",
         vec![FilePayload::new(
             PathBuf::from(path),
             "fn old_name() -> i32 {\n    1\n}\n",
         )],
-        rename_arguments(),
+        arguments,
     )
+}
+
+fn file_uri_for_path(path: &str) -> String {
+    let mut url = Url::parse("file:///").expect("static file URL should parse");
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .expect("file URL should accept path segments");
+        segments.extend(path.split('/'));
+    }
+    url.to_string()
 }

--- a/crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature
+++ b/crates/weaver-plugin-rust-analyzer/tests/features/rust_analyzer_plugin.feature
@@ -39,3 +39,4 @@ Feature: rust-analyzer actuator plugin
     When the plugin executes the request
     Then the plugin returns failure diagnostics
     And the failure message contains "no content changes"
+    And the failure reason code is "symbol_not_found"

--- a/crates/weaverd/src/dispatch/act/refactor/mod.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/mod.rs
@@ -317,11 +317,15 @@ fn apply_rename_symbol_mapping(
 ) {
     plugin_args.insert(
         String::from("uri"),
-        serde_json::Value::String(file.to_owned()),
+        serde_json::Value::String(to_file_uri(file)),
     );
     if let Some(offset_val) = plugin_args.remove("offset") {
         plugin_args.insert(String::from("position"), offset_val);
     }
+}
+
+fn to_file_uri(path: &str) -> String {
+    format!("file://{path}")
 }
 
 fn handle_plugin_response<W: Write>(

--- a/crates/weaverd/src/dispatch/act/refactor/mod.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/mod.rs
@@ -176,7 +176,7 @@ pub fn handle<W: Write>(
     // Map `--refactoring rename` to the `rename-symbol` capability contract.
     let effective_operation = match args.refactoring.as_str() {
         "rename" => {
-            apply_rename_symbol_mapping(&mut plugin_args, &args.file);
+            apply_rename_symbol_mapping(&mut plugin_args, &args.file)?;
             String::from("rename-symbol")
         }
         _ => args.refactoring.clone(),
@@ -315,22 +315,30 @@ fn resolve_file(workspace_root: &Path, file: &str) -> Result<std::path::PathBuf,
 fn apply_rename_symbol_mapping(
     plugin_args: &mut std::collections::HashMap<String, serde_json::Value>,
     file: &str,
-) {
+) -> Result<(), DispatchError> {
     plugin_args.insert(
         String::from("uri"),
-        serde_json::Value::String(to_file_uri(file)),
+        serde_json::Value::String(to_file_uri(file).map_err(|error| {
+            DispatchError::invalid_arguments(format!(
+                "cannot construct file URI for '{file}': {error}"
+            ))
+        })?),
     );
     if let Some(offset_val) = plugin_args.remove("offset") {
         plugin_args.insert(String::from("position"), offset_val);
     }
+    Ok(())
 }
 
-fn to_file_uri(path: &str) -> String {
-    Url::parse("file:///")
-        .expect("static file URI base must parse")
-        .join(path)
-        .expect("validated relative refactor paths should form a file URI")
-        .to_string()
+fn to_file_uri(path: &str) -> Result<String, url::ParseError> {
+    let mut url = Url::parse("file:///")?;
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|()| url::ParseError::RelativeUrlWithoutBase)?;
+        segments.extend(path.split('/'));
+    }
+    Ok(url.to_string())
 }
 
 fn handle_plugin_response<W: Write>(

--- a/crates/weaverd/src/dispatch/act/refactor/mod.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/mod.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tracing::debug;
+use url::Url;
 
 use weaver_plugins::process::SandboxExecutor;
 use weaver_plugins::protocol::FilePayload;
@@ -325,7 +326,11 @@ fn apply_rename_symbol_mapping(
 }
 
 fn to_file_uri(path: &str) -> String {
-    format!("file://{path}")
+    Url::parse("file:///")
+        .expect("static file URI base must parse")
+        .join(path)
+        .expect("validated relative refactor paths should form a file URI")
+        .to_string()
 }
 
 fn handle_plugin_response<W: Write>(

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -332,7 +332,7 @@ fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) 
     let args = plugin_request.arguments();
     assert_eq!(
         args.get("uri").and_then(|v| v.as_str()),
-        Some("file://notes.txt"),
+        Some("file:///notes.txt"),
         "uri should be injected from --file"
     );
     assert_eq!(
@@ -368,7 +368,7 @@ fn handler_overwrites_pre_existing_uri_with_file_path(socket_dir: TempDir) {
             .arguments()
             .get("uri")
             .and_then(|v| v.as_str()),
-        Some("file://notes.txt"),
+        Some("file:///notes.txt"),
         "uri should be overwritten with --file value, not pre-existing extra"
     );
 }
@@ -398,7 +398,7 @@ fn rust_analyzer_provider_uses_rename_symbol_contract(socket_dir: TempDir) {
             .arguments()
             .get("uri")
             .and_then(|value| value.as_str()),
-        Some("file://notes.txt"),
+        Some("file:///notes.txt"),
     );
     assert_eq!(
         plugin_request

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -332,7 +332,7 @@ fn handler_sends_rename_symbol_contract_conforming_request(socket_dir: TempDir) 
     let args = plugin_request.arguments();
     assert_eq!(
         args.get("uri").and_then(|v| v.as_str()),
-        Some("notes.txt"),
+        Some("file://notes.txt"),
         "uri should be injected from --file"
     );
     assert_eq!(
@@ -368,7 +368,7 @@ fn handler_overwrites_pre_existing_uri_with_file_path(socket_dir: TempDir) {
             .arguments()
             .get("uri")
             .and_then(|v| v.as_str()),
-        Some("notes.txt"),
+        Some("file://notes.txt"),
         "uri should be overwritten with --file value, not pre-existing extra"
     );
 }
@@ -398,7 +398,7 @@ fn rust_analyzer_provider_uses_rename_symbol_contract(socket_dir: TempDir) {
             .arguments()
             .get("uri")
             .and_then(|value| value.as_str()),
-        Some("notes.txt"),
+        Some("file://notes.txt"),
     );
     assert_eq!(
         plugin_request

--- a/docs/execplans/2-2-3-top-level-version-output.md
+++ b/docs/execplans/2-2-3-top-level-version-output.md
@@ -13,11 +13,10 @@ repository root.
 ## Purpose / big picture
 
 After this change, operators can run `weaver --version` or `weaver -V` to see
-the version string, exiting 0 and printing to standard output (stdout).
-Running `weaver --help`
-displays a purpose statement and runnable quick-start examples alongside the
-existing domain/operation catalogue. Both `--help` and `--version` now exit 0
-and write to stdout, matching standard CLI conventions.
+the version string, exiting 0 and printing to standard output (stdout). Running
+`weaver --help` displays a purpose statement and runnable quick-start examples
+alongside the existing domain/operation catalogue. Both `--help` and
+`--version` now exit 0 and write to stdout, matching standard CLI conventions.
 
 Observable behaviour after this change:
 
@@ -44,12 +43,13 @@ Observable behaviour after this change:
 3. **Strict Clippy.** Over 30 denied lint categories including `unwrap_used`,
    `expect_used`, `indexing_slicing`, `string_slice`, `missing_docs`,
    `cognitive_complexity`, `allow_attributes`, and `str_to_string`. All code
-   must pass `cargo clippy --workspace --all-targets --all-features -D warnings`.
+   must pass
+   `cargo clippy --workspace --all-targets --all-features -D warnings`.
 4. **en-GB-oxendict spelling.** Comments and documentation use British English
    with Oxford "-ize" / "-yse" / "-our" spelling.
 5. **rstest-bdd v0.5.0.** Behaviour-driven development (BDD) tests use
-   v0.5.0. The fixture parameter must be
-   named exactly `world`. Use `let _ = world;` to suppress unused warnings.
+   v0.5.0. The fixture parameter must be named exactly `world`. Use
+   `let _ = world;` to suppress unused warnings.
 6. **`concat!()` for multi-line strings.** Per AGENTS.md, use `concat!()` to
    combine long string literals rather than escaping newlines with backslash.
 7. **No new external dependencies.** The change uses only clap features already
@@ -66,8 +66,7 @@ Observable behaviour after this change:
 - **Scope:** If implementation requires changes to more than 12 files or more
   than 200 net lines of code, stop and escalate.
 - **Interface:** If a public application programming interface (API)
-  signature must change beyond adding the clap attributes, stop and
-  escalate.
+  signature must change beyond adding the clap attributes, stop and escalate.
 - **Dependencies:** If a new external dependency is required, stop and
   escalate.
 - **Iterations:** If tests still fail after 3 attempts at fixing, stop and
@@ -78,33 +77,29 @@ Observable behaviour after this change:
 ## Risks
 
 - Risk: `lib.rs` line budget (399/400 lines). Adding the exit-code fix
-  requires net new lines.
-  Severity: high. Likelihood: certain.
-  Mitigation: Extract the standalone `is_apply_patch()` function (7 lines)
-  from `lib.rs` to `command.rs` as a method on `CommandInvocation` before
-  adding the exit-code fix. This reclaims 7 lines, providing headroom for the
-  +3 line exit-code change.
+  requires net new lines. Severity: high. Likelihood: certain. Mitigation:
+  Extract the standalone `is_apply_patch()` function (7 lines) from `lib.rs` to
+  `command.rs` as a method on `CommandInvocation` before adding the exit-code
+  fix. This reclaims 7 lines, providing headroom for the +3 line exit-code
+  change.
 
 - Risk: Changing `--help` to stdout/exit-0 breaks existing integration test
-  `help_output_lists_all_domains_and_operations` in `main_entry.rs`.
-  Severity: medium. Likelihood: low.
-  Mitigation: The existing test (lines 28-54) intentionally uses combined
-  stdout+stderr output (`format!("{stdout}{stderr}")`) and does not assert on
-  exit code. Its comment states, "We intentionally avoid asserting on the exit
-  code so this test remains valid if --help is later changed to exit 0." No
-  change is needed.
+  `help_output_lists_all_domains_and_operations` in `main_entry.rs`. Severity:
+  medium. Likelihood: low. Mitigation: The existing test (lines 28-54)
+  intentionally uses combined stdout+stderr output
+  (`format!("{stdout}{stderr}")`) and does not assert on exit code. Its comment
+  states, "We intentionally avoid asserting on the exit code so this test
+  remains valid if --help is later changed to exit 0." No change is needed.
 
 - Risk: BDD tests break because `--help`/`--version` now behaves differently.
-  Severity: low. Likelihood: low.
-  Mitigation: No existing BDD scenario tests `--help` or `--version` directly.
-  The "Bare invocation shows short help" scenario tests bare invocation (no
-  args), which is handled by separate code (`write_bare_help` +
-  `BareInvocation` error) and is unaffected.
+  Severity: low. Likelihood: low. Mitigation: No existing BDD scenario tests
+  `--help` or `--version` directly. The "Bare invocation shows short help"
+  scenario tests bare invocation (no args), which is handled by separate code
+  (`write_bare_help` + `BareInvocation` error) and is unaffected.
 
 - Risk: `unit.rs` line budget (397/400 lines). Adding `mod version_output`
-  pushes it to 398.
-  Severity: low. Likelihood: certain.
-  Mitigation: One line is well within budget.
+  pushes it to 398. Severity: low. Likelihood: certain. Mitigation: One line is
+  well within budget.
 
 ## Progress
 
@@ -129,40 +124,35 @@ Observable behaviour after this change:
 ## Surprises & discoveries
 
 - Observation: `rustfmt` reformatted the `is_apply_patch` method body and
-  some assertion macros in `version_output.rs` to more compact forms.
-  Evidence: `make check-fmt` diff output.
-  Impact: None — applied `cargo fmt --all` and re-verified.
+  some assertion macros in `version_output.rs` to more compact forms. Evidence:
+  `make check-fmt` diff output. Impact: None — applied `cargo fmt --all` and
+  re-verified.
 
 ## Decision log
 
 - Decision: Use `clap::Error::use_stderr()` guard rather than matching
-  `ErrorKind::DisplayHelp | ErrorKind::DisplayVersion` directly.
-  Rationale: `use_stderr()` returns `false` exactly for informational outputs
-  (help and version). It is idiomatic, avoids importing `ErrorKind`, is more
-  compact (saves lines in the already-tight `lib.rs`), and automatically
-  handles any future clap informational error kinds.
-  Date: 2026-03-07.
+  `ErrorKind::DisplayHelp | ErrorKind::DisplayVersion` directly. Rationale:
+  `use_stderr()` returns `false` exactly for informational outputs (help and
+  version). It is idiomatic, avoids importing `ErrorKind`, is more compact
+  (saves lines in the already-tight `lib.rs`), and automatically handles any
+  future clap informational error kinds. Date: 2026-03-07.
 
 - Decision: Extract `is_apply_patch` as a method on `CommandInvocation`
-  rather than moving to a separate module.
-  Rationale: The function operates solely on `CommandInvocation` fields and
-  is a natural method. `command.rs` is at 91 lines and has ample headroom.
-  Date: 2026-03-07.
+  rather than moving to a separate module. Rationale: The function operates
+  solely on `CommandInvocation` fields and is a natural method. `command.rs` is
+  at 91 lines and has ample headroom. Date: 2026-03-07.
 
 - Decision: Place unit tests in a new `version_output.rs` file rather than
-  adding to `bare_invocation.rs`.
-  Rationale: The tests cover a distinct feature (version and help exit
-  behaviour) that is thematically separate from bare-invocation help.
-  Keeping them in a dedicated file aids discoverability and stays within the
-  400-line budget for both files.
-  Date: 2026-03-07.
+  adding to `bare_invocation.rs`. Rationale: The tests cover a distinct feature
+  (version and help exit behaviour) that is thematically separate from
+  bare-invocation help. Keeping them in a dedicated file aids discoverability
+  and stays within the 400-line budget for both files. Date: 2026-03-07.
 
 - Decision: Use `about` + `long_about` rather than only `long_about`.
-  Rationale: `about` shows in short help (`-h`) and subcommand listings,
-  giving users a purpose statement even in abbreviated output. `long_about`
-  extends this with quick-start examples in `--help`. Both are standard
-  clap attributes.
-  Date: 2026-03-07.
+  Rationale: `about` shows in short help (`-h`) and subcommand listings, giving
+  users a purpose statement even in abbreviated output. `long_about` extends
+  this with quick-start examples in `--help`. Both are standard clap
+  attributes. Date: 2026-03-07.
 
 ## Outcomes & retrospective
 
@@ -175,13 +165,13 @@ All acceptance criteria are met:
 3. `weaver` (bare invocation) continues to exit 1 and print to stderr.
 4. `make check-fmt`, `make lint`, and `make test` all pass clean.
 
-Line budget management was the key constraint. Extracting `is_apply_patch`
-to `command.rs` as a preparatory refactoring reclaimed 7 lines in `lib.rs`
-(399 to 392), providing headroom for the +3 line exit-code fix (final: 395).
-All files remain well within the 400-line limit.
+Line budget management was the key constraint. Extracting `is_apply_patch` to
+`command.rs` as a preparatory refactoring reclaimed 7 lines in `lib.rs` (399 to
+392), providing headroom for the +3 line exit-code fix (final: 395). All files
+remain well within the 400-line limit.
 
-The `clap::Error::use_stderr()` guard proved to be the right abstraction
-for detecting informational clap errors — compact, idiomatic, and
+The `clap::Error::use_stderr()` guard proved to be the right abstraction for
+detecting informational clap errors — compact, idiomatic, and
 forward-compatible.
 
 ## Context and orientation
@@ -191,16 +181,16 @@ in `src/cli.rs` and is parsed by `src/lib.rs`. The build script at `build.rs`
 includes `cli.rs` via `#[path = "src/cli.rs"]` for manpage generation. This
 dual-compilation means any code in `cli.rs` must compile in both contexts.
 
-The workspace version is `0.1.0` (set in `/home/user/project/Cargo.toml`
-line 22). Clap's derive macro reads `CARGO_PKG_VERSION` automatically when the
-bare `version` attribute is present in `#[command()]`.
+The workspace version is `0.1.0` (set in `/home/user/project/Cargo.toml` line
+22). Clap's derive macro reads `CARGO_PKG_VERSION` automatically when the bare
+`version` attribute is present in `#[command()]`.
 
-Currently, `Cli::try_parse_from()` returns `Err(clap::Error)` for both
-`--help` and `--version`. This error is wrapped in `AppError::CliUsage` and
-handled in `run_with_handler`'s match block (lib.rs lines 202-209), which
-writes all errors to stderr and returns `ExitCode::FAILURE`. The fix adds a
-guard that checks `clap_err.use_stderr()` — when false (for help and version),
-it writes to stdout and returns `ExitCode::SUCCESS`.
+Currently, `Cli::try_parse_from()` returns `Err(clap::Error)` for both `--help`
+and `--version`. This error is wrapped in `AppError::CliUsage` and handled in
+`run_with_handler`'s match block (lib.rs lines 202-209), which writes all
+errors to stderr and returns `ExitCode::FAILURE`. The fix adds a guard that
+checks `clap_err.use_stderr()` — when false (for help and version), it writes
+to stdout and returns `ExitCode::SUCCESS`.
 
 Key files and their current line counts:
 
@@ -220,8 +210,7 @@ Key files and their current line counts:
 Move the standalone `is_apply_patch()` function from `lib.rs` to `command.rs`
 as a method on `CommandInvocation`. This reclaims 7 lines in `lib.rs`.
 
-**`crates/weaver-cli/src/command.rs`** — Add an `impl CommandInvocation`
-block:
+**`crates/weaver-cli/src/command.rs`** — Add an `impl CommandInvocation` block:
 
 ```rust
 impl CommandInvocation {
@@ -237,9 +226,8 @@ impl CommandInvocation {
 ```
 
 **`crates/weaver-cli/src/lib.rs`** — Remove the standalone function
-`is_apply_patch` (lines 343-349). Update the call site in `build_request`
-(line 329) from `is_apply_patch(&invocation)` to
-`invocation.is_apply_patch()`.
+`is_apply_patch` (lines 343-349). Update the call site in `build_request` (line
+329) from `is_apply_patch(&invocation)` to `invocation.is_apply_patch()`.
 
 Net effect on `lib.rs`: -7 lines (399 to 392).
 
@@ -280,18 +268,16 @@ Validation: `make check-fmt && make lint && make test`.
 )]
 ```
 
-The bare `version` attribute causes clap to read `CARGO_PKG_VERSION`
-(`0.1.0`). The `about` shows in `-h` and subcommand listings. The
-`long_about` shows in `--help` and includes the required quick-start
-examples.
+The bare `version` attribute causes clap to read `CARGO_PKG_VERSION` (`0.1.0`).
+The `about` shows in `-h` and subcommand listings. The `long_about` shows in
+`--help` and includes the required quick-start examples.
 
 Line count: `cli.rs` goes from 87 to approximately 102 lines.
 
 ### Stage C: Fix exit code for `--help` and `--version` in `lib.rs`
 
-**`crates/weaver-cli/src/lib.rs`** — Replace the `match result` block
-(lines 202-209) in `run_with_handler`. Add a new arm before the catch-all
-`Err(error)`:
+**`crates/weaver-cli/src/lib.rs`** — Replace the `match result` block (lines
+202-209) in `run_with_handler`. Add a new arm before the catch-all `Err(error)`:
 
 ```rust
 match result {
@@ -309,8 +295,8 @@ match result {
 ```
 
 The guard `!clap_err.use_stderr()` is `true` for `DisplayHelp` and
-`DisplayVersion`. The output is written to stdout (not stderr) and the
-function returns `ExitCode::SUCCESS`.
+`DisplayVersion`. The output is written to stdout (not stderr) and the function
+returns `ExitCode::SUCCESS`.
 
 Line count: +3 lines net. After Stage A, `lib.rs` is at 392, so result is
 approximately 395.
@@ -320,8 +306,7 @@ approximately 395.
 **New file: `crates/weaver-cli/src/tests/unit/version_output.rs`**
 
 Tests using the same `PanickingLoader` pattern from `bare_invocation.rs` to
-prove that version and help output short-circuit before configuration
-loading:
+prove that version and help output short-circuit before configuration loading:
 
 1. `version_long_flag_exits_with_success` — `--version` returns
    `ExitCode::SUCCESS`.
@@ -338,13 +323,12 @@ loading:
 8. `help_output_contains_quick_start_example` — stdout contains
    "Quick start:" and "weaver observe get-definition".
 
-**`crates/weaver-cli/src/tests/unit.rs`** — Add `mod version_output;`
-(line 398).
+**`crates/weaver-cli/src/tests/unit.rs`** — Add `mod version_output;` (line
+398).
 
 ### Stage E: BDD tests
 
-**New file:
-`crates/weaver-cli/tests/features/weaver_cli_version.feature`**
+**New file: `crates/weaver-cli/tests/features/weaver_cli_version.feature`**
 
 ```gherkin
 Feature: Weaver CLI version output
@@ -422,13 +406,13 @@ fn help_flag_exits_successfully_with_quick_start() {
 **`docs/users-guide.md`** — Insert a "Version" subsection between "Bare
 invocation" (line 243) and "Top-level help" (line 245).
 
-Update the "Top-level help" section to mention exit code 0 and the
-quick-start block.
+Update the "Top-level help" section to mention exit code 0 and the quick-start
+block.
 
 ### Stage H: Mark roadmap done
 
-**`docs/roadmap.md`** — Change lines 168-178: replace `[ ]` with `[x]` on
-all four items (the parent 2.2.3 and its three sub-items).
+**`docs/roadmap.md`** — Change lines 168-178: replace `[ ]` with `[x]` on all
+four items (the parent 2.2.3 and its three sub-items).
 
 ## Concrete steps
 
@@ -494,8 +478,8 @@ make check-fmt && make lint && set -o pipefail \
 
 All steps are idempotent. If a step fails partway through, re-running the
 quality gate commands after fixing will verify correctness. The preparatory
-refactoring commit is behaviour-preserving and can be reverted independently
-if needed.
+refactoring commit is behaviour-preserving and can be reverted independently if
+needed.
 
 ## Interfaces and dependencies
 
@@ -506,8 +490,8 @@ change is the addition of clap-standard `--version`/`-V` flags and `about`/
 Existing reusable code:
 
 - `PanickingLoader` pattern from
-  `crates/weaver-cli/src/tests/unit/bare_invocation.rs` — reused for the
-  new version output unit tests.
+  `crates/weaver-cli/src/tests/unit/bare_invocation.rs` — reused for the new
+  version output unit tests.
 - BDD step definitions in
   `crates/weaver-cli/src/tests/behaviour.rs` — all steps needed by the new
   feature file already exist.
@@ -516,21 +500,21 @@ Existing reusable code:
 
 ## File change summary
 
-| File | Change | Lines before | Lines after |
-| --- | --- | --- | --- |
-| `src/command.rs` | Add `is_apply_patch` method | 91 | ~98 |
-| `src/lib.rs` | Remove `is_apply_patch`, add exit-code fix | 399 | ~395 |
-| `src/cli.rs` | Add `version`, `about`, `long_about` | 87 | ~102 |
-| `src/tests/unit.rs` | Add `mod version_output` | 397 | 398 |
-| `src/tests/unit/version_output.rs` | New file | 0 | ~100 |
-| `src/tests/behaviour.rs` | Add scenario registration | 340 | ~344 |
-| `tests/features/weaver_cli_version.feature` | New file | 0 | ~20 |
-| `tests/main_entry.rs` | Add version/help integration tests | 54 | ~79 |
-| `docs/users-guide.md` | Add version section, update help section | ~999 | ~1015 |
-| `docs/roadmap.md` | Mark 2.2.3 done | --- | --- |
+| File                                        | Change                                     | Lines before | Lines after |
+| ------------------------------------------- | ------------------------------------------ | ------------ | ----------- |
+| `src/command.rs`                            | Add `is_apply_patch` method                | 91           | ~98         |
+| `src/lib.rs`                                | Remove `is_apply_patch`, add exit-code fix | 399          | ~395        |
+| `src/cli.rs`                                | Add `version`, `about`, `long_about`       | 87           | ~102        |
+| `src/tests/unit.rs`                         | Add `mod version_output`                   | 397          | 398         |
+| `src/tests/unit/version_output.rs`          | New file                                   | 0            | ~100        |
+| `src/tests/behaviour.rs`                    | Add scenario registration                  | 340          | ~344        |
+| `tests/features/weaver_cli_version.feature` | New file                                   | 0            | ~20         |
+| `tests/main_entry.rs`                       | Add version/help integration tests         | 54           | ~79         |
+| `docs/users-guide.md`                       | Add version section, update help section   | ~999         | ~1015       |
+| `docs/roadmap.md`                           | Mark 2.2.3 done                            | ---          | ---         |
 
-All paths are relative to `crates/weaver-cli/` except `docs/` which is
-relative to workspace root.
+All paths are relative to `crates/weaver-cli/` except `docs/` which is relative
+to workspace root.
 
 ## Commit sequence
 

--- a/docs/execplans/2-2-3-top-level-version-output.md
+++ b/docs/execplans/2-2-3-top-level-version-output.md
@@ -88,8 +88,8 @@ Observable behaviour after this change:
   medium. Likelihood: low. Mitigation: The existing test (lines 28-54)
   intentionally uses combined stdout+stderr output
   (`format!("{stdout}{stderr}")`) and does not assert on exit code. Its comment
-  states, "We intentionally avoid asserting on the exit code so this test
-  remains valid if --help is later changed to exit 0." No change is needed.
+  states, "The test intentionally avoids asserting on the exit code so this
+  test remains valid if --help is later changed to exit 0." No change is needed.
 
 - Risk: BDD tests break because `--help`/`--version` now behaves differently.
   Severity: low. Likelihood: low. Mitigation: No existing BDD scenario tests

--- a/docs/execplans/2-2-3-top-level-version-output.md
+++ b/docs/execplans/2-2-3-top-level-version-output.md
@@ -424,7 +424,7 @@ All commands run from workspace root `/home/user/project`.
 
 Stage A (refactoring commit):
 
-```sh
+```bash
 # After making edits:
 make markdownlint && make fmt && make check-fmt && make lint && set -o pipefail \
   && make test 2>&1 | tee /tmp/2-2-3-test-a.log
@@ -432,7 +432,7 @@ make markdownlint && make fmt && make check-fmt && make lint && set -o pipefail 
 
 Stage B-H (feature commit):
 
-```sh
+```bash
 # After making all edits:
 make markdownlint && make fmt && make check-fmt && make lint && set -o pipefail \
   && make test 2>&1 | tee /tmp/2-2-3-test-b.log
@@ -473,7 +473,7 @@ Quality criteria:
 
 Quality method:
 
-```sh
+```bash
 make check-fmt && make lint && set -o pipefail \
   && make test 2>&1 | tee /tmp/2-2-3-final.log
 ```

--- a/docs/execplans/2-2-3-top-level-version-output.md
+++ b/docs/execplans/2-2-3-top-level-version-output.md
@@ -116,10 +116,11 @@ Observable behaviour after this change:
 - [x] (2026-03-07) Stage E: Add BDD feature file and register scenario.
 - [x] (2026-03-07) Stage F: Add integration tests in
   `tests/main_entry.rs`.
-- [x] (2026-03-07) Stage G: Update `docs/users-guide.md`.
+- [x] (2026-03-07) Stage G: Update `docs/users-guide.md` and run
+  `make markdownlint` plus `make fmt`.
 - [x] (2026-03-07) Stage H: Mark roadmap 2.2.3 as done.
-- [x] (2026-03-07) Run `make check-fmt && make lint && make test` and
-  verify all pass.
+- [x] (2026-03-07) Run `make markdownlint`, `make fmt`, `make check-fmt`,
+  `make lint`, and `make test`, and verify all pass.
 
 ## Surprises & discoveries
 
@@ -181,9 +182,9 @@ in `src/cli.rs` and is parsed by `src/lib.rs`. The build script at `build.rs`
 includes `cli.rs` via `#[path = "src/cli.rs"]` for manpage generation. This
 dual-compilation means any code in `cli.rs` must compile in both contexts.
 
-The workspace version is `0.1.0` (set in `/home/user/project/Cargo.toml` line
-22). Clap's derive macro reads `CARGO_PKG_VERSION` automatically when the bare
-`version` attribute is present in `#[command()]`.
+The workspace version is `0.1.0` (set in the workspace `Cargo.toml`). Clap's
+derive macro reads `CARGO_PKG_VERSION` automatically when the bare `version`
+attribute is present in `#[command()]`.
 
 Currently, `Cli::try_parse_from()` returns `Err(clap::Error)` for both `--help`
 and `--version`. This error is wrapped in `AppError::CliUsage` and handled in
@@ -401,13 +402,16 @@ fn help_flag_exits_successfully_with_quick_start() {
 }
 ```
 
-### Stage G: Documentation updates
+### Stage G: Documentation updates and Markdown quality gates
 
 **`docs/users-guide.md`** — Insert a "Version" subsection between "Bare
 invocation" (line 243) and "Top-level help" (line 245).
 
 Update the "Top-level help" section to mention exit code 0 and the quick-start
 block.
+
+Run `make markdownlint` and `make fmt` after the documentation edits so the
+guide and plan changes are validated and normalized before the Rust gates run.
 
 ### Stage H: Mark roadmap done
 
@@ -422,7 +426,7 @@ Stage A (refactoring commit):
 
 ```sh
 # After making edits:
-make check-fmt && make lint && set -o pipefail \
+make markdownlint && make fmt && make check-fmt && make lint && set -o pipefail \
   && make test 2>&1 | tee /tmp/2-2-3-test-a.log
 ```
 
@@ -430,7 +434,7 @@ Stage B-H (feature commit):
 
 ```sh
 # After making all edits:
-make check-fmt && make lint && set -o pipefail \
+make markdownlint && make fmt && make check-fmt && make lint && set -o pipefail \
   && make test 2>&1 | tee /tmp/2-2-3-test-b.log
 ```
 
@@ -499,6 +503,8 @@ Existing reusable code:
   unit tests to exercise the CLI without a real binary.
 
 ## File change summary
+
+Table 1. File change summary.
 
 | File                                        | Change                                     | Lines before | Lines after |
 | ------------------------------------------- | ------------------------------------------ | ------------ | ----------- |

--- a/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
+++ b/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
@@ -10,7 +10,7 @@ Status: COMPLETE
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root.
 
-Implementation was approved on 2026-03-07 and is now in progress.
+Implementation was approved on 2026-03-07 and completed on 2026-03-07.
 
 ## Purpose / big picture
 
@@ -22,7 +22,7 @@ the plugin accepts contract-conforming request payloads using `uri`,
 `position`, and `new_name`, and successful responses still return diff output
 that flows through the existing Double-Lock safety harness.
 
-The user-visible command stays the same:
+The user-visible command-line interface (CLI) stays the same:
 
 ```sh
 weaver act refactor \
@@ -49,8 +49,8 @@ Observable success for this roadmap item:
 - Successful plugin responses still use `PluginOutput::Diff`; failure payloads
   remain protocol-conforming and carry stable reason codes where the failure
   class is known.
-- Unit tests and `rstest-bdd` v0.5.0 behavioural tests cover happy paths,
-  unhappy paths, and edge cases for the contract migration.
+- Unit tests and `rstest-bdd` v0.5.0 behaviour-driven development (BDD) tests
+  cover happy paths, unhappy paths, and edge cases for the contract migration.
 - `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
   reflect the shipped behaviour.
 - `make fmt`, `make markdownlint`, `make check-fmt`, `make lint`, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -173,9 +173,12 @@ does* *not require source inspection or external runbooks.*
   - [x] Enable clap-provided `--version` and `-V` support.
   - [x] Add a `long_about` quick-start block aligned with the
         [user's guide](users-guide.md).
+  - [x] Validate the documentation updates with `make markdownlint` and
+        `make fmt` alongside the Rust quality gates.
   - [x] Acceptance criteria: `weaver --version` and `weaver -V` both exit 0
         and emit the same version string, and `weaver --help` includes at
-        least one runnable quick-start command example.
+        least one runnable quick-start command example, and `make check-fmt`,
+        `make markdownlint`, `make fmt`, `make lint`, and `make test` pass.
 - [ ] 2.2.4. Provide contextual guidance when a domain is supplied without an
       operation. See
       [Level 2](ui-gap-analysis.md#level-2--domain-without-operation-weaver-observe)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -173,8 +173,6 @@ does* *not require source inspection or external runbooks.*
   - [x] Enable clap-provided `--version` and `-V` support.
   - [x] Add a `long_about` quick-start block aligned with the
         [user's guide](users-guide.md).
-  - [x] Validate the documentation updates with `make markdownlint` and
-        `make fmt` alongside the Rust quality gates.
   - [x] Acceptance criteria: `weaver --version` and `weaver -V` both exit 0
         and emit the same version string, and `weaver --help` includes at
         least one runnable quick-start command example, and `make check-fmt`,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -244,8 +244,8 @@ This output does not require a configuration file or a running daemon. Use
 
 ### Version
 
-Running `weaver --version` or `weaver -V` prints the version string to
-standard output and exits with code 0:
+Running `weaver --version` or `weaver -V` prints the version string to standard
+output and exits with code 0:
 
 ```text
 weaver 0.1.0
@@ -785,9 +785,10 @@ Worked examples:
 
 The daemon ships with default actuator registrations:
 
-- `rope` for Python (`timeout_secs = 30`, `capabilities = rename-symbol`)
-- `rust-analyzer` for Rust (`timeout_secs = 60`,
-  `capabilities = rename-symbol`)
+- `rope` for Python
+  (`timeout_secs = 30`, `capabilities = ["rename-symbol"]`)
+- `rust-analyzer` for Rust
+  (`timeout_secs = 60`, `capabilities = ["rename-symbol"]`)
 
 By default, it expects plugin executables at:
 
@@ -863,12 +864,13 @@ For the current actuator rollout, `weaverd` registers:
 - `rope`
   - kind: `actuator`
   - language: `python`
-  - capabilities: `rename-symbol`
+  - capabilities: `["rename-symbol"]`
   - executable: `/usr/bin/weaver-plugin-rope` (or `WEAVER_ROPE_PLUGIN_PATH`)
   - timeout: `30s`
 - `rust-analyzer`
   - kind: `actuator`
   - language: `rust`
+  - capabilities: `["rename-symbol"]`
   - executable: `/usr/bin/weaver-plugin-rust-analyzer`
     (or `WEAVER_RUST_ANALYZER_PLUGIN_PATH`)
   - timeout: `60s`


### PR DESCRIPTION
## Summary
- Introduces a structured plugin failure model (PluginFailure) and centralizes failure-to-response conversion via failure_response.
- Normalizes and validates file:// URIs with normalize_request_uri; ensures URI payloads match payload paths and maps mismatches to a structured failure with ReasonCode::IncompletePayload.
- Updates rust-analyzer plugin to use the new failure module and URI normalization; symbol lookup errors map to plain PluginFailure to preserve existing behavior.
- Adds tests and fixtures updated to file:// URIs (rust-analyzer and weaverd), including RelativeUri scenarios and SymbolNotFound handling.
- Adds a helper in weaverd to inject file:// URIs via to_file_uri.
- Documentation and fixtures updated to reflect file:// URI usage and new failure codes.

## Changes
- New: crates/weaver-plugin-rust-analyzer/src/failure.rs
  - Adds PluginFailure with optional ReasonCode and conversion to PluginResponse via failure_response.
  - Implements Display for user-friendly messages.
  - Plain() and with_reason() constructors for different failure scenarios.
- Updated: crates/weaver-plugin-rust-analyzer/src/lib.rs
  - Replaces in-file failure handling with the new failure module (PluginFailure, failure_response).
  - Adds normalize_request_uri(uri) -> Result<String, RustAnalyzerAdapterError> to validate and normalize file:// URIs.
  - In execute_rename, uses normalize_request_uri to compare the request URI against the file payload path and maps URI mismatches to a structured failure with ReasonCode::IncompletePayload.
  - On symbol lookup errors from the adapter, maps to a plain PluginFailure without a reason code to preserve existing behavior where appropriate.
- Updated: tests for rust-analyzer and weaverd
  - rust-analyzer tests updated to use file:// URIs (e.g., file://src/main.rs) and include a new RelativeUri scenario.
  - NoChange failures now include a SymbolNotFound reason_code when appropriate; tests assert on the presence of ReasonCode::SymbolNotFound.
  - weaverd tests updated to inject and expect file:// URIs (e.g., file://notes.txt).
- New: in crates/weaverd/src/dispatch/act/refactor/mod.rs
  - Adds to_file_uri(path) -> String and uses it to inject file:// URIs when constructing plugin_args.
- Tests and fixtures adjustments
  - Updated test expectations in various modules to reflect file:// URIs and the new failure semantics.
- Documentation and fixtures
  - Documentation and feature files updated to reflect file:// URI usage, and new failure code expectations.
  - Updated examples in user guide to mention URI handling and version/help behavior where relevant.

📎 Task: https://www.devboxer.com/task/99d3abee-f949-400f-bd69-cc2a3ee3cbcc