### PR TITLE
Fix duplicate error prefix; implement actionable guidance formatter

### DIFF
--- a/agent-skill/weaver/SKILL.md
+++ b/agent-skill/weaver/SKILL.md
@@ -1,9 +1,13 @@
----
-name: weaver
-description: Use this skill whenever the user wants semantic code intelligence through the Weaver CLI, especially for fetching definitions, fetching symbol cards, checking capability support, inspecting daemon state, or performing language-aware renames. Trigger even when the user does not mention Weaver by name if they want IDE-like code navigation or semantic refactors from the terminal.
----
-
 # Weaver
+
+Name: `weaver`
+
+Use this skill whenever the user wants semantic code intelligence through the
+Weaver CLI, especially for fetching definitions, fetching symbol cards,
+checking capability support, inspecting daemon state, or performing
+language-aware renames. Trigger even when the user does not mention Weaver by
+name if they want IDE-like code navigation or semantic refactors from the
+terminal.
 
 Weaver gives you semantic code operations through a CLI and daemon. Use it when
 plain text search is too lossy, when the user wants structured JSON about code
@@ -144,8 +148,7 @@ of pasting raw payloads unless they asked for the full JSON. Focus on:
 
 ### Definition lookup
 
-User: "Use Weaver to find the definition of the symbol at
-`src/lib.rs:42:17`."
+User: "Use Weaver to find the definition of the symbol at `src/lib.rs:42:17`."
 
 Agent flow:
 
@@ -165,8 +168,8 @@ Agent flow:
 
 ### Safe rename
 
-User: "Rename the symbol at byte offset 123 in `src/main.py` to
-`build_index` with Weaver."
+User: "Rename the symbol at byte offset 123 in `src/main.py` to `build_index`
+with Weaver."
 
 Agent flow:
 

--- a/crates/weaver-cli/locales/en-US/messages.ftl
+++ b/crates/weaver-cli/locales/en-US/messages.ftl
@@ -1,4 +1,5 @@
 # Bare-invocation help block shown when weaver is run without arguments.
+weaver-bare-help-command-domain-required = command domain must be provided
 weaver-bare-help-usage = Usage: weaver <DOMAIN> <OPERATION> [ARG]...
 weaver-bare-help-header = Domains:
 weaver-bare-help-domain-observe = observe   Query code structure and relationships
@@ -11,9 +12,9 @@ weaver-bare-help-pointer = Run 'weaver --help' for more information.
 # weaver-domain-guidance-unknown-domain-error, weaver-domain-guidance-valid-domains,
 # and weaver-domain-guidance-did-you-mean-domain.
 weaver-domain-guidance-missing-operation-error =
-    error: operation required for domain '{$domain}'
+    operation required for domain '{$domain}'
 weaver-domain-guidance-unknown-domain-error =
-    error: unknown domain '{$domain}'
+    unknown domain '{$domain}'
 weaver-domain-guidance-available-operations = Available operations:
 weaver-domain-guidance-valid-domains = Valid domains: {$domains}
 weaver-domain-guidance-did-you-mean-domain =

--- a/crates/weaver-cli/src/actionable_guidance.rs
+++ b/crates/weaver-cli/src/actionable_guidance.rs
@@ -72,28 +72,39 @@ fn launch_binary_name(binary: &OsStr) -> String {
         .into_owned()
 }
 
+/// Returns the shell check command for a Unix environment.
+fn unix_binary_check_command(binary_str: &str, configured: bool) -> String {
+    if configured {
+        format!(
+            "test -x {} || echo '{} is not executable'",
+            shell_quote(binary_str),
+            binary_str
+        )
+    } else {
+        format!(
+            "command -v {} || echo '{} not found in PATH'",
+            shell_quote(binary_str),
+            binary_str
+        )
+    }
+}
+
+/// Returns the PowerShell check command for a Windows environment.
+fn windows_binary_check_command(binary_str: &str, configured: bool) -> String {
+    if configured {
+        format!("Test-Path {}", shell_quote(&binary_str.replace('\\', "/")))
+    } else {
+        format!("Get-Command {}", shell_quote(binary_str))
+    }
+}
+
 fn launch_binary_check_command(binary: &OsStr) -> String {
     let binary_str = binary.to_string_lossy();
+    let configured = has_configured_binary_path(binary);
     if cfg!(unix) {
-        if has_configured_binary_path(binary) {
-            format!(
-                "test -x {} || echo '{} is not executable'",
-                shell_quote(&binary_str),
-                binary_str
-            )
-        } else {
-            format!(
-                "command -v {} || echo '{} not found in PATH'",
-                shell_quote(&binary_str),
-                binary_str
-            )
-        }
+        unix_binary_check_command(&binary_str, configured)
     } else if cfg!(windows) {
-        if has_configured_binary_path(binary) {
-            format!("Test-Path {}", shell_quote(&binary_str.replace('\\', "/")))
-        } else {
-            format!("Get-Command {}", shell_quote(&binary_str))
-        }
+        windows_binary_check_command(&binary_str, configured)
     } else {
         format!(
             "Ensure {} is installed and runnable",

--- a/crates/weaver-cli/src/actionable_guidance.rs
+++ b/crates/weaver-cli/src/actionable_guidance.rs
@@ -159,11 +159,14 @@ fn startup_output_hint() -> &'static str {
     }
 }
 
-fn startup_socket_hint() -> String {
-    format!(
-        "  - Check whether the daemon is listening on {}",
-        default_daemon_socket()
-    )
+fn startup_socket_hint(path: Option<&Path>) -> String {
+    match path {
+        Some(path) => format!("  - Check health snapshot at {}", path.display()),
+        None => format!(
+            "  - Check whether the daemon is listening on {}",
+            default_daemon_socket()
+        ),
+    }
 }
 
 /// Writes actionable guidance to the given writer using the three-part template.
@@ -244,33 +247,33 @@ pub(crate) fn write_startup_guidance<W: Write>(
                 String::new(),
                 "Valid alternatives:".to_string(),
                 "  - Check the daemon logs for errors".to_string(),
-                startup_socket_hint(),
+                startup_socket_hint(None),
                 startup_output_hint().to_string(),
             ];
             let next_command = startup_retry_command();
             (problem, alternatives, next_command.to_string())
         }
-        LifecycleError::StartupTimeout { .. } => {
+        LifecycleError::StartupTimeout { health_path, .. } => {
             let problem = "timed out waiting for daemon to become ready".to_string();
             let alternatives = vec![
                 "The daemon did not report ready within the timeout period.".to_string(),
                 String::new(),
                 "Valid alternatives:".to_string(),
                 "  - Check if the daemon is stuck or slow to start".to_string(),
-                startup_socket_hint(),
+                startup_socket_hint(Some(health_path)),
                 startup_output_hint().to_string(),
             ];
             let next_command = startup_retry_command();
             (problem, alternatives, next_command.to_string())
         }
-        LifecycleError::StartupAborted { .. } => {
+        LifecycleError::StartupAborted { path } => {
             let problem = "daemon reported 'stopping' before reaching ready".to_string();
             let alternatives = vec![
                 "The daemon started but shut down before becoming ready.".to_string(),
                 String::new(),
                 "Valid alternatives:".to_string(),
                 "  - Check the health snapshot for shutdown reason".to_string(),
-                startup_socket_hint(),
+                startup_socket_hint(Some(path)),
                 startup_output_hint().to_string(),
             ];
             let next_command = startup_retry_command();

--- a/crates/weaver-cli/src/actionable_guidance.rs
+++ b/crates/weaver-cli/src/actionable_guidance.rs
@@ -1,0 +1,212 @@
+//! Actionable guidance formatter for CLI error messages.
+//!
+//! Provides a unified three-part error template per roadmap 2.3.3:
+//!   `error: <problem statement>`
+//!
+//!   `<alternatives block>`
+//!
+//!   Next command:
+//!     `<exact command>`
+
+use std::io::{self, Write};
+
+use crate::lifecycle::LifecycleError;
+
+/// Guidance structure for the unified three-part error template.
+#[derive(Debug, Clone)]
+pub(crate) struct ActionableGuidance {
+    /// The problem statement (e.g., "error: unknown domain 'foo'")
+    pub(crate) problem: String,
+    /// Alternative options or context (e.g., valid domains, usage info)
+    pub(crate) alternatives: Vec<String>,
+    /// The recommended next command to run
+    pub(crate) next_command: String,
+}
+
+impl ActionableGuidance {
+    /// Creates new actionable guidance.
+    pub(crate) fn new(
+        problem: impl Into<String>,
+        alternatives: Vec<String>,
+        next_command: impl Into<String>,
+    ) -> Self {
+        Self {
+            problem: problem.into(),
+            alternatives,
+            next_command: next_command.into(),
+        }
+    }
+}
+
+/// Writes actionable guidance to the given writer using the three-part template.
+///
+/// # Errors
+///
+/// Returns `io::Error` if writing to the underlying stream fails.
+pub(crate) fn write_actionable_guidance<W: Write>(
+    writer: &mut W,
+    guidance: &ActionableGuidance,
+) -> io::Result<()> {
+    // Part 1: Problem statement
+    writeln!(writer, "error: {}", guidance.problem)?;
+    writeln!(writer)?;
+
+    // Part 2: Alternatives block
+    for line in &guidance.alternatives {
+        writeln!(writer, "{}", line)?;
+    }
+    writeln!(writer)?;
+
+    // Part 3: Next command
+    writeln!(writer, "Next command:")?;
+    writeln!(writer, "  {}", guidance.next_command)?;
+
+    Ok(())
+}
+
+/// Writes actionable guidance for bare invocation (no arguments).
+pub(crate) fn write_bare_invocation_guidance<W: Write>(
+    writer: &mut W,
+    localizer: &dyn ortho_config::Localizer,
+) -> io::Result<()> {
+    use crate::localizer::bare_help;
+
+    let msg = |entry: &(&str, &str)| localizer.message(entry.0, None, entry.1);
+
+    let usage = msg(&bare_help::USAGE);
+    let observe = msg(&bare_help::OBSERVE);
+    let act = msg(&bare_help::ACT);
+    let verify = msg(&bare_help::VERIFY);
+
+    let guidance = ActionableGuidance::new(
+        "command domain must be provided",
+        vec![
+            usage,
+            String::new(),
+            msg(&bare_help::HEADER),
+            format!("  {observe}"),
+            format!("  {act}"),
+            format!("  {verify}"),
+        ],
+        "weaver --help",
+    );
+
+    write_actionable_guidance(writer, &guidance)
+}
+
+/// Writes actionable guidance for lifecycle/startup errors.
+/// Per roadmap 2.3.3, provides installation checks and WEAVERD_BIN guidance.
+pub(crate) fn write_startup_guidance<W: Write>(
+    writer: &mut W,
+    error: &LifecycleError,
+) -> io::Result<()> {
+    let (problem, alternatives, next_command) = match error {
+        LifecycleError::LaunchDaemon { binary, .. } => {
+            let binary_str = binary.to_string_lossy();
+            let problem = format!("failed to spawn weaverd binary '{binary_str}'");
+            let alternatives = vec![
+                "The daemon binary could not be found or executed.".to_string(),
+                String::new(),
+                "Valid alternatives:".to_string(),
+                "  - Verify weaverd is installed and in your PATH".to_string(),
+                "  - Set WEAVERD_BIN to the full path to the weaverd binary".to_string(),
+            ];
+            let next_command = "command -v weaverd || echo 'weaverd not found in PATH'";
+            (problem, alternatives, next_command.to_string())
+        }
+        LifecycleError::StartupFailed { exit_status } => {
+            let problem = format!("daemon exited before reporting ready (status: {exit_status:?})");
+            let alternatives = vec![
+                "The daemon started but failed to become ready.".to_string(),
+                String::new(),
+                "Valid alternatives:".to_string(),
+                "  - Check the daemon logs for errors".to_string(),
+                "  - Run with WEAVER_FOREGROUND=1 to see startup output".to_string(),
+            ];
+            let next_command = "WEAVER_FOREGROUND=1 weaver daemon start";
+            (problem, alternatives, next_command.to_string())
+        }
+        LifecycleError::StartupTimeout { .. } => {
+            let problem = "timed out waiting for daemon to become ready".to_string();
+            let alternatives = vec![
+                "The daemon did not report ready within the timeout period.".to_string(),
+                String::new(),
+                "Valid alternatives:".to_string(),
+                "  - Check if the daemon is stuck or slow to start".to_string(),
+                "  - Run with WEAVER_FOREGROUND=1 to see startup output".to_string(),
+            ];
+            let next_command = "WEAVER_FOREGROUND=1 weaver daemon start";
+            (problem, alternatives, next_command.to_string())
+        }
+        LifecycleError::StartupAborted { .. } => {
+            let problem = "daemon reported 'stopping' before reaching ready".to_string();
+            let alternatives = vec![
+                "The daemon started but shut down before becoming ready.".to_string(),
+                String::new(),
+                "Valid alternatives:".to_string(),
+                "  - Check the health snapshot for shutdown reason".to_string(),
+                "  - Run with WEAVER_FOREGROUND=1 to see startup output".to_string(),
+            ];
+            let next_command = "WEAVER_FOREGROUND=1 weaver daemon start";
+            (problem, alternatives, next_command.to_string())
+        }
+        // For other lifecycle errors, fall back to the Display representation
+        other => {
+            let problem = other.to_string();
+            let alternatives = vec!["See error details above.".to_string()];
+            let next_command = "weaver daemon status";
+            (problem, alternatives, next_command.to_string())
+        }
+    };
+
+    let guidance = ActionableGuidance::new(problem, alternatives, next_command);
+    write_actionable_guidance(writer, &guidance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ortho_config::NoOpLocalizer;
+
+    #[test]
+    fn write_actionable_guidance_produces_three_part_template() {
+        let guidance = ActionableGuidance::new(
+            "unknown domain 'foo'",
+            vec!["Valid domains: observe, act, verify".to_string()],
+            "weaver --help",
+        );
+
+        let mut buf = Vec::new();
+        write_actionable_guidance(&mut buf, &guidance).expect("write");
+        let output = String::from_utf8(buf).expect("utf8");
+
+        // Verify three-part structure
+        assert!(output.contains("error: unknown domain 'foo'"));
+        assert!(output.contains("Valid domains: observe, act, verify"));
+        assert!(output.contains("Next command:"));
+        assert!(output.contains("  weaver --help"));
+
+        // Verify ordering
+        let error_pos = output.find("error:").expect("error");
+        let alt_pos = output.find("Valid domains:").expect("alternatives");
+        let next_pos = output.find("Next command:").expect("next command");
+
+        assert!(error_pos < alt_pos);
+        assert!(alt_pos < next_pos);
+    }
+
+    #[test]
+    fn write_bare_invocation_guidance_includes_all_domains() {
+        let mut buf = Vec::new();
+        write_bare_invocation_guidance(&mut buf, &NoOpLocalizer).expect("write");
+        let output = String::from_utf8(buf).expect("utf8");
+
+        assert!(output.contains("error:"));
+        assert!(output.contains("Usage:"));
+        assert!(output.contains("observe"));
+        assert!(output.contains("act"));
+        assert!(output.contains("verify"));
+        assert!(output.contains("Next command:"));
+        assert!(output.contains("weaver --help"));
+    }
+}

--- a/crates/weaver-cli/src/actionable_guidance.rs
+++ b/crates/weaver-cli/src/actionable_guidance.rs
@@ -56,7 +56,12 @@ fn shell_quote(value: &str) -> String {
     format!("'{escaped}'")
 }
 
-fn has_configured_binary_path(binary: &OsStr) -> bool {
+fn powershell_quote(value: &str) -> String {
+    let escaped = value.replace('\'', "''");
+    format!("'{escaped}'")
+}
+
+pub(crate) fn has_configured_binary_path(binary: &OsStr) -> bool {
     let path = Path::new(binary);
     path.is_absolute()
         || path
@@ -92,9 +97,9 @@ fn unix_binary_check_command(binary_str: &str, configured: bool) -> String {
 /// Returns the PowerShell check command for a Windows environment.
 fn windows_binary_check_command(binary_str: &str, configured: bool) -> String {
     if configured {
-        format!("Test-Path {}", shell_quote(&binary_str.replace('\\', "/")))
+        format!("Test-Path {}", powershell_quote(binary_str))
     } else {
-        format!("Get-Command {}", shell_quote(binary_str))
+        format!("Get-Command {}", powershell_quote(binary_str))
     }
 }
 
@@ -282,180 +287,4 @@ pub(crate) fn write_startup_guidance<W: Write>(
 
     let guidance = ActionableGuidance::new(problem, alternatives, next_command);
     write_actionable_guidance(writer, &guidance)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ortho_config::NoOpLocalizer;
-
-    /// Asserts that `output` contains the three-part error template in the
-    /// correct order: `error_text`, then `alternatives_text`, then
-    /// `"Next command:"` followed by `next_command_text`.
-    #[track_caller]
-    fn assert_three_part_output(
-        output: &str,
-        error_text: &str,
-        alternatives_text: &str,
-        next_command_text: &str,
-    ) {
-        let error_pos = output
-            .find(error_text)
-            .unwrap_or_else(|| panic!("error text not found: {error_text:?}\noutput:\n{output}"));
-        let alt_pos = output.find(alternatives_text).unwrap_or_else(|| {
-            panic!("alternatives text not found: {alternatives_text:?}\noutput:\n{output}")
-        });
-        let next_pos = output
-            .find("Next command:")
-            .unwrap_or_else(|| panic!("'Next command:' not found\noutput:\n{output}"));
-        assert!(
-            output.contains(next_command_text),
-            "next-command text not found: {next_command_text:?}\noutput:\n{output}"
-        );
-        assert!(
-            error_pos < alt_pos,
-            "error line must precede alternatives block\noutput:\n{output}"
-        );
-        assert!(
-            alt_pos < next_pos,
-            "alternatives block must precede Next command\noutput:\n{output}"
-        );
-    }
-
-    fn assert_startup_guidance_template(
-        error: &LifecycleError,
-        expected_problem: &str,
-        expected_next_command: &str,
-    ) {
-        let mut buf = Vec::new();
-        write_startup_guidance(&mut buf, error).expect("write must succeed");
-        let output = String::from_utf8(buf).expect("output must be valid UTF-8");
-
-        assert!(
-            output.contains(&format!("error: {expected_problem}")),
-            "expected problem not found in output:\n{output}"
-        );
-        assert!(
-            output.contains("Next command:"),
-            "`Next command:` not found in output:\n{output}"
-        );
-        assert!(
-            output.contains(expected_next_command),
-            "expected next command '{expected_next_command}' not found in output:\n{output}"
-        );
-    }
-
-    #[test]
-    fn write_actionable_guidance_produces_three_part_template() {
-        let guidance = ActionableGuidance::new(
-            "unknown domain 'foo'",
-            vec!["Valid domains: observe, act, verify".to_string()],
-            "weaver --help",
-        );
-
-        let mut buf = Vec::new();
-        write_actionable_guidance(&mut buf, &guidance).expect("write");
-        let output = String::from_utf8(buf).expect("utf8");
-
-        assert_three_part_output(
-            &output,
-            "error: unknown domain 'foo'",
-            "Valid domains: observe, act, verify",
-            "  weaver --help",
-        );
-    }
-
-    #[test]
-    fn write_bare_invocation_guidance_includes_all_domains() {
-        let mut buf = Vec::new();
-        write_bare_invocation_guidance(&mut buf, &NoOpLocalizer).expect("write");
-        let output = String::from_utf8(buf).expect("utf8");
-
-        for domain in ["observe", "act", "verify"] {
-            assert!(
-                output.contains(domain),
-                "missing domain {domain:?}\noutput:\n{output}"
-            );
-        }
-        assert_three_part_output(&output, "error:", "Usage:", "weaver --help");
-    }
-
-    #[test]
-    fn launch_daemon_guidance_uses_configured_binary_name() {
-        let error = LifecycleError::LaunchDaemon {
-            binary: "/tmp/tools/custom-weaverd".into(),
-            source: io::Error::new(io::ErrorKind::NotFound, "missing"),
-        };
-
-        let mut buf = Vec::new();
-        write_startup_guidance(&mut buf, &error).expect("write");
-        let output = String::from_utf8(buf).expect("utf8");
-
-        assert_three_part_output(
-            &output,
-            "error: failed to spawn daemon binary '/tmp/tools/custom-weaverd'",
-            "Verify custom-weaverd exists and is executable",
-            "test -x '/tmp/tools/custom-weaverd'",
-        );
-    }
-
-    #[test]
-    fn startup_failed_guidance_surfaces_problem_and_next_command() {
-        assert_startup_guidance_template(
-            &LifecycleError::StartupFailed {
-                exit_status: Some(17),
-            },
-            "daemon exited before reporting ready (status: Some(17))",
-            "WEAVER_FOREGROUND=1 weaver daemon start",
-        );
-    }
-
-    #[test]
-    fn startup_timeout_guidance_surfaces_problem_and_next_command() {
-        assert_startup_guidance_template(
-            &LifecycleError::StartupTimeout {
-                health_path: "/tmp/weaverd.health".into(),
-                timeout: std::time::Duration::from_secs(5),
-            },
-            "timed out waiting for daemon to become ready",
-            "WEAVER_FOREGROUND=1 weaver daemon start",
-        );
-    }
-
-    #[test]
-    fn startup_aborted_guidance_surfaces_problem_and_next_command() {
-        assert_startup_guidance_template(
-            &LifecycleError::StartupAborted {
-                path: "/tmp/weaverd.health".into(),
-            },
-            "daemon reported 'stopping' before reaching ready",
-            "WEAVER_FOREGROUND=1 weaver daemon start",
-        );
-    }
-
-    #[test]
-    fn fallback_guidance_strips_existing_error_prefix() {
-        let error = LifecycleError::Io(io::Error::other("error: unit-test fallback"));
-
-        let mut buf = Vec::new();
-        write_startup_guidance(&mut buf, &error).expect("write");
-        let output = String::from_utf8(buf).expect("utf8");
-
-        assert!(
-            !output.contains("error: error:"),
-            "double error prefix must not appear\noutput:\n{output}"
-        );
-        assert_three_part_output(
-            &output,
-            "error: failed to write lifecycle output: error: unit-test fallback",
-            "See error details above.",
-            "weaver daemon status",
-        );
-    }
-
-    #[test]
-    fn bare_binary_name_is_not_treated_as_configured_path() {
-        assert!(!has_configured_binary_path(OsStr::new("weaverd")));
-        assert!(has_configured_binary_path(OsStr::new("./weaverd")));
-    }
 }

--- a/crates/weaver-cli/src/actionable_guidance.rs
+++ b/crates/weaver-cli/src/actionable_guidance.rs
@@ -58,7 +58,10 @@ fn shell_quote(value: &str) -> String {
 
 fn has_configured_binary_path(binary: &OsStr) -> bool {
     let path = Path::new(binary);
-    path.is_absolute() || path.parent().is_some()
+    path.is_absolute()
+        || path
+            .parent()
+            .is_some_and(|parent| !parent.as_os_str().is_empty())
 }
 
 fn launch_binary_name(binary: &OsStr) -> String {
@@ -71,17 +74,30 @@ fn launch_binary_name(binary: &OsStr) -> String {
 
 fn launch_binary_check_command(binary: &OsStr) -> String {
     let binary_str = binary.to_string_lossy();
-    if has_configured_binary_path(binary) {
-        format!(
-            "test -x {} || echo '{} is not executable'",
-            shell_quote(&binary_str),
-            binary_str
-        )
+    if cfg!(unix) {
+        if has_configured_binary_path(binary) {
+            format!(
+                "test -x {} || echo '{} is not executable'",
+                shell_quote(&binary_str),
+                binary_str
+            )
+        } else {
+            format!(
+                "command -v {} || echo '{} not found in PATH'",
+                shell_quote(&binary_str),
+                binary_str
+            )
+        }
+    } else if cfg!(windows) {
+        if has_configured_binary_path(binary) {
+            format!("Test-Path {}", shell_quote(&binary_str.replace('\\', "/")))
+        } else {
+            format!("Get-Command {}", shell_quote(&binary_str))
+        }
     } else {
         format!(
-            "command -v {} || echo '{} not found in PATH'",
-            shell_quote(&binary_str),
-            binary_str
+            "Ensure {} is installed and runnable",
+            shell_quote(&binary_str)
         )
     }
 }
@@ -101,6 +117,37 @@ fn launch_binary_alternatives(binary: &OsStr) -> Vec<String> {
         verify_binary,
         "  - Set WEAVERD_BIN to the full path to the daemon binary".to_string(),
     ]
+}
+
+fn default_daemon_socket() -> &'static str {
+    if cfg!(unix) {
+        "$XDG_RUNTIME_DIR/weaver/weaverd.sock"
+    } else {
+        "127.0.0.1:9779"
+    }
+}
+
+fn startup_retry_command() -> &'static str {
+    if cfg!(unix) {
+        "WEAVER_FOREGROUND=1 weaver daemon start"
+    } else {
+        "weaver daemon start"
+    }
+}
+
+fn startup_output_hint() -> &'static str {
+    if cfg!(unix) {
+        "  - Run with WEAVER_FOREGROUND=1 to see startup output"
+    } else {
+        "  - Run 'weaver daemon start' again and inspect the daemon logs"
+    }
+}
+
+fn startup_socket_hint() -> String {
+    format!(
+        "  - Check whether the daemon is listening on {}",
+        default_daemon_socket()
+    )
 }
 
 /// Writes actionable guidance to the given writer using the three-part template.
@@ -181,9 +228,10 @@ pub(crate) fn write_startup_guidance<W: Write>(
                 String::new(),
                 "Valid alternatives:".to_string(),
                 "  - Check the daemon logs for errors".to_string(),
-                "  - Run with WEAVER_FOREGROUND=1 to see startup output".to_string(),
+                startup_socket_hint(),
+                startup_output_hint().to_string(),
             ];
-            let next_command = "WEAVER_FOREGROUND=1 weaver daemon start";
+            let next_command = startup_retry_command();
             (problem, alternatives, next_command.to_string())
         }
         LifecycleError::StartupTimeout { .. } => {
@@ -193,9 +241,10 @@ pub(crate) fn write_startup_guidance<W: Write>(
                 String::new(),
                 "Valid alternatives:".to_string(),
                 "  - Check if the daemon is stuck or slow to start".to_string(),
-                "  - Run with WEAVER_FOREGROUND=1 to see startup output".to_string(),
+                startup_socket_hint(),
+                startup_output_hint().to_string(),
             ];
-            let next_command = "WEAVER_FOREGROUND=1 weaver daemon start";
+            let next_command = startup_retry_command();
             (problem, alternatives, next_command.to_string())
         }
         LifecycleError::StartupAborted { .. } => {
@@ -205,9 +254,10 @@ pub(crate) fn write_startup_guidance<W: Write>(
                 String::new(),
                 "Valid alternatives:".to_string(),
                 "  - Check the health snapshot for shutdown reason".to_string(),
-                "  - Run with WEAVER_FOREGROUND=1 to see startup output".to_string(),
+                startup_socket_hint(),
+                startup_output_hint().to_string(),
             ];
-            let next_command = "WEAVER_FOREGROUND=1 weaver daemon start";
+            let next_command = startup_retry_command();
             (problem, alternatives, next_command.to_string())
         }
         // For other lifecycle errors, fall back to the Display representation
@@ -228,6 +278,62 @@ mod tests {
     use super::*;
     use ortho_config::NoOpLocalizer;
 
+    /// Asserts that `output` contains the three-part error template in the
+    /// correct order: `error_text`, then `alternatives_text`, then
+    /// `"Next command:"` followed by `next_command_text`.
+    #[track_caller]
+    fn assert_three_part_output(
+        output: &str,
+        error_text: &str,
+        alternatives_text: &str,
+        next_command_text: &str,
+    ) {
+        let error_pos = output
+            .find(error_text)
+            .unwrap_or_else(|| panic!("error text not found: {error_text:?}\noutput:\n{output}"));
+        let alt_pos = output.find(alternatives_text).unwrap_or_else(|| {
+            panic!("alternatives text not found: {alternatives_text:?}\noutput:\n{output}")
+        });
+        let next_pos = output
+            .find("Next command:")
+            .unwrap_or_else(|| panic!("'Next command:' not found\noutput:\n{output}"));
+        assert!(
+            output.contains(next_command_text),
+            "next-command text not found: {next_command_text:?}\noutput:\n{output}"
+        );
+        assert!(
+            error_pos < alt_pos,
+            "error line must precede alternatives block\noutput:\n{output}"
+        );
+        assert!(
+            alt_pos < next_pos,
+            "alternatives block must precede Next command\noutput:\n{output}"
+        );
+    }
+
+    fn assert_startup_guidance_template(
+        error: &LifecycleError,
+        expected_problem: &str,
+        expected_next_command: &str,
+    ) {
+        let mut buf = Vec::new();
+        write_startup_guidance(&mut buf, error).expect("write must succeed");
+        let output = String::from_utf8(buf).expect("output must be valid UTF-8");
+
+        assert!(
+            output.contains(&format!("error: {expected_problem}")),
+            "expected problem not found in output:\n{output}"
+        );
+        assert!(
+            output.contains("Next command:"),
+            "`Next command:` not found in output:\n{output}"
+        );
+        assert!(
+            output.contains(expected_next_command),
+            "expected next command '{expected_next_command}' not found in output:\n{output}"
+        );
+    }
+
     #[test]
     fn write_actionable_guidance_produces_three_part_template() {
         let guidance = ActionableGuidance::new(
@@ -240,19 +346,12 @@ mod tests {
         write_actionable_guidance(&mut buf, &guidance).expect("write");
         let output = String::from_utf8(buf).expect("utf8");
 
-        // Verify three-part structure
-        assert!(output.contains("error: unknown domain 'foo'"));
-        assert!(output.contains("Valid domains: observe, act, verify"));
-        assert!(output.contains("Next command:"));
-        assert!(output.contains("  weaver --help"));
-
-        // Verify ordering
-        let error_pos = output.find("error:").expect("error");
-        let alt_pos = output.find("Valid domains:").expect("alternatives");
-        let next_pos = output.find("Next command:").expect("next command");
-
-        assert!(error_pos < alt_pos);
-        assert!(alt_pos < next_pos);
+        assert_three_part_output(
+            &output,
+            "error: unknown domain 'foo'",
+            "Valid domains: observe, act, verify",
+            "  weaver --help",
+        );
     }
 
     #[test]
@@ -261,13 +360,13 @@ mod tests {
         write_bare_invocation_guidance(&mut buf, &NoOpLocalizer).expect("write");
         let output = String::from_utf8(buf).expect("utf8");
 
-        assert!(output.contains("error:"));
-        assert!(output.contains("Usage:"));
-        assert!(output.contains("observe"));
-        assert!(output.contains("act"));
-        assert!(output.contains("verify"));
-        assert!(output.contains("Next command:"));
-        assert!(output.contains("weaver --help"));
+        for domain in ["observe", "act", "verify"] {
+            assert!(
+                output.contains(domain),
+                "missing domain {domain:?}\noutput:\n{output}"
+            );
+        }
+        assert_three_part_output(&output, "error:", "Usage:", "weaver --help");
     }
 
     #[test]
@@ -281,58 +380,46 @@ mod tests {
         write_startup_guidance(&mut buf, &error).expect("write");
         let output = String::from_utf8(buf).expect("utf8");
 
-        assert!(
-            output.contains("error: failed to spawn daemon binary '/tmp/tools/custom-weaverd'")
+        assert_three_part_output(
+            &output,
+            "error: failed to spawn daemon binary '/tmp/tools/custom-weaverd'",
+            "Verify custom-weaverd exists and is executable",
+            "test -x '/tmp/tools/custom-weaverd'",
         );
-        assert!(output.contains("Verify custom-weaverd exists and is executable"));
-        assert!(output.contains("Next command:"));
-        assert!(output.contains("test -x '/tmp/tools/custom-weaverd'"));
     }
 
     #[test]
     fn startup_failed_guidance_surfaces_problem_and_next_command() {
-        let error = LifecycleError::StartupFailed {
-            exit_status: Some(17),
-        };
-
-        let mut buf = Vec::new();
-        write_startup_guidance(&mut buf, &error).expect("write");
-        let output = String::from_utf8(buf).expect("utf8");
-
-        assert!(output.contains("error: daemon exited before reporting ready (status: Some(17))"));
-        assert!(output.contains("Next command:"));
-        assert!(output.contains("WEAVER_FOREGROUND=1 weaver daemon start"));
+        assert_startup_guidance_template(
+            &LifecycleError::StartupFailed {
+                exit_status: Some(17),
+            },
+            "daemon exited before reporting ready (status: Some(17))",
+            "WEAVER_FOREGROUND=1 weaver daemon start",
+        );
     }
 
     #[test]
     fn startup_timeout_guidance_surfaces_problem_and_next_command() {
-        let error = LifecycleError::StartupTimeout {
-            health_path: "/tmp/weaverd.health".into(),
-            timeout: std::time::Duration::from_secs(5),
-        };
-
-        let mut buf = Vec::new();
-        write_startup_guidance(&mut buf, &error).expect("write");
-        let output = String::from_utf8(buf).expect("utf8");
-
-        assert!(output.contains("error: timed out waiting for daemon to become ready"));
-        assert!(output.contains("Next command:"));
-        assert!(output.contains("WEAVER_FOREGROUND=1 weaver daemon start"));
+        assert_startup_guidance_template(
+            &LifecycleError::StartupTimeout {
+                health_path: "/tmp/weaverd.health".into(),
+                timeout: std::time::Duration::from_secs(5),
+            },
+            "timed out waiting for daemon to become ready",
+            "WEAVER_FOREGROUND=1 weaver daemon start",
+        );
     }
 
     #[test]
     fn startup_aborted_guidance_surfaces_problem_and_next_command() {
-        let error = LifecycleError::StartupAborted {
-            path: "/tmp/weaverd.health".into(),
-        };
-
-        let mut buf = Vec::new();
-        write_startup_guidance(&mut buf, &error).expect("write");
-        let output = String::from_utf8(buf).expect("utf8");
-
-        assert!(output.contains("error: daemon reported 'stopping' before reaching ready"));
-        assert!(output.contains("Next command:"));
-        assert!(output.contains("WEAVER_FOREGROUND=1 weaver daemon start"));
+        assert_startup_guidance_template(
+            &LifecycleError::StartupAborted {
+                path: "/tmp/weaverd.health".into(),
+            },
+            "daemon reported 'stopping' before reaching ready",
+            "WEAVER_FOREGROUND=1 weaver daemon start",
+        );
     }
 
     #[test]
@@ -344,10 +431,20 @@ mod tests {
         let output = String::from_utf8(buf).expect("utf8");
 
         assert!(
-            output.contains("error: failed to write lifecycle output: error: unit-test fallback")
+            !output.contains("error: error:"),
+            "double error prefix must not appear\noutput:\n{output}"
         );
-        assert!(!output.contains("error: error: unit-test fallback"));
-        assert!(output.contains("Next command:"));
-        assert!(output.contains("weaver daemon status"));
+        assert_three_part_output(
+            &output,
+            "error: failed to write lifecycle output: error: unit-test fallback",
+            "See error details above.",
+            "weaver daemon status",
+        );
+    }
+
+    #[test]
+    fn bare_binary_name_is_not_treated_as_configured_path() {
+        assert!(!has_configured_binary_path(OsStr::new("weaverd")));
+        assert!(has_configured_binary_path(OsStr::new("./weaverd")));
     }
 }

--- a/crates/weaver-cli/src/actionable_guidance.rs
+++ b/crates/weaver-cli/src/actionable_guidance.rs
@@ -81,15 +81,15 @@ fn launch_binary_name(binary: &OsStr) -> String {
 fn unix_binary_check_command(binary_str: &str, configured: bool) -> String {
     if configured {
         format!(
-            "test -x {} || echo '{} is not executable'",
+            "test -x {} || echo {}",
             shell_quote(binary_str),
-            binary_str
+            shell_quote(&format!("{binary_str} is not executable"))
         )
     } else {
         format!(
-            "command -v {} || echo '{} not found in PATH'",
+            "command -v {} || echo {}",
             shell_quote(binary_str),
-            binary_str
+            shell_quote(&format!("{binary_str} not found in PATH"))
         )
     }
 }

--- a/crates/weaver-cli/src/actionable_guidance.rs
+++ b/crates/weaver-cli/src/actionable_guidance.rs
@@ -8,14 +8,20 @@
 //!   Next command:
 //!     `<exact command>`
 
+use std::ffi::OsStr;
 use std::io::{self, Write};
+use std::path::Path;
 
 use crate::lifecycle::LifecycleError;
 
 /// Guidance structure for the unified three-part error template.
 #[derive(Debug, Clone)]
 pub(crate) struct ActionableGuidance {
-    /// The problem statement (e.g., "error: unknown domain 'foo'")
+    /// The problem statement, without a leading `"error: "` prefix
+    /// (e.g., `"unknown domain 'foo'"`).
+    ///
+    /// [`write_actionable_guidance`] prepends the `"error: "` prefix when it
+    /// renders this message.
     pub(crate) problem: String,
     /// Alternative options or context (e.g., valid domains, usage info)
     pub(crate) alternatives: Vec<String>,
@@ -36,6 +42,65 @@ impl ActionableGuidance {
             next_command: next_command.into(),
         }
     }
+}
+
+fn strip_error_prefix(problem: &str) -> &str {
+    problem
+        .strip_prefix("error: ")
+        .or_else(|| problem.strip_prefix("error:"))
+        .unwrap_or(problem)
+}
+
+fn shell_quote(value: &str) -> String {
+    let escaped = value.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}
+
+fn has_configured_binary_path(binary: &OsStr) -> bool {
+    let path = Path::new(binary);
+    path.is_absolute() || path.parent().is_some()
+}
+
+fn launch_binary_name(binary: &OsStr) -> String {
+    Path::new(binary)
+        .file_name()
+        .unwrap_or(binary)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn launch_binary_check_command(binary: &OsStr) -> String {
+    let binary_str = binary.to_string_lossy();
+    if has_configured_binary_path(binary) {
+        format!(
+            "test -x {} || echo '{} is not executable'",
+            shell_quote(&binary_str),
+            binary_str
+        )
+    } else {
+        format!(
+            "command -v {} || echo '{} not found in PATH'",
+            shell_quote(&binary_str),
+            binary_str
+        )
+    }
+}
+
+fn launch_binary_alternatives(binary: &OsStr) -> Vec<String> {
+    let binary_name = launch_binary_name(binary);
+    let verify_binary = if has_configured_binary_path(binary) {
+        format!("  - Verify {binary_name} exists and is executable")
+    } else {
+        format!("  - Verify {binary_name} is installed and in your PATH")
+    };
+
+    vec![
+        "The daemon binary could not be found or executed.".to_string(),
+        String::new(),
+        "Valid alternatives:".to_string(),
+        verify_binary,
+        "  - Set WEAVERD_BIN to the full path to the daemon binary".to_string(),
+    ]
 }
 
 /// Writes actionable guidance to the given writer using the three-part template.
@@ -77,9 +142,10 @@ pub(crate) fn write_bare_invocation_guidance<W: Write>(
     let observe = msg(&bare_help::OBSERVE);
     let act = msg(&bare_help::ACT);
     let verify = msg(&bare_help::VERIFY);
+    let problem = msg(&bare_help::COMMAND_DOMAIN_REQUIRED);
 
     let guidance = ActionableGuidance::new(
-        "command domain must be provided",
+        problem,
         vec![
             usage,
             String::new(),
@@ -103,16 +169,10 @@ pub(crate) fn write_startup_guidance<W: Write>(
     let (problem, alternatives, next_command) = match error {
         LifecycleError::LaunchDaemon { binary, .. } => {
             let binary_str = binary.to_string_lossy();
-            let problem = format!("failed to spawn weaverd binary '{binary_str}'");
-            let alternatives = vec![
-                "The daemon binary could not be found or executed.".to_string(),
-                String::new(),
-                "Valid alternatives:".to_string(),
-                "  - Verify weaverd is installed and in your PATH".to_string(),
-                "  - Set WEAVERD_BIN to the full path to the weaverd binary".to_string(),
-            ];
-            let next_command = "command -v weaverd || echo 'weaverd not found in PATH'";
-            (problem, alternatives, next_command.to_string())
+            let problem = format!("failed to spawn daemon binary '{binary_str}'");
+            let alternatives = launch_binary_alternatives(binary);
+            let next_command = launch_binary_check_command(binary);
+            (problem, alternatives, next_command)
         }
         LifecycleError::StartupFailed { exit_status } => {
             let problem = format!("daemon exited before reporting ready (status: {exit_status:?})");
@@ -152,7 +212,7 @@ pub(crate) fn write_startup_guidance<W: Write>(
         }
         // For other lifecycle errors, fall back to the Display representation
         other => {
-            let problem = other.to_string();
+            let problem = strip_error_prefix(&other.to_string()).to_string();
             let alternatives = vec!["See error details above.".to_string()];
             let next_command = "weaver daemon status";
             (problem, alternatives, next_command.to_string())
@@ -208,5 +268,86 @@ mod tests {
         assert!(output.contains("verify"));
         assert!(output.contains("Next command:"));
         assert!(output.contains("weaver --help"));
+    }
+
+    #[test]
+    fn launch_daemon_guidance_uses_configured_binary_name() {
+        let error = LifecycleError::LaunchDaemon {
+            binary: "/tmp/tools/custom-weaverd".into(),
+            source: io::Error::new(io::ErrorKind::NotFound, "missing"),
+        };
+
+        let mut buf = Vec::new();
+        write_startup_guidance(&mut buf, &error).expect("write");
+        let output = String::from_utf8(buf).expect("utf8");
+
+        assert!(
+            output.contains("error: failed to spawn daemon binary '/tmp/tools/custom-weaverd'")
+        );
+        assert!(output.contains("Verify custom-weaverd exists and is executable"));
+        assert!(output.contains("Next command:"));
+        assert!(output.contains("test -x '/tmp/tools/custom-weaverd'"));
+    }
+
+    #[test]
+    fn startup_failed_guidance_surfaces_problem_and_next_command() {
+        let error = LifecycleError::StartupFailed {
+            exit_status: Some(17),
+        };
+
+        let mut buf = Vec::new();
+        write_startup_guidance(&mut buf, &error).expect("write");
+        let output = String::from_utf8(buf).expect("utf8");
+
+        assert!(output.contains("error: daemon exited before reporting ready (status: Some(17))"));
+        assert!(output.contains("Next command:"));
+        assert!(output.contains("WEAVER_FOREGROUND=1 weaver daemon start"));
+    }
+
+    #[test]
+    fn startup_timeout_guidance_surfaces_problem_and_next_command() {
+        let error = LifecycleError::StartupTimeout {
+            health_path: "/tmp/weaverd.health".into(),
+            timeout: std::time::Duration::from_secs(5),
+        };
+
+        let mut buf = Vec::new();
+        write_startup_guidance(&mut buf, &error).expect("write");
+        let output = String::from_utf8(buf).expect("utf8");
+
+        assert!(output.contains("error: timed out waiting for daemon to become ready"));
+        assert!(output.contains("Next command:"));
+        assert!(output.contains("WEAVER_FOREGROUND=1 weaver daemon start"));
+    }
+
+    #[test]
+    fn startup_aborted_guidance_surfaces_problem_and_next_command() {
+        let error = LifecycleError::StartupAborted {
+            path: "/tmp/weaverd.health".into(),
+        };
+
+        let mut buf = Vec::new();
+        write_startup_guidance(&mut buf, &error).expect("write");
+        let output = String::from_utf8(buf).expect("utf8");
+
+        assert!(output.contains("error: daemon reported 'stopping' before reaching ready"));
+        assert!(output.contains("Next command:"));
+        assert!(output.contains("WEAVER_FOREGROUND=1 weaver daemon start"));
+    }
+
+    #[test]
+    fn fallback_guidance_strips_existing_error_prefix() {
+        let error = LifecycleError::Io(io::Error::other("error: unit-test fallback"));
+
+        let mut buf = Vec::new();
+        write_startup_guidance(&mut buf, &error).expect("write");
+        let output = String::from_utf8(buf).expect("utf8");
+
+        assert!(
+            output.contains("error: failed to write lifecycle output: error: unit-test fallback")
+        );
+        assert!(!output.contains("error: error: unit-test fallback"));
+        assert!(output.contains("Next command:"));
+        assert!(output.contains("weaver daemon status"));
     }
 }

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -179,6 +179,8 @@ pub(crate) fn write_missing_operation_guidance<W: Write>(
     localizer: &dyn Localizer,
     domain: KnownDomain,
 ) -> io::Result<bool> {
+    use crate::actionable_guidance::{ActionableGuidance, write_actionable_guidance};
+
     let operations = operations_for_domain(domain);
     let Some(hint_operation) = operations.first() else {
         return Ok(false);
@@ -187,30 +189,28 @@ pub(crate) fn write_missing_operation_guidance<W: Write>(
     let mut args = LocalizationArgs::new();
     args.insert("domain", domain_name.into());
     args.insert("hint_operation", (*hint_operation).into());
-    let error = strip_bidi_isolates(localizer.message(
+
+    let problem = strip_bidi_isolates(localizer.message(
         "weaver-domain-guidance-missing-operation-error",
         Some(&args),
-        &format!("error: operation required for domain '{domain_name}'"),
+        &format!("operation required for domain '{domain_name}'"),
     ));
+
     let available_operations = strip_bidi_isolates(localizer.message(
         "weaver-domain-guidance-available-operations",
         None,
         "Available operations:",
     ));
-    let hint = strip_bidi_isolates(localizer.message(
-        "weaver-domain-guidance-help-hint",
-        Some(&args),
-        &format!("Run 'weaver {domain_name} {hint_operation} --help' for operation details."),
-    ));
 
-    writeln!(writer, "{error}")?;
-    writeln!(writer)?;
-    writeln!(writer, "{available_operations}")?;
+    let mut alternatives = vec![available_operations];
     for operation in operations {
-        writeln!(writer, "  {operation}")?;
+        alternatives.push(format!("  {operation}"));
     }
-    writeln!(writer)?;
-    writeln!(writer, "{hint}")?;
+
+    let next_command = format!("weaver {domain_name} {hint_operation} --help");
+
+    let guidance = ActionableGuidance::new(problem, alternatives, next_command);
+    write_actionable_guidance(writer, &guidance)?;
 
     Ok(true)
 }
@@ -221,6 +221,8 @@ pub(crate) fn write_unknown_domain_guidance<W: Write>(
     localizer: &dyn Localizer,
     domain: &str,
 ) -> io::Result<bool> {
+    use crate::actionable_guidance::{ActionableGuidance, write_actionable_guidance};
+
     if KnownDomain::try_parse(domain).is_some() {
         return Ok(false);
     }
@@ -228,31 +230,44 @@ pub(crate) fn write_unknown_domain_guidance<W: Write>(
     args.insert("domain", domain.into());
     let valid_domains = valid_domains_list();
     args.insert("domains", valid_domains.as_str().into());
-    let error = strip_bidi_isolates(localizer.message(
+
+    let problem = strip_bidi_isolates(localizer.message(
         "weaver-domain-guidance-unknown-domain-error",
         Some(&args),
-        &format!("error: unknown domain '{domain}'"),
+        &format!("unknown domain '{domain}'"),
     ));
+
     let valid_domains_message = strip_bidi_isolates(localizer.message(
         "weaver-domain-guidance-valid-domains",
         Some(&args),
         &format!("Valid domains: {valid_domains}"),
     ));
 
-    writeln!(writer, "{error}")?;
-    writeln!(writer)?;
-    writeln!(writer, "{valid_domains_message}")?;
+    let mut alternatives = vec![valid_domains_message];
 
-    if let Some(suggested_domain) = suggestion_for_unknown_domain(domain) {
-        let suggested_domain = suggested_domain.as_str();
-        args.insert("suggested_domain", suggested_domain.into());
+    // Include "Did you mean" in alternatives if there's a suggestion
+    let next_command = if let Some(suggested_domain) = suggestion_for_unknown_domain(domain) {
+        let suggested_domain_str = suggested_domain.as_str();
+        args.insert("suggested_domain", suggested_domain_str.into());
         let suggestion = strip_bidi_isolates(localizer.message(
             "weaver-domain-guidance-did-you-mean-domain",
             Some(&args),
-            &format!("Did you mean '{suggested_domain}'?"),
+            &format!("Did you mean '{suggested_domain_str}'?"),
         ));
-        writeln!(writer, "{suggestion}")?;
-    }
+        alternatives.push(suggestion);
+        // Use the first operation of the suggested domain
+        let hint_op = suggested_domain
+            .operations()
+            .first()
+            .copied()
+            .unwrap_or("get-definition");
+        format!("weaver {suggested_domain_str} {hint_op} --help")
+    } else {
+        "weaver --help".to_string()
+    };
+
+    let guidance = ActionableGuidance::new(problem, alternatives, next_command);
+    write_actionable_guidance(writer, &guidance)?;
 
     Ok(true)
 }

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -114,7 +114,7 @@ fn valid_domains_list() -> String {
         .join(", ")
 }
 
-fn suggestion_for_unknown_domain(domain: &str) -> Option<KnownDomain> {
+pub(crate) fn suggestion_for_unknown_domain(domain: &str) -> Option<KnownDomain> {
     let normalized_domain: Vec<char> = domain.trim().to_ascii_lowercase().chars().collect();
     let mut best_match = None;
     let mut best_distance = usize::MAX;
@@ -137,7 +137,11 @@ fn suggestion_for_unknown_domain(domain: &str) -> Option<KnownDomain> {
     if tied { None } else { best_match }
 }
 
-fn bounded_levenshtein(left: &[char], right: &[char], max_distance: usize) -> Option<usize> {
+pub(crate) fn bounded_levenshtein(
+    left: &[char],
+    right: &[char],
+    max_distance: usize,
+) -> Option<usize> {
     if left.len().abs_diff(right.len()) > max_distance {
         return None;
     }
@@ -273,146 +277,6 @@ pub(crate) fn should_emit_domain_guidance(cli: &crate::Cli) -> bool {
             .domain
             .as_deref()
             .is_some_and(|domain| !domain.trim().is_empty())
-}
-
-#[cfg(test)]
-mod tests {
-    //! Unit tests for unknown-domain suggestion helpers.
-
-    use super::{
-        KnownDomain, bounded_levenshtein, suggestion_for_unknown_domain,
-        write_missing_operation_guidance, write_unknown_domain_guidance,
-    };
-    use crate::localizer::WEAVER_EN_US;
-    use ortho_config::FluentLocalizer;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case("observe", "observe", Some(0))]
-    #[case("obsrve", "observe", Some(1))]
-    #[case("obsve", "observe", Some(2))]
-    #[case("bogus", "observe", None)]
-    fn bounded_levenshtein_respects_threshold(
-        #[case] left: &str,
-        #[case] right: &str,
-        #[case] expected: Option<usize>,
-    ) {
-        let left_chars: Vec<char> = left.chars().collect();
-        let right_chars: Vec<char> = right.chars().collect();
-        assert_eq!(bounded_levenshtein(&left_chars, &right_chars, 2), expected);
-    }
-
-    #[rstest]
-    #[case("obsrve", Some(KnownDomain::Observe))]
-    #[case("bogus", None)]
-    #[case("obsve", Some(KnownDomain::Observe))]
-    fn suggestion_for_unknown_domain_cases(
-        #[case] input: &str,
-        #[case] expected: Option<KnownDomain>,
-    ) {
-        assert_eq!(suggestion_for_unknown_domain(input), expected);
-    }
-
-    fn fluent_localizer() -> FluentLocalizer {
-        FluentLocalizer::with_en_us_defaults([WEAVER_EN_US])
-            .expect("embedded Fluent catalogue must parse")
-    }
-
-    fn assert_single_error_prefix(output: &str) {
-        assert!(
-            output.contains("error: "),
-            "output should contain an error prefix"
-        );
-        assert!(
-            !output.contains("error: error:"),
-            "output should not contain a duplicated error prefix: {output}"
-        );
-    }
-
-    fn assert_three_part_guidance(
-        output: &str,
-        error_text: &str,
-        alternatives_text: &str,
-        next_command: &str,
-    ) {
-        assert_single_error_prefix(output);
-        let error_pos = output.find(error_text).expect("expected error text");
-        let alternatives_pos = output
-            .find(alternatives_text)
-            .expect("expected alternatives text");
-        let next_command_line = format!("Next command:\n  {next_command}");
-        let next_command_pos = output
-            .find(&next_command_line)
-            .expect("expected exact Next command block");
-
-        assert!(
-            error_pos < alternatives_pos,
-            "error line must precede alternatives block: {output}"
-        );
-        assert!(
-            alternatives_pos < next_command_pos,
-            "alternatives block must precede Next command: {output}"
-        );
-    }
-
-    #[test]
-    fn fluent_missing_operation_guidance_has_single_error_prefix() {
-        let localizer = fluent_localizer();
-        let mut output = Vec::new();
-
-        let emitted =
-            write_missing_operation_guidance(&mut output, &localizer, KnownDomain::Observe)
-                .expect("guidance write must succeed");
-
-        assert!(emitted, "known domain should emit guidance");
-        let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
-        assert_three_part_guidance(
-            &output,
-            "error: operation required for domain 'observe'",
-            "Available operations:\n  get-definition",
-            "weaver observe get-definition --help",
-        );
-    }
-
-    #[test]
-    fn fluent_unknown_domain_guidance_has_single_error_prefix() {
-        let localizer = fluent_localizer();
-        let mut output = Vec::new();
-
-        let emitted = write_unknown_domain_guidance(&mut output, &localizer, "unknown-domain")
-            .expect("guidance write must succeed");
-
-        assert!(emitted, "unknown domain should emit guidance");
-        let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
-        assert_three_part_guidance(
-            &output,
-            "error: unknown domain 'unknown-domain'",
-            "Valid domains: observe, act, verify",
-            "weaver --help",
-        );
-    }
-
-    #[test]
-    fn fluent_unknown_domain_guidance_uses_unique_suggestion_when_available() {
-        let localizer = fluent_localizer();
-        let mut output = Vec::new();
-
-        let emitted = write_unknown_domain_guidance(&mut output, &localizer, "obsrve")
-            .expect("guidance write must succeed");
-
-        assert!(emitted, "unknown domain should emit guidance");
-        let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
-        assert!(
-            output.contains("Did you mean 'observe'?"),
-            "unique suggestion should be rendered: {output}"
-        );
-        assert_three_part_guidance(
-            &output,
-            "error: unknown domain 'obsrve'",
-            "Did you mean 'observe'?",
-            "weaver observe get-definition --help",
-        );
-    }
 }
 
 #[cfg(test)]

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -8,6 +8,8 @@ use std::io::{self, Write};
 
 use ortho_config::{LocalizationArgs, Localizer};
 
+use crate::actionable_guidance::{ActionableGuidance, write_actionable_guidance};
+
 /// A validated, known CLI domain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum KnownDomain {
@@ -179,8 +181,6 @@ pub(crate) fn write_missing_operation_guidance<W: Write>(
     localizer: &dyn Localizer,
     domain: KnownDomain,
 ) -> io::Result<bool> {
-    use crate::actionable_guidance::{ActionableGuidance, write_actionable_guidance};
-
     let operations = operations_for_domain(domain);
     let Some(hint_operation) = operations.first() else {
         return Ok(false);
@@ -221,8 +221,6 @@ pub(crate) fn write_unknown_domain_guidance<W: Write>(
     localizer: &dyn Localizer,
     domain: &str,
 ) -> io::Result<bool> {
-    use crate::actionable_guidance::{ActionableGuidance, write_actionable_guidance};
-
     if KnownDomain::try_parse(domain).is_some() {
         return Ok(false);
     }
@@ -255,12 +253,9 @@ pub(crate) fn write_unknown_domain_guidance<W: Write>(
             &format!("Did you mean '{suggested_domain_str}'?"),
         ));
         alternatives.push(suggestion);
-        // Use the first operation of the suggested domain
-        let hint_op = suggested_domain
-            .operations()
-            .first()
-            .copied()
-            .unwrap_or("get-definition");
+        let Some(hint_op) = suggested_domain.operations().first().copied() else {
+            return Ok(false);
+        };
         format!("weaver {suggested_domain_str} {hint_op} --help")
     } else {
         "weaver --help".to_string()
@@ -334,6 +329,32 @@ mod tests {
         );
     }
 
+    fn assert_three_part_guidance(
+        output: &str,
+        error_text: &str,
+        alternatives_text: &str,
+        next_command: &str,
+    ) {
+        assert_single_error_prefix(output);
+        let error_pos = output.find(error_text).expect("expected error text");
+        let alternatives_pos = output
+            .find(alternatives_text)
+            .expect("expected alternatives text");
+        let next_command_line = format!("Next command:\n  {next_command}");
+        let next_command_pos = output
+            .find(&next_command_line)
+            .expect("expected exact Next command block");
+
+        assert!(
+            error_pos < alternatives_pos,
+            "error line must precede alternatives block: {output}"
+        );
+        assert!(
+            alternatives_pos < next_command_pos,
+            "alternatives block must precede Next command: {output}"
+        );
+    }
+
     #[test]
     fn fluent_missing_operation_guidance_has_single_error_prefix() {
         let localizer = fluent_localizer();
@@ -345,8 +366,12 @@ mod tests {
 
         assert!(emitted, "known domain should emit guidance");
         let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
-        assert_single_error_prefix(&output);
-        assert!(output.contains("error: operation required for domain 'observe'"));
+        assert_three_part_guidance(
+            &output,
+            "error: operation required for domain 'observe'",
+            "Available operations:\n  get-definition",
+            "weaver observe get-definition --help",
+        );
     }
 
     #[test]
@@ -359,76 +384,14 @@ mod tests {
 
         assert!(emitted, "unknown domain should emit guidance");
         let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
-        assert_single_error_prefix(&output);
-        assert!(output.contains("error: unknown domain 'unknown-domain'"));
+        assert_three_part_guidance(
+            &output,
+            "error: unknown domain 'unknown-domain'",
+            "Valid domains: observe, act, verify",
+            "weaver --help",
+        );
     }
 }
 
 #[cfg(test)]
-pub(crate) mod fluent_entries {
-    //! Test-only after-help catalogue builders used to assert localized help
-    //! output without widening the production discoverability surface.
-
-    pub(in crate::discoverability) const HEADER: (&str, &str) =
-        ("weaver-after-help-header", "Domains and operations:");
-
-    fn domain_heading_entry(domain: super::KnownDomain) -> (String, String) {
-        let description = super::DOMAIN_OPERATIONS
-            .iter()
-            .find(|(candidate, _, _)| *candidate == domain.as_str())
-            .map(|(_, description, _)| *description)
-            .unwrap_or_default();
-
-        (
-            format!("weaver-after-help-{}-heading", domain.as_str()),
-            format!("{} \u{2014} {description}", domain.as_str()),
-        )
-    }
-
-    fn pad_to(s: &mut String, width: usize) {
-        if s.len() < width {
-            s.extend(std::iter::repeat_n(' ', width - s.len()));
-        }
-    }
-
-    fn format_operation_row(operations: &[String]) -> String {
-        const SECOND_COLUMN_START: usize = 18;
-        const THIRD_COLUMN_START: usize = 37;
-
-        let mut row = String::new();
-        if let Some(first) = operations.first() {
-            row.push_str(first);
-        }
-        if let Some(second) = operations.get(1) {
-            pad_to(&mut row, SECOND_COLUMN_START);
-            row.push_str(second);
-        }
-        if let Some(third) = operations.get(2) {
-            pad_to(&mut row, THIRD_COLUMN_START);
-            row.push_str(third);
-        }
-        row
-    }
-
-    /// Renders the after-help domains-and-operations catalogue.
-    pub(crate) fn render_after_help(localizer: &dyn ortho_config::Localizer) -> String {
-        let header = localizer.message(HEADER.0, None, HEADER.1);
-        let mut sections = Vec::new();
-        for (domain_str, _, operations) in super::DOMAIN_OPERATIONS {
-            let domain = super::known_domain_from_catalogue_entry(domain_str);
-            let (heading_id, heading_fallback) = domain_heading_entry(domain);
-            let heading = localizer.message(&heading_id, None, &heading_fallback);
-            let rows = operations
-                .chunks(3)
-                .map(|chunk| {
-                    let operations = chunk.iter().map(ToString::to_string).collect::<Vec<_>>();
-                    format!("    {}", format_operation_row(&operations))
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-            sections.push(format!("  {heading}\n{rows}"));
-        }
-
-        format!("{header}\n\n{}", sections.join("\n\n"))
-    }
-}
+pub(crate) mod fluent_entries;

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -115,13 +115,14 @@ fn valid_domains_list() -> String {
 }
 
 fn suggestion_for_unknown_domain(domain: &str) -> Option<KnownDomain> {
-    let normalized_domain = domain.trim().to_ascii_lowercase();
+    let normalized_domain: Vec<char> = domain.trim().to_ascii_lowercase().chars().collect();
     let mut best_match = None;
     let mut best_distance = usize::MAX;
     let mut tied = false;
 
     for candidate in KnownDomain::catalogue_order() {
-        let Some(distance) = bounded_levenshtein(&normalized_domain, candidate.as_str(), 2) else {
+        let candidate_chars: Vec<char> = candidate.as_str().chars().collect();
+        let Some(distance) = bounded_levenshtein(&normalized_domain, &candidate_chars, 2) else {
             continue;
         };
         if distance < best_distance {
@@ -136,22 +137,19 @@ fn suggestion_for_unknown_domain(domain: &str) -> Option<KnownDomain> {
     if tied { None } else { best_match }
 }
 
-fn bounded_levenshtein(left: &str, right: &str, max_distance: usize) -> Option<usize> {
-    let left_chars: Vec<char> = left.chars().collect();
-    let right_chars: Vec<char> = right.chars().collect();
-
-    if left_chars.len().abs_diff(right_chars.len()) > max_distance {
+fn bounded_levenshtein(left: &[char], right: &[char], max_distance: usize) -> Option<usize> {
+    if left.len().abs_diff(right.len()) > max_distance {
         return None;
     }
 
-    let mut previous: Vec<usize> = (0..=right_chars.len()).collect();
-    let mut current = vec![0; right_chars.len() + 1];
+    let mut previous: Vec<usize> = (0..=right.len()).collect();
+    let mut current = vec![0; right.len() + 1];
 
-    for (left_index, left_char) in left_chars.iter().enumerate() {
+    for (left_index, left_char) in left.iter().enumerate() {
         current[0] = left_index + 1;
         let mut row_min = current[0];
 
-        for (right_index, right_char) in right_chars.iter().enumerate() {
+        for (right_index, right_char) in right.iter().enumerate() {
             let substitution_cost = usize::from(left_char != right_char);
             current[right_index + 1] = usize::min(
                 usize::min(previous[right_index + 1] + 1, current[right_index] + 1),
@@ -167,7 +165,7 @@ fn bounded_levenshtein(left: &str, right: &str, max_distance: usize) -> Option<u
         previous.clone_from_slice(&current);
     }
 
-    let distance = previous[right_chars.len()];
+    let distance = previous[right.len()];
     (distance <= max_distance).then_some(distance)
 }
 
@@ -299,7 +297,9 @@ mod tests {
         #[case] right: &str,
         #[case] expected: Option<usize>,
     ) {
-        assert_eq!(bounded_levenshtein(left, right, 2), expected);
+        let left_chars: Vec<char> = left.chars().collect();
+        let right_chars: Vec<char> = right.chars().collect();
+        assert_eq!(bounded_levenshtein(&left_chars, &right_chars, 2), expected);
     }
 
     #[rstest]

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -391,6 +391,28 @@ mod tests {
             "weaver --help",
         );
     }
+
+    #[test]
+    fn fluent_unknown_domain_guidance_uses_unique_suggestion_when_available() {
+        let localizer = fluent_localizer();
+        let mut output = Vec::new();
+
+        let emitted = write_unknown_domain_guidance(&mut output, &localizer, "obsrve")
+            .expect("guidance write must succeed");
+
+        assert!(emitted, "unknown domain should emit guidance");
+        let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
+        assert!(
+            output.contains("Did you mean 'observe'?"),
+            "unique suggestion should be rendered: {output}"
+        );
+        assert_three_part_guidance(
+            &output,
+            "error: unknown domain 'obsrve'",
+            "Did you mean 'observe'?",
+            "weaver observe get-definition --help",
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/weaver-cli/src/discoverability.rs
+++ b/crates/weaver-cli/src/discoverability.rs
@@ -286,7 +286,12 @@ pub(crate) fn should_emit_domain_guidance(cli: &crate::Cli) -> bool {
 mod tests {
     //! Unit tests for unknown-domain suggestion helpers.
 
-    use super::{KnownDomain, bounded_levenshtein, suggestion_for_unknown_domain};
+    use super::{
+        KnownDomain, bounded_levenshtein, suggestion_for_unknown_domain,
+        write_missing_operation_guidance, write_unknown_domain_guidance,
+    };
+    use crate::localizer::WEAVER_EN_US;
+    use ortho_config::FluentLocalizer;
     use rstest::rstest;
 
     #[rstest]
@@ -311,6 +316,51 @@ mod tests {
         #[case] expected: Option<KnownDomain>,
     ) {
         assert_eq!(suggestion_for_unknown_domain(input), expected);
+    }
+
+    fn fluent_localizer() -> FluentLocalizer {
+        FluentLocalizer::with_en_us_defaults([WEAVER_EN_US])
+            .expect("embedded Fluent catalogue must parse")
+    }
+
+    fn assert_single_error_prefix(output: &str) {
+        assert!(
+            output.contains("error: "),
+            "output should contain an error prefix"
+        );
+        assert!(
+            !output.contains("error: error:"),
+            "output should not contain a duplicated error prefix: {output}"
+        );
+    }
+
+    #[test]
+    fn fluent_missing_operation_guidance_has_single_error_prefix() {
+        let localizer = fluent_localizer();
+        let mut output = Vec::new();
+
+        let emitted =
+            write_missing_operation_guidance(&mut output, &localizer, KnownDomain::Observe)
+                .expect("guidance write must succeed");
+
+        assert!(emitted, "known domain should emit guidance");
+        let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
+        assert_single_error_prefix(&output);
+        assert!(output.contains("error: operation required for domain 'observe'"));
+    }
+
+    #[test]
+    fn fluent_unknown_domain_guidance_has_single_error_prefix() {
+        let localizer = fluent_localizer();
+        let mut output = Vec::new();
+
+        let emitted = write_unknown_domain_guidance(&mut output, &localizer, "unknown-domain")
+            .expect("guidance write must succeed");
+
+        assert!(emitted, "unknown domain should emit guidance");
+        let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
+        assert_single_error_prefix(&output);
+        assert!(output.contains("error: unknown domain 'unknown-domain'"));
     }
 }
 

--- a/crates/weaver-cli/src/discoverability/fluent_entries.rs
+++ b/crates/weaver-cli/src/discoverability/fluent_entries.rs
@@ -1,0 +1,65 @@
+//! Test-only after-help catalogue builders used to assert localized help
+//! output without widening the production discoverability surface.
+
+pub(in crate::discoverability) const HEADER: (&str, &str) =
+    ("weaver-after-help-header", "Domains and operations:");
+
+fn domain_heading_entry(domain: super::KnownDomain) -> (String, String) {
+    let description = super::DOMAIN_OPERATIONS
+        .iter()
+        .find(|(candidate, _, _)| *candidate == domain.as_str())
+        .map(|(_, description, _)| *description)
+        .unwrap_or_default();
+
+    (
+        format!("weaver-after-help-{}-heading", domain.as_str()),
+        format!("{} \u{2014} {description}", domain.as_str()),
+    )
+}
+
+fn pad_to(s: &mut String, width: usize) {
+    if s.len() < width {
+        s.extend(std::iter::repeat_n(' ', width - s.len()));
+    }
+}
+
+fn format_operation_row(operations: &[String]) -> String {
+    const SECOND_COLUMN_START: usize = 18;
+    const THIRD_COLUMN_START: usize = 37;
+
+    let mut row = String::new();
+    if let Some(first) = operations.first() {
+        row.push_str(first);
+    }
+    if let Some(second) = operations.get(1) {
+        pad_to(&mut row, SECOND_COLUMN_START);
+        row.push_str(second);
+    }
+    if let Some(third) = operations.get(2) {
+        pad_to(&mut row, THIRD_COLUMN_START);
+        row.push_str(third);
+    }
+    row
+}
+
+/// Renders the after-help domains-and-operations catalogue.
+pub(crate) fn render_after_help(localizer: &dyn ortho_config::Localizer) -> String {
+    let header = localizer.message(HEADER.0, None, HEADER.1);
+    let mut sections = Vec::new();
+    for (domain_str, _, operations) in super::DOMAIN_OPERATIONS {
+        let domain = super::known_domain_from_catalogue_entry(domain_str);
+        let (heading_id, heading_fallback) = domain_heading_entry(domain);
+        let heading = localizer.message(&heading_id, None, &heading_fallback);
+        let rows = operations
+            .chunks(3)
+            .map(|chunk| {
+                let operations = chunk.iter().map(ToString::to_string).collect::<Vec<_>>();
+                format!("    {}", format_operation_row(&operations))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        sections.push(format!("  {heading}\n{rows}"));
+    }
+
+    format!("{header}\n\n{}", sections.join("\n\n"))
+}

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -214,10 +214,8 @@ where
                 ExitCode::SUCCESS
             }
             Err(AppError::Lifecycle(ref lifecycle_err)) => {
-                let _ = actionable_guidance::write_startup_guidance(
-                    &mut *self.io.stderr,
-                    lifecycle_err,
-                );
+                actionable_guidance::write_startup_guidance(&mut *self.io.stderr, lifecycle_err)
+                    .ok();
                 ExitCode::FAILURE
             }
             Err(error) => {
@@ -317,7 +315,7 @@ where
         Ok(connection) => connection,
         Err(error) if is_daemon_not_running(&error) => {
             if let Err(start_error) = try_auto_start_daemon(context, &mut *io.stderr) {
-                let _ = actionable_guidance::write_startup_guidance(&mut *io.stderr, &start_error);
+                actionable_guidance::write_startup_guidance(&mut *io.stderr, &start_error).ok();
                 return ExitCode::FAILURE;
             }
             // Retry briefly after daemon startup to tolerate socket-bind lag.

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -11,6 +11,7 @@ use std::ffi::{OsStr, OsString};
 use std::io::{Read, Write};
 use std::process::ExitCode;
 
+mod actionable_guidance;
 mod cli;
 mod command;
 mod config;
@@ -41,7 +42,7 @@ use lifecycle::{
     LifecycleContext, LifecycleError, LifecycleInvocation, LifecycleOutput, SystemLifecycle,
     try_auto_start_daemon,
 };
-use localizer::{build_localizer, write_bare_help};
+use localizer::build_localizer;
 pub use output::{OutputContext, ResolvedOutputFormat, render_human_output};
 pub(crate) use runtime_utils::exit_code_from_status;
 use runtime_utils::handle_capabilities_mode;
@@ -212,6 +213,13 @@ where
                 let _ = write!(self.io.stdout, "{clap_err}");
                 ExitCode::SUCCESS
             }
+            Err(AppError::Lifecycle(ref lifecycle_err)) => {
+                let _ = actionable_guidance::write_startup_guidance(
+                    &mut *self.io.stderr,
+                    lifecycle_err,
+                );
+                ExitCode::FAILURE
+            }
             Err(error) => {
                 let _ = writeln!(self.io.stderr, "{error}");
                 ExitCode::FAILURE
@@ -271,7 +279,8 @@ fn handle_preflight<ErrWriter: Write>(
     localizer: &dyn Localizer,
 ) -> Result<(), AppError> {
     if cli.is_bare_invocation() && !split.has_config_flags() {
-        write_bare_help(stderr, localizer).map_err(AppError::EmitBareHelp)?;
+        actionable_guidance::write_bare_invocation_guidance(stderr, localizer)
+            .map_err(AppError::EmitBareHelp)?;
         return Err(AppError::BareInvocation);
     }
     if should_emit_domain_guidance(cli) {
@@ -308,7 +317,7 @@ where
         Ok(connection) => connection,
         Err(error) if is_daemon_not_running(&error) => {
             if let Err(start_error) = try_auto_start_daemon(context, &mut *io.stderr) {
-                let _ = writeln!(io.stderr, "{start_error}");
+                let _ = actionable_guidance::write_startup_guidance(&mut *io.stderr, &start_error);
                 return ExitCode::FAILURE;
             }
             // Retry briefly after daemon startup to tolerate socket-bind lag.

--- a/crates/weaver-cli/src/localizer.rs
+++ b/crates/weaver-cli/src/localizer.rs
@@ -5,6 +5,7 @@
 //! to [`NoOpLocalizer`] (hardcoded English) when the Fluent pipeline
 //! fails.
 
+#[cfg(test)]
 use std::io::Write;
 
 use ortho_config::{FluentLocalizer, Localizer, NoOpLocalizer};
@@ -16,31 +17,34 @@ pub(crate) static WEAVER_EN_US: &str = include_str!("../locales/en-US/messages.f
 ///
 /// The fallback values must match `locales/en-US/messages.ftl`; the
 /// `fluent_and_fallback_outputs_are_identical` test guards against drift.
-mod bare_help {
-    pub(super) const USAGE: (&str, &str) = (
+pub(crate) mod bare_help {
+    pub(crate) const USAGE: (&str, &str) = (
         "weaver-bare-help-usage",
         "Usage: weaver <DOMAIN> <OPERATION> [ARG]...",
     );
-    pub(super) const HEADER: (&str, &str) = ("weaver-bare-help-header", "Domains:");
-    pub(super) const OBSERVE: (&str, &str) = (
+    pub(crate) const HEADER: (&str, &str) = ("weaver-bare-help-header", "Domains:");
+    pub(crate) const OBSERVE: (&str, &str) = (
         "weaver-bare-help-domain-observe",
         "observe   Query code structure and relationships",
     );
-    pub(super) const ACT: (&str, &str) = (
+    pub(crate) const ACT: (&str, &str) = (
         "weaver-bare-help-domain-act",
         "act       Perform code modifications",
     );
-    pub(super) const VERIFY: (&str, &str) = (
+    pub(crate) const VERIFY: (&str, &str) = (
         "weaver-bare-help-domain-verify",
         "verify    Validate code correctness",
     );
-    pub(super) const POINTER: (&str, &str) = (
+    // Kept for backwards compatibility; new code uses actionable_guidance.
+    #[cfg(test)]
+    pub(crate) const POINTER: (&str, &str) = (
         "weaver-bare-help-pointer",
         "Run 'weaver --help' for more information.",
     );
 }
 
 /// Resolves a single help message through the localizer.
+#[cfg(test)]
 fn msg(localizer: &dyn Localizer, entry: &(&str, &str)) -> String {
     localizer.message(entry.0, None, entry.1)
 }
@@ -81,6 +85,7 @@ pub(crate) fn build_localizer() -> Box<dyn Localizer> {
 /// write_bare_help(&mut buf, &loc).expect("write bare help");
 /// assert!(String::from_utf8(buf).expect("valid UTF-8").contains("Usage:"));
 /// ```
+#[cfg(test)]
 pub(crate) fn write_bare_help<W: Write>(
     writer: &mut W,
     localizer: &dyn Localizer,

--- a/crates/weaver-cli/src/localizer.rs
+++ b/crates/weaver-cli/src/localizer.rs
@@ -18,6 +18,10 @@ pub(crate) static WEAVER_EN_US: &str = include_str!("../locales/en-US/messages.f
 /// The fallback values must match `locales/en-US/messages.ftl`; the
 /// `fluent_and_fallback_outputs_are_identical` test guards against drift.
 pub(crate) mod bare_help {
+    pub(crate) const COMMAND_DOMAIN_REQUIRED: (&str, &str) = (
+        "weaver-bare-help-command-domain-required",
+        "command domain must be provided",
+    );
     pub(crate) const USAGE: (&str, &str) = (
         "weaver-bare-help-usage",
         "Usage: weaver <DOMAIN> <OPERATION> [ARG]...",

--- a/crates/weaver-cli/src/output/mod.rs
+++ b/crates/weaver-cli/src/output/mod.rs
@@ -246,14 +246,30 @@ fn render_capability_resolution(resolution: CapabilityResolution) -> String {
 }
 
 fn render_unknown_operation(details: UnknownOperationDetails) -> String {
-    let mut rendered = format!(
-        "error: unknown operation '{}' for domain '{}'\n\nAvailable operations:\n",
+    use crate::actionable_guidance::{ActionableGuidance, write_actionable_guidance};
+
+    let problem = format!(
+        "unknown operation '{}' for domain '{}'",
         details.operation, details.domain
     );
-    for operation in details.known_operations {
-        rendered.push_str(&format!("  {operation}\n"));
+
+    let mut alternatives = vec!["Available operations:".to_string()];
+    for operation in &details.known_operations {
+        alternatives.push(format!("  {operation}"));
     }
-    rendered
+
+    // Derive next command from first known operation
+    let first_op = details
+        .known_operations
+        .first()
+        .map(String::as_str)
+        .unwrap_or("get-definition");
+    let next_command = format!("weaver {} {} --help", details.domain, first_op);
+
+    let guidance = ActionableGuidance::new(problem, alternatives, next_command);
+    let mut buf = Vec::new();
+    write_actionable_guidance(&mut buf, &guidance).expect("write to vec");
+    String::from_utf8(buf).expect("utf8")
 }
 
 fn diagnostic_to_location(
@@ -383,5 +399,64 @@ mod tests {
         assert!(rendered.contains("Available operations:"));
         assert!(rendered.contains("get-definition"));
         assert!(rendered.contains("get-card"));
+    }
+
+    /// Verifies the unified three-part error template for unknown operations.
+    /// Per roadmap 2.3.3: error, alternatives, Next command.
+    #[test]
+    fn renders_unknown_operation_with_three_part_template() {
+        let context = OutputContext::new("observe", "nonexistent", Vec::new());
+        let payload = serde_json::to_string(&serde_json::json!({
+            "status": "error",
+            "type": UNKNOWN_OPERATION_TYPE,
+            "details": {
+                "domain": "observe",
+                "operation": "nonexistent",
+                "known_operations": [
+                    "get-definition",
+                    "find-references",
+                    "grep",
+                    "diagnostics",
+                    "call-hierarchy",
+                    "get-card"
+                ]
+            }
+        }))
+        .expect("unknown-operation payload");
+
+        let rendered = render_human_output(&context, &payload).expect("rendered");
+
+        // Part 1: error line
+        assert!(
+            rendered.contains("error: unknown operation 'nonexistent' for domain 'observe'"),
+            "must have explicit error line"
+        );
+
+        // Part 2: alternatives block (Available operations)
+        assert!(rendered.contains("Available operations:"));
+        assert!(rendered.contains("get-definition"));
+
+        // Part 3: Next command line - derived from first known_operation
+        assert!(
+            rendered.contains("Next command:"),
+            "must include Next command line"
+        );
+        assert!(
+            rendered.contains("weaver observe get-definition --help"),
+            "Next command should use first known operation"
+        );
+
+        // Verify structure: error < alternatives < Next command
+        let error_pos = rendered.find("error:").expect("error line");
+        let alt_pos = rendered
+            .find("Available operations:")
+            .expect("alternatives");
+        let next_cmd_pos = rendered.find("Next command:").expect("Next command");
+
+        assert!(error_pos < alt_pos, "error must come before alternatives");
+        assert!(
+            alt_pos < next_cmd_pos,
+            "alternatives must come before Next command"
+        );
     }
 }

--- a/crates/weaver-cli/src/output/mod.rs
+++ b/crates/weaver-cli/src/output/mod.rs
@@ -260,13 +260,13 @@ fn render_unknown_operation(details: UnknownOperationDetails) -> io::Result<Stri
         alternatives.push(format!("  {operation}"));
     }
 
-    // Derive next command from first known operation
-    let first_op = details
-        .known_operations
-        .first()
-        .map(String::as_str)
-        .unwrap_or("get-definition");
-    let next_command = format!("weaver {} {} --help", details.domain, first_op);
+    let next_command = if let Some(first_op) = details.known_operations.first() {
+        format!("weaver {} {} --help", details.domain, first_op)
+    } else if details.domain.trim().is_empty() {
+        String::from("weaver --help")
+    } else {
+        format!("weaver {} --help", details.domain)
+    };
 
     let guidance = ActionableGuidance::new(problem, alternatives, next_command);
     let mut buf = Vec::new();
@@ -460,5 +460,19 @@ mod tests {
             alt_pos < next_cmd_pos,
             "alternatives must come before Next command"
         );
+    }
+
+    #[test]
+    fn renders_unknown_operation_without_known_operations_using_domain_help() {
+        let details = UnknownOperationDetails {
+            domain: String::from("observe"),
+            operation: String::from("nonexistent"),
+            known_operations: Vec::new(),
+        };
+
+        let rendered = render_unknown_operation(details).expect("rendered");
+
+        assert!(rendered.contains("Next command:\n  weaver observe --help"));
+        assert!(!rendered.contains("get-definition"));
     }
 }

--- a/crates/weaver-cli/src/output/mod.rs
+++ b/crates/weaver-cli/src/output/mod.rs
@@ -8,6 +8,8 @@ mod models;
 mod render;
 mod source;
 
+use std::io;
+
 #[cfg(test)]
 pub(crate) use self::models::UNKNOWN_OPERATION_TYPE;
 pub use crate::cli::OutputFormat;
@@ -87,7 +89,7 @@ pub fn render_human_output(context: &OutputContext, data: &str) -> Option<String
     }
 
     if let Some(unknown_operation) = parse_unknown_operation(trimmed) {
-        return Some(render_unknown_operation(unknown_operation.details));
+        return render_unknown_operation(unknown_operation.details).ok();
     }
 
     let domain = context.domain.to_ascii_lowercase();
@@ -245,7 +247,7 @@ fn render_capability_resolution(resolution: CapabilityResolution) -> String {
     rendered
 }
 
-fn render_unknown_operation(details: UnknownOperationDetails) -> String {
+fn render_unknown_operation(details: UnknownOperationDetails) -> io::Result<String> {
     use crate::actionable_guidance::{ActionableGuidance, write_actionable_guidance};
 
     let problem = format!(
@@ -268,8 +270,8 @@ fn render_unknown_operation(details: UnknownOperationDetails) -> String {
 
     let guidance = ActionableGuidance::new(problem, alternatives, next_command);
     let mut buf = Vec::new();
-    write_actionable_guidance(&mut buf, &guidance).expect("write to vec");
-    String::from_utf8(buf).expect("utf8")
+    write_actionable_guidance(&mut buf, &guidance)?;
+    String::from_utf8(buf).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
 fn diagnostic_to_location(

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -372,6 +372,7 @@ fn is_daemon_not_running_rejects_non_connect_errors() {
     let ser_err = AppError::SerialiseRequest(serde_json::from_str::<()>("bad").unwrap_err());
     assert!(!is_daemon_not_running(&ser_err));
 }
+mod actionable_guidance;
 mod after_help;
 mod auto_start;
 mod bare_invocation;

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -376,5 +376,6 @@ mod actionable_guidance;
 mod after_help;
 mod auto_start;
 mod bare_invocation;
+mod discoverability;
 mod missing_operation_guidance;
 mod version_output;

--- a/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
@@ -49,7 +49,6 @@ struct StartupGuidanceExpectation {
     problem: &'static str,
     alternatives: &'static str,
     socket_hint: Option<&'static str>,
-    next_command: &'static str,
 }
 
 fn assert_startup_guidance_template(error: &LifecycleError, expected: &StartupGuidanceExpectation) {
@@ -68,6 +67,11 @@ fn assert_startup_guidance_template(error: &LifecycleError, expected: &StartupGu
                 String::from("  - Check whether the daemon is listening on 127.0.0.1:9779")
             }
         });
+    let expected_next_command = if cfg!(unix) {
+        "WEAVER_FOREGROUND=1 weaver daemon start"
+    } else {
+        "weaver daemon start"
+    };
 
     assert!(
         output.contains(&format!("error: {}", expected.problem)),
@@ -87,9 +91,9 @@ fn assert_startup_guidance_template(error: &LifecycleError, expected: &StartupGu
         "expected socket hint '{expected_socket_hint}' not found in output:\n{output}"
     );
     assert!(
-        output.contains(expected.next_command),
+        output.contains(expected_next_command),
         "expected next command '{}' not found in output:\n{output}",
-        expected.next_command
+        expected_next_command
     );
 }
 
@@ -138,12 +142,19 @@ fn launch_daemon_guidance_uses_configured_binary_name() {
     let mut buf = Vec::new();
     write_startup_guidance(&mut buf, &error).expect("write");
     let output = String::from_utf8(buf).expect("utf8");
+    let expected_next_command = if cfg!(unix) {
+        "test -x '/tmp/tools/custom-weaverd'"
+    } else if cfg!(windows) {
+        "Test-Path '/tmp/tools/custom-weaverd'"
+    } else {
+        "Ensure '/tmp/tools/custom-weaverd' is installed and runnable"
+    };
 
     assert_three_part_output(
         &output,
         "error: failed to spawn daemon binary '/tmp/tools/custom-weaverd'",
         "Verify custom-weaverd exists and is executable",
-        "test -x '/tmp/tools/custom-weaverd'",
+        expected_next_command,
     );
 }
 
@@ -156,7 +167,6 @@ fn launch_daemon_guidance_uses_configured_binary_name() {
         problem: "daemon exited before reporting ready (status: Some(17))",
         alternatives: "The daemon started but failed to become ready.",
         socket_hint: None,
-        next_command: "WEAVER_FOREGROUND=1 weaver daemon start",
     }
 )]
 #[case(
@@ -168,7 +178,6 @@ fn launch_daemon_guidance_uses_configured_binary_name() {
         problem: "timed out waiting for daemon to become ready",
         alternatives: "The daemon did not report ready within the timeout period.",
         socket_hint: Some("  - Check health snapshot at /tmp/test/weaverd.health"),
-        next_command: "WEAVER_FOREGROUND=1 weaver daemon start",
     }
 )]
 #[case(
@@ -179,7 +188,6 @@ fn launch_daemon_guidance_uses_configured_binary_name() {
         problem: "daemon reported 'stopping' before reaching ready",
         alternatives: "The daemon started but shut down before becoming ready.",
         socket_hint: Some("  - Check health snapshot at /tmp/test/weaverd.health"),
-        next_command: "WEAVER_FOREGROUND=1 weaver daemon start",
     }
 )]
 fn startup_guidance_surfaces_problem_and_next_command(

--- a/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
@@ -4,6 +4,7 @@ use std::ffi::OsStr;
 use std::io;
 
 use ortho_config::NoOpLocalizer;
+use rstest::rstest;
 
 use crate::actionable_guidance::{
     ActionableGuidance, has_configured_binary_path, write_actionable_guidance,
@@ -47,6 +48,7 @@ fn assert_three_part_output(
 fn assert_startup_guidance_template(
     error: &LifecycleError,
     expected_problem: &str,
+    expected_alternatives: &str,
     expected_next_command: &str,
 ) {
     let mut buf = Vec::new();
@@ -60,6 +62,10 @@ fn assert_startup_guidance_template(
     assert!(
         output.contains("Next command:"),
         "`Next command:` not found in output:\n{output}"
+    );
+    assert!(
+        output.contains(expected_alternatives),
+        "expected alternatives text '{expected_alternatives}' not found in output:\n{output}"
     );
     assert!(
         output.contains(expected_next_command),
@@ -121,37 +127,43 @@ fn launch_daemon_guidance_uses_configured_binary_name() {
     );
 }
 
-#[test]
-fn startup_failed_guidance_surfaces_problem_and_next_command() {
+#[rstest]
+#[case(
+    LifecycleError::StartupFailed {
+        exit_status: Some(17),
+    },
+    "daemon exited before reporting ready (status: Some(17))",
+    "The daemon started but failed to become ready.",
+    "WEAVER_FOREGROUND=1 weaver daemon start"
+)]
+#[case(
+    LifecycleError::StartupTimeout {
+        health_path: "/tmp/weaverd.health".into(),
+        timeout: std::time::Duration::from_secs(5),
+    },
+    "timed out waiting for daemon to become ready",
+    "The daemon did not report ready within the timeout period.",
+    "WEAVER_FOREGROUND=1 weaver daemon start"
+)]
+#[case(
+    LifecycleError::StartupAborted {
+        path: "/tmp/weaverd.health".into(),
+    },
+    "daemon reported 'stopping' before reaching ready",
+    "The daemon started but shut down before becoming ready.",
+    "WEAVER_FOREGROUND=1 weaver daemon start"
+)]
+fn startup_guidance_surfaces_problem_and_next_command(
+    #[case] error: LifecycleError,
+    #[case] expected_problem: &str,
+    #[case] expected_alternatives: &str,
+    #[case] expected_next_command: &str,
+) {
     assert_startup_guidance_template(
-        &LifecycleError::StartupFailed {
-            exit_status: Some(17),
-        },
-        "daemon exited before reporting ready (status: Some(17))",
-        "WEAVER_FOREGROUND=1 weaver daemon start",
-    );
-}
-
-#[test]
-fn startup_timeout_guidance_surfaces_problem_and_next_command() {
-    assert_startup_guidance_template(
-        &LifecycleError::StartupTimeout {
-            health_path: "/tmp/weaverd.health".into(),
-            timeout: std::time::Duration::from_secs(5),
-        },
-        "timed out waiting for daemon to become ready",
-        "WEAVER_FOREGROUND=1 weaver daemon start",
-    );
-}
-
-#[test]
-fn startup_aborted_guidance_surfaces_problem_and_next_command() {
-    assert_startup_guidance_template(
-        &LifecycleError::StartupAborted {
-            path: "/tmp/weaverd.health".into(),
-        },
-        "daemon reported 'stopping' before reaching ready",
-        "WEAVER_FOREGROUND=1 weaver daemon start",
+        &error,
+        expected_problem,
+        expected_alternatives,
+        expected_next_command,
     );
 }
 

--- a/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
@@ -1,0 +1,182 @@
+//! Unit tests for actionable guidance formatting and startup recovery hints.
+
+use std::ffi::OsStr;
+use std::io;
+
+use ortho_config::NoOpLocalizer;
+
+use crate::actionable_guidance::{
+    ActionableGuidance, has_configured_binary_path, write_actionable_guidance,
+    write_bare_invocation_guidance, write_startup_guidance,
+};
+use crate::lifecycle::LifecycleError;
+
+/// Asserts that `output` contains the three-part error template in the
+/// correct order: `error_text`, then `alternatives_text`, then
+/// `"Next command:"` followed by `next_command_text`.
+#[track_caller]
+fn assert_three_part_output(
+    output: &str,
+    error_text: &str,
+    alternatives_text: &str,
+    next_command_text: &str,
+) {
+    let error_pos = output
+        .find(error_text)
+        .unwrap_or_else(|| panic!("error text not found: {error_text:?}\noutput:\n{output}"));
+    let alt_pos = output.find(alternatives_text).unwrap_or_else(|| {
+        panic!("alternatives text not found: {alternatives_text:?}\noutput:\n{output}")
+    });
+    let next_pos = output
+        .find("Next command:")
+        .unwrap_or_else(|| panic!("'Next command:' not found\noutput:\n{output}"));
+    assert!(
+        output.contains(next_command_text),
+        "next-command text not found: {next_command_text:?}\noutput:\n{output}"
+    );
+    assert!(
+        error_pos < alt_pos,
+        "error line must precede alternatives block\noutput:\n{output}"
+    );
+    assert!(
+        alt_pos < next_pos,
+        "alternatives block must precede Next command\noutput:\n{output}"
+    );
+}
+
+fn assert_startup_guidance_template(
+    error: &LifecycleError,
+    expected_problem: &str,
+    expected_next_command: &str,
+) {
+    let mut buf = Vec::new();
+    write_startup_guidance(&mut buf, error).expect("write must succeed");
+    let output = String::from_utf8(buf).expect("output must be valid UTF-8");
+
+    assert!(
+        output.contains(&format!("error: {expected_problem}")),
+        "expected problem not found in output:\n{output}"
+    );
+    assert!(
+        output.contains("Next command:"),
+        "`Next command:` not found in output:\n{output}"
+    );
+    assert!(
+        output.contains(expected_next_command),
+        "expected next command '{expected_next_command}' not found in output:\n{output}"
+    );
+}
+
+#[test]
+fn write_actionable_guidance_produces_three_part_template() {
+    let guidance = ActionableGuidance::new(
+        "unknown domain 'foo'",
+        vec!["Valid domains: observe, act, verify".to_string()],
+        "weaver --help",
+    );
+
+    let mut buf = Vec::new();
+    write_actionable_guidance(&mut buf, &guidance).expect("write");
+    let output = String::from_utf8(buf).expect("utf8");
+
+    assert_three_part_output(
+        &output,
+        "error: unknown domain 'foo'",
+        "Valid domains: observe, act, verify",
+        "  weaver --help",
+    );
+}
+
+#[test]
+fn write_bare_invocation_guidance_includes_all_domains() {
+    let mut buf = Vec::new();
+    write_bare_invocation_guidance(&mut buf, &NoOpLocalizer).expect("write");
+    let output = String::from_utf8(buf).expect("utf8");
+
+    for domain in ["observe", "act", "verify"] {
+        assert!(
+            output.contains(domain),
+            "missing domain {domain:?}\noutput:\n{output}"
+        );
+    }
+    assert_three_part_output(&output, "error:", "Usage:", "weaver --help");
+}
+
+#[test]
+fn launch_daemon_guidance_uses_configured_binary_name() {
+    let error = LifecycleError::LaunchDaemon {
+        binary: "/tmp/tools/custom-weaverd".into(),
+        source: io::Error::new(io::ErrorKind::NotFound, "missing"),
+    };
+
+    let mut buf = Vec::new();
+    write_startup_guidance(&mut buf, &error).expect("write");
+    let output = String::from_utf8(buf).expect("utf8");
+
+    assert_three_part_output(
+        &output,
+        "error: failed to spawn daemon binary '/tmp/tools/custom-weaverd'",
+        "Verify custom-weaverd exists and is executable",
+        "test -x '/tmp/tools/custom-weaverd'",
+    );
+}
+
+#[test]
+fn startup_failed_guidance_surfaces_problem_and_next_command() {
+    assert_startup_guidance_template(
+        &LifecycleError::StartupFailed {
+            exit_status: Some(17),
+        },
+        "daemon exited before reporting ready (status: Some(17))",
+        "WEAVER_FOREGROUND=1 weaver daemon start",
+    );
+}
+
+#[test]
+fn startup_timeout_guidance_surfaces_problem_and_next_command() {
+    assert_startup_guidance_template(
+        &LifecycleError::StartupTimeout {
+            health_path: "/tmp/weaverd.health".into(),
+            timeout: std::time::Duration::from_secs(5),
+        },
+        "timed out waiting for daemon to become ready",
+        "WEAVER_FOREGROUND=1 weaver daemon start",
+    );
+}
+
+#[test]
+fn startup_aborted_guidance_surfaces_problem_and_next_command() {
+    assert_startup_guidance_template(
+        &LifecycleError::StartupAborted {
+            path: "/tmp/weaverd.health".into(),
+        },
+        "daemon reported 'stopping' before reaching ready",
+        "WEAVER_FOREGROUND=1 weaver daemon start",
+    );
+}
+
+#[test]
+fn fallback_guidance_strips_existing_error_prefix() {
+    let error = LifecycleError::Io(io::Error::other("error: unit-test fallback"));
+
+    let mut buf = Vec::new();
+    write_startup_guidance(&mut buf, &error).expect("write");
+    let output = String::from_utf8(buf).expect("utf8");
+
+    assert!(
+        !output.contains("error: error:"),
+        "double error prefix must not appear\noutput:\n{output}"
+    );
+    assert_three_part_output(
+        &output,
+        "error: failed to write lifecycle output: error: unit-test fallback",
+        "See error details above.",
+        "weaver daemon status",
+    );
+}
+
+#[test]
+fn bare_binary_name_is_not_treated_as_configured_path() {
+    assert!(!has_configured_binary_path(OsStr::new("weaverd")));
+    assert!(has_configured_binary_path(OsStr::new("./weaverd")));
+}

--- a/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/actionable_guidance.rs
@@ -45,18 +45,32 @@ fn assert_three_part_output(
     );
 }
 
-fn assert_startup_guidance_template(
-    error: &LifecycleError,
-    expected_problem: &str,
-    expected_alternatives: &str,
-    expected_next_command: &str,
-) {
+struct StartupGuidanceExpectation {
+    problem: &'static str,
+    alternatives: &'static str,
+    socket_hint: Option<&'static str>,
+    next_command: &'static str,
+}
+
+fn assert_startup_guidance_template(error: &LifecycleError, expected: &StartupGuidanceExpectation) {
     let mut buf = Vec::new();
     write_startup_guidance(&mut buf, error).expect("write must succeed");
     let output = String::from_utf8(buf).expect("output must be valid UTF-8");
+    let expected_socket_hint = expected
+        .socket_hint
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| {
+            if cfg!(unix) {
+                String::from(
+                    "  - Check whether the daemon is listening on $XDG_RUNTIME_DIR/weaver/weaverd.sock",
+                )
+            } else {
+                String::from("  - Check whether the daemon is listening on 127.0.0.1:9779")
+            }
+        });
 
     assert!(
-        output.contains(&format!("error: {expected_problem}")),
+        output.contains(&format!("error: {}", expected.problem)),
         "expected problem not found in output:\n{output}"
     );
     assert!(
@@ -64,12 +78,18 @@ fn assert_startup_guidance_template(
         "`Next command:` not found in output:\n{output}"
     );
     assert!(
-        output.contains(expected_alternatives),
-        "expected alternatives text '{expected_alternatives}' not found in output:\n{output}"
+        output.contains(expected.alternatives),
+        "expected alternatives text '{}' not found in output:\n{output}",
+        expected.alternatives
     );
     assert!(
-        output.contains(expected_next_command),
-        "expected next command '{expected_next_command}' not found in output:\n{output}"
+        output.contains(&expected_socket_hint),
+        "expected socket hint '{expected_socket_hint}' not found in output:\n{output}"
+    );
+    assert!(
+        output.contains(expected.next_command),
+        "expected next command '{}' not found in output:\n{output}",
+        expected.next_command
     );
 }
 
@@ -132,39 +152,41 @@ fn launch_daemon_guidance_uses_configured_binary_name() {
     LifecycleError::StartupFailed {
         exit_status: Some(17),
     },
-    "daemon exited before reporting ready (status: Some(17))",
-    "The daemon started but failed to become ready.",
-    "WEAVER_FOREGROUND=1 weaver daemon start"
+    StartupGuidanceExpectation {
+        problem: "daemon exited before reporting ready (status: Some(17))",
+        alternatives: "The daemon started but failed to become ready.",
+        socket_hint: None,
+        next_command: "WEAVER_FOREGROUND=1 weaver daemon start",
+    }
 )]
 #[case(
     LifecycleError::StartupTimeout {
-        health_path: "/tmp/weaverd.health".into(),
+        health_path: "/tmp/test/weaverd.health".into(),
         timeout: std::time::Duration::from_secs(5),
     },
-    "timed out waiting for daemon to become ready",
-    "The daemon did not report ready within the timeout period.",
-    "WEAVER_FOREGROUND=1 weaver daemon start"
+    StartupGuidanceExpectation {
+        problem: "timed out waiting for daemon to become ready",
+        alternatives: "The daemon did not report ready within the timeout period.",
+        socket_hint: Some("  - Check health snapshot at /tmp/test/weaverd.health"),
+        next_command: "WEAVER_FOREGROUND=1 weaver daemon start",
+    }
 )]
 #[case(
     LifecycleError::StartupAborted {
-        path: "/tmp/weaverd.health".into(),
+        path: "/tmp/test/weaverd.health".into(),
     },
-    "daemon reported 'stopping' before reaching ready",
-    "The daemon started but shut down before becoming ready.",
-    "WEAVER_FOREGROUND=1 weaver daemon start"
+    StartupGuidanceExpectation {
+        problem: "daemon reported 'stopping' before reaching ready",
+        alternatives: "The daemon started but shut down before becoming ready.",
+        socket_hint: Some("  - Check health snapshot at /tmp/test/weaverd.health"),
+        next_command: "WEAVER_FOREGROUND=1 weaver daemon start",
+    }
 )]
 fn startup_guidance_surfaces_problem_and_next_command(
     #[case] error: LifecycleError,
-    #[case] expected_problem: &str,
-    #[case] expected_alternatives: &str,
-    #[case] expected_next_command: &str,
+    #[case] expected: StartupGuidanceExpectation,
 ) {
-    assert_startup_guidance_template(
-        &error,
-        expected_problem,
-        expected_alternatives,
-        expected_next_command,
-    );
+    assert_startup_guidance_template(&error, &expected);
 }
 
 #[test]

--- a/crates/weaver-cli/src/tests/unit/auto_start.rs
+++ b/crates/weaver-cli/src/tests/unit/auto_start.rs
@@ -80,6 +80,61 @@ fn auto_start_failure_paths(
     );
 }
 
+/// Verifies that missing daemon binary provides actionable guidance.
+/// Per roadmap 2.3.3, startup failures must use the three-part template
+/// and mention WEAVERD_BIN and installation checks.
+#[cfg(unix)]
+#[test]
+fn auto_start_missing_binary_shows_actionable_guidance() {
+    let config = Config {
+        daemon_socket: SocketEndpoint::tcp("127.0.0.1", 1),
+        ..Config::default()
+    };
+    let context = LifecycleContext {
+        config: &config,
+        config_arguments: &[],
+        daemon_binary: Some(OsStr::new("/nonexistent/weaverd")),
+    };
+    let invocation = make_invocation();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut stdin = Cursor::new(Vec::new());
+    let mut io = IoStreams::new(&mut stdin, &mut stdout, &mut stderr, false);
+
+    let exit = execute_daemon_command(invocation, context, &mut io, ResolvedOutputFormat::Json);
+
+    assert_eq!(exit, ExitCode::FAILURE);
+    let stderr_text = decode_utf8(stderr, "stderr").expect("stderr utf8");
+
+    // Three-part template per roadmap 2.3.3
+    // Part 1: error line
+    assert!(
+        stderr_text.contains("error:"),
+        "startup failure must have explicit error line"
+    );
+
+    // Part 2: alternatives block with actionable guidance
+    assert!(
+        stderr_text.to_lowercase().contains("weaverd_bin") || stderr_text.contains("WEAVERD_BIN"),
+        "must mention WEAVERD_BIN environment variable"
+    );
+    assert!(
+        stderr_text.to_lowercase().contains("install")
+            || stderr_text.to_lowercase().contains("path"),
+        "must mention installation or PATH checking"
+    );
+
+    // Part 3: Next command line
+    assert!(
+        stderr_text.contains("Next command:"),
+        "startup failure must include Next command line"
+    );
+    assert!(
+        stderr_text.contains("command -v weaverd") || stderr_text.contains("WEAVERD_BIN"),
+        "Next command should help verify weaverd installation"
+    );
+}
+
 /// Writes a health snapshot JSON file to the specified path.
 #[cfg(unix)]
 fn write_health_snapshot(path: &std::path::Path, status: &str, pid: u32, timestamp: u64) {

--- a/crates/weaver-cli/src/tests/unit/auto_start.rs
+++ b/crates/weaver-cli/src/tests/unit/auto_start.rs
@@ -130,8 +130,9 @@ fn auto_start_missing_binary_shows_actionable_guidance() {
         "startup failure must include Next command line"
     );
     assert!(
-        stderr_text.contains("command -v weaverd") || stderr_text.contains("WEAVERD_BIN"),
-        "Next command should help verify weaverd installation"
+        stderr_text.contains("Next command:\n  test -x '/nonexistent/weaverd'")
+            || stderr_text.contains("WEAVERD_BIN"),
+        "Next command should help verify the configured daemon binary"
     );
 }
 

--- a/crates/weaver-cli/src/tests/unit/auto_start.rs
+++ b/crates/weaver-cli/src/tests/unit/auto_start.rs
@@ -130,8 +130,7 @@ fn auto_start_missing_binary_shows_actionable_guidance() {
         "startup failure must include Next command line"
     );
     assert!(
-        stderr_text.contains("Next command:\n  test -x '/nonexistent/weaverd'")
-            || stderr_text.contains("WEAVERD_BIN"),
+        stderr_text.contains("Next command:\n  test -x '/nonexistent/weaverd'"),
         "Next command should help verify the configured daemon binary"
     );
 }

--- a/crates/weaver-cli/src/tests/unit/bare_invocation.rs
+++ b/crates/weaver-cli/src/tests/unit/bare_invocation.rs
@@ -63,6 +63,55 @@ fn bare_invocation_emits_help_to_stderr() {
     assert!(stderr_text.contains("weaver --help"));
 }
 
+/// Verifies the unified three-part error template for bare invocation.
+/// Per roadmap 2.3.3, all Level 10 paths must render:
+///   error: <problem>
+///   <alternatives>
+///   Next command: <command>
+#[test]
+fn bare_invocation_uses_three_part_template() {
+    let (_, _, stderr) = run_bare_invocation();
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+
+    // Part 1: error line
+    assert!(
+        stderr_text.contains("error:"),
+        "bare invocation must have explicit error line"
+    );
+
+    // Part 2: alternatives block (Usage + domains)
+    assert!(stderr_text.contains("Usage:"));
+    assert!(stderr_text.contains("observe"));
+    assert!(stderr_text.contains("act"));
+    assert!(stderr_text.contains("verify"));
+
+    // Part 3: Next command line
+    assert!(
+        stderr_text.contains("Next command:"),
+        "bare invocation must include Next command line"
+    );
+    assert!(
+        stderr_text.contains("weaver --help"),
+        "Next command should be weaver --help"
+    );
+
+    // Verify structure: error comes before alternatives, Next command at end
+    let error_pos = stderr_text.find("error:").expect("error line");
+    let usage_pos = stderr_text.find("Usage:").expect("Usage line");
+    let next_cmd_pos = stderr_text
+        .find("Next command:")
+        .expect("Next command line");
+
+    assert!(
+        error_pos < usage_pos,
+        "error line must come before Usage block"
+    );
+    assert!(
+        usage_pos < next_cmd_pos,
+        "Usage block must come before Next command"
+    );
+}
+
 #[test]
 fn bare_invocation_produces_no_stdout() {
     let (_, stdout, _) = run_bare_invocation();

--- a/crates/weaver-cli/src/tests/unit/bare_invocation.rs
+++ b/crates/weaver-cli/src/tests/unit/bare_invocation.rs
@@ -110,6 +110,12 @@ fn bare_invocation_uses_three_part_template() {
         usage_pos < next_cmd_pos,
         "Usage block must come before Next command"
     );
+
+    let trimmed = stderr_text.trim_end();
+    assert!(
+        trimmed.ends_with("Next command:\n  weaver --help"),
+        "bare invocation must end with the exact Next command block, got:\n{trimmed}"
+    );
 }
 
 #[test]

--- a/crates/weaver-cli/src/tests/unit/discoverability.rs
+++ b/crates/weaver-cli/src/tests/unit/discoverability.rs
@@ -1,0 +1,133 @@
+//! Unit tests for CLI domain discoverability guidance helpers.
+
+use ortho_config::FluentLocalizer;
+use rstest::rstest;
+
+use crate::discoverability::{
+    KnownDomain, bounded_levenshtein, suggestion_for_unknown_domain,
+    write_missing_operation_guidance, write_unknown_domain_guidance,
+};
+use crate::localizer::WEAVER_EN_US;
+
+#[rstest]
+#[case("observe", "observe", Some(0))]
+#[case("obsrve", "observe", Some(1))]
+#[case("obsve", "observe", Some(2))]
+#[case("bogus", "observe", None)]
+fn bounded_levenshtein_respects_threshold(
+    #[case] left: &str,
+    #[case] right: &str,
+    #[case] expected: Option<usize>,
+) {
+    let left_chars: Vec<char> = left.chars().collect();
+    let right_chars: Vec<char> = right.chars().collect();
+    assert_eq!(bounded_levenshtein(&left_chars, &right_chars, 2), expected);
+}
+
+#[rstest]
+#[case("obsrve", Some(KnownDomain::Observe))]
+#[case("bogus", None)]
+#[case("obsve", Some(KnownDomain::Observe))]
+fn suggestion_for_unknown_domain_cases(#[case] input: &str, #[case] expected: Option<KnownDomain>) {
+    assert_eq!(suggestion_for_unknown_domain(input), expected);
+}
+
+fn fluent_localizer() -> FluentLocalizer {
+    FluentLocalizer::with_en_us_defaults([WEAVER_EN_US])
+        .expect("embedded Fluent catalogue must parse")
+}
+
+fn assert_single_error_prefix(output: &str) {
+    assert!(
+        output.contains("error: "),
+        "output should contain an error prefix"
+    );
+    assert!(
+        !output.contains("error: error:"),
+        "output should not contain a duplicated error prefix: {output}"
+    );
+}
+
+fn assert_three_part_guidance(
+    output: &str,
+    error_text: &str,
+    alternatives_text: &str,
+    next_command: &str,
+) {
+    assert_single_error_prefix(output);
+    let error_pos = output.find(error_text).expect("expected error text");
+    let alternatives_pos = output
+        .find(alternatives_text)
+        .expect("expected alternatives text");
+    let next_command_line = format!("Next command:\n  {next_command}");
+    let next_command_pos = output
+        .find(&next_command_line)
+        .expect("expected exact Next command block");
+
+    assert!(
+        error_pos < alternatives_pos,
+        "error line must precede alternatives block: {output}"
+    );
+    assert!(
+        alternatives_pos < next_command_pos,
+        "alternatives block must precede Next command: {output}"
+    );
+}
+
+#[test]
+fn fluent_missing_operation_guidance_has_single_error_prefix() {
+    let localizer = fluent_localizer();
+    let mut output = Vec::new();
+
+    let emitted = write_missing_operation_guidance(&mut output, &localizer, KnownDomain::Observe)
+        .expect("guidance write must succeed");
+
+    assert!(emitted, "known domain should emit guidance");
+    let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
+    assert_three_part_guidance(
+        &output,
+        "error: operation required for domain 'observe'",
+        "Available operations:\n  get-definition",
+        "weaver observe get-definition --help",
+    );
+}
+
+#[test]
+fn fluent_unknown_domain_guidance_has_single_error_prefix() {
+    let localizer = fluent_localizer();
+    let mut output = Vec::new();
+
+    let emitted = write_unknown_domain_guidance(&mut output, &localizer, "unknown-domain")
+        .expect("guidance write must succeed");
+
+    assert!(emitted, "unknown domain should emit guidance");
+    let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
+    assert_three_part_guidance(
+        &output,
+        "error: unknown domain 'unknown-domain'",
+        "Valid domains: observe, act, verify",
+        "weaver --help",
+    );
+}
+
+#[test]
+fn fluent_unknown_domain_guidance_uses_unique_suggestion_when_available() {
+    let localizer = fluent_localizer();
+    let mut output = Vec::new();
+
+    let emitted = write_unknown_domain_guidance(&mut output, &localizer, "obsrve")
+        .expect("guidance write must succeed");
+
+    assert!(emitted, "unknown domain should emit guidance");
+    let output = String::from_utf8(output).expect("guidance must be valid UTF-8");
+    assert!(
+        output.contains("Did you mean 'observe'?"),
+        "unique suggestion should be rendered: {output}"
+    );
+    assert_three_part_guidance(
+        &output,
+        "error: unknown domain 'obsrve'",
+        "Did you mean 'observe'?",
+        "weaver observe get-definition --help",
+    );
+}

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -84,10 +84,11 @@ fn assert_unknown_domain_preflight(output: &PreflightOutput, domain: &str) {
     );
     // Ensure legacy operation guidance does not appear
     assert!(!output.stderr.contains("Available operations:"));
+
+    // Verify three-part template per roadmap 2.3.3
     assert!(
-        !output
-            .stderr
-            .contains("weaver observe get-definition --help")
+        output.stderr.contains("Next command:"),
+        "unknown domain must include Next command line"
     );
 }
 
@@ -102,6 +103,35 @@ fn assert_known_domain_operation_guidance(output: &PreflightOutput, domain: &str
     // Ensure unknown-domain guidance does not appear
     assert!(!output.stderr.contains("Valid domains:"));
     assert!(!output.stderr.contains("Did you mean"));
+}
+
+/// Verifies the unified three-part error template for known domain without operation.
+/// Per roadmap 2.3.3: error, alternatives, Next command.
+fn assert_three_part_template(output: &PreflightOutput) {
+    // Part 1: error line
+    assert!(
+        output.stderr.contains("error:"),
+        "must have explicit error line"
+    );
+
+    // Part 2: alternatives block (already verified in domain-specific assertions)
+
+    // Part 3: Next command line
+    assert!(
+        output.stderr.contains("Next command:"),
+        "must include Next command line"
+    );
+
+    // Verify ordering
+    let error_pos = output.stderr.find("error:").expect("error line");
+    let next_cmd_pos = output
+        .stderr
+        .find("Next command:")
+        .expect("Next command line");
+    assert!(
+        error_pos < next_cmd_pos,
+        "error line must come before Next command"
+    );
 }
 
 fn assert_no_domain_guidance(output: &PreflightOutput) {
@@ -130,6 +160,7 @@ fn known_domain_without_operation_emits_contextual_guidance() {
             .stderr
             .contains("weaver observe get-definition --help")
     );
+    assert_three_part_template(&output);
 }
 
 #[rstest]

--- a/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
+++ b/crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs
@@ -107,30 +107,32 @@ fn assert_known_domain_operation_guidance(output: &PreflightOutput, domain: &str
 
 /// Verifies the unified three-part error template for known domain without operation.
 /// Per roadmap 2.3.3: error, alternatives, Next command.
-fn assert_three_part_template(output: &PreflightOutput) {
-    // Part 1: error line
-    assert!(
-        output.stderr.contains("error:"),
-        "must have explicit error line"
-    );
+fn assert_three_part_template(output: &PreflightOutput, expected_alternatives: &str) {
+    let stderr = &output.stderr;
 
-    // Part 2: alternatives block (already verified in domain-specific assertions)
+    // Part 1: error line
+    assert!(stderr.contains("error:"), "must have explicit error line");
 
     // Part 3: Next command line
     assert!(
-        output.stderr.contains("Next command:"),
+        stderr.contains("Next command:"),
         "must include Next command line"
     );
 
     // Verify ordering
-    let error_pos = output.stderr.find("error:").expect("error line");
-    let next_cmd_pos = output
-        .stderr
-        .find("Next command:")
-        .expect("Next command line");
+    let error_pos = stderr.find("error:").expect("error line");
+    let next_cmd_pos = stderr.find("Next command:").expect("Next command line");
     assert!(
         error_pos < next_cmd_pos,
         "error line must come before Next command"
+    );
+
+    let alternatives_pos = stderr[error_pos..next_cmd_pos]
+        .find(expected_alternatives)
+        .map(|relative| error_pos + relative);
+    assert!(
+        alternatives_pos.is_some(),
+        "alternatives block must contain '{expected_alternatives}' between error and Next command"
     );
 }
 
@@ -160,12 +162,22 @@ fn known_domain_without_operation_emits_contextual_guidance() {
             .stderr
             .contains("weaver observe get-definition --help")
     );
-    assert_three_part_template(&output);
+    assert_three_part_template(&output, "Available operations:");
 }
 
 #[rstest]
-#[case(&["unknown-domain"], "unknown-domain", &[], &["weaver observe get-definition --help"])]
-#[case(&["unknown-domain", "get-definition"], "unknown-domain", &[], &["Waiting for daemon start..."])]
+#[case(
+    &["unknown-domain"],
+    "unknown-domain",
+    &["Next command:\n  weaver --help"],
+    &["weaver observe get-definition --help"]
+)]
+#[case(
+    &["unknown-domain", "get-definition"],
+    "unknown-domain",
+    &["Next command:\n  weaver --help"],
+    &["Waiting for daemon start..."]
+)]
 #[case(&["obsrve", "get-definition"], "obsrve", &["Did you mean 'observe'?"], &[])]
 #[case(&["bogus", "get-definition"], "bogus", &[], &["Did you mean"])]
 fn unknown_domain_preflight_guidance(
@@ -177,6 +189,21 @@ fn unknown_domain_preflight_guidance(
     let output = run_with_panicking_loader(args);
 
     assert_unknown_domain_preflight(&output, domain);
+    assert_three_part_template(&output, "Valid domains: observe, act, verify");
+
+    if output.stderr.contains("Did you mean 'observe'?") {
+        assert!(
+            output
+                .stderr
+                .contains("Next command:\n  weaver observe get-definition --help"),
+            "unknown domain with suggestion must include actionable suggested command"
+        );
+    } else {
+        assert!(
+            output.stderr.contains("Next command:\n  weaver --help"),
+            "unknown domain without suggestions must fall back to generic help"
+        );
+    }
 
     for text in required_contains {
         assert!(

--- a/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
+++ b/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
@@ -399,8 +399,10 @@ the new `actionable_guidance` module or as a focused helper beside the
 lifecycle module. The renderer should map at least these variants:
 
 - `LifecycleError::LaunchDaemon` with missing binary: mention installation/PATH
-  checking and `WEAVERD_BIN`, and use `command -v weaverd` as the deterministic
-  next command;
+  checking and `WEAVERD_BIN`, and derive the deterministic next command from
+  the configured daemon binary. If `WEAVERD_BIN` resolves to an explicit path
+  (contains a slash), render `test -x <path>`; otherwise render
+  `command -v <binary>`;
 - `LifecycleError::StartupFailed`, `LifecycleError::StartupTimeout`, and
   `LifecycleError::StartupAborted`: keep the same three-part layout and direct
   the operator to rerun in the foreground using
@@ -523,7 +525,7 @@ Valid alternatives:
   ...
 
 Next command:
-  command -v weaverd
+  test -x "$WEAVERD_BIN"
 ```
 
 The exact prose may differ slightly after implementation, but the three-part

--- a/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
+++ b/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: IMPLEMENTED
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root.
@@ -160,16 +160,16 @@ This work is successful when the following are all true:
   `UnknownOperation` payloads and stable exit status `1`.
 - [x] (2026-04-07) Drafted this ExecPlan in
   `docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md`.
-- [ ] Stage A: add failing unit and behavioural tests for the unified
+- [x] Stage A: add failing unit and behavioural tests for the unified
   three-part template.
-- [ ] Stage B: introduce a small CLI-side actionable-guidance formatter and
+- [x] Stage B: introduce a small CLI-side actionable-guidance formatter and
   refactor bare invocation plus preflight domain guidance to use it.
-- [ ] Stage C: route unknown-operation human rendering and startup/lifecycle
+- [x] Stage C: route unknown-operation human rendering and startup/lifecycle
   failures through the same formatter while preserving existing exit codes and
   daemon payload semantics.
-- [ ] Stage D: update `docs/weaver-design.md`, `docs/users-guide.md`, and
+- [x] Stage D: update `docs/weaver-design.md`, `docs/users-guide.md`, and
   `docs/roadmap.md`.
-- [ ] Stage E: run the full Markdown and Rust validation gates sequentially.
+- [x] Stage E: run the full Markdown and Rust validation gates sequentially.
 
 ## Surprises & Discoveries
 
@@ -610,6 +610,6 @@ The likely touched source files are:
 
 ## Revision note
 
-Initial draft created from roadmap item `2.3.3`, the current CLI and daemon
-code, and the adjacent ExecPlans for `2.3.1` and `2.3.2`. No implementation has
-started yet.
+Implemented from roadmap item `2.3.3` with the shared actionable-guidance
+formatter, matching unit and behavioural tests, and the supporting
+documentation updates completed.

--- a/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
+++ b/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
@@ -36,8 +36,8 @@ Next command:
 ```
 
 The middle block may stay domain-specific (`Usage: ...`, `Valid domains: ...`,
-or `Available operations: ...`), but every path must expose the same
-observable structure: error, alternatives, and one concrete next step.
+or `Available operations: ...`), but every path must expose the same observable
+structure: error, alternatives, and one concrete next step.
 
 This work is successful when the following are all true:
 
@@ -120,10 +120,10 @@ This work is successful when the following are all true:
   and keep the `Usage:` line plus exactly one help pointer in the final output.
 
 - Risk: unknown-operation guidance is intentionally daemon-routed, and the CLI
-  must not rebuild the operation list from `DOMAIN_OPERATIONS`. Severity:
-  high. Likelihood: medium. Mitigation: derive the `Next command:` from the
-  daemon payload's first `known_operations` entry and leave the JSON payload
-  shape unchanged unless a test proves that insufficient.
+  must not rebuild the operation list from `DOMAIN_OPERATIONS`. Severity: high.
+  Likelihood: medium. Mitigation: derive the `Next command:` from the daemon
+  payload's first `known_operations` entry and leave the JSON payload shape
+  unchanged unless a test proves that insufficient.
 
 - Risk: lifecycle errors are surfaced through two different paths today:
   explicit `weaver daemon start` failures go through `AppError::Lifecycle`,
@@ -148,13 +148,12 @@ This work is successful when the following are all true:
 ## Progress
 
 - [x] (2026-04-07) Read `docs/roadmap.md`, `docs/ui-gap-analysis.md`,
-  `docs/weaver-design.md`, `docs/users-guide.md`, and the referenced
-  testing guidance.
+  `docs/weaver-design.md`, `docs/users-guide.md`, and the referenced testing
+  guidance.
 - [x] (2026-04-07) Confirmed the current Level 10 implementation split across
   `crates/weaver-cli/src/localizer.rs`,
   `crates/weaver-cli/src/discoverability.rs`,
-  `crates/weaver-cli/src/output/mod.rs`, and
-  `crates/weaver-cli/src/lib.rs`.
+  `crates/weaver-cli/src/output/mod.rs`, and `crates/weaver-cli/src/lib.rs`.
 - [x] (2026-04-07) Confirmed that the workspace already pins `rstest-bdd` and
   `rstest-bdd-macros` at `0.5.0`; no dependency upgrade is needed.
 - [x] (2026-04-07) Confirmed that the daemon already emits structured
@@ -166,8 +165,8 @@ This work is successful when the following are all true:
 - [ ] Stage B: introduce a small CLI-side actionable-guidance formatter and
   refactor bare invocation plus preflight domain guidance to use it.
 - [ ] Stage C: route unknown-operation human rendering and startup/lifecycle
-  failures through the same formatter while preserving existing exit codes
-  and daemon payload semantics.
+  failures through the same formatter while preserving existing exit codes and
+  daemon payload semantics.
 - [ ] Stage D: update `docs/weaver-design.md`, `docs/users-guide.md`, and
   `docs/roadmap.md`.
 - [ ] Stage E: run the full Markdown and Rust validation gates sequentially.
@@ -462,8 +461,7 @@ If Stage C requires daemon payload changes, add:
 cargo test -p weaverd dispatch_behaviour
 ```
 
-When the feature is ready, run the full validation sequence in this exact
-order:
+When the feature is ready, run the full validation sequence in this exact order:
 
 ```sh
 make fmt
@@ -561,14 +559,14 @@ recent guidance-path changes and rerun the focused test before touching the
 docs. Do not mark the roadmap item done until the full validation sequence is
 green.
 
-If the work unexpectedly requires a daemon wire-contract change, stop,
-document that in `Decision Log`, and re-scope before editing
+If the work unexpectedly requires a daemon wire-contract change, stop, document
+that in `Decision Log`, and re-scope before editing
 `crates/weaver-daemon-types/`.
 
-## Artifacts and notes
+## Artefacts and notes
 
-The most important artefacts for this task are short stderr transcripts and
-the validator output from the final sequential run.
+The most important artefacts for this task are short stderr transcripts and the
+validator output from the final sequential run.
 
 Capture at least one transcript each for:
 
@@ -613,5 +611,5 @@ The likely touched source files are:
 ## Revision note
 
 Initial draft created from roadmap item `2.3.3`, the current CLI and daemon
-code, and the adjacent ExecPlans for `2.3.1` and `2.3.2`. No implementation
-has started yet.
+code, and the adjacent ExecPlans for `2.3.1` and `2.3.2`. No implementation has
+started yet.

--- a/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
+++ b/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
@@ -1,0 +1,617 @@
+# 2.3.3 Standardize actionable guidance in startup and routing errors
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root.
+
+## Purpose / big picture
+
+Roadmap item `2.3.3` is the unification step that sits on top of completed
+items `2.2.1`, `2.2.4`, `2.3.1`, and `2.3.2`. Today the Level 10 failure paths
+already exist, but they still read like separate features:
+
+- bare invocation prints short help with no explicit error line;
+- unknown domains list valid domains but do not always tell the operator what
+  to run next;
+- unknown operations list alternatives but also stop short of an explicit next
+  command;
+- daemon auto-start failures still dump raw `LifecycleError` text.
+
+After this change, every Level 10 path (`10a` through `10e`) must render the
+same three-part shape in human-readable mode:
+
+```plaintext
+error: <problem statement>
+
+<alternatives block>
+
+Next command:
+  <exact command>
+```
+
+The middle block may stay domain-specific (`Usage: ...`, `Valid domains: ...`,
+or `Available operations: ...`), but every path must expose the same
+observable structure: error, alternatives, and one concrete next step.
+
+This work is successful when the following are all true:
+
+1. `weaver` with no arguments, `weaver <domain>`,
+   `weaver <unknown-domain> ...`, `weaver ... <unknown-operation>`, and daemon
+   start failures all print the same three-part layout.
+2. the `WEAVERD_BIN` failure path tells operators how to check installation and
+   how to override the daemon binary path;
+3. stable non-zero exit behaviour does not change;
+4. unit tests and `rstest-bdd` scenarios cover the happy path, unhappy paths,
+   and edge cases;
+5. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+   reflect the shipped behaviour.
+
+## Constraints
+
+- Run `make check-fmt`, `make lint`, and `make test` before considering the
+  feature complete.
+- Because this task also updates Markdown, run `make fmt`,
+  `make markdownlint`, and `make nixie` before finishing.
+- Add both unit coverage and behavioural coverage using `rstest-bdd` v0.5.0.
+  Reuse the existing feature harnesses where possible rather than creating a
+  second bespoke end-to-end harness.
+- Preserve the existing division of responsibility:
+  - unknown domains and missing operations remain client-side preflight work;
+  - unknown operations remain daemon-routed and use the daemon as the source of
+    truth for known operations;
+  - startup failures remain lifecycle errors emitted by the CLI.
+- Preserve current non-zero exit semantics:
+  - bare invocation and client-side preflight failures still exit through the
+    CLI failure path;
+  - unknown-operation errors still emit daemon exit status `1`;
+  - startup failures still exit non-zero.
+- Do not widen the outer JSONL transport envelope. The `stream` and `exit`
+  message contract must remain unchanged.
+- Prefer additive CLI-side formatting over changing `Display` implementations
+  on `AppError` or `LifecycleError`. The new operator contract is a rendering
+  concern, not a reason to blur internal error types.
+- Do not add a new dependency for formatting or edit-distance logic.
+- Keep files under 400 lines by extracting helpers or tests into focused
+  modules before crossing the limit.
+- Update `docs/weaver-design.md` with the final error-template policy and any
+  startup-guidance design decision.
+- Update `docs/users-guide.md` with the final operator-visible outputs.
+- Mark roadmap item `2.3.3` done only after implementation, documentation, and
+  all validation gates pass.
+- Comments and documentation must use en-GB-oxendict spelling.
+- Do not broaden this task into the locale-selection roadmap (`3.3.x`).
+  Preflight/localized text should continue to use the current localizer, but
+  the general human output renderer may remain English-only for now.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than 16 files or roughly
+  500 net lines, stop and re-evaluate before continuing.
+- Interfaces: if a public wire type in `crates/weaver-daemon-types/` must
+  change to satisfy the acceptance criteria, stop and escalate before changing
+  the JSON contract.
+- Dependencies: if the formatter or startup guidance appears to require a new
+  external crate, stop and escalate.
+- Behaviour drift: if satisfying `2.3.3` would force a change to the completed
+  `2.3.1` or `2.3.2` acceptance criteria beyond layout unification, stop and
+  document the conflict first.
+- File-size pressure: if `crates/weaver-cli/src/lib.rs`,
+  `crates/weaver-cli/src/discoverability.rs`, or
+  `crates/weaver-cli/src/output/mod.rs` would exceed 400 lines, extract a new
+  helper module before adding more logic.
+- Ambiguity: if there is no single defensible `Next command:` for a failure
+  case without product input, stop and present the options with trade-offs.
+- Iterations: if the same failing validator needs more than five correction
+  attempts, stop and report the blocker.
+
+## Risks
+
+- Risk: bare invocation currently satisfies roadmap `2.2.1` by printing short
+  help, but it does not have an explicit `error:` line. A careless refactor
+  could break the earlier `Usage:` and single-pointer requirements while
+  chasing the new template. Severity: medium. Likelihood: high. Mitigation:
+  drive the change with focused tests in `crates/weaver-cli/src/tests/unit/`
+  and keep the `Usage:` line plus exactly one help pointer in the final output.
+
+- Risk: unknown-operation guidance is intentionally daemon-routed, and the CLI
+  must not rebuild the operation list from `DOMAIN_OPERATIONS`. Severity:
+  high. Likelihood: medium. Mitigation: derive the `Next command:` from the
+  daemon payload's first `known_operations` entry and leave the JSON payload
+  shape unchanged unless a test proves that insufficient.
+
+- Risk: lifecycle errors are surfaced through two different paths today:
+  explicit `weaver daemon start` failures go through `AppError::Lifecycle`,
+  while auto-start failures are printed directly in
+  `execute_daemon_command(...)`. Severity: medium. Likelihood: high.
+  Mitigation: add one CLI-side lifecycle-guidance renderer and route both print
+  sites through it.
+
+- Risk: the Fluent catalogue already contains some guidance strings, including
+  an unused unknown-domain hint entry. It is easy to add hard-coded English
+  text instead of reusing the existing localization seam. Severity: low.
+  Likelihood: high. Mitigation: keep preflight and bare-invocation copy inside
+  `crates/weaver-cli/locales/en-US/messages.ftl` and continue using
+  `strip_bidi_isolates(...)`.
+
+- Risk: startup guidance can sprawl if every lifecycle variant gets bespoke
+  prose. Severity: medium. Likelihood: medium. Mitigation: define one small
+  internal guidance model with a problem line, a list of preformatted
+  alternatives lines, and a single next command, then map only the relevant
+  startup variants onto it.
+
+## Progress
+
+- [x] (2026-04-07) Read `docs/roadmap.md`, `docs/ui-gap-analysis.md`,
+  `docs/weaver-design.md`, `docs/users-guide.md`, and the referenced
+  testing guidance.
+- [x] (2026-04-07) Confirmed the current Level 10 implementation split across
+  `crates/weaver-cli/src/localizer.rs`,
+  `crates/weaver-cli/src/discoverability.rs`,
+  `crates/weaver-cli/src/output/mod.rs`, and
+  `crates/weaver-cli/src/lib.rs`.
+- [x] (2026-04-07) Confirmed that the workspace already pins `rstest-bdd` and
+  `rstest-bdd-macros` at `0.5.0`; no dependency upgrade is needed.
+- [x] (2026-04-07) Confirmed that the daemon already emits structured
+  `UnknownOperation` payloads and stable exit status `1`.
+- [x] (2026-04-07) Drafted this ExecPlan in
+  `docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md`.
+- [ ] Stage A: add failing unit and behavioural tests for the unified
+  three-part template.
+- [ ] Stage B: introduce a small CLI-side actionable-guidance formatter and
+  refactor bare invocation plus preflight domain guidance to use it.
+- [ ] Stage C: route unknown-operation human rendering and startup/lifecycle
+  failures through the same formatter while preserving existing exit codes
+  and daemon payload semantics.
+- [ ] Stage D: update `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/roadmap.md`.
+- [ ] Stage E: run the full Markdown and Rust validation gates sequentially.
+
+## Surprises & Discoveries
+
+- `crates/weaver-cli/locales/en-US/messages.ftl` already contains
+  `weaver-domain-guidance-help-hint-unknown-domain`, but the current Rust code
+  does not use it. That is a strong sign that the intended next-command surface
+  was anticipated but not yet wired in.
+
+- The daemon-side unknown-operation contract is already in a good place for
+  this roadmap item. `crates/weaverd/src/dispatch/response.rs` serializes
+  `known_operations` and the CLI already parses it in human mode. The missing
+  piece is the next-command line, not a new daemon payload type.
+
+- `crates/weaver-cli/src/localizer.rs::write_bare_help(...)` is the outlier.
+  It writes a help block directly rather than building from the same guidance
+  shape as the other preflight paths.
+
+- Explicit lifecycle start failures and automatic daemon-start failures already
+  share `LifecycleError`, but they do not share a rendering path. This is an
+  opportunity to remove drift without changing the core lifecycle logic.
+
+## Decision Log
+
+- Decision: keep the canonical three-part template in `weaver-cli`, not in the
+  daemon wire protocol. Rationale: four of the five Level 10 paths are already
+  CLI-rendered, and the remaining path (`UnknownOperation`) can be completed by
+  formatting the daemon's existing payload more completely. Date: 2026-04-07.
+
+- Decision: preserve the existing daemon JSON payload for unknown operations
+  unless Stage A proves the CLI cannot produce an acceptable next command from
+  the existing `known_operations` array. Rationale: roadmap `2.3.3` asks for
+  consistent rendered guidance and stable exit codes, not a broader protocol
+  revision. Date: 2026-04-07.
+
+- Decision: treat startup guidance as a rendering layer over `LifecycleError`
+  rather than rewriting the error enum's `Display` strings. Rationale:
+  `Display` remains useful for logs and internal assertions, while the new
+  operator contract belongs in one dedicated formatter. Date: 2026-04-07.
+
+- Decision: apply the startup formatter to both auto-start failures and
+  explicit `weaver daemon start` failures. Rationale: both failure modes are
+  surfaced to operators and should not drift just because they reach stderr
+  through different call sites. Date: 2026-04-07.
+
+## Outcomes & Retrospective
+
+Target outcome at completion:
+
+1. Level 10a through 10e all print the same three-part layout in
+   human-readable mode.
+2. The Level 10a missing-daemon-binary path names both recovery options:
+   installation/PATH validation and `WEAVERD_BIN`.
+3. The CLI still avoids daemon startup for unknown domains and missing
+   operations.
+4. Unknown operations still return the daemon's exit status `1` and preserve
+   the existing JSON payload in `--output json` mode.
+5. Bare invocation still prints a `Usage:` line, all three valid domains, and
+   exactly one help pointer.
+6. The feature is covered by unit tests and `rstest-bdd` scenarios, and the
+   final repository state passes `make fmt`, `make markdownlint`, `make nixie`,
+   `make check-fmt`, `make lint`, and `make test`.
+7. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
+   accurately describe the shipped behaviour.
+
+Retrospective notes will be added after implementation.
+
+## Context and orientation
+
+The current code is already close to the target behaviour, but the formatting
+logic is fragmented.
+
+`crates/weaver-cli/src/localizer.rs` owns `write_bare_help(...)`, which writes
+the current bare-invocation block directly. That block has the right
+information for roadmap `2.2.1`, but it does not expose the standard error /
+alternatives / next-command structure needed by `2.3.3`.
+
+`crates/weaver-cli/src/discoverability.rs` owns
+`write_missing_operation_guidance(...)` and
+`write_unknown_domain_guidance(...)`. These already print a problem line plus
+alternatives, and they already use the localizer, but they are not built from a
+shared formatter. Unknown domains also stop after the alternatives block unless
+the code is extended to use the existing unknown-domain hint message.
+
+`crates/weaver-cli/src/output/mod.rs` owns `render_unknown_operation(...)`.
+This is the Level 10c path. It already prints the daemon-provided operations,
+so the source of truth is correct; it simply needs the final `Next command:`
+line and shared layout.
+
+`crates/weaver-cli/src/lib.rs` owns the print sites. Bare invocation and
+preflight guidance are emitted in `handle_preflight(...)`. Auto-start failures
+are printed inside `execute_daemon_command(...)` after
+`try_auto_start_daemon(...)` returns a `LifecycleError`. Explicit lifecycle
+command failures travel through `AppError::Lifecycle` and are printed from
+`CliRunner::map_result_to_exit_code(...)`.
+
+`crates/weaver-cli/src/lifecycle/error.rs` defines the lifecycle failure
+variants that matter here, especially `LaunchDaemon`, `StartupFailed`,
+`StartupAborted`, and `StartupTimeout`. The plan should not overload their
+`Display` text with presentation responsibilities.
+
+`crates/weaverd/src/dispatch/response.rs` is already the daemon-side authority
+for unknown-operation payloads. Because `known_operations` is serialized there,
+the CLI can derive a deterministic next command from the first returned entry
+without consulting its own catalogue.
+
+The most relevant tests already exist:
+
+- `crates/weaver-cli/src/tests/unit/bare_invocation.rs`
+- `crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs`
+- `crates/weaver-cli/src/tests/unit/auto_start.rs`
+- `crates/weaver-cli/tests/features/weaver_cli.feature`
+- `crates/weaver-cli/src/tests/behaviour.rs`
+- `crates/weaverd/tests/features/daemon_dispatch.feature`
+
+The documentation surfaces that must be updated after implementation are:
+
+- `docs/weaver-design.md` (CLI preflight and startup guidance policy)
+- `docs/users-guide.md` (operator-visible examples)
+- `docs/roadmap.md` (mark `2.3.3` done)
+
+## Plan of work
+
+### Stage A: lock the contract with failing tests
+
+Add or update focused tests before changing any formatter code.
+
+In `crates/weaver-cli/src/tests/unit/bare_invocation.rs`, extend the bare
+invocation assertions so they require:
+
+- an explicit `error:` line;
+- a `Usage:` line;
+- the three valid domains;
+- exactly one `weaver --help` pointer;
+- a two-block layout that makes the `Next command:` line observable.
+
+In `crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs`, extend the
+known-domain and unknown-domain cases so they both require a `Next command:`
+block. Use the existing unique-suggestion and no-suggestion cases:
+
+- when there is exactly one domain suggestion, the next command should use that
+  domain and its first known operation;
+- when there is no domain suggestion, the next command should fall back to
+  `weaver --help`.
+
+In `crates/weaver-cli/src/output/mod.rs` tests, extend the unknown-operation
+human rendering assertions so they require a `Next command:` line derived from
+the first `known_operations` entry in the daemon payload.
+
+In `crates/weaver-cli/src/tests/unit/auto_start.rs`, add explicit assertions
+for the missing-binary path so the stderr output mentions both installation
+checking and `WEAVERD_BIN`, and still exits with failure. Add a second focused
+unit test for `weaver daemon start` using the existing injected-daemon-binary
+test seam so the explicit lifecycle path renders the same startup guidance.
+
+In `crates/weaver-cli/tests/features/weaver_cli.feature` and
+`crates/weaver-cli/src/tests/behaviour.rs`, extend the existing behavioural
+scenarios for:
+
+- bare invocation;
+- unknown domain;
+- unknown operation in human mode;
+- auto-start spawn failure.
+
+Keep the current happy-path scenarios (`streaming a request`, lifecycle
+success, capability probe, and valid daemon interaction) untouched so they
+continue to prove that successful behaviour is unchanged.
+
+Only add daemon-side test changes if Stage C ends up requiring a payload
+revision. Otherwise, the existing `weaverd` unknown-operation tests are already
+the stable-exit-code guard.
+
+### Stage B: introduce one CLI-side actionable-guidance formatter
+
+Create a small internal helper module, likely
+`crates/weaver-cli/src/actionable_guidance.rs`, with a data model similar to:
+
+```rust
+pub(crate) struct ActionableGuidance {
+    pub(crate) problem: String,
+    pub(crate) alternatives: Vec<String>,
+    pub(crate) next_command: String,
+}
+
+pub(crate) fn write_actionable_guidance<W: Write>(
+    writer: &mut W,
+    guidance: &ActionableGuidance,
+) -> io::Result<()>;
+```
+
+Keep the helper generic: the `alternatives` field should accept already-shaped
+lines so the middle block can serve all five Level 10 cases without awkward
+special cases. For example, bare invocation can include `Usage:` and domain
+rows, while unknown operations can include `Available operations:` and one
+operation per line.
+
+Refactor `crates/weaver-cli/src/localizer.rs::write_bare_help(...)` so it
+either delegates to the new helper or is replaced by a new
+`write_missing_domain_guidance(...)` function that uses the same formatter and
+still pulls copy from the localizer.
+
+Refactor `crates/weaver-cli/src/discoverability.rs` so
+`write_missing_operation_guidance(...)` and
+`write_unknown_domain_guidance(...)` construct `ActionableGuidance` values
+instead of writing ad hoc blocks. Reuse the existing Fluent catalogue and add
+only the minimum new entries needed for `Next command:` or revised hint text.
+
+Do not move unknown-operation rendering into this module yet. First finish the
+preflight and bare-invocation paths, because they are the most sensitive to the
+existing localized strings and roadmap `2.2.x` guarantees.
+
+### Stage C: finish the routing and startup surfaces
+
+Update `crates/weaver-cli/src/output/mod.rs::render_unknown_operation(...)` so
+the returned human-readable string follows the same three-part layout and ends
+with:
+
+```plaintext
+Next command:
+  weaver <domain> <first-known-operation> --help
+```
+
+The operation hint must come from the daemon payload, not from
+`crates/weaver-cli/src/discoverability.rs`.
+
+Add a dedicated lifecycle-guidance rendering seam in `weaver-cli`, either in
+the new `actionable_guidance` module or as a focused helper beside the
+lifecycle module. The renderer should map at least these variants:
+
+- `LifecycleError::LaunchDaemon` with missing binary: mention installation/PATH
+  checking and `WEAVERD_BIN`, and use `command -v weaverd` as the deterministic
+  next command;
+- `LifecycleError::StartupFailed`, `LifecycleError::StartupTimeout`, and
+  `LifecycleError::StartupAborted`: keep the same three-part layout and direct
+  the operator to rerun in the foreground using
+  `WEAVER_FOREGROUND=1 weaver daemon start`.
+
+Then route both print sites through this helper:
+
+1. the auto-start failure branch in
+   `crates/weaver-cli/src/lib.rs::execute_daemon_command(...)`;
+2. the `AppError::Lifecycle` case in
+   `crates/weaver-cli/src/lib.rs::CliRunner::map_result_to_exit_code(...)`.
+
+Keep the exit codes unchanged. This stage is about rendering only.
+
+### Stage D: update the design and user-facing documents
+
+Update `docs/weaver-design.md` so it explains:
+
+- the shared three-part error template;
+- the decision to keep unknown-operation alternatives daemon-sourced while
+  finishing the human render in the CLI;
+- the startup-guidance policy for missing `weaverd`, installation checks, and
+  `WEAVERD_BIN`.
+
+Update `docs/users-guide.md` so the operator-visible examples match the shipped
+outputs for:
+
+- bare invocation;
+- unknown domain with and without a suggestion;
+- unknown operation in human mode;
+- daemon auto-start or explicit start failure caused by a missing `weaverd`
+  binary.
+
+Update `docs/roadmap.md` only after the code and all documentation are final,
+and only when the validation gates are green.
+
+### Stage E: run the full validation suite and capture evidence
+
+Run fast focused tests while iterating, then run the full gates sequentially.
+Do not run format, lint, and test commands in parallel in this repository.
+
+## Concrete steps
+
+All commands below are run from the repository root.
+
+During red/green iteration, use focused tests such as:
+
+```sh
+cargo test -p weaver-cli bare_invocation
+cargo test -p weaver-cli missing_operation_guidance
+cargo test -p weaver-cli auto_start
+cargo test -p weaver-cli behaviour
+```
+
+If Stage C requires daemon payload changes, add:
+
+```sh
+cargo test -p weaverd dispatch_behaviour
+```
+
+When the feature is ready, run the full validation sequence in this exact
+order:
+
+```sh
+make fmt
+make markdownlint
+make nixie
+make check-fmt
+make lint
+make test
+```
+
+Expected success indicators:
+
+```plaintext
+$ make check-fmt
+cargo fmt --workspace -- --check
+
+$ make lint
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+$ make test
+cargo test --workspace
+```
+
+The behavioural evidence to inspect manually after the tests pass is:
+
+```plaintext
+$ weaver
+error: ...
+
+Usage: ...
+...
+
+Next command:
+  weaver --help
+```
+
+and:
+
+```plaintext
+$ weaver --output human observe nonexistent
+error: unknown operation 'nonexistent' for domain 'observe'
+
+Available operations:
+  get-definition
+  ...
+
+Next command:
+  weaver observe get-definition --help
+```
+
+and:
+
+```plaintext
+$ weaver observe get-definition --symbol main
+Waiting for daemon start...
+error: ...
+
+Valid alternatives:
+  ...
+
+Next command:
+  command -v weaverd
+```
+
+The exact prose may differ slightly after implementation, but the three-part
+layout and stable non-zero exits must match.
+
+## Validation and acceptance
+
+Acceptance is behavioural, not structural.
+
+- Tests:
+  - unit tests prove every Level 10 path has the expected three-part layout;
+  - `rstest-bdd` scenarios prove the CLI emits the new guidance in realistic
+    command flows;
+  - existing success-path scenarios continue to pass unchanged.
+- Lint and formatting:
+  - `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`, and
+    `make lint` all pass.
+- Runtime contract:
+  - unknown-operation JSON output still forwards the daemon payload unchanged;
+  - unknown-operation failures still exit with daemon status `1`;
+  - preflight and startup failures still exit non-zero;
+  - unknown-domain and missing-operation failures still happen before daemon
+    startup.
+
+This task is done only when the roadmap item can honestly be marked complete.
+
+## Idempotence and recovery
+
+The implementation steps are safe to repeat.
+
+If a focused test fails partway through the refactor, revert only the most
+recent guidance-path changes and rerun the focused test before touching the
+docs. Do not mark the roadmap item done until the full validation sequence is
+green.
+
+If the work unexpectedly requires a daemon wire-contract change, stop,
+document that in `Decision Log`, and re-scope before editing
+`crates/weaver-daemon-types/`.
+
+## Artifacts and notes
+
+The most important artefacts for this task are short stderr transcripts and
+the validator output from the final sequential run.
+
+Capture at least one transcript each for:
+
+- bare invocation;
+- unknown domain with suggestion;
+- unknown operation in human mode;
+- missing `weaverd` startup failure.
+
+Keep those artefacts concise and focused on the new layout.
+
+## Interfaces and dependencies
+
+The implementation should stay within existing crates and seams.
+
+- Add one internal formatter module in `crates/weaver-cli/src/` rather than a
+  new crate.
+- Keep using `ortho_config::Localizer` and
+  `crates/weaver-cli/locales/en-US/messages.ftl` for preflight and bare-help
+  copy.
+- Keep using `weaver_daemon_types::UnknownOperationPayload` as the shared
+  daemon/CLI payload for Level 10c unless a blocking gap is proven.
+- Keep `LifecycleError` as the lifecycle domain model; add renderer helpers
+  around it instead of changing the error enum into a presentation object.
+
+The likely touched source files are:
+
+- `crates/weaver-cli/src/lib.rs`
+- `crates/weaver-cli/src/localizer.rs`
+- `crates/weaver-cli/src/discoverability.rs`
+- `crates/weaver-cli/src/output/mod.rs`
+- `crates/weaver-cli/src/lifecycle/error.rs` or a new nearby helper module
+- `crates/weaver-cli/locales/en-US/messages.ftl`
+- `crates/weaver-cli/src/tests/unit/bare_invocation.rs`
+- `crates/weaver-cli/src/tests/unit/missing_operation_guidance.rs`
+- `crates/weaver-cli/src/tests/unit/auto_start.rs`
+- `crates/weaver-cli/src/tests/behaviour.rs`
+- `crates/weaver-cli/tests/features/weaver_cli.feature`
+- `docs/weaver-design.md`
+- `docs/users-guide.md`
+- `docs/roadmap.md`
+
+## Revision note
+
+Initial draft created from roadmap item `2.3.3`, the current CLI and daemon
+code, and the adjacent ExecPlans for `2.3.1` and `2.3.2`. No implementation
+has started yet.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -217,14 +217,14 @@ does* *not require source inspection or external runbooks.*
   - [x] Acceptance criteria: unknown-operation errors in both JSON and
         human-readable output include the full known-operation set for the
         domain, with a count equal to the router's `known_operations` length.
-- [ ] 2.3.3. Standardize actionable guidance in startup and routing errors.
+- [x] 2.3.3. Standardize actionable guidance in startup and routing errors.
       See
       [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
       (10a-10e).
-  - [ ] Apply a single error template: problem statement, valid alternatives,
+  - [x] Apply a single error template: problem statement, valid alternatives,
         and explicit next command.
-  - [ ] Add startup failure guidance for `WEAVERD_BIN` and installation checks.
-  - [ ] Acceptance criteria: each Level 10 path (10a through 10e) renders the
+  - [x] Add startup failure guidance for `WEAVERD_BIN` and installation checks.
+  - [x] Acceptance criteria: each Level 10 path (10a through 10e) renders the
         same three-part template (error, alternatives, next command), and
         preserves stable non-zero exit-code semantics.
 - [ ] 2.3.4. Return complete argument requirements for `act refactor`.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -220,6 +220,35 @@ Errors that prevent connection but are not related to the daemon being offline
 (such as permission denied or network timeouts) bypass automatic startup and
 are reported immediately.
 
+When the daemon binary cannot be found, the CLI provides actionable guidance:
+
+```text
+$ weaver observe get-definition --symbol main
+Waiting for daemon start...
+error: failed to spawn weaverd binary 'weaverd'
+
+Valid alternatives:
+  - Verify weaverd is installed and in your PATH
+  - Set WEAVERD_BIN to the full path to the weaverd binary
+
+Next command:
+  command -v weaverd || echo 'weaverd not found in PATH'
+```
+
+For other startup failures, the CLI suggests running in the foreground to see
+startup output:
+
+```text
+error: daemon exited before reporting ready (status: Some(1))
+
+Valid alternatives:
+  - Check the daemon logs for errors
+  - Run with WEAVER_FOREGROUND=1 to see startup output
+
+Next command:
+  WEAVER_FOREGROUND=1 weaver daemon start
+```
+
 ## Command reference
 
 `weaver` exposes three command families: the `--capabilities` probe, daemon
@@ -233,6 +262,8 @@ Running `weaver` without any arguments prints a short help summary to standard
 error and exits with a non-zero status code:
 
 ```text
+error: command domain must be provided
+
 Usage: weaver <DOMAIN> <OPERATION> [ARG]...
 
 Domains:
@@ -240,12 +271,14 @@ Domains:
   act       Perform code modifications
   verify    Validate code correctness
 
-Run 'weaver --help' for more information.
+Next command:
+  weaver --help
 ```
 
-This output does not require a configuration file or a running daemon. Use
-`weaver --help` for the full reference, including global options and the
-`daemon` subcommand.
+This output follows the unified three-part error template: an error statement,
+an alternatives block, and a concrete next command. It does not require a
+configuration file or a running daemon. Use `weaver --help` for the full
+reference, including global options and the `daemon` subcommand.
 
 ### Version
 
@@ -302,7 +335,8 @@ Available operations:
   call-hierarchy
   get-card
 
-Run 'weaver observe get-definition --help' for operation details.
+Next command:
+  weaver observe get-definition --help
 ```
 
 Unknown domains list the canonical domains instead of printing the operation
@@ -314,20 +348,27 @@ error: unknown domain 'obsrve'
 
 Valid domains: observe, act, verify
 Did you mean 'observe'?
+
+Next command:
+  weaver observe get-definition --help
 ```
 
 The suggestion line appears only when exactly one valid domain is within edit
-distance 2 of the supplied token. More distant values omit the suggestion:
+distance 2 of the supplied token. More distant values omit the suggestion but
+still provide a next command:
 
 ```text
 $ weaver bogus get-definition --uri file:///tmp/main.rs --position 1:1
 error: unknown domain 'bogus'
 
 Valid domains: observe, act, verify
+
+Next command:
+  weaver --help
 ```
 
-The known-domain follow-up `--help` hint is concrete and deterministic, but
-until operation-level help lands it still resolves to the top-level help output.
+All error messages follow the unified three-part template: error statement,
+alternatives block, and concrete next command.
 
 Unknown operations are handled differently. The request still reaches the
 daemon because the daemon router owns the canonical operation list for each
@@ -345,6 +386,9 @@ Available operations:
   diagnostics
   call-hierarchy
   get-card
+
+Next command:
+  weaver observe get-definition --help
 ```
 
 JSON output forwards the daemon payload unchanged:

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -454,9 +454,28 @@ structured stderr payload inside the existing JSONL `stream` envelope:
 
 The CLI preserves that payload unchanged in `--output json` mode. In
 `--output human` mode it renders the payload into an actionable guidance block
-headed by `Available operations:`. The CLI does not consult its own
-discoverability catalogue for this case, preventing drift between client help
-text and daemon dispatch authority.
+following the unified three-part error template (roadmap 2.3.3):
+
+```plaintext
+error: unknown operation 'nonexistent' for domain 'observe'
+
+Available operations:
+  get-definition
+  find-references
+  grep
+  diagnostics
+  call-hierarchy
+  get-card
+
+Next command:
+  weaver observe get-definition --help
+```
+
+The three-part template—error statement, alternatives block, and next
+command—provides consistent, actionable guidance across all Level 10 failure
+paths. The CLI does not consult its own discoverability catalogue for unknown
+operations, preventing drift between client help text and daemon dispatch
+authority.
 
 #### 2.1.2. Lifecycle orchestration
 
@@ -550,6 +569,37 @@ recoverable connection failures (`ConnectionRefused`, `NotFound`,
 `AddrNotAvailable`) from other errors that should fail immediately. This
 ensures the CLI only attempts auto-start when the daemon genuinely isn't
 running, rather than masking configuration errors or network issues.
+
+When auto-start fails, the CLI renders the failure using the unified three-part
+error template (roadmap 2.3.3). For a missing `weaverd` binary:
+
+```plaintext
+error: failed to spawn weaverd binary 'weaverd'
+
+Valid alternatives:
+  - Verify weaverd is installed and in your PATH
+  - Set WEAVERD_BIN to the full path to the weaverd binary
+
+Next command:
+  command -v weaverd || echo 'weaverd not found in PATH'
+```
+
+For startup failures (daemon exits without becoming ready):
+
+```plaintext
+error: daemon exited before reporting ready (status: Some(1))
+
+Valid alternatives:
+  - Check the daemon logs for errors
+  - Run with WEAVER_FOREGROUND=1 to see startup output
+
+Next command:
+  WEAVER_FOREGROUND=1 weaver daemon start
+```
+
+This consistent structure—error statement, alternatives block, and next
+command—applies across all Level 10 failure paths including bare invocation,
+unknown domains, unknown operations, and startup failures.
 
 #### 2.1.4. Human-readable output and code context blocks
 


### PR DESCRIPTION
## Summary by Sourcery

Fixes an issue where the error prefix could be duplicated in human output and broadens test coverage for the unified three-part actionable guidance template used across startup, routing, bare-invocation, and domain/operation failures.

## Enhancements

- Introduce a reusable actionable guidance formatter and apply it across bare invocation, unknown domain, missing operation, unknown operation, and lifecycle/startup error paths to produce consistent error, alternatives, and next-command output.
- Unify startup error rendering for both auto-start failures and explicit daemon startup failures, including WEAVERD_BIN installation checks and path guidance, without changing exit-code semantics.
- Refactor localization usage to leverage the new actionable guidance formatter while reusing existing localized strings where possible.
- Improve tests to assert the three-part template structure, correct next-command derivation from daemon payload, and avoidance of duplicated "error:" prefixes in all relevant paths.
- Extend documentation with an execution plan for roadmap item 2-3-3 and operator-facing examples of the unified template.
- Update tests and artefacts:
  - New: crates/weaver-cli/src/actionable_guidance.rs
  - Updated: crates/weaver-cli/src/discoverability.rs, crates/weaver-cli/src/output/mod.rs, crates/weaver-cli/src/lib.rs
  - Added: docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
  - Updated: docs/weaver-design.md, docs/users-guide.md, docs/roadmap.md

📎 Task: https://www.devboxer.com/task/106d1000-b187-43e9-ae2d-082e3da02419