### PR TITLE
Document ortho_config v0.8.0 semantics and client-side domain validation (2.3.1)

### DIFF
--- a/crates/weaver-cli/locales/en-US/messages.ftl
+++ b/crates/weaver-cli/locales/en-US/messages.ftl
@@ -12,6 +12,9 @@ weaver-domain-guidance-missing-operation-error =
 weaver-domain-guidance-unknown-domain-error =
     error: unknown domain '{$domain}'
 weaver-domain-guidance-available-operations = Available operations:
+weaver-domain-guidance-valid-domains = Valid domains: {$domains}
+weaver-domain-guidance-did-you-mean-domain =
+    Did you mean '{$suggested_domain}'?
 weaver-domain-guidance-help-hint =
     Run 'weaver {$domain} {$hint_operation} --help' for operation details.
 weaver-domain-guidance-help-hint-unknown-domain =

--- a/crates/weaver-cli/locales/en-US/messages.ftl
+++ b/crates/weaver-cli/locales/en-US/messages.ftl
@@ -6,7 +6,10 @@ weaver-bare-help-domain-act = act       Perform code modifications
 weaver-bare-help-domain-verify = verify    Validate code correctness
 weaver-bare-help-pointer = Run 'weaver --help' for more information.
 
-# Preflight domain guidance shown when a domain lacks an operation.
+# Preflight domain guidance for missing operations and unknown domain validation.
+# Includes messages for weaver-domain-guidance-missing-operation-error,
+# weaver-domain-guidance-unknown-domain-error, weaver-domain-guidance-valid-domains,
+# and weaver-domain-guidance-did-you-mean-domain.
 weaver-domain-guidance-missing-operation-error =
     error: operation required for domain '{$domain}'
 weaver-domain-guidance-unknown-domain-error =

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -42,6 +42,12 @@ impl KnownDomain {
             .map(|(_, _, ops)| *ops)
             .unwrap_or_else(|| panic!("missing DOMAIN_OPERATIONS entry for '{}'", self.as_str()))
     }
+
+    fn catalogue_order() -> impl Iterator<Item = Self> {
+        DOMAIN_OPERATIONS
+            .iter()
+            .map(|(domain, _, _)| known_domain_from_catalogue_entry(domain))
+    }
 }
 
 /// Canonical domain-to-operation mapping for CLI discoverability features.
@@ -91,13 +97,68 @@ fn known_domain_from_catalogue_entry(domain: &str) -> KnownDomain {
     })
 }
 
-/// Returns the first domain plus its first operation from `DOMAIN_OPERATIONS`.
-///
-/// Returns `None` when the catalogue is empty or when the first domain has no
-/// registered operations.
-fn first_known_command() -> Option<(&'static str, &'static str)> {
-    let (domain, _, operations) = DOMAIN_OPERATIONS.first().copied()?;
-    Some((domain, operations.first().copied()?))
+fn valid_domains_list() -> String {
+    KnownDomain::catalogue_order()
+        .map(KnownDomain::as_str)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn suggestion_for_unknown_domain(domain: &str) -> Option<KnownDomain> {
+    let normalized_domain = domain.trim().to_ascii_lowercase();
+    let mut best_match = None;
+    let mut best_distance = usize::MAX;
+    let mut tied = false;
+
+    for candidate in KnownDomain::catalogue_order() {
+        let Some(distance) = bounded_levenshtein(&normalized_domain, candidate.as_str(), 2) else {
+            continue;
+        };
+        if distance < best_distance {
+            best_distance = distance;
+            best_match = Some(candidate);
+            tied = false;
+        } else if distance == best_distance {
+            tied = true;
+        }
+    }
+
+    if tied { None } else { best_match }
+}
+
+fn bounded_levenshtein(left: &str, right: &str, max_distance: usize) -> Option<usize> {
+    let left_chars: Vec<char> = left.chars().collect();
+    let right_chars: Vec<char> = right.chars().collect();
+
+    if left_chars.len().abs_diff(right_chars.len()) > max_distance {
+        return None;
+    }
+
+    let mut previous: Vec<usize> = (0..=right_chars.len()).collect();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (left_index, left_char) in left_chars.iter().enumerate() {
+        current[0] = left_index + 1;
+        let mut row_min = current[0];
+
+        for (right_index, right_char) in right_chars.iter().enumerate() {
+            let substitution_cost = usize::from(left_char != right_char);
+            current[right_index + 1] = usize::min(
+                usize::min(previous[right_index + 1] + 1, current[right_index] + 1),
+                previous[right_index] + substitution_cost,
+            );
+            row_min = row_min.min(current[right_index + 1]);
+        }
+
+        if row_min > max_distance {
+            return None;
+        }
+
+        previous.clone_from_slice(&current);
+    }
+
+    let distance = previous[right_chars.len()];
+    (distance <= max_distance).then_some(distance)
 }
 
 /// Writes contextual guidance for a known domain missing its operation.
@@ -146,7 +207,7 @@ pub(crate) fn write_missing_operation_guidance<W: Write>(
     Ok(true)
 }
 
-/// Writes contextual guidance for an unknown domain missing its operation.
+/// Writes contextual guidance for an unknown domain.
 pub(crate) fn write_unknown_domain_guidance<W: Write>(
     writer: &mut W,
     localizer: &dyn Localizer,
@@ -155,41 +216,35 @@ pub(crate) fn write_unknown_domain_guidance<W: Write>(
     if KnownDomain::try_parse(domain).is_some() {
         return Ok(false);
     }
-    let Some((hint_domain, hint_operation)) = first_known_command() else {
-        return Ok(false);
-    };
     let mut args = LocalizationArgs::new();
     args.insert("domain", domain.into());
-    args.insert("hint_domain", hint_domain.into());
-    args.insert("hint_operation", hint_operation.into());
+    let valid_domains = valid_domains_list();
+    args.insert("domains", valid_domains.as_str().into());
     let error = strip_bidi_isolates(localizer.message(
         "weaver-domain-guidance-unknown-domain-error",
         Some(&args),
         &format!("error: unknown domain '{domain}'"),
     ));
-    let available_operations = strip_bidi_isolates(localizer.message(
-        "weaver-domain-guidance-available-operations",
-        None,
-        "Available operations:",
-    ));
-    let hint = strip_bidi_isolates(localizer.message(
-        "weaver-domain-guidance-help-hint-unknown-domain",
+    let valid_domains_message = strip_bidi_isolates(localizer.message(
+        "weaver-domain-guidance-valid-domains",
         Some(&args),
-        &format!("Run 'weaver {hint_domain} {hint_operation} --help' for operation details."),
+        &format!("Valid domains: {valid_domains}"),
     ));
 
     writeln!(writer, "{error}")?;
     writeln!(writer)?;
-    writeln!(writer, "{available_operations}")?;
-    for (known_domain, _, operations) in DOMAIN_OPERATIONS {
-        let known_domain_enum = known_domain_from_catalogue_entry(known_domain);
-        for operation in *operations {
-            debug_assert_eq!(known_domain_enum.as_str(), *known_domain);
-            writeln!(writer, "  {known_domain} {operation}")?;
-        }
+    writeln!(writer, "{valid_domains_message}")?;
+
+    if let Some(suggested_domain) = suggestion_for_unknown_domain(domain) {
+        let suggested_domain = suggested_domain.as_str();
+        args.insert("suggested_domain", suggested_domain.into());
+        let suggestion = strip_bidi_isolates(localizer.message(
+            "weaver-domain-guidance-did-you-mean-domain",
+            Some(&args),
+            &format!("Did you mean '{suggested_domain}'?"),
+        ));
+        writeln!(writer, "{suggestion}")?;
     }
-    writeln!(writer)?;
-    writeln!(writer, "{hint}")?;
 
     Ok(true)
 }
@@ -202,10 +257,39 @@ pub(crate) fn should_emit_domain_guidance(cli: &crate::Cli) -> bool {
             .domain
             .as_deref()
             .is_some_and(|domain| !domain.trim().is_empty())
-        && cli
-            .operation
-            .as_deref()
-            .is_none_or(|operation| operation.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for unknown-domain suggestion helpers.
+
+    use super::{KnownDomain, bounded_levenshtein, suggestion_for_unknown_domain};
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("observe", "observe", Some(0))]
+    #[case("obsrve", "observe", Some(1))]
+    #[case("bogus", "observe", None)]
+    fn bounded_levenshtein_respects_threshold(
+        #[case] left: &str,
+        #[case] right: &str,
+        #[case] expected: Option<usize>,
+    ) {
+        assert_eq!(bounded_levenshtein(left, right, 2), expected);
+    }
+
+    #[test]
+    fn suggestion_for_unknown_domain_returns_closest_match_within_threshold() {
+        assert_eq!(
+            suggestion_for_unknown_domain("obsrve"),
+            Some(KnownDomain::Observe)
+        );
+    }
+
+    #[test]
+    fn suggestion_for_unknown_domain_rejects_distant_values() {
+        assert_eq!(suggestion_for_unknown_domain("bogus"), None);
+    }
 }
 
 #[cfg(test)]

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -26,13 +26,18 @@ impl KnownDomain {
     }
 
     /// Resolves a raw string to a known domain, case-insensitively.
+    /// Uses DOMAIN_OPERATIONS as the single source of truth.
     pub(crate) fn try_parse(s: &str) -> Option<Self> {
-        match s.trim().to_ascii_lowercase().as_str() {
-            "observe" => Some(Self::Observe),
-            "act" => Some(Self::Act),
-            "verify" => Some(Self::Verify),
-            _ => None,
-        }
+        let normalized = s.trim().to_ascii_lowercase();
+        DOMAIN_OPERATIONS
+            .iter()
+            .find(|(domain, _, _)| *domain == normalized.as_str())
+            .map(|(domain, _, _)| match *domain {
+                "observe" => Self::Observe,
+                "act" => Self::Act,
+                "verify" => Self::Verify,
+                _ => panic!("DOMAIN_OPERATIONS contains unknown domain: {domain}"),
+            })
     }
 
     fn operations(self) -> &'static [&'static str] {
@@ -92,9 +97,12 @@ fn strip_bidi_isolates(text: String) -> String {
 }
 
 fn known_domain_from_catalogue_entry(domain: &str) -> KnownDomain {
-    KnownDomain::try_parse(domain).unwrap_or_else(|| {
-        panic!("DOMAIN_OPERATIONS must contain valid KnownDomain entries: {domain}")
-    })
+    match domain {
+        "observe" => KnownDomain::Observe,
+        "act" => KnownDomain::Act,
+        "verify" => KnownDomain::Verify,
+        _ => panic!("DOMAIN_OPERATIONS must contain valid KnownDomain entries: {domain}"),
+    }
 }
 
 fn valid_domains_list() -> String {

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -287,25 +287,15 @@ mod tests {
         assert_eq!(bounded_levenshtein(left, right, 2), expected);
     }
 
-    #[test]
-    fn suggestion_for_unknown_domain_returns_closest_match_within_threshold() {
-        assert_eq!(
-            suggestion_for_unknown_domain("obsrve"),
-            Some(KnownDomain::Observe)
-        );
-    }
-
-    #[test]
-    fn suggestion_for_unknown_domain_rejects_distant_values() {
-        assert_eq!(suggestion_for_unknown_domain("bogus"), None);
-    }
-
-    #[test]
-    fn suggestion_for_unknown_domain_accepts_distance_two_match() {
-        assert_eq!(
-            suggestion_for_unknown_domain("obsve"),
-            Some(KnownDomain::Observe)
-        );
+    #[rstest]
+    #[case("obsrve", Some(KnownDomain::Observe))]
+    #[case("bogus", None)]
+    #[case("obsve", Some(KnownDomain::Observe))]
+    fn suggestion_for_unknown_domain_cases(
+        #[case] input: &str,
+        #[case] expected: Option<KnownDomain>,
+    ) {
+        assert_eq!(suggestion_for_unknown_domain(input), expected);
     }
 }
 

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -269,6 +269,7 @@ mod tests {
     #[rstest]
     #[case("observe", "observe", Some(0))]
     #[case("obsrve", "observe", Some(1))]
+    #[case("obsve", "observe", Some(2))]
     #[case("bogus", "observe", None)]
     fn bounded_levenshtein_respects_threshold(
         #[case] left: &str,
@@ -289,6 +290,14 @@ mod tests {
     #[test]
     fn suggestion_for_unknown_domain_rejects_distant_values() {
         assert_eq!(suggestion_for_unknown_domain("bogus"), None);
+    }
+
+    #[test]
+    fn suggestion_for_unknown_domain_accepts_distance_two_match() {
+        assert_eq!(
+            suggestion_for_unknown_domain("obsve"),
+            Some(KnownDomain::Observe)
+        );
     }
 }
 

--- a/crates/weaver-cli/src/errors.rs
+++ b/crates/weaver-cli/src/errors.rs
@@ -22,9 +22,10 @@ pub(crate) enum AppError {
     /// Sentinel for bare invocation — help has already been written.
     #[error("bare invocation")]
     BareInvocation,
-    /// Sentinel for contextual missing-operation guidance.
-    #[error("missing operation guidance")]
-    MissingOperationGuidance,
+    /// Sentinel for client-side preflight guidance that has already been
+    /// written to stderr.
+    #[error("preflight guidance")]
+    PreflightGuidance,
     #[error("failed to resolve daemon address {endpoint}: {source}")]
     Resolve { endpoint: String, source: io::Error },
     #[error("failed to connect to daemon at {endpoint}: {source}")]
@@ -52,7 +53,7 @@ pub(crate) enum AppError {
     SerialiseCapabilities(serde_json::Error),
     #[error("failed to emit capabilities: {0}")]
     EmitCapabilities(io::Error),
-    #[error("failed to emit missing-operation guidance: {0}")]
+    #[error("failed to emit preflight guidance: {0}")]
     EmitGuidance(io::Error),
     #[error("daemon lifecycle command failed: {0}")]
     Lifecycle(#[from] LifecycleError),

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -232,6 +232,38 @@ where
     run_with_loader(args, io, &OrthoConfigLoader)
 }
 
+fn preflight_result(written: bool) -> Result<(), AppError> {
+    if written {
+        Err(AppError::PreflightGuidance)
+    } else {
+        Ok(())
+    }
+}
+
+fn emit_domain_guidance<ErrWriter: Write>(
+    cli: &Cli,
+    stderr: &mut ErrWriter,
+    localizer: &dyn Localizer,
+    raw_domain: &str,
+) -> Result<(), AppError> {
+    let operation_is_missing = cli
+        .operation
+        .as_deref()
+        .is_none_or(|op| op.trim().is_empty());
+
+    match KnownDomain::try_parse(raw_domain) {
+        Some(domain) if operation_is_missing => preflight_result(
+            write_missing_operation_guidance(stderr, localizer, domain)
+                .map_err(AppError::EmitGuidance)?,
+        ),
+        Some(_) => Ok(()),
+        None => preflight_result(
+            write_unknown_domain_guidance(stderr, localizer, raw_domain)
+                .map_err(AppError::EmitGuidance)?,
+        ),
+    }
+}
+
 fn handle_preflight<ErrWriter: Write>(
     cli: &Cli,
     split: &ConfigArgumentSplit,
@@ -244,28 +276,7 @@ fn handle_preflight<ErrWriter: Write>(
     }
     if should_emit_domain_guidance(cli) {
         let raw_domain = cli.domain.as_deref().map(str::trim).unwrap_or_default();
-        match KnownDomain::try_parse(raw_domain) {
-            Some(domain)
-                if cli
-                    .operation
-                    .as_deref()
-                    .is_none_or(|operation| operation.trim().is_empty()) =>
-            {
-                if write_missing_operation_guidance(stderr, localizer, domain)
-                    .map_err(AppError::EmitGuidance)?
-                {
-                    return Err(AppError::PreflightGuidance);
-                }
-            }
-            Some(_) => {}
-            None => {
-                if write_unknown_domain_guidance(stderr, localizer, raw_domain)
-                    .map_err(AppError::EmitGuidance)?
-                {
-                    return Err(AppError::PreflightGuidance);
-                }
-            }
-        }
+        emit_domain_guidance(cli, stderr, localizer, raw_domain)?;
     }
     Ok(())
 }

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -207,7 +207,7 @@ where
         match result {
             Ok(exit_code) => exit_code,
             Err(AppError::BareInvocation) => ExitCode::FAILURE,
-            Err(AppError::MissingOperationGuidance) => ExitCode::FAILURE,
+            Err(AppError::PreflightGuidance) => ExitCode::FAILURE,
             Err(AppError::CliUsage(ref clap_err)) if !clap_err.use_stderr() => {
                 let _ = write!(self.io.stdout, "{clap_err}");
                 ExitCode::SUCCESS
@@ -244,16 +244,27 @@ fn handle_preflight<ErrWriter: Write>(
     }
     if should_emit_domain_guidance(cli) {
         let raw_domain = cli.domain.as_deref().map(str::trim).unwrap_or_default();
-        let emitted_missing_operation_guidance = match KnownDomain::try_parse(raw_domain) {
-            Some(domain) => write_missing_operation_guidance(stderr, localizer, domain)
-                .map_err(AppError::EmitGuidance)?,
-            None => false,
-        };
-        if emitted_missing_operation_guidance
-            || write_unknown_domain_guidance(stderr, localizer, raw_domain)
-                .map_err(AppError::EmitGuidance)?
-        {
-            return Err(AppError::MissingOperationGuidance);
+        match KnownDomain::try_parse(raw_domain) {
+            Some(domain)
+                if cli
+                    .operation
+                    .as_deref()
+                    .is_none_or(|operation| operation.trim().is_empty()) =>
+            {
+                if write_missing_operation_guidance(stderr, localizer, domain)
+                    .map_err(AppError::EmitGuidance)?
+                {
+                    return Err(AppError::PreflightGuidance);
+                }
+            }
+            Some(_) => {}
+            None => {
+                if write_unknown_domain_guidance(stderr, localizer, raw_domain)
+                    .map_err(AppError::EmitGuidance)?
+                {
+                    return Err(AppError::PreflightGuidance);
+                }
+            }
         }
     }
     Ok(())

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -368,7 +368,7 @@ fn is_daemon_not_running_rejects_non_connect_errors() {
     assert!(!is_daemon_not_running(&AppError::MissingOperation));
     assert!(!is_daemon_not_running(&AppError::MissingExit));
     assert!(!is_daemon_not_running(&AppError::BareInvocation));
-    assert!(!is_daemon_not_running(&AppError::MissingOperationGuidance));
+    assert!(!is_daemon_not_running(&AppError::PreflightGuidance));
     let ser_err = AppError::SerialiseRequest(serde_json::from_str::<()>("bad").unwrap_err());
     assert!(!is_daemon_not_running(&ser_err));
 }

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -51,6 +51,23 @@ fn assert_preflight_failure(output: &PreflightOutput) {
         output.stdout.is_empty(),
         "guidance must not write to stdout"
     );
+    assert_no_daemon_start_text(output);
+}
+
+fn assert_no_daemon_start_text(output: &PreflightOutput) {
+    let stdout = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+    let stderr = output.stderr.to_ascii_lowercase();
+
+    for phrase in ["starting daemon", "daemon started"] {
+        assert!(
+            !stdout.contains(phrase),
+            "stdout should not contain daemon-start text '{phrase}'"
+        );
+        assert!(
+            !stderr.contains(phrase),
+            "stderr should not contain daemon-start text '{phrase}'"
+        );
+    }
 }
 
 fn assert_unknown_domain_preflight(output: &PreflightOutput, domain: &str) {

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -63,6 +63,13 @@ fn assert_unknown_domain_preflight(output: &PreflightOutput, domain: &str) {
             .stderr
             .contains("Valid domains: observe, act, verify")
     );
+    // Ensure legacy operation guidance does not appear
+    assert!(!output.stderr.contains("Available operations:"));
+    assert!(
+        !output
+            .stderr
+            .contains("weaver observe get-definition --help")
+    );
 }
 
 fn assert_known_domain_operation_guidance(output: &PreflightOutput, domain: &str) {

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -113,36 +113,28 @@ fn known_domain_without_operation_emits_contextual_guidance() {
 }
 
 #[rstest]
-#[case(&["unknown-domain"], "unknown-domain", None, None, Some("weaver observe get-definition --help"))]
-#[case(&["unknown-domain", "get-definition"], "unknown-domain", None, Some("Waiting for daemon start..."), None)]
-#[case(&["obsrve", "get-definition"], "obsrve", Some("Did you mean 'observe'?"), None, None)]
-#[case(&["bogus", "get-definition"], "bogus", None, None, Some("Did you mean"))]
+#[case(&["unknown-domain"], "unknown-domain", &[], &["weaver observe get-definition --help"])]
+#[case(&["unknown-domain", "get-definition"], "unknown-domain", &[], &["Waiting for daemon start..."])]
+#[case(&["obsrve", "get-definition"], "obsrve", &["Did you mean 'observe'?"], &[])]
+#[case(&["bogus", "get-definition"], "bogus", &[], &["Did you mean"])]
 fn unknown_domain_preflight_guidance(
     #[case] args: &[&str],
     #[case] domain: &str,
-    #[case] should_contain: Option<&str>,
-    #[case] should_not_contain_daemon: Option<&str>,
-    #[case] should_not_contain_other: Option<&str>,
+    #[case] required_contains: &[&str],
+    #[case] forbidden_contains: &[&str],
 ) {
     let output = run_with_panicking_loader(args);
 
     assert_unknown_domain_preflight(&output, domain);
 
-    if let Some(text) = should_contain {
+    for text in required_contains {
         assert!(
             output.stderr.contains(text),
             "stderr should contain '{text}'"
         );
     }
 
-    if let Some(text) = should_not_contain_daemon {
-        assert!(
-            !output.stderr.contains(text),
-            "stderr should not contain '{text}'"
-        );
-    }
-
-    if let Some(text) = should_not_contain_other {
+    for text in forbidden_contains {
         assert!(
             !output.stderr.contains(text),
             "stderr should not contain '{text}'"

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -82,6 +82,9 @@ fn assert_known_domain_operation_guidance(output: &PreflightOutput, domain: &str
             .contains(&format!("error: operation required for domain '{domain}'"))
     );
     assert!(output.stderr.contains("Available operations:"));
+    // Ensure unknown-domain guidance does not appear
+    assert!(!output.stderr.contains("Valid domains:"));
+    assert!(!output.stderr.contains("Did you mean"));
 }
 
 fn assert_no_domain_guidance(output: &PreflightOutput) {

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -18,7 +18,13 @@ impl ConfigLoader for PanickingLoader {
     }
 }
 
-fn run_with_panicking_loader(args: &[&str]) -> (ExitCode, Vec<u8>, String) {
+struct PreflightOutput {
+    exit: ExitCode,
+    stdout: Vec<u8>,
+    stderr: String,
+}
+
+fn run_with_panicking_loader(args: &[&str]) -> PreflightOutput {
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     let mut stdin = Cursor::new(Vec::new());
@@ -30,75 +36,104 @@ fn run_with_panicking_loader(args: &[&str]) -> (ExitCode, Vec<u8>, String) {
     let exit = run_with_loader(cli_args, &mut io, &PanickingLoader);
     let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
 
-    (exit, stdout, stderr_text)
+    PreflightOutput {
+        exit,
+        stdout,
+        stderr: stderr_text,
+    }
 }
 
-fn assert_unknown_domain_preflight(exit: ExitCode, stdout: &[u8], stderr_text: &str, domain: &str) {
+fn assert_preflight_failure(exit: ExitCode, stdout: &[u8]) {
     assert_eq!(exit, ExitCode::FAILURE);
     assert!(stdout.is_empty(), "guidance must not write to stdout");
-    assert!(stderr_text.contains(&format!("error: unknown domain '{domain}'")));
-    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
 }
 
-fn assert_known_domain_operation_guidance(
-    exit: ExitCode,
-    stdout: &[u8],
-    stderr_text: &str,
-    domain: &str,
-) {
-    assert_eq!(exit, ExitCode::FAILURE);
-    assert!(stdout.is_empty(), "guidance must not write to stdout");
-    assert!(stderr_text.contains(&format!("error: operation required for domain '{domain}'")));
-    assert!(stderr_text.contains("Available operations:"));
+fn assert_unknown_domain_preflight(output: &PreflightOutput, domain: &str) {
+    assert_preflight_failure(output.exit, &output.stdout);
+    assert!(
+        output
+            .stderr
+            .contains(&format!("error: unknown domain '{domain}'"))
+    );
+    assert!(
+        output
+            .stderr
+            .contains("Valid domains: observe, act, verify")
+    );
 }
 
-fn assert_no_domain_guidance(stderr_text: &str) {
-    assert!(!stderr_text.contains("error: operation required for domain"));
-    assert!(!stderr_text.contains("Available operations:"));
-    assert!(!stderr_text.contains("Valid domains: observe, act, verify"));
+fn assert_known_domain_operation_guidance(output: &PreflightOutput, domain: &str) {
+    assert_preflight_failure(output.exit, &output.stdout);
+    assert!(
+        output
+            .stderr
+            .contains(&format!("error: operation required for domain '{domain}'"))
+    );
+    assert!(output.stderr.contains("Available operations:"));
+}
+
+fn assert_no_domain_guidance(output: &PreflightOutput) {
+    assert!(
+        !output
+            .stderr
+            .contains("error: operation required for domain")
+    );
+    assert!(!output.stderr.contains("Available operations:"));
+    assert!(
+        !output
+            .stderr
+            .contains("Valid domains: observe, act, verify")
+    );
 }
 
 #[test]
 fn known_domain_without_operation_emits_contextual_guidance() {
-    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["observe"]);
+    let output = run_with_panicking_loader(&["observe"]);
 
-    assert_known_domain_operation_guidance(exit, &stdout, &stderr_text, "observe");
-    assert!(stderr_text.contains("get-definition"));
-    assert!(stderr_text.contains("get-card"));
-    assert!(stderr_text.contains("weaver observe get-definition --help"));
+    assert_known_domain_operation_guidance(&output, "observe");
+    assert!(output.stderr.contains("get-definition"));
+    assert!(output.stderr.contains("get-card"));
+    assert!(
+        output
+            .stderr
+            .contains("weaver observe get-definition --help")
+    );
 }
 
 #[test]
 fn unknown_domain_without_operation_emits_global_guidance() {
-    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["unknown-domain"]);
+    let output = run_with_panicking_loader(&["unknown-domain"]);
 
-    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "unknown-domain");
-    assert!(!stderr_text.contains("weaver observe get-definition --help"));
+    assert_unknown_domain_preflight(&output, "unknown-domain");
+    assert!(
+        !output
+            .stderr
+            .contains("weaver observe get-definition --help")
+    );
 }
 
 #[test]
 fn unknown_domain_with_operation_emits_global_guidance_before_configuration_loading() {
-    let (exit, stdout, stderr_text) =
-        run_with_panicking_loader(&["unknown-domain", "get-definition"]);
+    let output = run_with_panicking_loader(&["unknown-domain", "get-definition"]);
 
-    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "unknown-domain");
-    assert!(!stderr_text.contains("Waiting for daemon start..."));
+    assert_unknown_domain_preflight(&output, "unknown-domain");
+    assert!(!output.stderr.contains("Waiting for daemon start..."));
 }
 
 #[test]
 fn typo_domain_emits_single_suggestion() {
-    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["obsrve", "get-definition"]);
+    let output = run_with_panicking_loader(&["obsrve", "get-definition"]);
 
-    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "obsrve");
-    assert!(stderr_text.contains("Did you mean 'observe'?"));
+    assert_unknown_domain_preflight(&output, "obsrve");
+    assert!(output.stderr.contains("Did you mean 'observe'?"));
 }
 
 #[test]
 fn distant_unknown_domain_omits_suggestion() {
-    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["bogus", "get-definition"]);
+    let output = run_with_panicking_loader(&["bogus", "get-definition"]);
 
-    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "bogus");
-    assert!(!stderr_text.contains("Did you mean"));
+    assert_unknown_domain_preflight(&output, "bogus");
+    assert!(!output.stderr.contains("Did you mean"));
 }
 
 #[test]
@@ -125,8 +160,12 @@ fn complete_command_still_reports_configuration_failures() {
         &FailingLoader,
     );
 
-    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert_eq!(exit, ExitCode::FAILURE);
-    assert!(stderr_text.contains("command domain"));
-    assert_no_domain_guidance(&stderr_text);
+    let output = PreflightOutput {
+        exit,
+        stdout,
+        stderr: String::from_utf8(stderr).expect("stderr utf8"),
+    };
+    assert_eq!(output.exit, ExitCode::FAILURE);
+    assert!(output.stderr.contains("command domain"));
+    assert_no_domain_guidance(&output);
 }

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -18,24 +18,51 @@ impl ConfigLoader for PanickingLoader {
     }
 }
 
-#[test]
-fn known_domain_without_operation_emits_contextual_guidance() {
+fn run_with_panicking_loader(args: &[&str]) -> (ExitCode, Vec<u8>, String) {
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     let mut stdin = Cursor::new(Vec::new());
     let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
-
-    let exit = run_with_loader(
-        vec![OsString::from("weaver"), OsString::from("observe")],
-        &mut io,
-        &PanickingLoader,
-    );
-
+    let cli_args = std::iter::once("weaver")
+        .chain(args.iter().copied())
+        .map(OsString::from)
+        .collect::<Vec<_>>();
+    let exit = run_with_loader(cli_args, &mut io, &PanickingLoader);
     let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+
+    (exit, stdout, stderr_text)
+}
+
+fn assert_unknown_domain_preflight(exit: ExitCode, stdout: &[u8], stderr_text: &str, domain: &str) {
     assert_eq!(exit, ExitCode::FAILURE);
     assert!(stdout.is_empty(), "guidance must not write to stdout");
-    assert!(stderr_text.contains("error: operation required for domain 'observe'"));
+    assert!(stderr_text.contains(&format!("error: unknown domain '{domain}'")));
+    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+}
+
+fn assert_known_domain_operation_guidance(
+    exit: ExitCode,
+    stdout: &[u8],
+    stderr_text: &str,
+    domain: &str,
+) {
+    assert_eq!(exit, ExitCode::FAILURE);
+    assert!(stdout.is_empty(), "guidance must not write to stdout");
+    assert!(stderr_text.contains(&format!("error: operation required for domain '{domain}'")));
     assert!(stderr_text.contains("Available operations:"));
+}
+
+fn assert_no_domain_guidance(stderr_text: &str) {
+    assert!(!stderr_text.contains("error: operation required for domain"));
+    assert!(!stderr_text.contains("Available operations:"));
+    assert!(!stderr_text.contains("Valid domains: observe, act, verify"));
+}
+
+#[test]
+fn known_domain_without_operation_emits_contextual_guidance() {
+    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["observe"]);
+
+    assert_known_domain_operation_guidance(exit, &stdout, &stderr_text, "observe");
     assert!(stderr_text.contains("get-definition"));
     assert!(stderr_text.contains("get-card"));
     assert!(stderr_text.contains("weaver observe get-definition --help"));
@@ -43,98 +70,34 @@ fn known_domain_without_operation_emits_contextual_guidance() {
 
 #[test]
 fn unknown_domain_without_operation_emits_global_guidance() {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    let mut stdin = Cursor::new(Vec::new());
-    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["unknown-domain"]);
 
-    let exit = run_with_loader(
-        vec![OsString::from("weaver"), OsString::from("unknown-domain")],
-        &mut io,
-        &PanickingLoader,
-    );
-
-    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert_eq!(exit, ExitCode::FAILURE);
-    assert!(stdout.is_empty(), "guidance must not write to stdout");
-    assert!(stderr_text.contains("error: unknown domain 'unknown-domain'"));
-    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
-    assert!(!stderr_text.contains("Available operations:"));
+    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "unknown-domain");
     assert!(!stderr_text.contains("weaver observe get-definition --help"));
 }
 
 #[test]
 fn unknown_domain_with_operation_emits_global_guidance_before_configuration_loading() {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    let mut stdin = Cursor::new(Vec::new());
-    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let (exit, stdout, stderr_text) =
+        run_with_panicking_loader(&["unknown-domain", "get-definition"]);
 
-    let exit = run_with_loader(
-        vec![
-            OsString::from("weaver"),
-            OsString::from("unknown-domain"),
-            OsString::from("get-definition"),
-        ],
-        &mut io,
-        &PanickingLoader,
-    );
-
-    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert_eq!(exit, ExitCode::FAILURE);
-    assert!(stdout.is_empty(), "guidance must not write to stdout");
-    assert!(stderr_text.contains("error: unknown domain 'unknown-domain'"));
-    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "unknown-domain");
     assert!(!stderr_text.contains("Waiting for daemon start..."));
 }
 
 #[test]
 fn typo_domain_emits_single_suggestion() {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    let mut stdin = Cursor::new(Vec::new());
-    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["obsrve", "get-definition"]);
 
-    let exit = run_with_loader(
-        vec![
-            OsString::from("weaver"),
-            OsString::from("obsrve"),
-            OsString::from("get-definition"),
-        ],
-        &mut io,
-        &PanickingLoader,
-    );
-
-    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert_eq!(exit, ExitCode::FAILURE);
-    assert!(stdout.is_empty(), "guidance must not write to stdout");
-    assert!(stderr_text.contains("error: unknown domain 'obsrve'"));
-    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "obsrve");
     assert!(stderr_text.contains("Did you mean 'observe'?"));
 }
 
 #[test]
 fn distant_unknown_domain_omits_suggestion() {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    let mut stdin = Cursor::new(Vec::new());
-    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+    let (exit, stdout, stderr_text) = run_with_panicking_loader(&["bogus", "get-definition"]);
 
-    let exit = run_with_loader(
-        vec![
-            OsString::from("weaver"),
-            OsString::from("bogus"),
-            OsString::from("get-definition"),
-        ],
-        &mut io,
-        &PanickingLoader,
-    );
-
-    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert_eq!(exit, ExitCode::FAILURE);
-    assert!(stdout.is_empty(), "guidance must not write to stdout");
-    assert!(stderr_text.contains("error: unknown domain 'bogus'"));
-    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+    assert_unknown_domain_preflight(exit, &stdout, &stderr_text, "bogus");
     assert!(!stderr_text.contains("Did you mean"));
 }
 
@@ -165,7 +128,5 @@ fn complete_command_still_reports_configuration_failures() {
     let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
     assert_eq!(exit, ExitCode::FAILURE);
     assert!(stderr_text.contains("command domain"));
-    assert!(!stderr_text.contains("error: operation required for domain"));
-    assert!(!stderr_text.contains("Available operations:"));
-    assert!(!stderr_text.contains("Valid domains: observe, act, verify"));
+    assert_no_domain_guidance(&stderr_text);
 }

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -7,6 +7,8 @@ use std::ffi::OsString;
 use std::io::Cursor;
 use std::process::ExitCode;
 
+use rstest::rstest;
+
 use crate::{AppError, ConfigLoader, IoStreams, run_with_loader};
 use weaver_config::Config;
 
@@ -110,40 +112,42 @@ fn known_domain_without_operation_emits_contextual_guidance() {
     );
 }
 
-#[test]
-fn unknown_domain_without_operation_emits_global_guidance() {
-    let output = run_with_panicking_loader(&["unknown-domain"]);
+#[rstest]
+#[case(&["unknown-domain"], "unknown-domain", None, None, Some("weaver observe get-definition --help"))]
+#[case(&["unknown-domain", "get-definition"], "unknown-domain", None, Some("Waiting for daemon start..."), None)]
+#[case(&["obsrve", "get-definition"], "obsrve", Some("Did you mean 'observe'?"), None, None)]
+#[case(&["bogus", "get-definition"], "bogus", None, None, Some("Did you mean"))]
+fn unknown_domain_preflight_guidance(
+    #[case] args: &[&str],
+    #[case] domain: &str,
+    #[case] should_contain: Option<&str>,
+    #[case] should_not_contain_daemon: Option<&str>,
+    #[case] should_not_contain_other: Option<&str>,
+) {
+    let output = run_with_panicking_loader(args);
 
-    assert_unknown_domain_preflight(&output, "unknown-domain");
-    assert!(
-        !output
-            .stderr
-            .contains("weaver observe get-definition --help")
-    );
-}
+    assert_unknown_domain_preflight(&output, domain);
 
-#[test]
-fn unknown_domain_with_operation_emits_global_guidance_before_configuration_loading() {
-    let output = run_with_panicking_loader(&["unknown-domain", "get-definition"]);
+    if let Some(text) = should_contain {
+        assert!(
+            output.stderr.contains(text),
+            "stderr should contain '{text}'"
+        );
+    }
 
-    assert_unknown_domain_preflight(&output, "unknown-domain");
-    assert!(!output.stderr.contains("Waiting for daemon start..."));
-}
+    if let Some(text) = should_not_contain_daemon {
+        assert!(
+            !output.stderr.contains(text),
+            "stderr should not contain '{text}'"
+        );
+    }
 
-#[test]
-fn typo_domain_emits_single_suggestion() {
-    let output = run_with_panicking_loader(&["obsrve", "get-definition"]);
-
-    assert_unknown_domain_preflight(&output, "obsrve");
-    assert!(output.stderr.contains("Did you mean 'observe'?"));
-}
-
-#[test]
-fn distant_unknown_domain_omits_suggestion() {
-    let output = run_with_panicking_loader(&["bogus", "get-definition"]);
-
-    assert_unknown_domain_preflight(&output, "bogus");
-    assert!(!output.stderr.contains("Did you mean"));
+    if let Some(text) = should_not_contain_other {
+        assert!(
+            !output.stderr.contains(text),
+            "stderr should not contain '{text}'"
+        );
+    }
 }
 
 #[test]

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -58,10 +58,84 @@ fn unknown_domain_without_operation_emits_global_guidance() {
     assert_eq!(exit, ExitCode::FAILURE);
     assert!(stdout.is_empty(), "guidance must not write to stdout");
     assert!(stderr_text.contains("error: unknown domain 'unknown-domain'"));
-    assert!(stderr_text.contains("Available operations:"));
-    assert!(stderr_text.contains("observe get-definition"));
-    assert!(stderr_text.contains("act rename-symbol"));
-    assert!(stderr_text.contains("weaver observe get-definition --help"));
+    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+    assert!(!stderr_text.contains("Available operations:"));
+    assert!(!stderr_text.contains("weaver observe get-definition --help"));
+}
+
+#[test]
+fn unknown_domain_with_operation_emits_global_guidance_before_configuration_loading() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+
+    let exit = run_with_loader(
+        vec![
+            OsString::from("weaver"),
+            OsString::from("unknown-domain"),
+            OsString::from("get-definition"),
+        ],
+        &mut io,
+        &PanickingLoader,
+    );
+
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    assert_eq!(exit, ExitCode::FAILURE);
+    assert!(stdout.is_empty(), "guidance must not write to stdout");
+    assert!(stderr_text.contains("error: unknown domain 'unknown-domain'"));
+    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+    assert!(!stderr_text.contains("Waiting for daemon start..."));
+}
+
+#[test]
+fn typo_domain_emits_single_suggestion() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+
+    let exit = run_with_loader(
+        vec![
+            OsString::from("weaver"),
+            OsString::from("obsrve"),
+            OsString::from("get-definition"),
+        ],
+        &mut io,
+        &PanickingLoader,
+    );
+
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    assert_eq!(exit, ExitCode::FAILURE);
+    assert!(stdout.is_empty(), "guidance must not write to stdout");
+    assert!(stderr_text.contains("error: unknown domain 'obsrve'"));
+    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+    assert!(stderr_text.contains("Did you mean 'observe'?"));
+}
+
+#[test]
+fn distant_unknown_domain_omits_suggestion() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+
+    let exit = run_with_loader(
+        vec![
+            OsString::from("weaver"),
+            OsString::from("bogus"),
+            OsString::from("get-definition"),
+        ],
+        &mut io,
+        &PanickingLoader,
+    );
+
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    assert_eq!(exit, ExitCode::FAILURE);
+    assert!(stdout.is_empty(), "guidance must not write to stdout");
+    assert!(stderr_text.contains("error: unknown domain 'bogus'"));
+    assert!(stderr_text.contains("Valid domains: observe, act, verify"));
+    assert!(!stderr_text.contains("Did you mean"));
 }
 
 #[test]
@@ -93,4 +167,5 @@ fn complete_command_still_reports_configuration_failures() {
     assert!(stderr_text.contains("command domain"));
     assert!(!stderr_text.contains("error: operation required for domain"));
     assert!(!stderr_text.contains("Available operations:"));
+    assert!(!stderr_text.contains("Valid domains: observe, act, verify"));
 }

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -43,13 +43,16 @@ fn run_with_panicking_loader(args: &[&str]) -> PreflightOutput {
     }
 }
 
-fn assert_preflight_failure(exit: ExitCode, stdout: &[u8]) {
-    assert_eq!(exit, ExitCode::FAILURE);
-    assert!(stdout.is_empty(), "guidance must not write to stdout");
+fn assert_preflight_failure(output: &PreflightOutput) {
+    assert_eq!(output.exit, ExitCode::FAILURE);
+    assert!(
+        output.stdout.is_empty(),
+        "guidance must not write to stdout"
+    );
 }
 
 fn assert_unknown_domain_preflight(output: &PreflightOutput, domain: &str) {
-    assert_preflight_failure(output.exit, &output.stdout);
+    assert_preflight_failure(output);
     assert!(
         output
             .stderr
@@ -63,7 +66,7 @@ fn assert_unknown_domain_preflight(output: &PreflightOutput, domain: &str) {
 }
 
 fn assert_known_domain_operation_guidance(output: &PreflightOutput, domain: &str) {
-    assert_preflight_failure(output.exit, &output.stdout);
+    assert_preflight_failure(output);
     assert!(
         output
             .stderr

--- a/crates/weaver-cli/tests/features/weaver_cli.feature
+++ b/crates/weaver-cli/tests/features/weaver_cli.feature
@@ -53,6 +53,7 @@ Feature: Weaver CLI behaviour
     And stderr contains "error: unknown domain 'obsrve'"
     And stderr contains "Valid domains: observe, act, verify"
     And stderr contains "Did you mean 'observe'?"
+    And stderr does not contain "Waiting for daemon start..."
     And no daemon command was sent
 
   Scenario: Reporting malformed daemon responses

--- a/crates/weaver-cli/tests/features/weaver_cli.feature
+++ b/crates/weaver-cli/tests/features/weaver_cli.feature
@@ -35,9 +35,23 @@ Feature: Weaver CLI behaviour
     When the operator runs "unknown-domain"
     Then the CLI fails
     And stderr contains "error: unknown domain 'unknown-domain'"
-    And stderr contains "Available operations:"
-    And stderr contains "observe get-definition"
-    And stderr contains "weaver observe get-definition --help"
+    And stderr contains "Valid domains: observe, act, verify"
+    And no daemon command was sent
+
+  Scenario: Rejecting an unknown domain before daemon startup when an operation is present
+    When the operator runs "unknown-domain get-definition"
+    Then the CLI fails
+    And stderr contains "error: unknown domain 'unknown-domain'"
+    And stderr contains "Valid domains: observe, act, verify"
+    And stderr does not contain "Waiting for daemon start..."
+    And no daemon command was sent
+
+  Scenario: Suggesting the closest valid domain for a typo
+    When the operator runs "obsrve get-definition"
+    Then the CLI fails
+    And stderr contains "error: unknown domain 'obsrve'"
+    And stderr contains "Valid domains: observe, act, verify"
+    And stderr contains "Did you mean 'observe'?"
     And no daemon command was sent
 
   Scenario: Reporting malformed daemon responses

--- a/crates/weaver-cli/tests/features/weaver_cli.feature
+++ b/crates/weaver-cli/tests/features/weaver_cli.feature
@@ -36,6 +36,7 @@ Feature: Weaver CLI behaviour
     Then the CLI fails
     And stderr contains "error: unknown domain 'unknown-domain'"
     And stderr contains "Valid domains: observe, act, verify"
+    And stderr does not contain "Did you mean"
     And no daemon command was sent
 
   Scenario: Rejecting an unknown domain before daemon startup when an operation is present

--- a/crates/weaver-cli/tests/main_entry.rs
+++ b/crates/weaver-cli/tests/main_entry.rs
@@ -4,6 +4,7 @@
 //! and user-facing error handling when required arguments are missing.
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::{contains, is_empty};
 use weaver_cli::DOMAIN_OPERATIONS;
 
@@ -25,6 +26,33 @@ fn missing_operation_exits_with_failure() {
         .stderr(contains("error: operation required for domain 'observe'"))
         .stderr(contains("get-card"))
         .stderr(contains("weaver observe get-definition --help"));
+}
+
+#[test]
+fn unknown_domain_exits_with_failure_before_daemon_startup() {
+    let mut command = cargo_bin_cmd!("weaver");
+    command.args(["unknown-domain", "get-definition"]);
+    command
+        .assert()
+        .failure()
+        .stdout(is_empty())
+        .stderr(contains("error: unknown domain 'unknown-domain'"))
+        .stderr(contains("Valid domains: observe, act, verify"))
+        .stderr(predicates::str::contains("Did you mean").not())
+        .stderr(predicates::str::contains("Waiting for daemon start...").not());
+}
+
+#[test]
+fn typo_domain_suggests_closest_known_domain() {
+    let mut command = cargo_bin_cmd!("weaver");
+    command.args(["obsrve", "get-definition"]);
+    command
+        .assert()
+        .failure()
+        .stdout(is_empty())
+        .stderr(contains("error: unknown domain 'obsrve'"))
+        .stderr(contains("Valid domains: observe, act, verify"))
+        .stderr(contains("Did you mean 'observe'?"));
 }
 
 #[test]

--- a/crates/weaver-cli/tests/main_entry.rs
+++ b/crates/weaver-cli/tests/main_entry.rs
@@ -46,13 +46,28 @@ fn unknown_domain_exits_with_failure_before_daemon_startup() {
 fn typo_domain_suggests_closest_known_domain() {
     let mut command = cargo_bin_cmd!("weaver");
     command.args(["obsrve", "get-definition"]);
-    command
-        .assert()
-        .failure()
-        .stdout(is_empty())
-        .stderr(contains("error: unknown domain 'obsrve'"))
-        .stderr(contains("Valid domains: observe, act, verify"))
-        .stderr(contains("Did you mean 'observe'?"));
+    let output = command.output().expect("failed to execute weaver");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "process should fail");
+    assert!(output.stdout.is_empty(), "stdout should be empty");
+    assert!(
+        stderr.contains("error: unknown domain 'obsrve'"),
+        "stderr should contain unknown domain error"
+    );
+    assert!(
+        stderr.contains("Valid domains: observe, act, verify"),
+        "stderr should contain valid domains list"
+    );
+    assert_eq!(
+        stderr.matches("Did you mean 'observe'?").count(),
+        1,
+        "stderr should contain exactly one suggestion"
+    );
+    assert!(
+        !stderr.contains("Waiting for daemon start..."),
+        "stderr should not contain daemon startup message"
+    );
 }
 
 #[test]

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -29,6 +29,9 @@
 - [Code complexity guide](complexity-antipatterns-and-refactoring-strategies.md)
   - Patterns for identifying complexity anti-patterns and planning
     refactoring.
+- [Developer's guide](developers-guide.md)
+  - Weaver developer's guide covering setup, architecture, and contribution
+    guidelines.
 - [Documentation style guide](documentation-style-guide.md)
   - Writing, formatting, grammar, and structure standards for repository docs.
 - [Formal verification methods in Weaver](formal-verification-methods-in-weaver.md)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -19,10 +19,10 @@ file, and `--config-path` flag are all defined next to the struct, so every
 consumer shares the same generated loader without bespoke builders.
 
 The `ortho_config` v0.8.0 loader preserves the stricter discovery and parsing
-model adopted in earlier releases: if any discovered configuration file fails to
-parse, `ConfigDiscovery::load_first` returns an aggregated `OrthoError`. Both
-the CLI and daemon bubble that error to the user instead of quietly falling back
-to defaults, making misconfigurations immediately visible.
+model adopted in earlier releases: if any discovered configuration file fails
+to parse, `ConfigDiscovery::load_first` returns an aggregated `OrthoError`.
+Both the CLI and daemon bubble that error to the user instead of quietly
+falling back to defaults, making misconfigurations immediately visible.
 
 Configuration is layered with `ortho_config`, producing the precedence order
 `defaults < files < environment < CLI`. File discovery honours `--config-path`

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,0 +1,47 @@
+# Weaver developer's guide
+
+This guide documents internal development concerns: toolchain baselines,
+configuration framework internals, and implementation details that contributors
+need but operators do not. For user-facing behaviour see the
+[user's guide](users-guide.md).
+
+## Workspace baseline
+
+The workspace targets `ortho_config` v0.8.0 and Rust 1.88.
+
+## Configuration framework internals
+
+### `ortho_config` v0.8.0 integration
+
+`weaver_config::Config` declares its discovery policy inline through the
+`#[ortho_config(discovery(...))]` attribute. The app name, dotfile, project
+file, and `--config-path` flag are all defined next to the struct, so every
+consumer shares the same generated loader without bespoke builders.
+
+The `ortho_config` v0.8.0 loader preserves the stricter discovery and parsing
+model adopted in earlier releases: if any discovered configuration file fails to
+parse, `ConfigDiscovery::load_first` returns an aggregated `OrthoError`. Both
+the CLI and daemon bubble that error to the user instead of quietly falling back
+to defaults, making misconfigurations immediately visible.
+
+Configuration is layered with `ortho_config`, producing the precedence order
+`defaults < files < environment < CLI`. File discovery honours `--config-path`
+alongside the standard XDG locations, ensuring the CLI and daemon resolve
+identical results regardless of which component loads the settings.
+
+### Dependency-graph resolution
+
+The loader uses a dependency-graph model for layered configuration sources.
+Sources are merged in precedence order: built-in defaults are overridden by
+discovered files, which are overridden by environment variables, which are in
+turn overridden by CLI flags. When multiple configuration files are discovered,
+they are merged in the order `--config-path` first, then XDG locations in
+standard search order. Later sources override earlier ones field-by-field.
+
+### TOML parsing semantics
+
+All configuration inputs are parsed per TOML v1 rules. Anchors and tags are not
+applicable (those are YAML concepts); TOML scalars are strongly typed and
+preserve their declared type without implicit coercion. Boolean values must be
+`true` or `false` (the string `"yes"` is rejected as an invalid boolean, as
+shown in the user-facing error example).

--- a/docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md
+++ b/docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md
@@ -1,0 +1,425 @@
+# 2.3.1 Validate domains client-side before daemon startup
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root.
+
+## Purpose / big picture
+
+Today, `weaver` still treats unknown domains inconsistently.
+
+- `weaver unknown-domain` already fails on the client side, but it prints a
+  built-in catalogue of domain-operation pairs rather than the roadmap's
+  required valid-domain list.
+- `weaver unknown-domain anything` does not fail client-side at all. It loads
+  configuration and can attempt daemon auto-start before the daemon rejects the
+  request.
+
+Roadmap item `2.3.1` requires a tighter contract.[^roadmap] After this change,
+any invocation whose first positional token is not one of the three valid
+domains must fail in the CLI before configuration loading, daemon connection,
+or daemon auto-start. The error body must always list the valid domains
+`observe`, `act`, and `verify`. When the invalid domain is within edit distance
+2 of exactly one valid domain, the output must also include one deterministic
+`did you mean` suggestion.[^level3] This closes Level 3 and the Level 10b
+error-guidance gap.[^level10]
+
+Observable outcome after implementation:
+
+```plaintext
+$ weaver obsrve get-definition --uri file:///tmp/x.rs --position 1:1
+error: unknown domain 'obsrve'
+
+Valid domains: observe, act, verify
+Did you mean 'observe'?
+```
+
+And:
+
+```plaintext
+$ weaver bogus get-definition --uri file:///tmp/x.rs --position 1:1
+error: unknown domain 'bogus'
+
+Valid domains: observe, act, verify
+```
+
+Both commands exit non-zero and do not print `Waiting for daemon start...`.
+
+## Constraints
+
+- Run `make check-fmt`, `make lint`, and `make test` before considering the
+  feature complete.
+- Because the implementation also updates Markdown, run `make fmt`,
+  `make markdownlint`, and `make nixie` before finishing.
+- Add both unit coverage and behavioural coverage using `rstest-bdd` v0.5.0
+  for happy paths, unhappy paths, and edge cases.
+- Keep the CLI flat. Do not restructure the command surface into nested clap
+  subcommands as part of this task.
+- Keep validation client-side. Unknown domains must fail before configuration
+  discovery, daemon socket connection, or daemon auto-start.
+- Preserve the existing known-domain missing-operation behaviour from roadmap
+  `2.2.4`. `weaver observe` should still emit the per-domain operation list.
+- Replace the current unknown-domain guidance contract for domain-only
+  invocations. The roadmap requires a valid-domain list, not a catalogue of
+  domain-operation pairs.
+- The valid-domain list must contain all three canonical domains:
+  `observe`, `act`, and `verify`.
+- Emit at most one suggestion line, and only when the best edit distance is 2
+  or less.
+- Do not add new third-party dependencies for edit-distance matching.
+- Keep files under 400 lines. Split helpers or tests into dedicated modules
+  before violating the limit.
+- Update `docs/weaver-design.md` with the final validation policy and the
+  suggestion rule.
+- Update `docs/users-guide.md` so operators see the new unknown-domain
+  behaviour.
+- Mark roadmap item `2.3.1` done only after the implementation, documentation
+  updates, and all gates pass.
+- Comments and documentation must use en-GB-oxendict spelling.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation grows beyond 12 touched files or roughly 250 net
+  lines, stop and escalate.
+- Interfaces: if meeting the acceptance criteria requires a public API change
+  outside `weaver-cli`, stop and escalate.
+- Dependencies: if the suggestion logic seems to require an external crate,
+  stop and escalate rather than adding one.
+- Help model: if satisfying the acceptance criteria would require changing the
+  `weaver <domain>` and `weaver <domain> <operation>` help contract beyond this
+  roadmap item, stop and escalate.
+- Ambiguity: if a tie between multiple valid domains at the same minimum edit
+  distance cannot be resolved deterministically without product input, stop and
+  escalate.
+- File size: if `crates/weaver-cli/src/lib.rs`,
+  `crates/weaver-cli/src/discoverability.rs`, or
+  `crates/weaver-cli/src/tests/behaviour.rs` would exceed 400 lines, extract a
+  helper module before adding more logic.
+
+## Risks
+
+- Risk: there is already an unknown-domain preflight path, but it only runs for
+  `weaver <unknown-domain>` and currently prints `Available operations:` plus
+  every built-in domain-operation pair. Mitigation: replace this path with the
+  roadmap's valid-domain contract and extend it to the
+  `weaver <unknown-domain> <operation>` shape as part of the same change.
+
+- Risk: the current preflight sentinel `AppError::MissingOperationGuidance`
+  describes only one of the paths it now covers. Mitigation: consider renaming
+  the sentinel to something broader such as `PreflightGuidance` if that keeps
+  the runtime flow clearer without widening public surface area.
+
+- Risk: localized messages interpolate variables through Fluent, which can
+  inject bidi isolate markers into rendered output. Mitigation: keep using the
+  existing `strip_bidi_isolates(...)` sanitation path for new suggestion and
+  valid-domain messages.
+
+- Risk: the source of truth for valid domains currently exists in more than one
+  place: `KnownDomain`, `DOMAIN_OPERATIONS`, and the daemon router's `Domain`
+  enum. Mitigation: this task should choose one authoritative CLI-side source
+  for user guidance and add regression tests so the three-domain set does not
+  drift.
+
+- Risk: edit-distance helpers can attract accidental complexity and Clippy
+  warnings if written imperatively. Mitigation: keep the helper tiny, pure, and
+  directly unit-tested, with an early-exit threshold at distance 2.
+
+## Progress
+
+- [x] (2026-03-22 00:00Z) Read `docs/roadmap.md`, `docs/ui-gap-analysis.md`,
+      `docs/weaver-design.md`, the relevant testing guides, and the prior
+      `2.2.4` ExecPlan.
+- [x] (2026-03-22 00:00Z) Confirmed the current runtime path in
+      `crates/weaver-cli/src/lib.rs`: `handle_preflight(...)` already runs
+      before config loading, but only emits unknown-domain guidance when the
+      operator provides no operation.
+- [x] (2026-03-22 00:00Z) Confirmed the current implementation gap in
+      `crates/weaver-cli/src/discoverability.rs`: `write_unknown_domain_guidance(...)`
+      prints a full domain-operation catalogue and offers no edit-distance
+      suggestion.
+- [x] (2026-03-22 00:00Z) Confirmed the current documentation drift in
+      `docs/users-guide.md`: unknown domains are still documented as printing
+      the built-in domain-operation catalogue.
+- [x] (2026-03-22 00:00Z) Drafted this ExecPlan in
+      `docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md`.
+- [ ] Stage A: add failing unit, integration, and BDD tests for the new
+      unknown-domain contract.
+- [ ] Stage B: implement shared client-side domain validation plus suggestion
+      selection before daemon startup.
+- [ ] Stage C: update design and user docs, then mark roadmap item `2.3.1`
+      done.
+- [ ] Stage D: run `make fmt`, `make markdownlint`, `make nixie`,
+      `make check-fmt`, `make lint`, and `make test` with logged output.
+
+## Surprises & Discoveries
+
+- `crates/weaver-cli/src/discoverability.rs` already contains
+  `write_unknown_domain_guidance(...)`. This is not greenfield work; it is a
+  contract correction and scope extension.
+
+- `handle_preflight(...)` in `crates/weaver-cli/src/lib.rs` only enters the
+  unknown-domain branch when `cli.operation` is missing or blank. That means
+  the roadmap's main Level 3 case, `weaver bogus something`, still reaches the
+  daemon path today.
+
+- The current unknown-domain output is stronger than the old daemon error, but
+  it still does not satisfy the roadmap. It prints `Available operations:` and
+  lists command pairs such as `observe get-definition`, which is different from
+  the required `Valid domains: observe, act, verify`.
+
+- `KnownDomain::try_parse(...)` already performs case-insensitive parsing, so
+  this task must preserve case-insensitive acceptance of the three valid
+  domains while only rejecting truly unknown values.
+
+- The workspace already pins `rstest-bdd` and `rstest-bdd-macros` at `0.5.0`,
+  so no dependency update is required.
+
+## Decision Log
+
+- Decision: treat all unknown-domain invocations the same way regardless of
+  whether an operation token is present. Rationale: the roadmap frames domain
+  validation as a client-side pre-daemon concern, and operators should not see
+  different unknown-domain contracts based solely on the presence of an
+  operation. Date: 2026-03-22.
+
+- Decision: keep the existing known-domain missing-operation flow and layer the
+  new unknown-domain validation beside it instead of folding both into one
+  message path. Rationale: roadmap `2.2.4` and `2.3.1` have different operator
+  outcomes and acceptance criteria. Date: 2026-03-22.
+
+- Decision: implement the edit-distance helper in `weaver-cli` with no new
+  dependency. Rationale: the domain set is fixed at three values, the threshold
+  is small, and a small pure helper is easier to audit and test than a new
+  crate. Date: 2026-03-22.
+
+- Decision: when exactly one valid domain is within distance 2, emit one
+  suggestion. When none qualify, emit no suggestion. When multiple domains tie
+  at the same best distance within the threshold, prefer catalogue order only
+  if that rule is explicitly documented in `docs/weaver-design.md`; otherwise
+  stop and escalate under the ambiguity tolerance. Rationale: the roadmap
+  requires a single suggestion, so any tie-break policy must be explicit and
+  reviewable. Date: 2026-03-22.
+
+- Decision: update the Fluent catalogue rather than hard-coding new English
+  strings directly in Rust. Rationale: the CLI already routes discoverability
+  copy through `ortho_config::Localizer`, and this task should preserve that
+  pattern. Date: 2026-03-22.
+
+## Outcomes & Retrospective
+
+Target outcome at completion:
+
+1. `weaver <unknown-domain>` fails client-side with the canonical valid-domain
+   list and no daemon interaction.
+2. `weaver <unknown-domain> <operation>` also fails client-side before config
+   load or daemon auto-start.
+3. A close typo such as `obsrve` emits exactly one `Did you mean 'observe'?`
+   line.
+4. A distant invalid domain emits no suggestion line.
+5. Known-domain missing-operation guidance still behaves as delivered in
+   roadmap `2.2.4`.
+6. Unit tests, integration tests, and `rstest-bdd` scenarios cover happy,
+   unhappy, and edge cases.
+7. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+   reflect the final behaviour.
+8. `make check-fmt`, `make lint`, and `make test` pass, along with the
+   Markdown gates required by `AGENTS.md`.
+
+Retrospective notes will be filled in once implementation is complete.
+
+## Context and orientation
+
+The implementation surface is concentrated in `weaver-cli`.
+
+- `crates/weaver-cli/src/lib.rs`
+  Owns `CliRunner::run_with_handler(...)` and `handle_preflight(...)`. This is
+  where the CLI currently decides whether to exit before config loading.
+- `crates/weaver-cli/src/discoverability.rs`
+  Owns `KnownDomain`, `DOMAIN_OPERATIONS`,
+  `write_missing_operation_guidance(...)`,
+  `write_unknown_domain_guidance(...)`, and the current
+  `should_emit_domain_guidance(...)` predicate.
+- `crates/weaver-cli/src/errors.rs`
+  Owns the current sentinel `AppError::MissingOperationGuidance`.
+- `crates/weaver-cli/locales/en-US/messages.ftl`
+  Holds the localized message IDs for the discoverability and guidance paths.
+- `crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs`
+  Already verifies that preflight guidance avoids config loading by using a
+  panicking loader.
+- `crates/weaver-cli/src/tests/behaviour.rs` and
+  `crates/weaver-cli/tests/features/weaver_cli.feature` Provide the
+  `rstest-bdd` coverage for operator-visible CLI flows.
+- `crates/weaver-cli/tests/main_entry.rs`
+  Verifies binary-level behaviour with `assert_cmd`.
+- `crates/weaverd/src/dispatch/router.rs`
+  Remains the daemon-side backstop and still owns the daemon's own domain set,
+  but the roadmap item here is explicitly about the CLI rejecting invalid
+  domains before reaching that layer.
+
+Current behaviour to replace:
+
+```plaintext
+$ weaver unknown-domain
+error: unknown domain 'unknown-domain'
+
+Available operations:
+  observe get-definition
+  observe find-references
+  ...
+```
+
+Current behaviour still missing:
+
+```plaintext
+$ weaver unknown-domain get-definition
+Waiting for daemon start...
+failed to spawn weaverd binary '"weaverd"': No such file or directory
+```
+
+The finished feature must remove both mismatches.
+
+## Plan of work
+
+### Stage A: lock the desired contract in tests first (red phase)
+
+Add failing tests before editing the runtime code.
+
+Unit coverage in
+`crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs` should cover:
+
+- Unknown domain without operation emits `error: unknown domain '<value>'`.
+- Unknown domain without operation emits `Valid domains: observe, act, verify`.
+- Unknown domain without operation does not emit `Available operations:` or any
+  domain-operation pairs.
+- Unknown domain with an operation still fails before configuration loading.
+  Use the existing panicking-loader pattern so the red test proves there is no
+  config discovery.
+- Close typo cases produce exactly one suggestion line.
+- Non-close typo cases produce no suggestion line.
+- Edge cases for the pure distance/suggestion helper:
+  trimming, case-insensitive comparison, exact match, threshold `2`, and
+  deterministic tie handling if a tie-break rule is adopted.
+
+Integration coverage in `crates/weaver-cli/tests/main_entry.rs` should assert
+the same operator-visible contract for the compiled binary, especially:
+
+- `weaver obsrve get-definition` fails without printing
+  `Waiting for daemon start...`.
+- `stderr` includes the valid-domain list.
+- `stderr` includes exactly one suggestion for `obsrve`.
+
+BDD coverage in `crates/weaver-cli/tests/features/weaver_cli.feature` and
+`crates/weaver-cli/src/tests/behaviour.rs` should add or replace scenarios for:
+
+- Unknown domain without operation.
+- Unknown domain with operation.
+- Close typo with suggestion.
+- Distant typo without suggestion.
+
+Each scenario must finish with `And no daemon command was sent`.
+
+Go/no-go:
+
+- Do not proceed until at least one new test fails because the old
+  implementation still prints `Available operations:` or still attempts the
+  daemon path for `weaver <unknown-domain> <operation>`.
+
+### Stage B: implement shared preflight validation and suggestion logic (green phase)
+
+Refactor the discoverability layer so the CLI can answer one question before
+config loading: "is the supplied domain valid, and if not, what guidance should
+the operator see?"
+
+Implementation outline:
+
+1. Introduce a small pure helper in `crates/weaver-cli/src/discoverability.rs`
+   or a sibling helper module that:
+   - normalizes the raw domain token,
+   - recognizes the three valid domains,
+   - calculates the best edit-distance match within threshold 2, and
+   - returns a structured result the writer can render.
+2. Broaden the preflight predicate so it covers both:
+   - known domain with missing operation, and
+   - unknown domain with or without an operation.
+3. Keep `write_missing_operation_guidance(...)` for the known-domain path.
+4. Replace `write_unknown_domain_guidance(...)` output so it writes:
+   - the unknown-domain error line,
+   - a blank line,
+   - `Valid domains: observe, act, verify`,
+   - an optional `Did you mean '<domain>'?` line, and
+   - no operation catalogue.
+5. Update `handle_preflight(...)` so an unknown-domain result returns the
+   preflight sentinel before config loading or daemon startup.
+6. If the sentinel name is now misleading, rename it and update the narrow
+   error-to-exit-code mapping in `CliRunner::map_result_to_exit_code(...)`.
+7. Update `crates/weaver-cli/locales/en-US/messages.ftl` with the new message
+   IDs and fallbacks for:
+   - valid-domain list heading/body,
+   - optional suggestion line,
+   - any renamed unknown-domain guidance strings.
+
+Keep the implementation idempotent and low-risk:
+
+- Use the existing `strip_bidi_isolates(...)` helper on any localized string
+  with interpolated variables.
+- Do not touch daemon routing in this roadmap item.
+- Do not broaden this task into unknown-operation suggestions; that is roadmap
+  `2.3.2`.
+
+Go/no-go:
+
+- Do not proceed until the targeted `weaver-cli` unit, integration, and BDD
+  tests pass locally.
+
+### Stage C: document the contract and mark the roadmap item complete
+
+Update the design and operator docs once the code and tests are stable.
+
+- `docs/weaver-design.md`
+  Document that unknown-domain validation now happens client-side before config
+  load and daemon startup, and record the suggestion rule: distance threshold
+  2, single suggestion only, and the final tie behaviour.
+- `docs/users-guide.md`
+  Replace the current statement that unknown domains print the built-in
+  domain-operation catalogue. Include one concrete example showing the new
+  `Valid domains:` line and, if retained, the `Did you mean` hint.
+- `docs/roadmap.md`
+  Mark item `2.3.1` complete only after the implementation and all gates pass.
+
+Go/no-go:
+
+- Do not mark the roadmap item complete before the final quality gates succeed.
+
+### Stage D: run the full gate sequence and capture evidence
+
+Run the required gates with `tee` and `set -o pipefail` so failures are
+observable despite truncated terminal output:
+
+```sh
+set -o pipefail; make fmt 2>&1 | tee /tmp/2-3-1-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/2-3-1-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/2-3-1-make-nixie.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/2-3-1-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/2-3-1-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/2-3-1-make-test.log
+```
+
+Expected evidence:
+
+- All six commands exit `0`.
+- `make test` output shows the new `weaver-cli` unit, integration, and BDD
+  cases passing.
+- No test output includes `Waiting for daemon start...` for the new
+  unknown-domain scenarios.
+
+## References
+
+[^roadmap]: [docs/roadmap.md](../roadmap.md)
+[^level3]: [docs/ui-gap-analysis.md Level 3](../ui-gap-analysis.md#level-3--unknown-domain-weaver-bogus-something)
+[^level10]: [docs/ui-gap-analysis.md Level 10](../ui-gap-analysis.md#level-10--error-messages-and-exit-codes)

--- a/docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md
+++ b/docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: DONE
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root.
@@ -148,14 +148,20 @@ Both commands exit non-zero and do not print `Waiting for daemon start...`.
       the built-in domain-operation catalogue.
 - [x] (2026-03-22 00:00Z) Drafted this ExecPlan in
       `docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md`.
-- [ ] Stage A: add failing unit, integration, and BDD tests for the new
-      unknown-domain contract.
-- [ ] Stage B: implement shared client-side domain validation plus suggestion
-      selection before daemon startup.
-- [ ] Stage C: update design and user docs, then mark roadmap item `2.3.1`
-      done.
-- [ ] Stage D: run `make fmt`, `make markdownlint`, `make nixie`,
-      `make check-fmt`, `make lint`, and `make test` with logged output.
+- [x] (2026-03-22 14:00Z) Stage A: added unit, integration, and BDD coverage
+      for unknown domains with and without operations, plus typo suggestion and
+      no-suggestion cases.
+- [x] (2026-03-22 14:05Z) Stage B: broadened CLI preflight validation to all
+      unknown domains before config loading or daemon startup, replaced the
+      unknown-domain output contract with the valid-domain list, added bounded
+      edit-distance suggestions, and renamed the sentinel to
+      `PreflightGuidance`.
+- [x] (2026-03-22 14:10Z) Stage C: updated `docs/weaver-design.md`,
+      `docs/users-guide.md`, and `docs/roadmap.md` to reflect the shipped
+      behaviour.
+- [x] (2026-03-22 14:20Z) Stage D: ran `make fmt`, `make markdownlint`,
+      `make nixie`, `make check-fmt`, `make lint`, and `make test` with logged
+      output.
 
 ## Surprises & Discoveries
 
@@ -231,7 +237,15 @@ Target outcome at completion:
 8. `make check-fmt`, `make lint`, and `make test` pass, along with the
    Markdown gates required by `AGENTS.md`.
 
-Retrospective notes will be filled in once implementation is complete.
+Retrospective notes:
+
+- Reusing the `2.2.4` preflight seam kept the change local to `weaver-cli`
+  and avoided any daemon or config-surface edits.
+- Renaming the sentinel from `MissingOperationGuidance` to
+  `PreflightGuidance` clarified the now-shared early-exit path and reduced
+  future maintenance ambiguity.
+- A tiny bounded Levenshtein helper was sufficient for the fixed three-domain
+  set; no external dependency or broader fuzzy-matching framework was needed.
 
 ## Context and orientation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -204,7 +204,8 @@ does* *not require source inspection or external runbooks.*
   - [x] Add edit-distance suggestions for close typos.
   - [x] Acceptance criteria: invalid domains fail before daemon spawn, return
         all three valid domains in the error body, and include a single
-        "did you mean" suggestion when edit distance is 2 or less.
+        "did you mean" suggestion only when exactly one valid domain is within
+        edit distance 2.
 - [ ] 2.3.2. Include valid operation alternatives for unknown operations.
       See
       [Level 4](ui-gap-analysis.md#level-4--unknown-operation-weaver-observe-nonexistent)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,9 +200,9 @@ does* *not require source inspection or external runbooks.*
       and
       [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
       (10b).
-  - [ ] Reject unknown domains with a valid-domain list.
-  - [ ] Add edit-distance suggestions for close typos.
-  - [ ] Acceptance criteria: invalid domains fail before daemon spawn, return
+  - [x] Reject unknown domains with a valid-domain list.
+  - [x] Add edit-distance suggestions for close typos.
+  - [x] Acceptance criteria: invalid domains fail before daemon spawn, return
         all three valid domains in the error body, and include a single
         "did you mean" suggestion when edit distance is 2 or less.
 - [ ] 2.3.2. Include valid operation alternatives for unknown operations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -194,7 +194,7 @@ does* *not require source inspection or external runbooks.*
 *Outcome: Ensure MVP error paths fail fast with deterministic, actionable*
 *operator guidance before daemon startup and during command routing.*
 
-- [ ] 2.3.1. Validate domains client-side before daemon startup.
+- [x] 2.3.1. Validate domains client-side before daemon startup.
       See
       [Level 3](ui-gap-analysis.md#level-3--unknown-domain-weaver-bogus-something)
       and

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -71,7 +71,7 @@ loader treats invalid configuration files as fatal. When `--config-path` points
 at a broken file, or when discovery finds a malformed `weaver.toml`/`.weaver.toml`,
 both the CLI and daemon abort with a `LoadConfiguration` error that lists every
 offending path. Remove or fix the reported files before retrying. If no
-configuration files exist at all the loader still falls back to the built-in
+configuration files exist at all, the loader still falls back to the built-in
 defaults described below.
 
 Operators will see aggregated errors enumerated in the order discovery

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -66,13 +66,13 @@ directive = "force"
 
 ### Validation and error reporting
 
-`weaver` now uses `ortho-config` v0.8.0 and Rust 1.88, which treats invalid
-configuration files as fatal. When `--config-path` points at a broken file, or
-when discovery finds a malformed `weaver.toml`/`.weaver.toml`, both the CLI and
-daemon abort with a `LoadConfiguration` error that lists every offending path.
-Remove or fix the reported files before retrying. If no configuration files
-exist at all the loader still falls back to the built-in defaults described
-below.
+`weaver` now uses `ortho_config` v0.8.0 and Rust 1.88. The `ortho_config` v0.8.0
+loader treats invalid configuration files as fatal. When `--config-path` points
+at a broken file, or when discovery finds a malformed `weaver.toml`/`.weaver.toml`,
+both the CLI and daemon abort with a `LoadConfiguration` error that lists every
+offending path. Remove or fix the reported files before retrying. If no
+configuration files exist at all the loader still falls back to the built-in
+defaults described below.
 
 Operators will see aggregated errors enumerated in the order discovery
 encounters them. For example:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -66,13 +66,14 @@ directive = "force"
 
 ### Validation and error reporting
 
-Invalid configuration files are treated as fatal. When `--config-path` points at
-a broken file, or when discovery finds a malformed `weaver.toml`/`.weaver.toml`,
-both the CLI and daemon abort with a `LoadConfiguration` error that lists every
-offending path. Remove or fix the reported files before retrying. If no
-configuration files exist at all, the loader still falls back to the built-in
-defaults described below. See the [developer's guide](developers-guide.md) for
-toolchain baseline and configuration framework internals.
+Invalid configuration files are treated as fatal. When `--config-path` points
+at a broken file, or when discovery finds a malformed
+`weaver.toml`/`.weaver.toml`, both the CLI and daemon abort with a
+`LoadConfiguration` error that lists every offending path. Remove or fix the
+reported files before retrying. If no configuration files exist at all, the
+loader still falls back to the built-in defaults described below. See the
+[developer's guide](developers-guide.md) for toolchain baseline and
+configuration framework internals.
 
 Operators will see aggregated errors enumerated in the order discovery
 encounters them. For example:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -66,12 +66,13 @@ directive = "force"
 
 ### Validation and error reporting
 
-`weaver` now uses `ortho-config` v0.8.0, which treats invalid configuration
-files as fatal. When `--config-path` points at a broken file, or when discovery
-finds a malformed `weaver.toml`/`.weaver.toml`, both the CLI and daemon abort
-with a `LoadConfiguration` error that lists every offending path. Remove or fix
-the reported files before retrying. If no configuration files exist at all the
-loader still falls back to the built-in defaults described below.
+`weaver` now uses `ortho-config` v0.8.0 and Rust 1.88, which treats invalid
+configuration files as fatal. When `--config-path` points at a broken file, or
+when discovery finds a malformed `weaver.toml`/`.weaver.toml`, both the CLI and
+daemon abort with a `LoadConfiguration` error that lists every offending path.
+Remove or fix the reported files before retrying. If no configuration files
+exist at all the loader still falls back to the built-in defaults described
+below.
 
 Operators will see aggregated errors enumerated in the order discovery
 encounters them. For example:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -66,13 +66,13 @@ directive = "force"
 
 ### Validation and error reporting
 
-`weaver` now uses `ortho_config` v0.8.0 and Rust 1.88. The `ortho_config` v0.8.0
-loader treats invalid configuration files as fatal. When `--config-path` points
-at a broken file, or when discovery finds a malformed `weaver.toml`/`.weaver.toml`,
+Invalid configuration files are treated as fatal. When `--config-path` points at
+a broken file, or when discovery finds a malformed `weaver.toml`/`.weaver.toml`,
 both the CLI and daemon abort with a `LoadConfiguration` error that lists every
 offending path. Remove or fix the reported files before retrying. If no
 configuration files exist at all, the loader still falls back to the built-in
-defaults described below.
+defaults described below. See the [developer's guide](developers-guide.md) for
+toolchain baseline and configuration framework internals.
 
 Operators will see aggregated errors enumerated in the order discovery
 encounters them. For example:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -284,9 +284,9 @@ or configuration file.
 ### Domain-only guidance
 
 Running a domain without an operation fails fast on the client side. Known
-domains print the valid operations for that domain; unknown domains print the
-built-in catalogue of available domain-operation pairs. This happens before
-configuration loading, daemon startup, or socket access. Example:
+domains print the valid operations for that domain. Unknown domains also fail
+fast on the client side, even when an operation token is present. This happens
+before configuration loading, daemon startup, or socket access. Example:
 
 ```text
 $ weaver observe
@@ -303,8 +303,29 @@ Available operations:
 Run 'weaver observe get-definition --help' for operation details.
 ```
 
-The follow-up `--help` hint is concrete and deterministic, but until
-operation-level help lands it still resolves to the top-level help output.
+Unknown domains list the canonical domains instead of printing the operation
+catalogue:
+
+```text
+$ weaver obsrve get-definition --uri file:///tmp/main.rs --position 1:1
+error: unknown domain 'obsrve'
+
+Valid domains: observe, act, verify
+Did you mean 'observe'?
+```
+
+The suggestion line appears only when exactly one valid domain is within edit
+distance 2 of the supplied token. More distant values omit the suggestion:
+
+```text
+$ weaver bogus get-definition --uri file:///tmp/main.rs --position 1:1
+error: unknown domain 'bogus'
+
+Valid domains: observe, act, verify
+```
+
+The known-domain follow-up `--help` hint is concrete and deterministic, but
+until operation-level help lands it still resolves to the top-level help output.
 
 ### Output formats
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -417,9 +417,16 @@ Known-domain invocations that omit the operation (for example,
 `weaver observe`) are also handled entirely on the client side. The CLI now
 consults a canonical built-in domain catalogue, prints the valid operations for
 the supplied domain, and exits non-zero before configuration discovery, daemon
-startup, or transport setup. Unknown domains intentionally remain outside this
-preflight path until roadmap item 2.3.1 adds dedicated client-side domain
-validation.
+startup, or transport setup.
+
+Unknown domains follow a separate client-side preflight rule. Any invocation
+whose first positional token is not one of the canonical domains `observe`,
+`act`, or `verify` fails before configuration discovery, daemon startup, or
+transport setup regardless of whether an operation token is present. The error
+body always includes `Valid domains: observe, act, verify`. When exactly one
+valid domain is within edit distance 2 of the supplied token, the CLI appends a
+single deterministic `Did you mean ...?` suggestion; otherwise it emits no
+suggestion.
 
 #### 2.1.2. Lifecycle orchestration
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1012,7 +1012,7 @@ Configuration is layered with `ortho-config`, producing the precedence order
 alongside the standard XDG locations, ensuring the CLI and daemon resolve
 identical results regardless of which component loads the settings.
 
-The workspace now targets `ortho-config` v0.8.0. The switch lets
+The workspace now targets `ortho-config` v0.8.0 and Rust 1.88. The switch lets
 `weaver-config::Config` declare its discovery policy inline through the
 `#[ortho_config(discovery(...))]` attribute. The app name, dotfile, project
 file, and `--config-path` flag are all defined next to the struct, so every

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1024,6 +1024,18 @@ parse, `ConfigDiscovery::load_first` returns an aggregated `OrthoError`. Both
 the CLI and daemon bubble that error to the user instead of quietly falling back
 to defaults, making misconfigurations immediately visible.
 
+`ortho_config` v0.8.0 also resolves layered and overriding configuration
+sources through its dependency-graph model, so the effective merge order
+remains `defaults < files < environment < CLI` even when multiple discovered
+files and overrides participate in the same load. Later sources shadow earlier
+values without bespoke builder calls, because the generated loader derives the
+full precedence graph from the inline discovery contract. All YAML
+configuration files are parsed according to the YAML 1.2 specification, which
+means bare scalars such as `on`, `off`, `yes`, and `no` remain strings unless
+tagged or quoted as booleans, anchors and aliases follow YAML 1.2 node-reuse
+rules, and tag resolution follows the YAML 1.2 core schema rather than legacy
+YAML 1.1 implicit typing.
+
 The daemon transport defaults to a Unix domain socket placed under
 `$XDG_RUNTIME_DIR/weaver/weaverd.sock`. When the runtime directory is absent,
 or otherwise unavailable, the path falls back to a per-user namespace under the

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1012,17 +1012,17 @@ Configuration is layered with `ortho-config`, producing the precedence order
 alongside the standard XDG locations, ensuring the CLI and daemon resolve
 identical results regardless of which component loads the settings.
 
-The workspace now targets `ortho-config` v0.8.0 and Rust 1.88. The switch lets
-`weaver-config::Config` declare its discovery policy inline through the
-`#[ortho_config(discovery(...))]` attribute. The app name, dotfile, project
-file, and `--config-path` flag are all defined next to the struct, so every
-consumer shares the same generated loader without bespoke builders.
+The workspace now targets `ortho_config` v0.8.0 and Rust 1.88. The `ortho_config`
+v0.8.0 switch lets `weaver-config::Config` declare its discovery policy inline
+through the `#[ortho_config(discovery(...))]` attribute. The app name, dotfile,
+project file, and `--config-path` flag are all defined next to the struct, so
+every consumer shares the same generated loader without bespoke builders.
 
-Version 0.8.0 also preserves the stricter discovery and parsing model adopted
-in earlier releases: if any discovered configuration file fails to parse,
-`ConfigDiscovery::load_first` returns an aggregated `OrthoError`. Both the CLI
-and daemon bubble that error to the user instead of quietly falling back to
-defaults, making misconfigurations immediately visible.
+The `ortho_config` v0.8.0 loader preserves the stricter discovery and parsing
+model adopted in earlier releases: if any discovered configuration file fails to
+parse, `ConfigDiscovery::load_first` returns an aggregated `OrthoError`. Both
+the CLI and daemon bubble that error to the user instead of quietly falling back
+to defaults, making misconfigurations immediately visible.
 
 The daemon transport defaults to a Unix domain socket placed under
 `$XDG_RUNTIME_DIR/weaver/weaverd.sock`. When the runtime directory is absent,

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1012,29 +1012,31 @@ Configuration is layered with `ortho-config`, producing the precedence order
 alongside the standard XDG locations, ensuring the CLI and daemon resolve
 identical results regardless of which component loads the settings.
 
-The workspace now targets `ortho_config` v0.8.0 and Rust 1.88. The `ortho_config`
-v0.8.0 switch lets `weaver_config::Config` declare its discovery policy inline
-through the `#[ortho_config(discovery(...))]` attribute. The app name, dotfile,
-project file, and `--config-path` flag are all defined next to the struct, so
-every consumer shares the same generated loader without bespoke builders.
+The workspace now targets `ortho_config` v0.8.0 and Rust 1.88. The
+`ortho_config` v0.8.0 switch lets `weaver_config::Config` declare its discovery
+policy inline through the `#[ortho_config(discovery(...))]` attribute. The app
+name, dotfile, project file, and `--config-path` flag are all defined next to
+the struct, so every consumer shares the same generated loader without bespoke
+builders.
 
 The `ortho_config` v0.8.0 loader preserves the stricter discovery and parsing
-model adopted in earlier releases: if any discovered configuration file fails to
-parse, `ConfigDiscovery::load_first` returns an aggregated `OrthoError`. Both
-the CLI and daemon bubble that error to the user instead of quietly falling back
-to defaults, making misconfigurations immediately visible.
+model adopted in earlier releases: if any discovered configuration file fails
+to parse, `ConfigDiscovery::load_first` returns an aggregated `OrthoError`.
+Both the CLI and daemon bubble that error to the user instead of quietly
+falling back to defaults, making misconfigurations immediately visible.
 
 `ortho_config` v0.8.0 also resolves layered and overriding configuration
 sources through its dependency-graph model, so the effective merge order
 remains `defaults < files < environment < CLI` even when multiple discovered
 files and overrides participate in the same load. Later sources shadow earlier
 values without bespoke builder calls, because the generated loader derives the
-full precedence graph from the inline discovery contract. All YAML
-configuration files are parsed according to the YAML 1.2 specification, which
-means bare scalars such as `on`, `off`, `yes`, and `no` remain strings unless
-tagged or quoted as booleans, anchors and aliases follow YAML 1.2 node-reuse
-rules, and tag resolution follows the YAML 1.2 core schema rather than legacy
-YAML 1.1 implicit typing.
+full precedence graph from the inline discovery contract. All configuration
+files are parsed according to TOML v1 rules, including explicit `true` and
+`false` booleans, TOML integer, float, and datetime formats, quoted and
+multiline string forms, table and dotted-key merging semantics, and the
+explicit typing rules for arrays and inline tables. TOML does not provide YAML
+anchors or aliases, and it does not perform implicit `yes` or `no` boolean
+conversion, so authored configuration must use TOML's explicit value syntax.
 
 The daemon transport defaults to a Unix domain socket placed under
 `$XDG_RUNTIME_DIR/weaver/weaverd.sock`. When the runtime directory is absent,

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1013,7 +1013,7 @@ alongside the standard XDG locations, ensuring the CLI and daemon resolve
 identical results regardless of which component loads the settings.
 
 The workspace now targets `ortho_config` v0.8.0 and Rust 1.88. The `ortho_config`
-v0.8.0 switch lets `weaver-config::Config` declare its discovery policy inline
+v0.8.0 switch lets `weaver_config::Config` declare its discovery policy inline
 through the `#[ortho_config(discovery(...))]` attribute. The app name, dotfile,
 project file, and `--config-path` flag are all defined next to the struct, so
 every consumer shares the same generated loader without bespoke builders.


### PR DESCRIPTION
<pr-body>
## Summary
- Documents ortho_config v0.8.0 semantics and the final client-side domain validation contract. 
- Adds an ExecPlan doc for 2.3.1: Validate domains client-side before daemon startup. 
- Reworks preflight UX: now shows a canonical list of valid domains and a single optional did-you-mean suggestion; no operation catalogue is emitted; unknown-domain handling is implemented before config loading/daemon startup. 
- Adds canonical three-domain set: observe, act, verify; bounded Levenshtein-based distance threshold 2. 
- Localization/messages updated to support new guidance flow and wording. 
- Tests extended to cover unknown-domain handling, typo suggestions, and preflight guidance without daemon interaction. 
- Documentation updates across weaver-design.md, users-guide.md, and roadmap.md; ExecPlan doc added and maintained as a living document.

## Changes
- ExecPlan documentation:
  - Added docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md
- CLI and discoverability:
  - Introduces a canonical three-domain set: observe, act, verify
  - Adds a bounded Levenshtein-based suggestion helper with threshold 2
  - Reworks preflight guidance output to:
    - error: unknown domain '<domain>'
    - blank line
    - Valid domains: observe, act, verify
    - Optional Did you mean '<domain>'? (only if exactly one valid domain within distance 2)
    - No operation catalogue, no daemon-start messages
  - Updates handle_preflight and related flow to emit preflight guidance before config loading/daemon startup
- Refactors and error handling:
  - Renames MissingOperationGuidance to PreflightGuidance and updates related exit-code mapping
  - Updates Lib/Runner wiring to map PreflightGuidance as a failure exit when guidance is written
- Localization and messaging:
  - crates/weaver-cli/locales/en-US/messages.ftl updated with new IDs for valid domains and optional did-you-mean guidance
- Tests:
  - Adds unit tests for the bounded Levenshtein helper and domain suggestion logic
  - Updates unit tests to reflect new PreflightGuidance flow
  - Updates integration/behavior tests and main entry tests to verify unknown-domain handling and typo suggestions without daemon interaction
- Documentation and roadmap:
  - Updates docs/weaver-design.md and docs/users-guide.md to reflect final client-side validation behavior
  - Updates docs/roadmap.md to mark 2.3.1 as DONE
  - ExecPlan doc added and will be maintained as a living document for roadmap-driven changes
- Other:
  - Updates to main test entry points to assert the new guidance path and exit codes
  - Various test fixtures and feature files adjusted to reflect the new guidance contract

## Rationale
- Establishes a clear client-side contract: any invocation with an invalid first token (domain) must fail client-side before any configuration loading or daemon interaction, with a definitive list of valid domains and an optional single suggestion for close typos. This aligns CLI behavior with roadmap item 2.3.1 and reduces exposure to daemon startup until the contract is satisfied.

## Content overview of the ExecPlan (highlights)
- Purpose: enforce a strict client-side contract for unknown-domain handling on the CLI prior to any daemon interaction.
- Constraints, Tolerances, Risks: enumerates non-breaking changes, failure modes, and escalation criteria.
- Plan of work: Stage A through Stage D with gating criteria and testing scope.
- Context and orientation: maps the CLI surface and relevant components for domain validation.
- References: follow-up work in design/docs updates.
- Roadmap reference: ExecPlan: 2-3-1 Validate domains client-side before daemon startup; Roadmap item 2.3.1: DONE.

## Plan of work (high level)
- Stage A: lock the contract in tests first (red phase) by adding/adjusting unit, integration, and BDD tests before code changes.
  - Stage A tests cover: unknown-domain, unknown-domain with operation, close typo with a single suggestion, distant typo without suggestion, edge cases for distance/suggestion helper, and ensure daemon interaction is not leaked in preflight paths.
- Stage B: implement shared preflight validation and suggestion logic (green phase).
  - Introduces helper in crates/weaver-cli/src/discoverability.rs to normalize tokens, recognize domains, compute distance within threshold, and return renderable results.
  - Broadens preflight predicate to cover known-domain-without-operation and unknown-domain paths.
  - Reworks output to show valid domains, optional suggestion, and no operation catalogue.
  - Rewrites handle_preflight flow to emit guidance prior to config loading/daemon startup.
  - Renames sentinel to PreflightGuidance and update tests
  - Update Lib/Runner etc.
- Documentation updates: ... etc.

### Stage C: document the contract and mark the roadmap item complete
+
- Update the design and operator docs once the code and tests are stable.
+
- Stage D: run the full gate sequence and capture evidence
+
- Go/no-go gates described in ExecPlan.

## References
- ExecPlan: 2-3-1 Validate domains client-side before daemon startup
- Roadmap item 2.3.1: DONE


📎 **Task**: https://www.devboxer.com/task/662331d0-4f89-48f5-9a8b-3d2c729d1fde
</pr-body>