### PR TITLE
Design localization support for Weaver CLI, docs and artefacts

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -237,8 +237,8 @@ does* *not require source inspection or external runbooks.*
 ## 3. Syntactic & relational intelligence
 
 *Goal: Add the Tree-sitter and call graph layers to provide deeper structural*
-*and relational understanding of code, and pair this with operation-level help*
-*for dependable day-to-day operation.*
+*and relational understanding of code, and pair this with operation-level and*
+*localized help for dependable day-to-day operation.*
 
 ### 3.1. Deliver syntax and graph foundations
 
@@ -285,9 +285,14 @@ does* *not require source inspection or external runbooks.*
       [Gap 1c](ui-gap-analysis.md#gap-1c--configuration-flags-invisible)
       and
       [Level 6](ui-gap-analysis.md#level-6--configuration-flags-invisible-in-help).
+      See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces)
+      and
+      [weaver design §2.3.1](weaver-design.md#231-configuration-contract).
   - [ ] Register `--config-path`, `--daemon-socket`, `--log-filter`,
-        `--log-format`, and `--capability-overrides` as visible global flags.
-  - [ ] Acceptance criteria: all five flags appear in both `weaver --help` and
+        `--log-format`, `--capability-overrides`, and `--locale` as visible
+        global flags.
+  - [ ] Acceptance criteria: all six flags appear in both `weaver --help` and
         `weaver daemon start --help`, and existing precedence tests
         (file < env < CLI) continue to pass.
 - [ ] 3.2.2. Extend `daemon start` help with config and environment guidance.
@@ -331,6 +336,58 @@ does* *not require source inspection or external runbooks.*
         updated with explicit sections for dependency graph, fail-fast
         discovery, and YAML 1.2 semantics; and `make markdownlint`,
         `make fmt`, `make nixie`, and documentation tests pass.
+
+### 3.3. Deliver localized CLI and reference outputs
+
+*Outcome: Let operators choose a locale once and receive consistent Fluent-*
+*backed help, error text, and generated reference artefacts across Weaver.*
+
+- [ ] 3.3.1. Introduce locale selection in the shared configuration contract.
+      See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces)
+      and
+      [weaver design §2.3.1](weaver-design.md#231-configuration-contract).
+  - [ ] Add a `locale` field to `weaver-config`, surfaced as `--locale`,
+        `WEAVER_LOCALE`, and a config-file key.
+  - [ ] Bootstrap locale selection from `LC_ALL`, `LC_MESSAGES`, and `LANG`
+        before full config loading, then rebuild the localizer if the resolved
+        config locale differs.
+  - [ ] Acceptance criteria: invalid locale identifiers fail fast during
+        config loading, `weaver --help` can be rendered through a non-default
+        locale selected by CLI, environment, or config file, and `en-US`
+        remains the guaranteed fallback.
+- [ ] 3.3.2. Localize clap help and parse errors through `ortho_config`.
+      Requires 3.3.1. See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Drive clap help with `Cli::command().localize(&localizer)` and route
+        parse failures through `localize_clap_error_with_command`.
+  - [ ] Move bare-invocation help, lifecycle guidance, and other manual
+        operator text to Fluent message IDs with argument-aware rendering.
+  - [ ] Acceptance criteria: bare invocation, `weaver --help`, and common clap
+        validation failures render translated copy for supported locales
+        without changing existing exit-code semantics.
+- [ ] 3.3.3. Centralize the localized command and operation catalogue.
+      Requires 2.2.4 and 3.3.2. See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Replace duplicated domain and operation tables with one structured
+        catalogue shared by the router, contextual-help renderer, and test
+        fixtures.
+  - [ ] Store message IDs, examples, and operation descriptions in that
+        catalogue instead of hard-coded padded English strings.
+  - [ ] Acceptance criteria: top-level help, domain-without-operation
+        guidance, and `weaver help <topic>` all read from the same catalogue,
+        and adding a new operation requires one metadata change rather than
+        parallel edits in help, tests, and routing.
+- [ ] 3.3.4. Generate localized reference artefacts from ortho-config
+      metadata. Requires 3.2.4 and 3.3.2. See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Add stable documentation IDs to config-backed fields and expose
+        `OrthoConfigDocs` metadata for the generated help schema.
+  - [ ] Add `[package.metadata.ortho_config]` wiring and `cargo orthohelp`
+        generation for at least `en-US` and one secondary locale.
+  - [ ] Acceptance criteria: localized IR files are generated per locale,
+        `en-US` manpage packaging remains intact, and artefact validation
+        proves the generated help text matches the runtime Fluent catalogue.
 
 ## 4. Query language infrastructure (Sempai)
 
@@ -657,14 +714,17 @@ initial* *Python delivery and shared failure semantics.*
   - [ ] Acceptance criteria: every provider-related error points users to a
         discoverability command by including the exact string
         `weaver list-plugins`.
-- [ ] 5.7.3. Regenerate and validate the manpage from the improved clap model.
-      Requires 2.2.2, 3.2.1, and 3.2.3. See
+- [ ] 5.7.3. Regenerate and validate localized manpages from the schema-backed
+      help model. Requires 2.2.2, 3.2.1, 3.2.3, and 3.3.4. See
       [Level 11](ui-gap-analysis.md#level-11--manpage).
+      See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
   - [ ] Verify that domain listings, operation listings, global config flags,
-        and help-topic text render in troff output.
-  - [ ] Acceptance criteria: generated manpage includes all updated help
-        surfaces with no manual post-processing, including three domain
-        listings and all five global config flags.
+        locale-aware help text, and help-topic content render in troff output.
+  - [ ] Acceptance criteria: generated manpages include all updated help
+        surfaces with no manual post-processing, ship `en-US` by default, and
+        can be emitted for additional supported locales including all six
+        global config flags.
 
 Capability probe discoverability tasks:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -349,13 +349,15 @@ does* *not require source inspection or external runbooks.*
       [weaver design §2.3.1](weaver-design.md#231-configuration-contract).
   - [ ] Add a `locale` field to `weaver-config`, surfaced as `--locale`,
         `WEAVER_LOCALE`, and a config-file key.
-  - [ ] Bootstrap locale selection from `LC_ALL`, `LC_MESSAGES`, and `LANG`
-        before full config loading, then rebuild the localizer if the resolved
-        config locale differs.
-  - [ ] Acceptance criteria: invalid locale identifiers fail fast during
-        config loading, `weaver --help` can be rendered through a non-default
-        locale selected by CLI, environment, or config file, and `en-US`
-        remains the guaranteed fallback.
+  - [ ] Add a pre-config bootstrap pass that honours `--locale` and
+        `WEAVER_LOCALE` before consulting `LC_ALL`, `LC_MESSAGES`, and `LANG`,
+        then rebuild the localizer if the resolved config locale differs.
+  - [ ] Acceptance criteria: `weaver --help` and other pre-config clap display
+        paths honour `--locale` and `WEAVER_LOCALE` immediately; malformed
+        `--locale` and `WEAVER_LOCALE` values fail fast; malformed ambient
+        `LC_*` or `LANG` values warn and fall back; file-backed locale
+        settings apply after full config loading; and `en-US` remains the
+        guaranteed fallback.
 - [ ] 3.3.2. Localize clap help and parse errors through `ortho_config`.
       Requires 3.3.1. See
       [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
@@ -385,9 +387,10 @@ does* *not require source inspection or external runbooks.*
         `OrthoConfigDocs` metadata for the generated help schema.
   - [ ] Add `[package.metadata.ortho_config]` wiring and `cargo orthohelp`
         generation for at least `en-US` and one secondary locale.
-  - [ ] Acceptance criteria: localized IR files are generated per locale,
-        `en-US` manpage packaging remains intact, and artefact validation
-        proves the generated help text matches the runtime Fluent catalogue.
+  - [ ] Acceptance criteria: localized intermediate representation (IR) files
+        are generated per locale, `en-US` manpage packaging remains intact,
+        and artefact validation proves the generated help text matches the
+        runtime Fluent catalogue.
 
 ## 4. Query language infrastructure (Sempai)
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -564,11 +564,24 @@ shared `Config` schema gains a `locale` field surfaced as `--locale`,
 the rest of the configuration contract. The CLI still needs a bootstrap locale
 before full configuration loading so `--help`, bare-invocation guidance, and
 parse failures can be localized even when they occur before the full config has
-been merged. The bootstrap order should therefore be `LC_ALL`, `LC_MESSAGES`,
-`LANG`, then `en-US`; once `Config::load` succeeds, the CLI rebuilds the
-localizer if `Config::locale` resolves to a different value. Locale values are
-validated as BCP 47 language identifiers during config loading so malformed
-settings fail fast instead of silently falling back to the wrong language.
+been merged. Weaver therefore performs a narrow pre-config pass that extracts
+`--locale` (including `--locale=<tag>`) before constructing any clap display
+surface. The bootstrap order should therefore be `--locale`, `WEAVER_LOCALE`,
+`LC_ALL`, `LC_MESSAGES`, `LANG`, then `en-US`; once `Config::load` succeeds,
+the CLI rebuilds the localizer if `Config::locale` resolves to a different
+value. This means early clap-only paths can honour the explicit CLI flag and
+the Weaver-scoped environment override immediately, while file-backed locale
+selection becomes authoritative only after the full config load completes.
+
+Bootstrap locale handling should distinguish explicit overrides from inherited
+process hints. Malformed `--locale` and `WEAVER_LOCALE` values are hard errors
+because they are explicit Weaver inputs and should behave like other invalid
+configuration values. Malformed `LC_ALL`, `LC_MESSAGES`, or `LANG` values
+should emit a warning and fall through to the next source so inherited shell
+state does not break `weaver --help`. Locale values read during config loading
+continue to be validated as BCP 47 language identifiers so malformed
+configuration files fail fast instead of silently falling back to the wrong
+language.
 
 Runtime localization should use `ortho_config::FluentLocalizer` with an
 embedded mandatory `en-US` bundle and optional consumer bundles under

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -549,6 +549,60 @@ error: Undefined variable `new_function_name`
    |           ^^^^^^^^^^^^^^^^^ not found in this scope
 ```
 
+#### 2.1.5. Localized help and reference surfaces
+
+Weaver's human-facing text should be localized without changing the JSONL
+protocol or daemon routing semantics. The daemon continues to emit stable
+reason codes and structured payloads; the CLI is responsible for rendering
+those codes into locale-specific prose. This keeps automation, plugin
+contracts, and test fixtures language-neutral while still allowing operators to
+work in their preferred language.
+
+Locale selection belongs to `weaver-config` rather than ad-hoc CLI parsing. The
+shared `Config` schema gains a `locale` field surfaced as `--locale`,
+`WEAVER_LOCALE`, and a config-file key, following the same precedence order as
+the rest of the configuration contract. The CLI still needs a bootstrap locale
+before full configuration loading so `--help`, bare-invocation guidance, and
+parse failures can be localized even when they occur before the full config has
+been merged. The bootstrap order should therefore be `LC_ALL`, `LC_MESSAGES`,
+`LANG`, then `en-US`; once `Config::load` succeeds, the CLI rebuilds the
+localizer if `Config::locale` resolves to a different value. Locale values are
+validated as BCP 47 language identifiers during config loading so malformed
+settings fail fast instead of silently falling back to the wrong language.
+
+Runtime localization should use `ortho_config::FluentLocalizer` with an
+embedded mandatory `en-US` bundle and optional consumer bundles under
+`crates/weaver-cli/locales/<locale>/messages.ftl`. Building the localizer via
+`FluentLocalizer::builder(...)` allows Weaver to layer the selected locale over
+`en-US`, attach an error reporter for Fluent formatting failures, and fall back
+deterministically when a message is missing. `NoOpLocalizer` remains the final
+safety net so the CLI never crashes because of a malformed translation bundle.
+
+Clap integration should use `Cli::command().localize(&localizer)` for help text
+and `localize_clap_error_with_command` for parse and validation errors. Manual
+surfaces such as bare-invocation help, lifecycle guidance, and daemon-side
+human-readable rendering should resolve Fluent IDs through the same helper API
+and pass variable data through `LocalizationArgs`, rather than embedding
+English prose in code. This gives Weaver one message catalogue for static help,
+dynamic errors, and config-derived guidance.
+
+Localization also requires a single structured command catalogue. The current
+hard-coded `after_help` strings are sufficient for English smoke tests, but
+they duplicate router knowledge and will drift as new operations are added.
+Weaver should define one catalogue describing domains, operations, examples,
+and message IDs. The router, contextual-help renderer, `weaver help` topics,
+and test fixtures should all read from that catalogue so adding an operation
+updates validation, localization, and help output in one place.
+
+To take advantage of `ortho_config` v0.8.0 beyond runtime help, `weaver-config`
+should annotate config-backed fields with stable documentation IDs and expose
+`OrthoConfigDocs` metadata. Once the schema-backed operation-help work in the
+roadmap lands, `cargo orthohelp` can render localized intermediate
+representation (IR) files and manpages from the same Fluent catalogues,
+removing the current drift risk between clap-generated roff output and runtime
+help text. The packaging contract should still guarantee an `en-US` manpage,
+while allowing distributors to ship additional locales as optional artefacts.
+
 ### 2.2. Semantic, Syntactic, and Relational Fusion
 
 A core premise of `Weaver` is that a truly robust understanding of a codebase
@@ -957,6 +1011,14 @@ Structured logging is configured through the `--log-filter` flag (or
 uses an `info` filter with JSON output by default, giving operators structured
 events suitable for ingestion by observability stacks while keeping console
 noise predictable.
+
+User-interface localization follows the same shared contract. `Config` gains a
+locale field surfaced as `--locale`, `WEAVER_LOCALE`, and a config-file key.
+The value controls help text, human-readable diagnostics, generated reference
+artefacts, and other operator-facing strings, but does not affect the JSONL
+protocol or plugin execution environment. Invalid locale identifiers are
+reported as configuration errors instead of silently falling back, preserving
+the fail-fast behaviour expected from the rest of the config loader.
 
 The capability override matrix is expressed as a sequence of directives using
 the syntax `language:capability=directive`. The directive may be `allow`,


### PR DESCRIPTION
## Summary
- Introduces a localization design for Weaver, enabling locale-aware CLI help, errors, and generated reference artefacts.
- Updates the roadmap and design docs to describe localized surfaces, including a centralized command catalogue and Fluent-based localization workflow.
- Lays groundwork for a config-backed locale (default fallback to en-US) and CLI surface flags to control locale.

## Changes
### Documentation
- docs/weaver-design.md
  - Add section 2.1.5: Localized help and reference surfaces, detailing how locale integrates with the shared config contract, CLI rendering, and runtime localisation strategy.
- docs/roadmap.md
  - Introduce 3.3.x series: Deliver localized CLI and reference outputs with the following milestones:
    - 3.3.1: Locale in shared configuration contract (config field, CLI flag, env var, and file key); bootstrap locale before full config load; fast-fail on invalid locales; en-US as fallback.
    - 3.3.2: Localize clap help and parse errors via ortho_config; route translations through localizer; migrate surface text to Fluent IDs.
    - 3.3.3: Centralize the localized command catalogue for domains/operations; single source of truth for localisation texts.
    - 3.3.4: Generate localized reference artefacts from ortho-config metadata; emit per-locale artefacts and maintain en-US as default.
  - Update global flags section to include --locale (Locale), ensuring six visible flags across weaver --help and weaver daemon start --help.
  - Cross-reference design §2.1.5 and §2.3.1 for localized help and configuration contract.

### Configuration and Runtime Design
- Add locale field to weaver-config surfaced as:
  - CLI flag: --locale
  - Environment variable: WEAVER_LOCALE
  - Config-file key: locale
- Bootstrap locale selection from LC_ALL, LC_MESSAGES, and LANG before full config load; rebuild localizer if resolved locale differs from Config::locale; enforce valid BCP-47 identifiers.
- Fluent-based runtime localization plan:
  - Use FluentLocalizer with en-US embedded bundle and per-locale bundles under crates/weaver-cli/locales/<locale>/messages.ftl.
  - Build localizer via FluentLocalizer::builder(...) with a NoOpLocalizer fallback and error reporter for formatting failures.
- Clap integration: use Cli::command().localize(&localizer) for help and route parse failures through localize_clap_error_with_command.
- Centralized command catalogue: replace hard-coded surfaces with a single metadata catalogue describing domains, operations, and examples; all components (router, help renderer, tests) rely on it.
- OrthoConfig-based generation: annotate config-backed fields with stable documentation IDs; wire cargo orthohelp to generate localized IR files (en-US plus at least one secondary locale).

### Testing and Compatibility
- No runtime changes unless --locale is used; en-US remains the guaranteed default fallback.
- Acceptance criteria: translated output is produced for supported locales, and existing exit-code semantics are preserved.

## Rationale
- Consolidates text into a single localisation surface, reducing drift between help text, errors, docs, and generated artefacts.
- Enables operators to interact in their preferred language without altering the daemon routing or JSONL protocol.

## Test plan
- [ ] Build and render docs to confirm cross-references and new sections are wired correctly.
- [ ] Validate that new locale scaffolding appears in CLI help when --locale is supplied (default remains en-US).
- [ ] Ensure en-US remains the stable fallback in all non-localized paths.
- [ ] Verify that localization-related references in docs link to the new 2.1.5 section and 3.3.x milestones.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/8b90ff5b-cf58-4cdc-91fe-5c0f66357e15

## Summary by Sourcery

Document the planned design and roadmap for introducing locale-aware CLI help, errors, and reference artefacts in Weaver, including configuration, runtime localization, and manpage generation.

Documentation:
- Add a design section detailing localized help and reference surfaces, including locale selection, validation, and Fluent-based runtime localization strategy.
- Extend the configuration contract docs to describe the new locale field and its impact on operator-facing text while keeping protocols language-neutral.
- Update the roadmap with a new localization-focused milestone series covering config-backed locale selection, localized CLI help/errors, centralized command catalogue, and localized reference artefact generation, including manpages.