### PR TITLE
Normalize ADR headings: Migration Plan and Non-Goals

### DIFF
--- a/docs/adr-005-verification-trust-boundary.md
+++ b/docs/adr-005-verification-trust-boundary.md
@@ -87,7 +87,7 @@ tools introduce.
 - Prove the correctness of Tree-sitter or sandbox internals.
 - Remove all runtime assumptions from the system.
 
-## Migration plan
+## Migration Plan
 
 1. Name the verified kernel in the design and roadmap docs.
 2. List trusted external tools and filesystem assumptions explicitly.

--- a/docs/adr-006-plugin-execution-and-orchestration-strategy.md
+++ b/docs/adr-006-plugin-execution-and-orchestration-strategy.md
@@ -77,13 +77,13 @@ not control commit behaviour directly.
 - Keep plugin lifecycles easy to sandbox.
 - Keep orchestration logic centralized in the broker.
 
-### Non-goals
+### Non-Goals
 
 - Maintain per-plugin sessions across requests.
 - Expose plugin protocol details in the CLI contract.
 - Move commit responsibility out of Weaver's safety harness.
 
-## Migration plan
+## Migration Plan
 
 1. Keep plugin requests to one JSONL line in and one JSONL line out.
 2. Make broker validation and routing explicit.


### PR DESCRIPTION
## Summary
- Normalize header capitalization in ADR documents to maintain consistency across the repo.
- Adjust section headings: 'Migration Plan' and 'Non-Goals' where applicable.
- No substantive content changes; only presentation.

## Changes
- docs/adr-005-verification-trust-boundary.md: Capitalized the 'Migration Plan' heading.
- docs/adr-006-plugin-execution-and-orchestration-strategy.md: Capitalized the 'Non-Goals' and 'Migration Plan' headings.

## Rationale
- Consistent ADR formatting improves readability and tooling expectations.

## Test plan
- [x] Manual review of ADRs to verify heading capitalization is consistent.
- [x] Confirm no content changes beyond heading capitalization.

## Notes
- No dates were present in the changed headings; no date updates were required.


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/8b79568b-7076-4dd3-9ba3-898b22db7828

## Summary by Sourcery

Documentation:
- Standardize the capitalization of 'Migration Plan' and 'Non-Goals' headings in ADR documents without altering their content.