### PR TITLE
Refactor diagnostics: canonical JSON shape with primary_span and tests

### DIFF
--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -205,6 +205,7 @@ impl Diagnostic {
     /// This compatibility alias will be removed once downstream callers have
     /// migrated to [`primary_span`](Self::primary_span).
     #[must_use]
+    #[deprecated(since = "0.1.0", note = "use `primary_span()` instead")]
     pub const fn span(&self) -> Option<&SourceSpan> {
         self.primary_span()
     }

--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -153,8 +153,10 @@ pub struct Diagnostic {
     code: DiagnosticCode,
     /// A human-readable description of the problem.
     message: String,
-    /// The source location where the problem was detected, if available.
-    span: Option<SourceSpan>,
+    /// The primary source location where the problem was detected, if
+    /// available.
+    #[serde(rename = "primary_span", alias = "span")]
+    primary_span: Option<SourceSpan>,
     /// Additional notes providing context or suggestions.
     notes: Vec<String>,
 }
@@ -169,15 +171,37 @@ impl Diagnostic {
     pub fn new(
         code: DiagnosticCode,
         message: String,
-        span: Option<SourceSpan>,
+        primary_span: Option<SourceSpan>,
         notes: Vec<String>,
     ) -> Self {
         Self {
             code,
             message,
-            span,
+            primary_span,
             notes,
         }
+    }
+
+    /// Creates a parser-path diagnostic.
+    #[must_use]
+    pub fn parser(
+        code: DiagnosticCode,
+        message: String,
+        primary_span: Option<SourceSpan>,
+        notes: Vec<String>,
+    ) -> Self {
+        Self::new(code, message, primary_span, notes)
+    }
+
+    /// Creates a validator-path diagnostic.
+    #[must_use]
+    pub fn validator(
+        code: DiagnosticCode,
+        message: String,
+        primary_span: Option<SourceSpan>,
+        notes: Vec<String>,
+    ) -> Self {
+        Self::new(code, message, primary_span, notes)
     }
 
     /// Returns the diagnostic code.
@@ -194,8 +218,17 @@ impl Diagnostic {
 
     /// Returns the source span, if available.
     #[must_use]
+    pub const fn primary_span(&self) -> Option<&SourceSpan> {
+        self.primary_span.as_ref()
+    }
+
+    /// Returns the primary source span, if available.
+    ///
+    /// This compatibility alias will be removed once downstream callers have
+    /// migrated to [`primary_span`](Self::primary_span).
+    #[must_use]
     pub const fn span(&self) -> Option<&SourceSpan> {
-        self.span.as_ref()
+        self.primary_span()
     }
 
     /// Returns the supplementary notes.
@@ -242,6 +275,33 @@ impl DiagnosticReport {
     )]
     pub fn new(diagnostics: Vec<Diagnostic>) -> Self {
         Self { diagnostics }
+    }
+
+    /// Creates a report containing a single parser diagnostic.
+    #[must_use]
+    pub fn parser_error(
+        code: DiagnosticCode,
+        message: String,
+        primary_span: Option<SourceSpan>,
+        notes: Vec<String>,
+    ) -> Self {
+        Self::new(vec![Diagnostic::parser(code, message, primary_span, notes)])
+    }
+
+    /// Creates a report containing a single validation diagnostic.
+    #[must_use]
+    pub fn validation_error(
+        code: DiagnosticCode,
+        message: String,
+        primary_span: Option<SourceSpan>,
+        notes: Vec<String>,
+    ) -> Self {
+        Self::new(vec![Diagnostic::validator(
+            code,
+            message,
+            primary_span,
+            notes,
+        )])
     }
 
     /// Creates a single-diagnostic report indicating that a feature is not

--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -182,28 +182,6 @@ impl Diagnostic {
         }
     }
 
-    /// Creates a parser-path diagnostic.
-    #[must_use]
-    pub fn parser(
-        code: DiagnosticCode,
-        message: String,
-        primary_span: Option<SourceSpan>,
-        notes: Vec<String>,
-    ) -> Self {
-        Self::new(code, message, primary_span, notes)
-    }
-
-    /// Creates a validator-path diagnostic.
-    #[must_use]
-    pub fn validator(
-        code: DiagnosticCode,
-        message: String,
-        primary_span: Option<SourceSpan>,
-        notes: Vec<String>,
-    ) -> Self {
-        Self::new(code, message, primary_span, notes)
-    }
-
     /// Returns the diagnostic code.
     #[must_use]
     pub const fn code(&self) -> DiagnosticCode {
@@ -277,6 +255,16 @@ impl DiagnosticReport {
         Self { diagnostics }
     }
 
+    /// Creates a report containing a single diagnostic.
+    fn single(
+        code: DiagnosticCode,
+        message: String,
+        primary_span: Option<SourceSpan>,
+        notes: Vec<String>,
+    ) -> Self {
+        Self::new(vec![Diagnostic::new(code, message, primary_span, notes)])
+    }
+
     /// Creates a report containing a single parser diagnostic.
     #[must_use]
     pub fn parser_error(
@@ -285,7 +273,7 @@ impl DiagnosticReport {
         primary_span: Option<SourceSpan>,
         notes: Vec<String>,
     ) -> Self {
-        Self::new(vec![Diagnostic::parser(code, message, primary_span, notes)])
+        Self::single(code, message, primary_span, notes)
     }
 
     /// Creates a report containing a single validation diagnostic.
@@ -296,12 +284,7 @@ impl DiagnosticReport {
         primary_span: Option<SourceSpan>,
         notes: Vec<String>,
     ) -> Self {
-        Self::new(vec![Diagnostic::validator(
-            code,
-            message,
-            primary_span,
-            notes,
-        )])
+        Self::single(code, message, primary_span, notes)
     }
 
     /// Creates a single-diagnostic report indicating that a feature is not

--- a/crates/sempai-core/src/diagnostic.rs
+++ b/crates/sempai-core/src/diagnostic.rs
@@ -257,7 +257,25 @@ impl DiagnosticReport {
     }
 
     /// Creates a report containing a single diagnostic.
-    fn single(
+    ///
+    /// This is the unified constructor for all single-diagnostic reports,
+    /// including parser errors, validation errors, and other diagnostic types.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sempai_core::{DiagnosticCode, DiagnosticReport};
+    ///
+    /// let report = DiagnosticReport::single_error(
+    ///     DiagnosticCode::ESempaiYamlParse,
+    ///     String::from("invalid yaml"),
+    ///     None,
+    ///     vec![],
+    /// );
+    /// assert_eq!(report.len(), 1);
+    /// ```
+    #[must_use]
+    pub fn single_error(
         code: DiagnosticCode,
         message: String,
         primary_span: Option<SourceSpan>,
@@ -267,6 +285,9 @@ impl DiagnosticReport {
     }
 
     /// Creates a report containing a single parser diagnostic.
+    ///
+    /// This is a convenience wrapper around [`single_error`](Self::single_error)
+    /// for parser-related diagnostics.
     #[must_use]
     pub fn parser_error(
         code: DiagnosticCode,
@@ -274,10 +295,13 @@ impl DiagnosticReport {
         primary_span: Option<SourceSpan>,
         notes: Vec<String>,
     ) -> Self {
-        Self::single(code, message, primary_span, notes)
+        Self::single_error(code, message, primary_span, notes)
     }
 
     /// Creates a report containing a single validation diagnostic.
+    ///
+    /// This is a convenience wrapper around [`single_error`](Self::single_error)
+    /// for validation-related diagnostics.
     #[must_use]
     pub fn validation_error(
         code: DiagnosticCode,
@@ -285,7 +309,7 @@ impl DiagnosticReport {
         primary_span: Option<SourceSpan>,
         notes: Vec<String>,
     ) -> Self {
-        Self::single(code, message, primary_span, notes)
+        Self::single_error(code, message, primary_span, notes)
     }
 
     /// Creates a single-diagnostic report indicating that a feature is not

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -28,13 +28,8 @@ fn world() -> TestWorld {
 }
 
 fn parse_diagnostic_code(code: &str) -> DiagnosticCode {
-    match code {
-        "E_SEMPAI_YAML_PARSE" => DiagnosticCode::ESempaiYamlParse,
-        "E_SEMPAI_DSL_PARSE" => DiagnosticCode::ESempaiDslParse,
-        "E_SEMPAI_SCHEMA_INVALID" => DiagnosticCode::ESempaiSchemaInvalid,
-        "E_SEMPAI_INVALID_NOT_IN_OR" => DiagnosticCode::ESempaiInvalidNotInOr,
-        other => panic!("unsupported diagnostic code: {other}"),
-    }
+    let json = format!("\"{code}\"");
+    serde_json::from_str(&json).unwrap_or_else(|_| panic!("unrecognised diagnostic code: {code}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -73,18 +68,12 @@ fn given_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedSt
 
 #[given("a parser diagnostic with code {code} and message {message}")]
 fn given_parser_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    world.report = Some(build_single_diagnostic_report(
-        code.as_str(),
-        message.as_str(),
-    ));
+    given_diagnostic(world, code, message);
 }
 
 #[given("a validator diagnostic with code {code} and message {message}")]
 fn given_validator_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    world.report = Some(build_single_diagnostic_report(
-        code.as_str(),
-        message.as_str(),
-    ));
+    given_diagnostic(world, code, message);
 }
 
 #[given("a not-implemented report for feature {feature}")]
@@ -94,7 +83,8 @@ fn given_not_implemented_report(world: &mut TestWorld, feature: QuotedString) {
 
 #[given("diagnostic code payload {code}")]
 fn given_diagnostic_code_payload(world: &mut TestWorld, code: QuotedString) {
-    world.diagnostic_code_payload = Some(format!("\"{}\"", code.as_str()));
+    world.diagnostic_code_payload =
+        Some(serde_json::to_string(code.as_str()).expect("serialize diagnostic code payload"));
 }
 
 // ---------------------------------------------------------------------------
@@ -134,9 +124,7 @@ fn when_deserialize_diagnostic_code_payload(world: &mut TestWorld) {
         .as_ref()
         .expect("diagnostic code payload should be set");
     let result = serde_json::from_str::<DiagnosticCode>(payload);
-    if let Err(err) = result {
-        world.deserialization_error = Some(err.to_string());
-    }
+    world.deserialization_error = result.err().map(|e| e.to_string());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -4,7 +4,7 @@ use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 use crate::test_support::{QuotedString, parse_byte_range, parse_line_range};
-use crate::{DiagnosticCode, DiagnosticReport, Language, Span};
+use crate::{DiagnosticCode, DiagnosticReport, Language, SourceSpan, Span};
 
 // ---------------------------------------------------------------------------
 // Test world
@@ -36,9 +36,26 @@ fn parse_diagnostic_code(code: &str) -> DiagnosticCode {
 // Given steps
 // ---------------------------------------------------------------------------
 
-fn build_single_diagnostic_report(code: &str, message: &str) -> DiagnosticReport {
+fn build_single_diagnostic_report(
+    constructor: fn(DiagnosticCode, String, Option<SourceSpan>, Vec<String>) -> DiagnosticReport,
+    code: &str,
+    message: &str,
+) -> DiagnosticReport {
     let diagnostic_code = parse_diagnostic_code(code);
-    DiagnosticReport::single_error(diagnostic_code, message.to_owned(), None, vec![])
+    constructor(diagnostic_code, message.to_owned(), None, vec![])
+}
+
+fn given_report_with_constructor(
+    world: &mut TestWorld,
+    code: &QuotedString,
+    message: &QuotedString,
+    constructor: fn(DiagnosticCode, String, Option<SourceSpan>, Vec<String>) -> DiagnosticReport,
+) {
+    world.report = Some(build_single_diagnostic_report(
+        constructor,
+        code.as_str(),
+        message.as_str(),
+    ));
 }
 
 #[given("a span from bytes {byte_range} at lines {line_range}")]
@@ -55,30 +72,17 @@ fn given_language(world: &mut TestWorld, name: QuotedString) {
 
 #[given("a diagnostic with code {code} and message {message}")]
 fn given_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    world.report = Some(build_single_diagnostic_report(
-        code.as_str(),
-        message.as_str(),
-    ));
+    given_report_with_constructor(world, &code, &message, DiagnosticReport::single_error);
 }
 
 #[given("a parser diagnostic with code {code} and message {message}")]
 fn given_parser_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    world.report = Some(DiagnosticReport::parser_error(
-        parse_diagnostic_code(code.as_str()),
-        message.as_str().to_owned(),
-        None,
-        vec![],
-    ));
+    given_report_with_constructor(world, &code, &message, DiagnosticReport::parser_error);
 }
 
 #[given("a validator diagnostic with code {code} and message {message}")]
 fn given_validator_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    world.report = Some(DiagnosticReport::validation_error(
-        parse_diagnostic_code(code.as_str()),
-        message.as_str().to_owned(),
-        None,
-        vec![],
-    ));
+    given_report_with_constructor(world, &code, &message, DiagnosticReport::validation_error);
 }
 
 #[given("a not-implemented report for feature {feature}")]

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -18,11 +18,23 @@ struct TestWorld {
     report: Option<DiagnosticReport>,
     formatted_output: Option<String>,
     json_output: Option<String>,
+    diagnostic_code_payload: Option<String>,
+    deserialization_error: Option<String>,
 }
 
 #[fixture]
 fn world() -> TestWorld {
     TestWorld::default()
+}
+
+fn parse_diagnostic_code(code: &str) -> DiagnosticCode {
+    match code {
+        "E_SEMPAI_YAML_PARSE" => DiagnosticCode::ESempaiYamlParse,
+        "E_SEMPAI_DSL_PARSE" => DiagnosticCode::ESempaiDslParse,
+        "E_SEMPAI_SCHEMA_INVALID" => DiagnosticCode::ESempaiSchemaInvalid,
+        "E_SEMPAI_INVALID_NOT_IN_OR" => DiagnosticCode::ESempaiInvalidNotInOr,
+        other => panic!("unsupported diagnostic code: {other}"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -43,11 +55,7 @@ fn given_language(world: &mut TestWorld, name: QuotedString) {
 
 #[given("a diagnostic with code {code} and message {message}")]
 fn given_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    let diag_code = match code.as_str() {
-        "E_SEMPAI_YAML_PARSE" => DiagnosticCode::ESempaiYamlParse,
-        "E_SEMPAI_DSL_PARSE" => DiagnosticCode::ESempaiDslParse,
-        other => panic!("unsupported diagnostic code: {other}"),
-    };
+    let diag_code = parse_diagnostic_code(code.as_str());
     let report = DiagnosticReport::new(vec![Diagnostic::new(
         diag_code,
         message.as_str().to_owned(),
@@ -57,9 +65,36 @@ fn given_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedSt
     world.report = Some(report);
 }
 
+#[given("a parser diagnostic with code {code} and message {message}")]
+fn given_parser_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
+    let diag_code = parse_diagnostic_code(code.as_str());
+    world.report = Some(DiagnosticReport::new(vec![Diagnostic::parser(
+        diag_code,
+        message.as_str().to_owned(),
+        None,
+        vec![],
+    )]));
+}
+
+#[given("a validator diagnostic with code {code} and message {message}")]
+fn given_validator_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
+    let diag_code = parse_diagnostic_code(code.as_str());
+    world.report = Some(DiagnosticReport::new(vec![Diagnostic::validator(
+        diag_code,
+        message.as_str().to_owned(),
+        None,
+        vec![],
+    )]));
+}
+
 #[given("a not-implemented report for feature {feature}")]
 fn given_not_implemented_report(world: &mut TestWorld, feature: QuotedString) {
     world.report = Some(DiagnosticReport::not_implemented(feature.as_str()));
+}
+
+#[given("diagnostic code payload {code}")]
+fn given_diagnostic_code_payload(world: &mut TestWorld, code: QuotedString) {
+    world.diagnostic_code_payload = Some(format!("\"{}\"", code.as_str()));
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +119,24 @@ fn when_language_round_trip(world: &mut TestWorld) {
 fn when_format_report(world: &mut TestWorld) {
     let report = world.report.as_ref().expect("report should be set");
     world.formatted_output = Some(format!("{report}"));
+}
+
+#[when("the diagnostic report is serialized to JSON")]
+fn when_serialize_diagnostic_report(world: &mut TestWorld) {
+    let report = world.report.as_ref().expect("report should be set");
+    world.json_output = Some(serde_json::to_string(report).expect("serialize report"));
+}
+
+#[when("the diagnostic code payload is deserialized")]
+fn when_deserialize_diagnostic_code_payload(world: &mut TestWorld) {
+    let payload = world
+        .diagnostic_code_payload
+        .as_ref()
+        .expect("diagnostic code payload should be set");
+    let result = serde_json::from_str::<DiagnosticCode>(payload);
+    if let Err(err) = result {
+        world.deserialization_error = Some(err.to_string());
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +164,73 @@ fn then_json_contains(world: &mut TestWorld, key: QuotedString, value: QuotedStr
     );
 }
 
+#[then("the first diagnostic JSON contains key {key}")]
+fn then_first_diagnostic_contains_key(world: &mut TestWorld, key: QuotedString) {
+    let json = world.json_output.as_ref().expect("JSON should be set");
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).expect("JSON output should be valid");
+    let first = parsed
+        .get("diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|diagnostics| diagnostics.first())
+        .and_then(serde_json::Value::as_object)
+        .expect("first diagnostic object should exist");
+    assert!(
+        first.contains_key(key.as_str()),
+        "expected first diagnostic JSON to contain key '{}', got: {first:?}",
+        key.as_str()
+    );
+}
+
+#[then("the first diagnostic JSON does not contain key {key}")]
+fn then_first_diagnostic_does_not_contain_key(world: &mut TestWorld, key: QuotedString) {
+    let json = world.json_output.as_ref().expect("JSON should be set");
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).expect("JSON output should be valid");
+    let first = parsed
+        .get("diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|diagnostics| diagnostics.first())
+        .and_then(serde_json::Value::as_object)
+        .expect("first diagnostic object should exist");
+    assert!(
+        !first.contains_key(key.as_str()),
+        "expected first diagnostic JSON to not contain key '{}', got: {first:?}",
+        key.as_str()
+    );
+}
+
+#[then("the first diagnostic JSON contains key {key} with value {value}")]
+fn then_first_diagnostic_contains_key_with_value(
+    world: &mut TestWorld,
+    key: QuotedString,
+    value: QuotedString,
+) {
+    let json = world.json_output.as_ref().expect("JSON should be set");
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).expect("JSON output should be valid");
+    let first = parsed
+        .get("diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|diagnostics| diagnostics.first())
+        .and_then(serde_json::Value::as_object)
+        .expect("first diagnostic object should exist");
+    let actual = first.get(key.as_str()).unwrap_or_else(|| {
+        panic!(
+            "expected first diagnostic JSON to contain key '{}', got: {first:?}",
+            key.as_str()
+        )
+    });
+    let expected: serde_json::Value = serde_json::from_str(value.as_str())
+        .unwrap_or_else(|_| serde_json::Value::String(value.as_str().to_owned()));
+    assert_eq!(
+        actual,
+        &expected,
+        "expected key '{}' to have value {expected:?}, got {actual:?}",
+        key.as_str()
+    );
+}
+
 #[then("the round-tripped language equals the original")]
 fn then_language_round_trip_equals(world: &mut TestWorld) {
     let original = world.language.expect("original language should be set");
@@ -131,6 +251,19 @@ fn then_formatted_contains(world: &mut TestWorld, snippet: QuotedString) {
         "expected output to contain '{}', got: {}",
         snippet.as_str(),
         output
+    );
+}
+
+#[then("deserialization fails with message containing {snippet}")]
+fn then_deserialization_fails(world: &mut TestWorld, snippet: QuotedString) {
+    let err = world
+        .deserialization_error
+        .as_ref()
+        .expect("deserialization error should be set");
+    assert!(
+        err.contains(snippet.as_str()),
+        "expected deserialization error to contain '{}', got: {err}",
+        snippet.as_str()
     );
 }
 

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -4,7 +4,7 @@ use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 use crate::test_support::{QuotedString, parse_byte_range, parse_line_range};
-use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, Language, Span};
+use crate::{DiagnosticCode, DiagnosticReport, Language, Span};
 
 // ---------------------------------------------------------------------------
 // Test world
@@ -37,13 +37,8 @@ fn parse_diagnostic_code(code: &str) -> DiagnosticCode {
 // ---------------------------------------------------------------------------
 
 fn build_single_diagnostic_report(code: &str, message: &str) -> DiagnosticReport {
-    let diag_code = parse_diagnostic_code(code);
-    DiagnosticReport::new(vec![Diagnostic::new(
-        diag_code,
-        message.to_owned(),
-        None,
-        vec![],
-    )])
+    let diagnostic_code = parse_diagnostic_code(code);
+    DiagnosticReport::single_error(diagnostic_code, message.to_owned(), None, vec![])
 }
 
 #[given("a span from bytes {byte_range} at lines {line_range}")]

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -41,6 +41,16 @@ fn parse_diagnostic_code(code: &str) -> DiagnosticCode {
 // Given steps
 // ---------------------------------------------------------------------------
 
+fn build_single_diagnostic_report(code: &str, message: &str) -> DiagnosticReport {
+    let diag_code = parse_diagnostic_code(code);
+    DiagnosticReport::new(vec![Diagnostic::new(
+        diag_code,
+        message.to_owned(),
+        None,
+        vec![],
+    )])
+}
+
 #[given("a span from bytes {byte_range} at lines {line_range}")]
 fn given_span(world: &mut TestWorld, byte_range: QuotedString, line_range: QuotedString) {
     let (start_byte, end_byte) = parse_byte_range(byte_range.as_str()).expect("valid byte range");
@@ -55,36 +65,26 @@ fn given_language(world: &mut TestWorld, name: QuotedString) {
 
 #[given("a diagnostic with code {code} and message {message}")]
 fn given_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    let diag_code = parse_diagnostic_code(code.as_str());
-    let report = DiagnosticReport::new(vec![Diagnostic::new(
-        diag_code,
-        message.as_str().to_owned(),
-        None,
-        vec![],
-    )]);
-    world.report = Some(report);
+    world.report = Some(build_single_diagnostic_report(
+        code.as_str(),
+        message.as_str(),
+    ));
 }
 
 #[given("a parser diagnostic with code {code} and message {message}")]
 fn given_parser_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    let diag_code = parse_diagnostic_code(code.as_str());
-    world.report = Some(DiagnosticReport::new(vec![Diagnostic::parser(
-        diag_code,
-        message.as_str().to_owned(),
-        None,
-        vec![],
-    )]));
+    world.report = Some(build_single_diagnostic_report(
+        code.as_str(),
+        message.as_str(),
+    ));
 }
 
 #[given("a validator diagnostic with code {code} and message {message}")]
 fn given_validator_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    let diag_code = parse_diagnostic_code(code.as_str());
-    world.report = Some(DiagnosticReport::new(vec![Diagnostic::validator(
-        diag_code,
-        message.as_str().to_owned(),
-        None,
-        vec![],
-    )]));
+    world.report = Some(build_single_diagnostic_report(
+        code.as_str(),
+        message.as_str(),
+    ));
 }
 
 #[given("a not-implemented report for feature {feature}")]

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -68,12 +68,22 @@ fn given_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedSt
 
 #[given("a parser diagnostic with code {code} and message {message}")]
 fn given_parser_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    given_diagnostic(world, code, message);
+    world.report = Some(DiagnosticReport::parser_error(
+        parse_diagnostic_code(code.as_str()),
+        message.as_str().to_owned(),
+        None,
+        vec![],
+    ));
 }
 
 #[given("a validator diagnostic with code {code} and message {message}")]
 fn given_validator_diagnostic(world: &mut TestWorld, code: QuotedString, message: QuotedString) {
-    given_diagnostic(world, code, message);
+    world.report = Some(DiagnosticReport::validation_error(
+        parse_diagnostic_code(code.as_str()),
+        message.as_str().to_owned(),
+        None,
+        vec![],
+    ));
 }
 
 #[given("a not-implemented report for feature {feature}")]
@@ -84,7 +94,7 @@ fn given_not_implemented_report(world: &mut TestWorld, feature: QuotedString) {
 #[given("diagnostic code payload {code}")]
 fn given_diagnostic_code_payload(world: &mut TestWorld, code: QuotedString) {
     world.diagnostic_code_payload =
-        Some(serde_json::to_string(code.as_str()).expect("serialize diagnostic code payload"));
+        Some(serde_json::to_string(code.as_str()).expect("serialise diagnostic code payload"));
 }
 
 // ---------------------------------------------------------------------------
@@ -123,8 +133,9 @@ fn when_deserialize_diagnostic_code_payload(world: &mut TestWorld) {
         .diagnostic_code_payload
         .as_ref()
         .expect("diagnostic code payload should be set");
-    let result = serde_json::from_str::<DiagnosticCode>(payload);
-    world.deserialization_error = result.err().map(|e| e.to_string());
+    world.deserialization_error = serde_json::from_str::<DiagnosticCode>(payload)
+        .err()
+        .map(|e| e.to_string());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -143,6 +143,26 @@ fn when_deserialize_diagnostic_code_payload(world: &mut TestWorld) {
 // Then steps
 // ---------------------------------------------------------------------------
 
+fn first_diagnostic_object(world: &TestWorld) -> serde_json::Map<String, serde_json::Value> {
+    let json = world.json_output.as_ref().expect("JSON should be set");
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).expect("JSON output should be valid");
+    parsed
+        .get("diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|diagnostics| diagnostics.first())
+        .and_then(serde_json::Value::as_object)
+        .expect("first diagnostic object should exist")
+        .clone()
+}
+
+fn assert_str_contains(haystack: &str, needle: &str, label: &str) {
+    assert!(
+        haystack.contains(needle),
+        "expected {label} to contain '{needle}', got: {haystack}"
+    );
+}
+
 #[then("the JSON contains key {key} with value {value}")]
 fn then_json_contains(world: &mut TestWorld, key: QuotedString, value: QuotedString) {
     let json = world.json_output.as_ref().expect("JSON should be set");
@@ -166,15 +186,7 @@ fn then_json_contains(world: &mut TestWorld, key: QuotedString, value: QuotedStr
 
 #[then("the first diagnostic JSON contains key {key}")]
 fn then_first_diagnostic_contains_key(world: &mut TestWorld, key: QuotedString) {
-    let json = world.json_output.as_ref().expect("JSON should be set");
-    let parsed: serde_json::Value =
-        serde_json::from_str(json).expect("JSON output should be valid");
-    let first = parsed
-        .get("diagnostics")
-        .and_then(serde_json::Value::as_array)
-        .and_then(|diagnostics| diagnostics.first())
-        .and_then(serde_json::Value::as_object)
-        .expect("first diagnostic object should exist");
+    let first = first_diagnostic_object(world);
     assert!(
         first.contains_key(key.as_str()),
         "expected first diagnostic JSON to contain key '{}', got: {first:?}",
@@ -184,15 +196,7 @@ fn then_first_diagnostic_contains_key(world: &mut TestWorld, key: QuotedString) 
 
 #[then("the first diagnostic JSON does not contain key {key}")]
 fn then_first_diagnostic_does_not_contain_key(world: &mut TestWorld, key: QuotedString) {
-    let json = world.json_output.as_ref().expect("JSON should be set");
-    let parsed: serde_json::Value =
-        serde_json::from_str(json).expect("JSON output should be valid");
-    let first = parsed
-        .get("diagnostics")
-        .and_then(serde_json::Value::as_array)
-        .and_then(|diagnostics| diagnostics.first())
-        .and_then(serde_json::Value::as_object)
-        .expect("first diagnostic object should exist");
+    let first = first_diagnostic_object(world);
     assert!(
         !first.contains_key(key.as_str()),
         "expected first diagnostic JSON to not contain key '{}', got: {first:?}",
@@ -206,15 +210,7 @@ fn then_first_diagnostic_contains_key_with_value(
     key: QuotedString,
     value: QuotedString,
 ) {
-    let json = world.json_output.as_ref().expect("JSON should be set");
-    let parsed: serde_json::Value =
-        serde_json::from_str(json).expect("JSON output should be valid");
-    let first = parsed
-        .get("diagnostics")
-        .and_then(serde_json::Value::as_array)
-        .and_then(|diagnostics| diagnostics.first())
-        .and_then(serde_json::Value::as_object)
-        .expect("first diagnostic object should exist");
+    let first = first_diagnostic_object(world);
     let actual = first.get(key.as_str()).unwrap_or_else(|| {
         panic!(
             "expected first diagnostic JSON to contain key '{}', got: {first:?}",
@@ -246,12 +242,7 @@ fn then_formatted_contains(world: &mut TestWorld, snippet: QuotedString) {
         .formatted_output
         .as_ref()
         .expect("formatted output should be set");
-    assert!(
-        output.contains(snippet.as_str()),
-        "expected output to contain '{}', got: {}",
-        snippet.as_str(),
-        output
-    );
+    assert_str_contains(output, snippet.as_str(), "formatted output");
 }
 
 #[then("deserialization fails with message containing {snippet}")]
@@ -260,11 +251,7 @@ fn then_deserialization_fails(world: &mut TestWorld, snippet: QuotedString) {
         .deserialization_error
         .as_ref()
         .expect("deserialization error should be set");
-    assert!(
-        err.contains(snippet.as_str()),
-        "expected deserialization error to contain '{}', got: {err}",
-        snippet.as_str()
-    );
+    assert_str_contains(err, snippet.as_str(), "deserialization error");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sempai-core/src/tests/behaviour.rs
+++ b/crates/sempai-core/src/tests/behaviour.rs
@@ -28,7 +28,7 @@ fn world() -> TestWorld {
 }
 
 fn parse_diagnostic_code(code: &str) -> DiagnosticCode {
-    let json = format!("\"{code}\"");
+    let json = serde_json::to_string(code).expect("serialise diagnostic code");
     serde_json::from_str(&json).unwrap_or_else(|_| panic!("unrecognised diagnostic code: {code}"))
 }
 

--- a/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
@@ -1,0 +1,65 @@
+//! Snapshot tests for stable diagnostic JSON schemas.
+
+use insta::assert_snapshot;
+
+use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
+
+#[test]
+fn parser_diagnostic_report_json_snapshot() {
+    let report = DiagnosticReport::parser_error(
+        DiagnosticCode::ESempaiYamlParse,
+        String::from("failed to parse YAML"),
+        Some(SourceSpan::new(
+            0,
+            12,
+            Some(String::from("file:///rule.yaml")),
+        )),
+        vec![
+            String::from("expected mapping"),
+            String::from("found sequence"),
+        ],
+    );
+
+    assert_snapshot!(
+        "parser_diagnostic_report",
+        serde_json::to_string_pretty(&report).expect("serialize parser report")
+    );
+}
+
+#[test]
+fn validator_diagnostic_report_json_snapshot() {
+    let report = DiagnosticReport::validation_error(
+        DiagnosticCode::ESempaiSchemaInvalid,
+        String::from("rule id is required"),
+        None,
+        vec![String::from("add an id field")],
+    );
+
+    assert_snapshot!(
+        "validator_diagnostic_report",
+        serde_json::to_string_pretty(&report).expect("serialize validator report")
+    );
+}
+
+#[test]
+fn mixed_report_ordering_json_snapshot() {
+    let report = DiagnosticReport::new(vec![
+        Diagnostic::parser(
+            DiagnosticCode::ESempaiDslParse,
+            String::from("unexpected token"),
+            Some(SourceSpan::new(4, 6, None)),
+            vec![String::from("while parsing parser clause")],
+        ),
+        Diagnostic::validator(
+            DiagnosticCode::ESempaiInvalidNotInOr,
+            String::from("negated branch in pattern-either"),
+            None,
+            vec![String::from("rewrite as positive branch")],
+        ),
+    ]);
+
+    assert_snapshot!(
+        "mixed_diagnostic_report_ordering",
+        serde_json::to_string_pretty(&report).expect("serialize mixed report")
+    );
+}

--- a/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
@@ -8,7 +8,7 @@ use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
 #[rstest]
 #[case(
     "parser_diagnostic_report",
-    DiagnosticReport::single_error(
+    DiagnosticReport::parser_error(
         DiagnosticCode::ESempaiYamlParse,
         String::from("failed to parse YAML"),
         Some(SourceSpan::new(
@@ -24,7 +24,7 @@ use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
 )]
 #[case(
     "validator_diagnostic_report",
-    DiagnosticReport::single_error(
+    DiagnosticReport::validation_error(
         DiagnosticCode::ESempaiSchemaInvalid,
         String::from("rule id is required"),
         None,

--- a/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
@@ -44,13 +44,13 @@ fn validator_diagnostic_report_json_snapshot() {
 #[test]
 fn mixed_report_ordering_json_snapshot() {
     let report = DiagnosticReport::new(vec![
-        Diagnostic::parser(
+        Diagnostic::new(
             DiagnosticCode::ESempaiDslParse,
             String::from("unexpected token"),
             Some(SourceSpan::new(4, 6, None)),
             vec![String::from("while parsing parser clause")],
         ),
-        Diagnostic::validator(
+        Diagnostic::new(
             DiagnosticCode::ESempaiInvalidNotInOr,
             String::from("negated branch in pattern-either"),
             None,

--- a/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
@@ -1,12 +1,14 @@
 //! Snapshot tests for stable diagnostic JSON schemas.
 
 use insta::assert_snapshot;
+use rstest::rstest;
 
 use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
 
-#[test]
-fn parser_diagnostic_report_json_snapshot() {
-    let report = DiagnosticReport::parser_error(
+#[rstest]
+#[case(
+    "parser_diagnostic_report",
+    DiagnosticReport::parser_error(
         DiagnosticCode::ESempaiYamlParse,
         String::from("failed to parse YAML"),
         Some(SourceSpan::new(
@@ -18,26 +20,24 @@ fn parser_diagnostic_report_json_snapshot() {
             String::from("expected mapping"),
             String::from("found sequence"),
         ],
-    );
-
-    assert_snapshot!(
-        "parser_diagnostic_report",
-        serde_json::to_string_pretty(&report).expect("serialize parser report")
-    );
-}
-
-#[test]
-fn validator_diagnostic_report_json_snapshot() {
-    let report = DiagnosticReport::validation_error(
+    )
+)]
+#[case(
+    "validator_diagnostic_report",
+    DiagnosticReport::validation_error(
         DiagnosticCode::ESempaiSchemaInvalid,
         String::from("rule id is required"),
         None,
         vec![String::from("add an id field")],
-    );
-
+    )
+)]
+fn single_diagnostic_report_json_snapshot(
+    #[case] snapshot_name: &str,
+    #[case] report: DiagnosticReport,
+) {
     assert_snapshot!(
-        "validator_diagnostic_report",
-        serde_json::to_string_pretty(&report).expect("serialize validator report")
+        snapshot_name,
+        serde_json::to_string_pretty(&report).expect("serialize diagnostic report")
     );
 }
 

--- a/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
@@ -8,7 +8,7 @@ use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
 #[rstest]
 #[case(
     "parser_diagnostic_report",
-    DiagnosticReport::parser_error(
+    DiagnosticReport::single_error(
         DiagnosticCode::ESempaiYamlParse,
         String::from("failed to parse YAML"),
         Some(SourceSpan::new(
@@ -24,7 +24,7 @@ use crate::{Diagnostic, DiagnosticCode, DiagnosticReport, SourceSpan};
 )]
 #[case(
     "validator_diagnostic_report",
-    DiagnosticReport::validation_error(
+    DiagnosticReport::single_error(
         DiagnosticCode::ESempaiSchemaInvalid,
         String::from("rule id is required"),
         None,

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -81,13 +81,13 @@ fn diagnostic_construction_and_accessors() {
 
 #[test]
 fn parser_and_validator_diagnostics_share_schema_shape() {
-    let parser = Diagnostic::parser(
+    let parser = Diagnostic::new(
         DiagnosticCode::ESempaiYamlParse,
         String::from("bad yaml"),
         Some(SourceSpan::new(0, 1, None)),
         vec![String::from("line 1")],
     );
-    let validator = Diagnostic::validator(
+    let validator = Diagnostic::new(
         DiagnosticCode::ESempaiSchemaInvalid,
         String::from("missing id"),
         Some(SourceSpan::new(
@@ -117,6 +117,20 @@ fn parser_and_validator_diagnostics_share_schema_shape() {
     }
     assert!(!parser_object.contains_key("span"));
     assert!(!validator_object.contains_key("span"));
+}
+
+fn assert_single_diagnostic_report(
+    report: &DiagnosticReport,
+    expected_code: DiagnosticCode,
+    expect_span: bool,
+) {
+    assert_eq!(report.len(), 1);
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    assert_eq!(first.code(), expected_code);
+    assert_eq!(first.primary_span().is_some(), expect_span);
 }
 
 #[test]
@@ -183,13 +197,7 @@ fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
         Some(SourceSpan::new(0, 5, None)),
         vec![String::from("check indentation")],
     );
-    assert_eq!(report.len(), 1);
-    let first = report
-        .diagnostics()
-        .first()
-        .expect("at least one diagnostic");
-    assert_eq!(first.code(), DiagnosticCode::ESempaiYamlParse);
-    assert!(first.primary_span().is_some());
+    assert_single_diagnostic_report(&report, DiagnosticCode::ESempaiYamlParse, true);
 }
 
 #[test]
@@ -200,13 +208,7 @@ fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
         None,
         vec![],
     );
-    assert_eq!(report.len(), 1);
-    let first = report
-        .diagnostics()
-        .first()
-        .expect("at least one diagnostic");
-    assert_eq!(first.code(), DiagnosticCode::ESempaiSchemaInvalid);
-    assert!(first.primary_span().is_none());
+    assert_single_diagnostic_report(&report, DiagnosticCode::ESempaiSchemaInvalid, false);
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -191,24 +191,44 @@ fn diagnostic_deserialization_rejects_malformed_primary_span_payload() {
 
 #[test]
 fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
+    let message = "invalid yaml";
+    let notes = vec![String::from("check indentation")];
+
     let report = DiagnosticReport::parser_error(
         DiagnosticCode::ESempaiYamlParse,
-        String::from("invalid yaml"),
+        String::from(message),
         Some(SourceSpan::new(0, 5, None)),
-        vec![String::from("check indentation")],
+        notes.clone(),
     );
     assert_single_diagnostic_report(&report, DiagnosticCode::ESempaiYamlParse, true);
+
+    let diagnostic = report
+        .diagnostics()
+        .first()
+        .expect("parser_error should produce a single diagnostic");
+    assert_eq!(diagnostic.message(), message);
+    assert_eq!(diagnostic.notes(), &notes);
 }
 
 #[test]
 fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
+    let message = "missing id";
+    let notes: Vec<String> = vec![];
+
     let report = DiagnosticReport::validation_error(
         DiagnosticCode::ESempaiSchemaInvalid,
-        String::from("missing id"),
+        String::from(message),
         None,
-        vec![],
+        notes.clone(),
     );
     assert_single_diagnostic_report(&report, DiagnosticCode::ESempaiSchemaInvalid, false);
+
+    let diagnostic = report
+        .diagnostics()
+        .first()
+        .expect("validation_error should produce a single diagnostic");
+    assert_eq!(diagnostic.message(), message);
+    assert_eq!(diagnostic.notes(), &notes);
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -119,10 +119,16 @@ fn parser_and_validator_diagnostics_share_schema_shape() {
     assert!(!validator_object.contains_key("span"));
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "test helper consolidates repetitive assertions"
+)]
 fn assert_single_diagnostic_report(
     report: &DiagnosticReport,
     expected_code: DiagnosticCode,
     expect_span: bool,
+    expected_message: &str,
+    expected_notes: &[String],
 ) {
     assert_eq!(report.len(), 1);
     let first = report
@@ -131,6 +137,8 @@ fn assert_single_diagnostic_report(
         .expect("at least one diagnostic");
     assert_eq!(first.code(), expected_code);
     assert_eq!(first.primary_span().is_some(), expect_span);
+    assert_eq!(first.message(), expected_message);
+    assert_eq!(first.notes(), expected_notes);
 }
 
 #[test]
@@ -191,44 +199,61 @@ fn diagnostic_deserialization_rejects_malformed_primary_span_payload() {
 
 #[test]
 fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
-    let message = "invalid yaml";
     let notes = vec![String::from("check indentation")];
-
     let report = DiagnosticReport::parser_error(
         DiagnosticCode::ESempaiYamlParse,
-        String::from(message),
+        String::from("invalid yaml"),
         Some(SourceSpan::new(0, 5, None)),
         notes.clone(),
     );
-    assert_single_diagnostic_report(&report, DiagnosticCode::ESempaiYamlParse, true);
-
-    let diagnostic = report
-        .diagnostics()
-        .first()
-        .expect("parser_error should produce a single diagnostic");
-    assert_eq!(diagnostic.message(), message);
-    assert_eq!(diagnostic.notes(), &notes);
+    assert_single_diagnostic_report(
+        &report,
+        DiagnosticCode::ESempaiYamlParse,
+        true,
+        "invalid yaml",
+        &notes,
+    );
 }
 
 #[test]
 fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
-    let message = "missing id";
     let notes: Vec<String> = vec![];
-
     let report = DiagnosticReport::validation_error(
         DiagnosticCode::ESempaiSchemaInvalid,
-        String::from(message),
+        String::from("missing id"),
         None,
         notes.clone(),
     );
-    assert_single_diagnostic_report(&report, DiagnosticCode::ESempaiSchemaInvalid, false);
+    assert_single_diagnostic_report(
+        &report,
+        DiagnosticCode::ESempaiSchemaInvalid,
+        false,
+        "missing id",
+        &notes,
+    );
+}
 
+#[test]
+fn diagnostic_report_single_error_constructor() {
+    let message = "syntax error";
+    let notes = vec![String::from("check syntax")];
+
+    let report = DiagnosticReport::single_error(
+        DiagnosticCode::ESempaiDslParse,
+        String::from(message),
+        Some(SourceSpan::new(10, 15, None)),
+        notes.clone(),
+    );
+
+    assert_eq!(report.len(), 1);
     let diagnostic = report
         .diagnostics()
         .first()
-        .expect("validation_error should produce a single diagnostic");
+        .expect("single_error should produce a single diagnostic");
+    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiDslParse);
     assert_eq!(diagnostic.message(), message);
     assert_eq!(diagnostic.notes(), &notes);
+    assert!(diagnostic.primary_span().is_some());
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -119,26 +119,23 @@ fn parser_and_validator_diagnostics_share_schema_shape() {
     assert!(!validator_object.contains_key("span"));
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "test helper consolidates repetitive assertions"
-)]
-fn assert_single_diagnostic_report(
-    report: &DiagnosticReport,
-    expected_code: DiagnosticCode,
-    expect_span: bool,
-    expected_message: &str,
-    expected_notes: &[String],
-) {
+struct ExpectedDiagnostic<'a> {
+    code: DiagnosticCode,
+    has_span: bool,
+    message: &'a str,
+    notes: &'a [String],
+}
+
+fn assert_single_diagnostic_report(report: &DiagnosticReport, expected: &ExpectedDiagnostic<'_>) {
     assert_eq!(report.len(), 1);
     let first = report
         .diagnostics()
         .first()
         .expect("at least one diagnostic");
-    assert_eq!(first.code(), expected_code);
-    assert_eq!(first.primary_span().is_some(), expect_span);
-    assert_eq!(first.message(), expected_message);
-    assert_eq!(first.notes(), expected_notes);
+    assert_eq!(first.code(), expected.code);
+    assert_eq!(first.primary_span().is_some(), expected.has_span);
+    assert_eq!(first.message(), expected.message);
+    assert_eq!(first.notes(), expected.notes);
 }
 
 #[test]
@@ -206,13 +203,13 @@ fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
         Some(SourceSpan::new(0, 5, None)),
         notes.clone(),
     );
-    assert_single_diagnostic_report(
-        &report,
-        DiagnosticCode::ESempaiYamlParse,
-        true,
-        "invalid yaml",
-        &notes,
-    );
+    let expected = ExpectedDiagnostic {
+        code: DiagnosticCode::ESempaiYamlParse,
+        has_span: true,
+        message: "invalid yaml",
+        notes: &notes,
+    };
+    assert_single_diagnostic_report(&report, &expected);
 }
 
 #[test]
@@ -224,13 +221,13 @@ fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
         None,
         notes.clone(),
     );
-    assert_single_diagnostic_report(
-        &report,
-        DiagnosticCode::ESempaiSchemaInvalid,
-        false,
-        "missing id",
-        &notes,
-    );
+    let expected = ExpectedDiagnostic {
+        code: DiagnosticCode::ESempaiSchemaInvalid,
+        has_span: false,
+        message: "missing id",
+        notes: &notes,
+    };
+    assert_single_diagnostic_report(&report, &expected);
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -37,6 +37,13 @@ fn diagnostic_code_serde_round_trip() {
 }
 
 #[test]
+fn diagnostic_code_deserialization_rejects_unknown_code() {
+    let err = serde_json::from_str::<DiagnosticCode>("\"E_SEMPAI_DOES_NOT_EXIST\"")
+        .expect_err("unknown diagnostic code should fail");
+    assert!(err.to_string().contains("E_SEMPAI_DOES_NOT_EXIST"));
+}
+
+#[test]
 fn source_span_construction_and_accessors() {
     let span = SourceSpan::new(10, 42, Some(String::from("file:///rule.yml")));
     assert_eq!(span.start(), 10);
@@ -68,22 +75,138 @@ fn diagnostic_construction_and_accessors() {
     );
     assert_eq!(diag.code(), DiagnosticCode::ESempaiYamlParse);
     assert_eq!(diag.message(), "unexpected key 'patterns'");
-    assert!(diag.span().is_some());
+    assert!(diag.primary_span().is_some());
     assert_eq!(diag.notes().len(), 1);
 }
 
 #[test]
-fn diagnostic_serde_round_trip() {
+fn parser_and_validator_diagnostics_share_schema_shape() {
+    let parser = Diagnostic::parser(
+        DiagnosticCode::ESempaiYamlParse,
+        String::from("bad yaml"),
+        Some(SourceSpan::new(0, 1, None)),
+        vec![String::from("line 1")],
+    );
+    let validator = Diagnostic::validator(
+        DiagnosticCode::ESempaiSchemaInvalid,
+        String::from("missing id"),
+        Some(SourceSpan::new(
+            2,
+            4,
+            Some(String::from("file:///rules.yaml")),
+        )),
+        vec![],
+    );
+
+    let parser_json: serde_json::Value = serde_json::to_value(parser).expect("serialize parser");
+    let validator_json: serde_json::Value =
+        serde_json::to_value(validator).expect("serialize validator");
+
+    let parser_object = parser_json
+        .as_object()
+        .expect("parser diagnostic should be object");
+    let validator_object = validator_json
+        .as_object()
+        .expect("validator diagnostic should be object");
+
+    assert_eq!(parser_object.len(), 4);
+    assert_eq!(validator_object.len(), 4);
+    for key in ["code", "message", "primary_span", "notes"] {
+        assert!(parser_object.contains_key(key));
+        assert!(validator_object.contains_key(key));
+    }
+    assert!(!parser_object.contains_key("span"));
+    assert!(!validator_object.contains_key("span"));
+}
+
+#[test]
+fn diagnostic_serde_round_trip_uses_primary_span() {
     let diag = Diagnostic::new(
         DiagnosticCode::ESempaiDslParse,
         String::from("unexpected token"),
         None,
         vec![],
     );
-    let json = serde_json::to_string(&diag).expect("serialize");
-    let deserialized: Diagnostic = serde_json::from_str(&json).expect("deserialize");
+    let json = serde_json::to_value(&diag).expect("serialize");
+    let object = json.as_object().expect("diagnostic should be object");
+    assert!(object.contains_key("primary_span"));
+    assert!(!object.contains_key("span"));
+
+    let deserialized: Diagnostic = serde_json::from_value(json).expect("deserialize");
     assert_eq!(deserialized.code(), DiagnosticCode::ESempaiDslParse);
     assert_eq!(deserialized.message(), "unexpected token");
+    assert!(deserialized.primary_span().is_none());
+}
+
+#[test]
+fn diagnostic_deserializes_legacy_span_alias() {
+    let json = serde_json::json!({
+        "code": "E_SEMPAI_DSL_PARSE",
+        "message": "legacy format",
+        "span": {
+            "start": 1,
+            "end": 3,
+            "uri": null
+        },
+        "notes": []
+    });
+    let deserialized: Diagnostic = serde_json::from_value(json).expect("deserialize");
+    let span = deserialized
+        .primary_span()
+        .expect("legacy span should map to primary span");
+    assert_eq!(span.start(), 1);
+    assert_eq!(span.end(), 3);
+}
+
+#[test]
+fn diagnostic_deserialization_rejects_malformed_primary_span_payload() {
+    let json = serde_json::json!({
+        "code": "E_SEMPAI_DSL_PARSE",
+        "message": "bad span",
+        "primary_span": {
+            "start": "oops",
+            "end": 2,
+            "uri": null
+        },
+        "notes": []
+    });
+    let err = serde_json::from_value::<Diagnostic>(json)
+        .expect_err("invalid primary span payload should fail");
+    assert!(err.to_string().contains("invalid type"));
+}
+
+#[test]
+fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
+    let report = DiagnosticReport::parser_error(
+        DiagnosticCode::ESempaiYamlParse,
+        String::from("invalid yaml"),
+        Some(SourceSpan::new(0, 5, None)),
+        vec![String::from("check indentation")],
+    );
+    assert_eq!(report.len(), 1);
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::ESempaiYamlParse);
+    assert!(first.primary_span().is_some());
+}
+
+#[test]
+fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
+    let report = DiagnosticReport::validation_error(
+        DiagnosticCode::ESempaiSchemaInvalid,
+        String::from("missing id"),
+        None,
+        vec![],
+    );
+    assert_eq!(report.len(), 1);
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("at least one diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::ESempaiSchemaInvalid);
+    assert!(first.primary_span().is_none());
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -121,7 +121,7 @@ fn parser_and_validator_diagnostics_share_schema_shape() {
 
 struct ExpectedDiagnostic<'a> {
     code: DiagnosticCode,
-    has_span: bool,
+    primary_span: Option<SourceSpan>,
     message: &'a str,
     notes: &'a [String],
 }
@@ -133,7 +133,7 @@ fn assert_single_diagnostic_report(report: &DiagnosticReport, expected: &Expecte
         .first()
         .expect("at least one diagnostic");
     assert_eq!(first.code(), expected.code);
-    assert_eq!(first.primary_span().is_some(), expected.has_span);
+    assert_eq!(first.primary_span(), expected.primary_span.as_ref());
     assert_eq!(first.message(), expected.message);
     assert_eq!(first.notes(), expected.notes);
 }
@@ -213,7 +213,7 @@ fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
     let notes = vec![String::from("check indentation")];
     let expected = ExpectedDiagnostic {
         code: DiagnosticCode::ESempaiYamlParse,
-        has_span: true,
+        primary_span: Some(SourceSpan::new(0, 5, None)),
         message: "invalid yaml",
         notes: &notes,
     };
@@ -229,7 +229,7 @@ fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
     let notes: Vec<String> = vec![];
     let expected = ExpectedDiagnostic {
         code: DiagnosticCode::ESempaiSchemaInvalid,
-        has_span: false,
+        primary_span: None,
         message: "missing id",
         notes: &notes,
     };
@@ -245,7 +245,7 @@ fn diagnostic_report_single_error_constructor() {
     let notes = vec![String::from("check syntax")];
     let expected = ExpectedDiagnostic {
         code: DiagnosticCode::ESempaiDslParse,
-        has_span: true,
+        primary_span: Some(SourceSpan::new(10, 15, None)),
         message: "syntax error",
         notes: &notes,
     };

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -242,15 +242,13 @@ fn diagnostic_report_single_error_constructor() {
         notes.clone(),
     );
 
-    assert_eq!(report.len(), 1);
-    let diagnostic = report
-        .diagnostics()
-        .first()
-        .expect("single_error should produce a single diagnostic");
-    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiDslParse);
-    assert_eq!(diagnostic.message(), message);
-    assert_eq!(diagnostic.notes(), &notes);
-    assert!(diagnostic.primary_span().is_some());
+    let expected = ExpectedDiagnostic {
+        code: DiagnosticCode::ESempaiDslParse,
+        has_span: true,
+        message,
+        notes: &notes,
+    };
+    assert_single_diagnostic_report(&report, &expected);
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -126,6 +126,13 @@ struct ExpectedDiagnostic<'a> {
     notes: &'a [String],
 }
 
+struct ExpectedDiagnosticCase {
+    code: DiagnosticCode,
+    primary_span: Option<SourceSpan>,
+    message: &'static str,
+    notes: Vec<String>,
+}
+
 fn assert_single_diagnostic_report(report: &DiagnosticReport, expected: &ExpectedDiagnostic<'_>) {
     assert_eq!(report.len(), 1);
     let first = report
@@ -187,6 +194,8 @@ fn diagnostic_deserializes_legacy_span_alias() {
     let span = deserialized
         .primary_span()
         .expect("legacy span should map to primary span");
+    let expected = SourceSpan::new(1, 3, None);
+    assert_eq!(span, &expected);
     assert_eq!(span.start(), 1);
     assert_eq!(span.end(), 3);
 }
@@ -208,52 +217,51 @@ fn diagnostic_deserialization_rejects_malformed_primary_span_payload() {
     assert!(err.to_string().contains("invalid type"));
 }
 
-#[test]
-fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
-    let notes = vec![String::from("check indentation")];
-    let expected = ExpectedDiagnostic {
+#[rstest]
+#[case(
+    DiagnosticReport::parser_error,
+    ExpectedDiagnosticCase {
         code: DiagnosticCode::ESempaiYamlParse,
         primary_span: Some(SourceSpan::new(0, 5, None)),
         message: "invalid yaml",
-        notes: &notes,
-    };
-    assert_report_constructor_builds_single_diagnostic(
-        DiagnosticReport::parser_error,
-        Some(SourceSpan::new(0, 5, None)),
-        &expected,
-    );
-}
-
-#[test]
-fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
-    let notes: Vec<String> = vec![];
-    let expected = ExpectedDiagnostic {
+        notes: vec![String::from("check indentation")],
+    }
+)]
+#[case(
+    DiagnosticReport::validation_error,
+    ExpectedDiagnosticCase {
         code: DiagnosticCode::ESempaiSchemaInvalid,
         primary_span: None,
         message: "missing id",
-        notes: &notes,
-    };
-    assert_report_constructor_builds_single_diagnostic(
-        DiagnosticReport::validation_error,
-        None,
-        &expected,
-    );
-}
-
-#[test]
-fn diagnostic_report_single_error_constructor() {
-    let notes = vec![String::from("check syntax")];
-    let expected = ExpectedDiagnostic {
+        notes: vec![],
+    }
+)]
+#[case(
+    DiagnosticReport::single_error,
+    ExpectedDiagnosticCase {
         code: DiagnosticCode::ESempaiDslParse,
         primary_span: Some(SourceSpan::new(10, 15, None)),
         message: "syntax error",
-        notes: &notes,
+        notes: vec![String::from("check syntax")],
+    }
+)]
+fn diagnostic_report_constructors_build_single_diagnostic(
+    #[case] constructor: fn(
+        DiagnosticCode,
+        String,
+        Option<SourceSpan>,
+        Vec<String>,
+    ) -> DiagnosticReport,
+    #[case] expected: ExpectedDiagnosticCase,
+) {
+    let span = expected.primary_span.clone();
+    let borrowed_expected = ExpectedDiagnostic {
+        code: expected.code,
+        primary_span: expected.primary_span,
+        message: expected.message,
+        notes: &expected.notes,
     };
-    assert_report_constructor_builds_single_diagnostic(
-        DiagnosticReport::single_error,
-        Some(SourceSpan::new(10, 15, None)),
-        &expected,
-    );
+    assert_report_constructor_builds_single_diagnostic(constructor, span, &borrowed_expected);
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/diagnostic_tests.rs
+++ b/crates/sempai-core/src/tests/diagnostic_tests.rs
@@ -138,6 +138,20 @@ fn assert_single_diagnostic_report(report: &DiagnosticReport, expected: &Expecte
     assert_eq!(first.notes(), expected.notes);
 }
 
+fn assert_report_constructor_builds_single_diagnostic(
+    constructor: fn(DiagnosticCode, String, Option<SourceSpan>, Vec<String>) -> DiagnosticReport,
+    span: Option<SourceSpan>,
+    expected: &ExpectedDiagnostic<'_>,
+) {
+    let report = constructor(
+        expected.code,
+        expected.message.to_owned(),
+        span,
+        expected.notes.to_vec(),
+    );
+    assert_single_diagnostic_report(&report, expected);
+}
+
 #[test]
 fn diagnostic_serde_round_trip_uses_primary_span() {
     let diag = Diagnostic::new(
@@ -197,58 +211,49 @@ fn diagnostic_deserialization_rejects_malformed_primary_span_payload() {
 #[test]
 fn diagnostic_report_parser_error_constructor_builds_single_diagnostic() {
     let notes = vec![String::from("check indentation")];
-    let report = DiagnosticReport::parser_error(
-        DiagnosticCode::ESempaiYamlParse,
-        String::from("invalid yaml"),
-        Some(SourceSpan::new(0, 5, None)),
-        notes.clone(),
-    );
     let expected = ExpectedDiagnostic {
         code: DiagnosticCode::ESempaiYamlParse,
         has_span: true,
         message: "invalid yaml",
         notes: &notes,
     };
-    assert_single_diagnostic_report(&report, &expected);
+    assert_report_constructor_builds_single_diagnostic(
+        DiagnosticReport::parser_error,
+        Some(SourceSpan::new(0, 5, None)),
+        &expected,
+    );
 }
 
 #[test]
 fn diagnostic_report_validation_error_constructor_builds_single_diagnostic() {
     let notes: Vec<String> = vec![];
-    let report = DiagnosticReport::validation_error(
-        DiagnosticCode::ESempaiSchemaInvalid,
-        String::from("missing id"),
-        None,
-        notes.clone(),
-    );
     let expected = ExpectedDiagnostic {
         code: DiagnosticCode::ESempaiSchemaInvalid,
         has_span: false,
         message: "missing id",
         notes: &notes,
     };
-    assert_single_diagnostic_report(&report, &expected);
+    assert_report_constructor_builds_single_diagnostic(
+        DiagnosticReport::validation_error,
+        None,
+        &expected,
+    );
 }
 
 #[test]
 fn diagnostic_report_single_error_constructor() {
-    let message = "syntax error";
     let notes = vec![String::from("check syntax")];
-
-    let report = DiagnosticReport::single_error(
-        DiagnosticCode::ESempaiDslParse,
-        String::from(message),
-        Some(SourceSpan::new(10, 15, None)),
-        notes.clone(),
-    );
-
     let expected = ExpectedDiagnostic {
         code: DiagnosticCode::ESempaiDslParse,
         has_span: true,
-        message,
+        message: "syntax error",
         notes: &notes,
     };
-    assert_single_diagnostic_report(&report, &expected);
+    assert_report_constructor_builds_single_diagnostic(
+        DiagnosticReport::single_error,
+        Some(SourceSpan::new(10, 15, None)),
+        &expected,
+    );
 }
 
 #[test]

--- a/crates/sempai-core/src/tests/mod.rs
+++ b/crates/sempai-core/src/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod capture_tests;
 mod config_tests;
+mod diagnostic_snapshot_tests;
 mod diagnostic_tests;
 mod language_tests;
 mod match_tests;

--- a/crates/sempai-core/src/tests/snapshots/sempai_core__tests__diagnostic_snapshot_tests__mixed_diagnostic_report_ordering.snap
+++ b/crates/sempai-core/src/tests/snapshots/sempai_core__tests__diagnostic_snapshot_tests__mixed_diagnostic_report_ordering.snap
@@ -1,0 +1,28 @@
+---
+source: crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+expression: "serde_json::to_string_pretty(&report).expect(\"serialize mixed report\")"
+---
+{
+  "diagnostics": [
+    {
+      "code": "E_SEMPAI_DSL_PARSE",
+      "message": "unexpected token",
+      "primary_span": {
+        "start": 4,
+        "end": 6,
+        "uri": null
+      },
+      "notes": [
+        "while parsing parser clause"
+      ]
+    },
+    {
+      "code": "E_SEMPAI_INVALID_NOT_IN_OR",
+      "message": "negated branch in pattern-either",
+      "primary_span": null,
+      "notes": [
+        "rewrite as positive branch"
+      ]
+    }
+  ]
+}

--- a/crates/sempai-core/src/tests/snapshots/sempai_core__tests__diagnostic_snapshot_tests__parser_diagnostic_report.snap
+++ b/crates/sempai-core/src/tests/snapshots/sempai_core__tests__diagnostic_snapshot_tests__parser_diagnostic_report.snap
@@ -1,0 +1,21 @@
+---
+source: crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+expression: "serde_json::to_string_pretty(&report).expect(\"serialize parser report\")"
+---
+{
+  "diagnostics": [
+    {
+      "code": "E_SEMPAI_YAML_PARSE",
+      "message": "failed to parse YAML",
+      "primary_span": {
+        "start": 0,
+        "end": 12,
+        "uri": "file:///rule.yaml"
+      },
+      "notes": [
+        "expected mapping",
+        "found sequence"
+      ]
+    }
+  ]
+}

--- a/crates/sempai-core/src/tests/snapshots/sempai_core__tests__diagnostic_snapshot_tests__validator_diagnostic_report.snap
+++ b/crates/sempai-core/src/tests/snapshots/sempai_core__tests__diagnostic_snapshot_tests__validator_diagnostic_report.snap
@@ -1,0 +1,16 @@
+---
+source: crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs
+expression: "serde_json::to_string_pretty(&report).expect(\"serialize validator report\")"
+---
+{
+  "diagnostics": [
+    {
+      "code": "E_SEMPAI_SCHEMA_INVALID",
+      "message": "rule id is required",
+      "primary_span": null,
+      "notes": [
+        "add an id field"
+      ]
+    }
+  ]
+}

--- a/crates/sempai-core/tests/features/sempai_core.feature
+++ b/crates/sempai-core/tests/features/sempai_core.feature
@@ -22,3 +22,22 @@ Feature: Sempai core type construction and serialization
     When the diagnostic report is formatted
     Then the formatted output contains "NOT_IMPLEMENTED"
     And the formatted output contains "compile_yaml"
+
+  Scenario: Parser diagnostic JSON uses the stable schema fields
+    Given a parser diagnostic with code "E_SEMPAI_YAML_PARSE" and message "invalid YAML"
+    When the diagnostic report is serialized to JSON
+    Then the first diagnostic JSON contains key "code"
+    And the first diagnostic JSON contains key "message"
+    And the first diagnostic JSON contains key "primary_span"
+    And the first diagnostic JSON contains key "notes"
+    And the first diagnostic JSON does not contain key "span"
+
+  Scenario: Invalid diagnostic code payload fails deterministically
+    Given diagnostic code payload "E_SEMPAI_NOT_A_REAL_CODE"
+    When the diagnostic code payload is deserialized
+    Then deserialization fails with message containing "E_SEMPAI_NOT_A_REAL_CODE"
+
+  Scenario: Null primary span remains explicit in JSON
+    Given a validator diagnostic with code "E_SEMPAI_SCHEMA_INVALID" and message "missing id"
+    When the diagnostic report is serialized to JSON
+    Then the first diagnostic JSON contains key "primary_span" with value "null"

--- a/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
+++ b/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -74,50 +74,50 @@ make nixie        # exits 0
 ## Risks
 
 - Risk: Existing diagnostics use `span`, while acceptance language uses
-  "primary span".
-  Severity: medium.
-  Likelihood: medium.
-  Mitigation: Define a canonical JSON field (`primary_span`) and, if needed,
-  support backward compatibility via serde aliasing and clear docs.
+  "primary span". Severity: medium. Likelihood: medium. Mitigation: Define a
+  canonical JSON field (`primary_span`) and, if needed, support backward
+  compatibility via serde aliasing and clear docs.
 
 - Risk: Parser and validator crates are not yet implemented, so "both paths"
-  must be represented via contract constructors/tests now.
-  Severity: medium.
-  Likelihood: high.
-  Mitigation: Add explicit parser/validator constructor paths in
-  `sempai_core::diagnostic` and lock both with snapshots and BDD scenarios.
+  must be represented via contract constructors/tests now. Severity: medium.
+  Likelihood: high. Mitigation: Add explicit parser/validator constructor paths
+  in `sempai_core::diagnostic` and lock both with snapshots and BDD scenarios.
 
 - Risk: Strict Clippy lints on tests can block concise fixture-heavy behaviour
-  tests.
-  Severity: low.
-  Likelihood: medium.
-  Mitigation: Keep helpers small, split modules early, and use scoped
-  `#[expect]` with reason only when structurally necessary.
+  tests. Severity: low. Likelihood: medium. Mitigation: Keep helpers small,
+  split modules early, and use scoped `#[expect]` with reason only when
+  structurally necessary.
 
 ## Progress
 
 - [x] (2026-03-11 00:00Z) Drafted this ExecPlan from roadmap and design docs.
-- [ ] Stage A: Write failing unit/snapshot/BDD tests for schema stability.
-- [ ] Stage B: Implement diagnostic schema and stable code mappings.
-- [ ] Stage C: Stabilize parser/validator diagnostic construction paths.
-- [ ] Stage D: Update design/user docs and mark roadmap item 4.1.2 done.
-- [ ] Stage E: Run quality gates and capture evidence.
+- [x] Stage A: Write failing unit/snapshot/BDD tests for schema stability.
+- [x] Stage B: Implement diagnostic schema and stable code mappings.
+- [x] Stage C: Stabilize parser/validator diagnostic construction paths.
+- [x] Stage D: Update design/user docs and mark roadmap item 4.1.2 done.
+- [x] Stage E: Run quality gates and capture evidence.
 
 ## Surprises & discoveries
 
 - Observation: `sempai_core` already defines all target `E_SEMPAI_*` variants,
   but current contract wording and tests do not yet lock parser-vs-validator
-  schema parity via snapshots.
-  Evidence:
+  schema parity via snapshots. Evidence:
   [crates/sempai-core/src/diagnostic.rs](../../crates/sempai-core/src/diagnostic.rs)
-  and
+   and
   [crates/sempai-core/src/tests/diagnostic_tests.rs](../../crates/sempai-core/src/tests/diagnostic_tests.rs).
-  Impact: Work should focus on schema hardening and path parity, not inventing
+   Impact: Work should focus on schema hardening and path parity, not inventing
   a new code set.
 
 - Observation: `rstest-bdd` v0.5.0 is already pinned at workspace level.
   Evidence: [Cargo.toml](../../Cargo.toml). Impact: No dependency update is
   required; tests should reuse current setup.
+
+- Observation: `insta::assert_json_snapshot!` is unavailable in the current
+  `insta` configuration, while `assert_snapshot!` is available and stable.
+  Evidence:
+  [crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs](../../crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs).
+   Impact: Snapshot tests should serialize deterministic pretty JSON strings
+  and use `assert_snapshot!`.
 
 ## Decision log
 
@@ -131,6 +131,11 @@ make nixie        # exits 0
   Rationale: Snapshots provide explicit, reviewable contract evidence and catch
   accidental field-shape drift. Date/Author: 2026-03-11 / Codex.
 
+- Decision: Emit `primary_span` in JSON while accepting legacy `span` on input
+  via serde aliasing. Rationale: This satisfies the roadmap contract and keeps
+  backward compatibility for older payloads during transition. Date/Author:
+  2026-03-14 / Codex.
+
 ## Outcomes & retrospective
 
 Target outcome at completion:
@@ -143,7 +148,19 @@ Target outcome at completion:
 6. Roadmap item 4.1.2 is checked off.
 7. `make check-fmt`, `make lint`, and `make test` pass.
 
-Retrospective notes will be filled after implementation.
+Retrospective notes:
+
+- Implemented canonical diagnostic JSON keys (`code`, `message`,
+  `primary_span`, `notes`) and maintained input compatibility for legacy `span`
+  payloads through serde aliasing.
+- Added parser/validator constructor helpers in `Diagnostic` and
+  `DiagnosticReport` to encode path parity in the type surface.
+- Added unit tests for happy/unhappy/edge paths, plus BDD scenarios and
+  snapshot tests proving parser/validator schema consistency.
+- Verified complete gate sequence with logs:
+  `/tmp/4-1-2-make-fmt.log`, `/tmp/4-1-2-make-markdownlint.log`,
+  `/tmp/4-1-2-make-nixie.log`, `/tmp/4-1-2-make-check-fmt.log`,
+  `/tmp/4-1-2-make-lint.log`, `/tmp/4-1-2-make-test.log`.
 
 ## Context and orientation
 

--- a/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
+++ b/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
@@ -1,0 +1,379 @@
+# 4.1.2 Define structured diagnostics with stable `E_SEMPAI_*` error codes and report schema
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+After this change, Sempai diagnostics will have one stable machine-readable
+contract regardless of whether the diagnostic is emitted by parsing logic or
+semantic validation logic. Every emitted diagnostic payload will include:
+`code`, `message`, `primary_span`, and `notes`, with stable `E_SEMPAI_*` codes
+and snapshot-locked JSON output.
+
+This directly fulfills roadmap item 4.1.2 in [docs/roadmap.md](../roadmap.md):
+
+- Define structured diagnostics with stable `E_SEMPAI_*` error codes and
+  report schema.
+- Ensure JSON snapshots remain stable across parser and validator paths.
+
+Observable outcome after implementation:
+
+```plaintext
+make check-fmt   # exits 0
+make lint        # exits 0
+make test        # exits 0
+```
+
+And additionally (because docs are updated):
+
+```plaintext
+make fmt          # exits 0
+make markdownlint # exits 0
+make nixie        # exits 0
+```
+
+## Constraints
+
+- Keep the implementation aligned with
+  [docs/sempai-query-language-design.md](../sempai-query-language-design.md),
+  especially the Diagnostics section and `E_SEMPAI_*` list.
+- Preserve the `sempai` facade as the stable entrypoint. Any schema changes in
+  `sempai_core` must remain consumable through `sempai` re-exports.
+- Follow workspace lint policy (`[lints] workspace = true`) and do not add
+  `#[allow(...)]`; use tightly scoped `#[expect(..., reason = "...")]` only
+  when unavoidable.
+- Keep files below 400 lines; split test or behaviour modules if needed.
+- Add both unit tests and behaviour tests using `rstest-bdd` v0.5.0 for happy
+  and unhappy paths, plus relevant edge cases.
+- Snapshot tests must assert stable JSON for parser and validator diagnostic
+  paths.
+- Update documentation:
+  - `docs/sempai-query-language-design.md` for design decisions.
+  - `docs/users-guide.md` for user-visible diagnostic contract changes.
+  - `docs/roadmap.md` mark 4.1.2 done when implementation is complete.
+- Run all required quality gates before completion.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation exceeds 12 touched files (net), stop and escalate.
+- Interface: if a breaking change to currently public Sempai API is required
+  (for example, removing/renaming existing public methods without backward
+  compatibility), stop and escalate.
+- Dependencies: if any new third-party dependency is needed, stop and
+  escalate.
+- Iterations: if the same failing test/lint loop is attempted 5 times without
+  progress, stop and escalate.
+- Ambiguity: if schema naming is ambiguous (`span` vs `primary_span`) and the
+  choice materially affects compatibility, stop and escalate with options.
+
+## Risks
+
+- Risk: Existing diagnostics use `span`, while acceptance language uses
+  "primary span".
+  Severity: medium.
+  Likelihood: medium.
+  Mitigation: Define a canonical JSON field (`primary_span`) and, if needed,
+  support backward compatibility via serde aliasing and clear docs.
+
+- Risk: Parser and validator crates are not yet implemented, so "both paths"
+  must be represented via contract constructors/tests now.
+  Severity: medium.
+  Likelihood: high.
+  Mitigation: Add explicit parser/validator constructor paths in
+  `sempai_core::diagnostic` and lock both with snapshots and BDD scenarios.
+
+- Risk: Strict Clippy lints on tests can block concise fixture-heavy behaviour
+  tests.
+  Severity: low.
+  Likelihood: medium.
+  Mitigation: Keep helpers small, split modules early, and use scoped
+  `#[expect]` with reason only when structurally necessary.
+
+## Progress
+
+- [x] (2026-03-11 00:00Z) Drafted this ExecPlan from roadmap and design docs.
+- [ ] Stage A: Write failing unit/snapshot/BDD tests for schema stability.
+- [ ] Stage B: Implement diagnostic schema and stable code mappings.
+- [ ] Stage C: Stabilize parser/validator diagnostic construction paths.
+- [ ] Stage D: Update design/user docs and mark roadmap item 4.1.2 done.
+- [ ] Stage E: Run quality gates and capture evidence.
+
+## Surprises & discoveries
+
+- Observation: `sempai_core` already defines all target `E_SEMPAI_*` variants,
+  but current contract wording and tests do not yet lock parser-vs-validator
+  schema parity via snapshots.
+  Evidence:
+  [crates/sempai-core/src/diagnostic.rs](../../crates/sempai-core/src/diagnostic.rs)
+  and
+  [crates/sempai-core/src/tests/diagnostic_tests.rs](../../crates/sempai-core/src/tests/diagnostic_tests.rs).
+  Impact: Work should focus on schema hardening and path parity, not inventing
+  a new code set.
+
+- Observation: `rstest-bdd` v0.5.0 is already pinned at workspace level.
+  Evidence: [Cargo.toml](../../Cargo.toml). Impact: No dependency update is
+  required; tests should reuse current setup.
+
+## Decision log
+
+- Decision: Keep this milestone narrowly focused on diagnostics contract
+  infrastructure in `sempai_core`; defer parser implementation details to 4.1.3
+  and validation engine logic to 4.1.4/4.1.5. Rationale: 4.1.2 is explicitly
+  contract-focused and should reduce risk for follow-on parser and validator
+  milestones. Date/Author: 2026-03-11 / Codex.
+
+- Decision: Lock JSON schema with snapshot tests in addition to unit assertions.
+  Rationale: Snapshots provide explicit, reviewable contract evidence and catch
+  accidental field-shape drift. Date/Author: 2026-03-11 / Codex.
+
+## Outcomes & retrospective
+
+Target outcome at completion:
+
+1. Stable diagnostic payload contract exists and is documented.
+2. Parser-path and validator-path diagnostics serialize to the same schema.
+3. Unit, behavioural, and snapshot tests cover happy/unhappy/edge paths.
+4. `docs/users-guide.md` explains the updated diagnostic contract.
+5. `docs/sempai-query-language-design.md` records decisions made here.
+6. Roadmap item 4.1.2 is checked off.
+7. `make check-fmt`, `make lint`, and `make test` pass.
+
+Retrospective notes will be filled after implementation.
+
+## Context and orientation
+
+Current Sempai state relevant to this milestone:
+
+- `sempai_core` already exposes:
+  - `DiagnosticCode` with `E_SEMPAI_*` variants.
+  - `Diagnostic`, `SourceSpan`, and `DiagnosticReport`.
+- The existing `Diagnostic` struct currently uses a `span` field, and tests
+  validate construction/serde/display, but they do not enforce parser/validator
+  contract parity with schema snapshots.
+- `sempai` engine entrypoints remain stubs and currently emit
+  `NOT_IMPLEMENTED`, which is outside the final parser/validator code paths.
+
+Primary files for this work:
+
+- [crates/sempai-core/src/diagnostic.rs](../../crates/sempai-core/src/diagnostic.rs)
+- [crates/sempai-core/src/tests/diagnostic_tests.rs](../../crates/sempai-core/src/tests/diagnostic_tests.rs)
+- [crates/sempai-core/src/tests/behaviour.rs](../../crates/sempai-core/src/tests/behaviour.rs)
+- [crates/sempai-core/tests/features/sempai_core.feature](../../crates/sempai-core/tests/features/sempai_core.feature)
+- [docs/sempai-query-language-design.md](../sempai-query-language-design.md)
+- [docs/users-guide.md](../users-guide.md)
+- [docs/roadmap.md](../roadmap.md)
+
+## Plan of work
+
+### Stage A: Define the contract in tests first (red phase)
+
+Add failing tests that express the intended contract before editing production
+diagnostic code:
+
+- Unit tests:
+  - Assert the serialized diagnostic object contains exactly `code`, `message`,
+    `primary_span`, and `notes`.
+  - Add parser-path and validator-path constructors/fixtures in tests and
+    assert they serialize to the same shape.
+  - Add unhappy-path tests for unknown code deserialization and malformed span
+    payloads.
+- Snapshot tests (`insta`):
+  - Snapshot parser diagnostic report JSON.
+  - Snapshot validator diagnostic report JSON.
+  - Snapshot mixed-report ordering stability.
+- BDD (`rstest-bdd` v0.5.0):
+  - Happy path: parser and validator reports expose all required fields.
+  - Unhappy path: invalid code payload fails with deterministic error text.
+  - Edge path: `primary_span = null` remains explicit and stable.
+
+Go/no-go:
+
+- Do not proceed until at least one new test fails for the intended schema
+  change.
+
+### Stage B: Implement the schema and stable constructors (green phase)
+
+Update `sempai_core` diagnostics implementation to satisfy Stage A tests:
+
+- Make `Diagnostic` schema explicitly model primary span
+  (`primary_span` in JSON).
+- Keep accessors ergonomic and explicit (`primary_span()`), and preserve
+  compatibility helpers only if required by existing callers.
+- Add explicit constructors or helper functions for parser-path and
+  validator-path diagnostics so both routes share one shape and code surface.
+- Ensure `DiagnosticCode` display/serde remains stable and only emits the
+  documented code set.
+
+Go/no-go:
+
+- Do not proceed until targeted unit and snapshot tests pass.
+
+### Stage C: Behaviour coverage and hardening (refactor phase)
+
+Refactor tests and step definitions for clarity and maintainability:
+
+- If `behaviour.rs` approaches 400 lines, split into `diagnostic_behaviour.rs`
+  and keep scenario registration clear.
+- Ensure BDD scenarios verify observable behaviour rather than implementation
+  internals.
+- Remove duplicate assertions by reusing shared fixtures/helpers.
+
+Go/no-go:
+
+- Do not proceed until `cargo test -p sempai-core --all-targets --all-features`
+  passes.
+
+### Stage D: Documentation and roadmap synchronization
+
+Update docs once implementation is stable:
+
+- `docs/sempai-query-language-design.md`:
+  - Record decisions (field naming, parser/validator parity, stability rules).
+  - Include a canonical JSON diagnostic example.
+- `docs/users-guide.md`:
+  - Document the diagnostic schema users can rely on.
+  - Clarify code semantics and parser/validator applicability.
+- `docs/roadmap.md`:
+  - Mark 4.1.2 as done only after all tests and gates pass.
+
+Go/no-go:
+
+- Do not finalize until markdown and Rust quality gates pass.
+
+## Concrete steps
+
+Run from repository root (`/home/user/project`).
+
+1. Establish baseline and create red tests.
+
+```plaintext
+cargo test -p sempai-core --all-targets --all-features
+```
+
+Expected: baseline passes before adding new assertions.
+
+1. Add unit tests, BDD scenarios, and snapshots that encode the new contract.
+
+```plaintext
+cargo test -p sempai-core diagnostic --all-targets --all-features
+```
+
+Expected: new tests fail before implementation changes.
+
+1. Implement schema and constructor changes in `diagnostic.rs`.
+
+```plaintext
+cargo test -p sempai-core --all-targets --all-features
+```
+
+Expected: all `sempai-core` tests pass; snapshot outputs are stable.
+
+1. Update docs and roadmap, then run formatting/lint/test gates with logs.
+
+```plaintext
+set -o pipefail; make fmt 2>&1 | tee /tmp/4-1-2-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/4-1-2-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-2-make-nixie.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/4-1-2-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/4-1-2-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/4-1-2-make-test.log
+```
+
+Expected transcript endings:
+
+```plaintext
+... Finished `dev` profile ...
+... test result: ok. <N> passed; 0 failed ...
+```
+
+## Validation and acceptance
+
+Acceptance is satisfied when all are true:
+
+- Diagnostics serialize with required fields: `code`, `message`,
+  `primary_span`, `notes`.
+- Parser-path and validator-path diagnostic JSON snapshots match the same
+  schema contract and remain stable.
+- Unit tests cover:
+  - Happy path serialization and accessor behaviour.
+  - Unhappy path deserialization failures.
+  - Edge cases (null span, empty notes, mixed report ordering).
+- Behaviour tests (`rstest-bdd` v0.5.0) cover happy, unhappy, and edge paths.
+- Design and user documentation reflect the finalized behaviour.
+- Roadmap item 4.1.2 is checked as complete.
+- `make check-fmt`, `make lint`, and `make test` all exit 0.
+
+## Idempotence and recovery
+
+- All commands above are safe to re-run.
+- Snapshot generation should be deterministic; if snapshots change unexpectedly,
+  inspect diffs before accepting.
+- If a documentation gate fails after code gates pass, fix docs and re-run only
+  doc gates first, then re-run `make check-fmt`, `make lint`, `make test` to
+  confirm no regressions.
+- If tolerance triggers are hit, stop and record escalation details in
+  `Decision Log` before proceeding.
+
+## Artifacts and notes
+
+Capture the following during implementation:
+
+- Snapshot files proving parser/validator schema stability.
+- Final gate logs:
+  - `/tmp/4-1-2-make-check-fmt.log`
+  - `/tmp/4-1-2-make-lint.log`
+  - `/tmp/4-1-2-make-test.log`
+  - `/tmp/4-1-2-make-markdownlint.log`
+  - `/tmp/4-1-2-make-nixie.log`
+- Brief changelog note summarizing final schema and code mapping.
+
+## Interfaces and dependencies
+
+Implementation should preserve and/or define these stable interfaces in
+`sempai_core`:
+
+```rust
+pub enum DiagnosticCode {
+    // stable E_SEMPAI_* variants
+}
+
+pub struct SourceSpan {
+    // byte offsets and optional URI
+}
+
+pub struct Diagnostic {
+    // code, message, primary_span, notes
+}
+
+pub struct DiagnosticReport {
+    // ordered list of diagnostics
+}
+```
+
+Recommended API additions for parser/validator parity:
+
+```rust
+impl Diagnostic {
+    pub fn parser(... ) -> Self;
+    pub fn validator(... ) -> Self;
+    pub fn primary_span(&self) -> Option<&SourceSpan>;
+}
+
+impl DiagnosticReport {
+    pub fn parser_error(... ) -> Self;
+    pub fn validation_error(... ) -> Self;
+}
+```
+
+Dependencies remain within existing workspace crates:
+
+- `serde`, `serde_json`, `thiserror`
+- `rstest`, `rstest-bdd`, `rstest-bdd-macros`
+- `insta`
+
+No new dependencies should be introduced for this milestone.

--- a/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
+++ b/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
@@ -260,7 +260,7 @@ Update docs once implementation is stable:
 
 Go/no-go:
 
-- Do not finalize until markdown and Rust quality gates pass.
+- Do not finalize until Markdown and Rust quality gates pass.
 
 ## Concrete steps
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -349,7 +349,7 @@ phase* *with explicit parser, backend, and Weaver-integration milestones.*
       facade entrypoints.
   - Acceptance criteria: public API documentation builds for `sempai`, and
     stable types cover language, span, match, capture, and diagnostics models.
-- [ ] 4.1.2. Define structured diagnostics with stable `E_SEMPAI_*` error
+- [x] 4.1.2. Define structured diagnostics with stable `E_SEMPAI_*` error
       codes and report schema.
   - Acceptance criteria: diagnostics include code, message, primary span, and
     notes, and JSON snapshots remain stable across parser and validator paths.

--- a/docs/sempai-query-language-design.md
+++ b/docs/sempai-query-language-design.md
@@ -966,6 +966,34 @@ Diagnostic fields:
 - Primary span: source location in rule file or DSL string
 - Notes: additional context (wrapper attempts, language profile used)
 
+Canonical JSON shape:
+
+```json
+{
+  "diagnostics": [
+    {
+      "code": "E_SEMPAI_SCHEMA_INVALID",
+      "message": "missing required field 'id'",
+      "primary_span": {
+        "start": 12,
+        "end": 26,
+        "uri": "file:///rules.yaml"
+      },
+      "notes": ["add a stable rule id"]
+    }
+  ]
+}
+```
+
+Stability rules:
+
+- Parser and validator diagnostics must serialize using the same schema.
+- The required keys for each diagnostic are `code`, `message`,
+  `primary_span`, and `notes`.
+- `primary_span` may be `null` when no source location is available.
+- Legacy payloads using `span` may be accepted for compatibility, but emitted
+  JSON must use `primary_span`.
+
 ### Error codes
 
 A minimal initial set:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1135,4 +1135,6 @@ All error conditions are reported through `DiagnosticReport`, which carries
 stable diagnostic codes suitable for programmatic consumption. Stub methods
 currently return the `NOT_IMPLEMENTED` code; real `E_SEMPAI_*` codes will be
 used once the corresponding backends are implemented. Diagnostics include a
-code, message, optional source span, and supplementary notes.
+code, message, `primary_span` (or `null` when unavailable), and supplementary
+notes. Both parser-path and validator-path diagnostics use the same JSON
+schema, and snapshot tests lock this contract.


### PR DESCRIPTION
## Summary
- Refactors diagnostic report tests and constructors to support canonical JSON shape by introducing a single-diagnostic builder and dedicated parser/validator constructors on Diagnostic and DiagnosticReport.
- Canonical JSON uses a primary_span field (serde alias "span" for input compatibility) and standardizing codes to E_SEMPAI_* across parser/validator backends.
- Adds milestone 4.1.2 planning/docs and snapshot tests to lock the new JSON shape, with updates to docs to reflect stability rules.

## Changes
- crates/sempai-core/src/diagnostic.rs
  - Rename span to primary_span and expose it as the canonical field for serialized JSON, with serde alias to accept legacy input payloads via span.
  - Add a primary_span() accessor and keep span() as a compatibility alias delegating to primary_span().
  - Extend DiagnosticReport with constructors for parser_error and validation_error, and a small helper for creating a single-diagnostic report.
- crates/sempai-core/src/tests/behaviour.rs
  - Add parse_diagnostic_code(code: &str) -> DiagnosticCode helper.
  - Add build_single_diagnostic_report(code, message) to centralize single-diagnostic creation.
  - Introduce new BDD steps:
    - given_parser_diagnostic(world, code, message)
    - given_validator_diagnostic(world, code, message)
  - The existing given_diagnostic(...) path now uses the shared builder for parity.
- crates/sempai-core/src/tests/diagnostic_tests.rs
  - Adjust tests to reflect new primary_span JSON shape and compatibility aliasing.
  - Add tests for unknown diagnostic code deserialization and legacy span alias handling.
  - Validate that the JSON output uses primary_span and not span.
- crates/sempai-core/src/tests/diagnostic_snapshot_tests.rs (new)
  - Snapshot tests for:
    - parser_diagnostic_report_json_snapshot
    - validator_diagnostic_report_json_snapshot
    - mixed_report_ordering_json_snapshot
- crates/sempai-core/src/tests/mod.rs updated to include diagnostic_snapshot_tests module.
- crates/sempai-core/src/tests/snapshots/ (new) and related snapshot files created to lock JSON shapes.
- crates/sempai-core/tests/features/sempai_core.feature (updated)
  - Adds scenarios validating JSON shape: presence of primary_span, absence of span, and deserialization behavior for diagnostic codes.
- crates/sempai-core/src/tests/diagnostic_tests.rs (updated) and related snapshot files created to lock JSON shapes.
- crates/sempai-core/tests/features/sempai_core.feature
  - Added scenarios around JSON contract validation (primary_span presence/absence, unknown code handling).
- docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md (new)
  - New ExecPlan detailing the canonical diagnostic contract, stability rules, and validation plan.
- docs/sempai-query-language-design.md, docs/users-guide.md, docs/roadmap.md
  - Updated to reflect canonical JSON diagnostic shape, stable E_SEMPAI_* codes, and input compatibility via serde aliasing.
- Documentation and planning artifacts updated accordingly to reflect milestone 4.1.2.

## Rationale
- Establishes a single, stable JSON contract for diagnostics across parser and validator backends, with stable E_SEMPAI_* codes and a canonical diagnostic shape. The primary_span field replaces the old span in outputs, while span remains accepted on input via serde aliasing. Snapshot-based tests lock the contract and guard against drift across paths.

## Validation and testing
- Tests updated/added to cover:
  - JSON shape: required fields code, message, primary_span, notes; primary_span may be null.
  - Backwards compatibility: input payloads containing span deserialize into primary_span.
  - Parser/validator parity: both backends share the same diagnostic shape and serialization.
  - Deserialization errors for unknown codes and malformed payloads.
  - Snapshot tests lock the JSON output for parser, validator, and mixed diagnostic reports.
- How to validate locally:
  - cargo test -p sempai-core --all-targets --all-features
  - See new/updated snapshot tests under crates/sempai-core/src/tests/snapshots for expected JSON shapes.

## Impact
- Public API changes:
  - Diagnostic now exposes primary_span in serialized JSON, with legacy span accepted on input via serde aliasing.
  - New constructors: Diagnostic::parser, Diagnostic::validator and DiagnosticReport::parser_error, DiagnosticReport::validation_error.
  - Existing callers can continue using span() for compatibility, which now delegates to primary_span.
- No runtime behavior changes beyond diagnostics production/serialization; the contract is hardened and stabilized.

## Notes
- The ExecPlan document for milestone 4.1.2 has been added (docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md).
- Roadmap and docs updated to reflect the canonical JSON contract and stability rules, and to lock the JSON shape with snapshots.
- Task references from the original PR body are preserved in the repo where applicable.

- Task: https://www.devboxer.com/task/17e6a947-3f23-4a5a-a961-70d9263dbe7f
- Task: https://www.devboxer.com/task/7019b135-70da-4246-a4c0-da5f00a33b23
- Task: https://www.devboxer.com/task/00b28a5f-ac96-491d-997d-08d5fa14d813

📎 **Task**: https://www.devboxer.com/task/8aa20135-edce-4e12-9c05-bc4ca721ba2c