### PR TITLE
Implement normalization into canonical Formula with semantic checks (4.1.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,6 +2119,7 @@ dependencies = [
  "sempai_core",
  "sempai_yaml",
  "serde_json",
+ "tracing",
  "weaver-test-macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 name = "sempai"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 name = "sempai"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
  "rstest",
  "rstest-bdd",

--- a/crates/sempai-core/Cargo.toml
+++ b/crates/sempai-core/Cargo.toml
@@ -9,6 +9,7 @@ test-support = []
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sempai-core/Cargo.toml
+++ b/crates/sempai-core/Cargo.toml
@@ -9,7 +9,6 @@ test-support = []
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sempai-core/src/formula.rs
+++ b/crates/sempai-core/src/formula.rs
@@ -1,0 +1,173 @@
+//! Canonical normalized query formula model.
+//!
+//! All legacy (`pattern*`) and v2 (`match`) syntaxes are lowered into this
+//! shared representation before semantic validation and plan compilation.
+//!
+//! # Overview
+//!
+//! The [`Formula`] enum represents the normalized query structure with
+//! boolean operators (`And`, `Or`), negation (`Not`), context constraints
+//! (`Inside`, `Anywhere`), and leaf atoms ([`Atom`]).  Each formula node
+//! can be wrapped in a [`Decorated`] container that carries optional
+//! metadata like `where` clauses, alias bindings, and fix templates.
+//!
+//! # Example
+//!
+//! ```
+//! use sempai_core::formula::{Formula, Atom, PatternAtom, Decorated};
+//!
+//! // A simple pattern atom
+//! let pattern = PatternAtom { text: String::from("foo($X)") };
+//! let formula = Formula::Atom(Atom::Pattern(pattern));
+//!
+//! // Wrap in a decorator with no metadata
+//! let decorated = Decorated {
+//!     node: formula,
+//!     where_clauses: vec![],
+//!     as_name: None,
+//!     fix: None,
+//!     span: None,
+//! };
+//! ```
+
+use crate::SourceSpan;
+use serde_json::Value;
+
+/// Canonical normalized query formula.
+///
+/// All legacy and v2 syntaxes are lowered into this shared representation
+/// before semantic validation and plan compilation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Formula {
+    /// A leaf pattern or regex atom.
+    Atom(Atom),
+    /// Negation: the inner formula must not match.
+    Not(Box<Decorated<Formula>>),
+    /// Context constraint: the anchor must be inside a match of the inner.
+    Inside(Box<Decorated<Formula>>),
+    /// Context constraint: the inner must match somewhere in scope.
+    Anywhere(Box<Decorated<Formula>>),
+    /// Conjunction: all branches must match.
+    And(Vec<Decorated<Formula>>),
+    /// Disjunction: at least one branch must match.
+    Or(Vec<Decorated<Formula>>),
+}
+
+/// A leaf atom in the formula tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Atom {
+    /// A host-language pattern snippet.
+    Pattern(PatternAtom),
+    /// A regex pattern.
+    Regex(RegexAtom),
+    /// A raw Tree-sitter query (escape hatch).
+    TreeSitterQuery(TreeSitterQueryAtom),
+}
+
+/// A pattern snippet atom containing a host-language code fragment.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::formula::PatternAtom;
+///
+/// let pattern = PatternAtom {
+///     text: String::from("def $FUNC($...ARGS):"),
+/// };
+/// assert_eq!(pattern.text, "def $FUNC($...ARGS):");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatternAtom {
+    /// The raw host-language code fragment with Semgrep tokens.
+    pub text: String,
+}
+
+/// A regex atom.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::formula::RegexAtom;
+///
+/// let regex = RegexAtom {
+///     pattern: String::from(r"foo_\d+"),
+/// };
+/// assert_eq!(regex.pattern, r"foo_\d+");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegexAtom {
+    /// The regular expression pattern string.
+    pub pattern: String,
+}
+
+/// A raw Tree-sitter query atom (escape hatch for direct Tree-sitter queries).
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::formula::TreeSitterQueryAtom;
+///
+/// let ts_query = TreeSitterQueryAtom {
+///     query: String::from("(function_definition) @func"),
+/// };
+/// assert_eq!(ts_query.query, "(function_definition) @func");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeSitterQueryAtom {
+    /// The Tree-sitter query string.
+    pub query: String,
+}
+
+/// Wraps a formula node with optional decorator metadata.
+///
+/// Decorators carry `where` constraint clauses, alias bindings (`as`),
+/// fix templates, and source span information for diagnostic anchoring.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::formula::{Decorated, Formula, Atom, PatternAtom};
+///
+/// let pattern = PatternAtom { text: String::from("foo($X)") };
+/// let decorated = Decorated {
+///     node: Formula::Atom(Atom::Pattern(pattern)),
+///     where_clauses: vec![],
+///     as_name: Some(String::from("my_match")),
+///     fix: None,
+///     span: None,
+/// };
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Decorated<T> {
+    /// The core formula or atom.
+    pub node: T,
+    /// Optional `where` constraint clauses.
+    pub where_clauses: Vec<WhereClause>,
+    /// Optional alias binding name.
+    pub as_name: Option<String>,
+    /// Optional fix template text.
+    pub fix: Option<String>,
+    /// Source span for diagnostic anchoring.
+    pub span: Option<SourceSpan>,
+}
+
+/// An opaque `where` constraint clause preserved for later interpretation.
+///
+/// Where clauses are stored as raw JSON values during normalization and
+/// are interpreted semantically in later compilation phases.
+///
+/// # Example
+///
+/// ```
+/// use sempai_core::formula::WhereClause;
+/// use serde_json::json;
+///
+/// let clause = WhereClause {
+///     raw: json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}}),
+/// };
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhereClause {
+    /// The raw JSON value of the constraint.
+    pub raw: Value,
+}

--- a/crates/sempai-core/src/formula.rs
+++ b/crates/sempai-core/src/formula.rs
@@ -32,15 +32,13 @@
 //! };
 //! ```
 
-use serde_json::Value;
-
 use crate::SourceSpan;
 
 /// Canonical normalized query formula.
 ///
 /// All legacy and v2 syntaxes are lowered into this shared representation
 /// before semantic validation and plan compilation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Formula {
     /// A leaf pattern or regex atom.
     Atom(Atom),
@@ -142,7 +140,7 @@ pub struct TreeSitterQueryAtom {
 ///     span: None,
 /// };
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Decorated<T> {
     /// The core formula or atom.
     pub node: T,
@@ -156,23 +154,47 @@ pub struct Decorated<T> {
     pub span: Option<SourceSpan>,
 }
 
-/// An opaque `where` constraint clause preserved for later interpretation.
+/// A normalized `where` constraint.
 ///
-/// Where clauses are stored as raw JSON values during normalization and
-/// are interpreted semantically in later compilation phases.
+/// Known Semgrep constraint shapes are represented structurally. Unknown
+/// constraint shapes are preserved as strings for later interpretation by
+/// adapter or compilation layers.
 ///
 /// # Example
 ///
 /// ```
-/// use sempai_core::formula::WhereClause;
-/// use serde_json::json;
+/// use sempai_core::formula::{Constraint, WhereClause};
 ///
 /// let clause = WhereClause {
-///     raw: json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}}),
+///     constraint: Constraint::MetavariableRegex {
+///         metavariable: String::from("$X"),
+///         regex: String::from("foo.*"),
+///     },
 /// };
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WhereClause {
-    /// The raw JSON value of the constraint.
-    pub raw: Value,
+    /// The normalized constraint payload.
+    pub constraint: Constraint,
+}
+
+/// A normalized `where` constraint payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Constraint {
+    /// A metavariable must match the given regular expression.
+    MetavariableRegex {
+        /// The metavariable name, including the leading `$`.
+        metavariable: String,
+        /// The regular expression pattern.
+        regex: String,
+    },
+    /// A metavariable must match the given Semgrep pattern.
+    MetavariablePattern {
+        /// The metavariable name, including the leading `$`.
+        metavariable: String,
+        /// The Semgrep pattern text.
+        pattern: String,
+    },
+    /// A currently unmodelled constraint, preserved lossily as JSON text.
+    Other(String),
 }

--- a/crates/sempai-core/src/formula.rs
+++ b/crates/sempai-core/src/formula.rs
@@ -40,7 +40,7 @@ use crate::SourceSpan;
 ///
 /// All legacy and v2 syntaxes are lowered into this shared representation
 /// before semantic validation and plan compilation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Formula {
     /// A leaf pattern or regex atom.
     Atom(Atom),
@@ -142,7 +142,7 @@ pub struct TreeSitterQueryAtom {
 ///     span: None,
 /// };
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Decorated<T> {
     /// The core formula or atom.
     pub node: T,
@@ -171,7 +171,7 @@ pub struct Decorated<T> {
 ///     raw: json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}}),
 /// };
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhereClause {
     /// The raw JSON value of the constraint.
     pub raw: Value,

--- a/crates/sempai-core/src/formula.rs
+++ b/crates/sempai-core/src/formula.rs
@@ -14,10 +14,12 @@
 //! # Example
 //!
 //! ```
-//! use sempai_core::formula::{Formula, Atom, PatternAtom, Decorated};
+//! use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 //!
 //! // A simple pattern atom
-//! let pattern = PatternAtom { text: String::from("foo($X)") };
+//! let pattern = PatternAtom {
+//!     text: String::from("foo($X)"),
+//! };
 //! let formula = Formula::Atom(Atom::Pattern(pattern));
 //!
 //! // Wrap in a decorator with no metadata
@@ -30,8 +32,9 @@
 //! };
 //! ```
 
-use crate::SourceSpan;
 use serde_json::Value;
+
+use crate::SourceSpan;
 
 /// Canonical normalized query formula.
 ///
@@ -42,15 +45,15 @@ pub enum Formula {
     /// A leaf pattern or regex atom.
     Atom(Atom),
     /// Negation: the inner formula must not match.
-    Not(Box<Decorated<Formula>>),
+    Not(Box<Decorated<Self>>),
     /// Context constraint: the anchor must be inside a match of the inner.
-    Inside(Box<Decorated<Formula>>),
+    Inside(Box<Decorated<Self>>),
     /// Context constraint: the inner must match somewhere in scope.
-    Anywhere(Box<Decorated<Formula>>),
+    Anywhere(Box<Decorated<Self>>),
     /// Conjunction: all branches must match.
-    And(Vec<Decorated<Formula>>),
+    And(Vec<Decorated<Self>>),
     /// Disjunction: at least one branch must match.
-    Or(Vec<Decorated<Formula>>),
+    Or(Vec<Decorated<Self>>),
 }
 
 /// A leaf atom in the formula tree.
@@ -126,9 +129,11 @@ pub struct TreeSitterQueryAtom {
 /// # Example
 ///
 /// ```
-/// use sempai_core::formula::{Decorated, Formula, Atom, PatternAtom};
+/// use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 ///
-/// let pattern = PatternAtom { text: String::from("foo($X)") };
+/// let pattern = PatternAtom {
+///     text: String::from("foo($X)"),
+/// };
 /// let decorated = Decorated {
 ///     node: Formula::Atom(Atom::Pattern(pattern)),
 ///     where_clauses: vec![],

--- a/crates/sempai-core/src/lib.rs
+++ b/crates/sempai-core/src/lib.rs
@@ -28,6 +28,7 @@
 mod capture;
 mod config;
 mod diagnostic;
+pub mod formula;
 mod language;
 mod match_result;
 mod span;

--- a/crates/sempai/Cargo.toml
+++ b/crates/sempai/Cargo.toml
@@ -10,6 +10,7 @@ sempai_yaml = { path = "../sempai-yaml" }
 tracing = "0.1"
 
 [dev-dependencies]
+insta = "1"
 proptest = "1.5"
 sempai_core = { path = "../sempai-core", features = ["test-support"] }
 rstest = { workspace = true }

--- a/crates/sempai/Cargo.toml
+++ b/crates/sempai/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 [dependencies]
 sempai_core = { path = "../sempai-core" }
 sempai_yaml = { path = "../sempai-yaml" }
+tracing = "0.1"
 
 [dev-dependencies]
 sempai_core = { path = "../sempai-core", features = ["test-support"] }

--- a/crates/sempai/Cargo.toml
+++ b/crates/sempai/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 [dependencies]
 sempai_core = { path = "../sempai-core" }
 sempai_yaml = { path = "../sempai-yaml" }
+serde_json = { workspace = true }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/sempai/Cargo.toml
+++ b/crates/sempai/Cargo.toml
@@ -10,6 +10,7 @@ sempai_yaml = { path = "../sempai-yaml" }
 tracing = "0.1"
 
 [dev-dependencies]
+proptest = "1.5"
 sempai_core = { path = "../sempai-core", features = ["test-support"] }
 rstest = { workspace = true }
 rstest-bdd = { workspace = true }

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -155,7 +155,7 @@ impl Engine {
                 }
             })
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
-                let formula = normalize_search_principal(principal, rule.rule_span())?;
+                let formula = normalize_search_principal(principal, rule.rule_span());
                 validate_formula(&formula)?;
                 let rule_plans = compile_rule_plans(rule, &formula)?;
                 plans.extend(rule_plans);

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -7,7 +7,7 @@
 
 use sempai_core::formula::{Decorated, Formula};
 use sempai_core::{DiagnosticCode, DiagnosticReport, EngineConfig, Language, Match};
-use sempai_yaml::{parse_rule_file, Rule, RulePrincipal};
+use sempai_yaml::{Rule, RulePrincipal, parse_rule_file};
 
 use crate::mode_validation::validate_supported_modes;
 use crate::normalize::normalize_search_principal;

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -5,10 +5,38 @@
 //! Compilation and execution are separate phases, allowing a compiled
 //! [`QueryPlan`] to be reused across multiple source files.
 
-use sempai_core::{DiagnosticReport, EngineConfig, Language, Match};
-use sempai_yaml::parse_rule_file;
+use sempai_core::formula::{Decorated, Formula};
+use sempai_core::{DiagnosticCode, DiagnosticReport, EngineConfig, Language, Match};
+use sempai_yaml::{parse_rule_file, Rule, RulePrincipal};
 
 use crate::mode_validation::validate_supported_modes;
+use crate::normalize::normalize_search_principal;
+use crate::semantic_check::validate_formula;
+
+/// Compiles query plans for a single rule's languages.
+fn compile_rule_plans(
+    rule: &Rule,
+    formula: &Decorated<Formula>,
+) -> Result<Vec<QueryPlan>, DiagnosticReport> {
+    rule.languages()
+        .iter()
+        .map(|lang_str| {
+            let language = lang_str.parse::<Language>().map_err(|e| {
+                DiagnosticReport::validation_error(
+                    DiagnosticCode::ESempaiSchemaInvalid,
+                    format!("unsupported language '{lang_str}': {e}"),
+                    rule.rule_span().cloned(),
+                    vec![],
+                )
+            })?;
+            Ok(QueryPlan::new(
+                rule.id().to_owned(),
+                language,
+                formula.clone(),
+            ))
+        })
+        .collect()
+}
 
 /// A compiled query plan for one rule and one language.
 ///
@@ -30,26 +58,22 @@ use crate::mode_validation::validate_supported_modes;
 pub struct QueryPlan {
     rule_id: String,
     language: Language,
-    /// Placeholder for the internal plan representation.  Will be replaced
-    /// by `sempai_core::PlanNode` once the normalization layer is built.
-    _plan: (),
+    /// The normalized canonical formula.
+    formula: Decorated<Formula>,
 }
 
 impl QueryPlan {
     /// Creates a new query plan (crate-internal).
-    // FIXME: remove `#[cfg(test)]` when `compile_yaml` / `compile_dsl` produce
-    // real plans — https://github.com/leynos/weaver/issues/67
-    #[cfg(test)]
     #[must_use]
     #[expect(
         clippy::missing_const_for_fn,
         reason = "heap types cannot be used in const contexts"
     )]
-    pub(crate) fn new(rule_id: String, language: Language) -> Self {
+    pub(crate) fn new(rule_id: String, language: Language, formula: Decorated<Formula>) -> Self {
         Self {
             rule_id,
             language,
-            _plan: (),
+            formula,
         }
     }
 
@@ -63,6 +87,12 @@ impl QueryPlan {
     #[must_use]
     pub const fn language(&self) -> Language {
         self.language
+    }
+
+    /// Returns the normalized canonical formula.
+    #[must_use]
+    pub const fn formula(&self) -> &Decorated<Formula> {
+        &self.formula
     }
 }
 
@@ -80,9 +110,13 @@ impl QueryPlan {
 /// use sempai::{Engine, EngineConfig};
 ///
 /// let engine = Engine::new(EngineConfig::default());
-/// let result = engine.compile_yaml("rules: []");
-/// // Malformed YAML and schema errors now surface parser diagnostics.
-/// assert!(result.is_err());
+/// // Valid YAML with rules compiles successfully
+/// let result = engine.compile_yaml("rules:\n  - id: test\n    message: test\n    languages: [rust]\n    severity: ERROR\n    pattern: foo\n");
+/// assert!(result.is_ok());
+///
+/// // Malformed YAML returns a parser diagnostic
+/// let bad_result = engine.compile_yaml("{ invalid yaml");
+/// assert!(bad_result.is_err());
 /// ```
 #[derive(Debug)]
 pub struct Engine {
@@ -106,16 +140,27 @@ impl Engine {
     ///
     /// # Errors
     ///
-    /// Returns a diagnostic report if parsing or validation fails.
-    ///
-    /// Successful YAML parsing still stops at the post-parse placeholder until
-    /// rule normalization is implemented.
+    /// Returns a diagnostic report if parsing, normalization, or validation fails.
     pub fn compile_yaml(&self, yaml: &str) -> Result<Vec<QueryPlan>, DiagnosticReport> {
         let file = parse_rule_file(yaml, None)?;
         validate_supported_modes(&file)?;
-        Err(DiagnosticReport::not_implemented(
-            "compile_yaml query-plan normalization",
-        ))
+
+        file.rules()
+            .iter()
+            .filter_map(|rule| {
+                if let RulePrincipal::Search(principal) = rule.principal() {
+                    Some((rule, principal))
+                } else {
+                    None
+                }
+            })
+            .try_fold(Vec::new(), |mut plans, (rule, principal)| {
+                let formula = normalize_search_principal(principal, rule.rule_span())?;
+                validate_formula(&formula)?;
+                let rule_plans = compile_rule_plans(rule, &formula)?;
+                plans.extend(rule_plans);
+                Ok(plans)
+            })
     }
 
     /// Compiles a one-liner query DSL expression into a query plan.

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -99,7 +99,7 @@ impl Engine {
                 }
             })
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
-                let formula = normalize_search_principal(principal, rule.rule_span())?;
+                let formula = normalize_search_principal(principal, rule.rule_span());
                 validate_formula(&formula)?;
                 let rule_plans = compile_rule_plans(rule, &formula)?;
                 plans.extend(rule_plans);

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -20,7 +20,7 @@ use sempai_yaml::{Rule, RulePrincipal, parse_rule_file};
 use crate::{
     mode_validation::validate_supported_modes,
     normalize::normalize_search_principal,
-    semantic_check::{MAX_FORMULA_DEPTH, formula_depth, validate_formula},
+    semantic_check::{validate_formula, validate_formula_depth},
 };
 
 /// A compiled query plan for one rule and target language.
@@ -165,22 +165,6 @@ impl Engine {
     ) -> Result<Vec<Match>, DiagnosticReport> {
         Err(DiagnosticReport::not_implemented("execute"))
     }
-}
-
-pub(crate) fn validate_formula_depth(
-    formula: &Decorated<Formula>,
-    rule_span: Option<&sempai_core::SourceSpan>,
-) -> Result<(), DiagnosticReport> {
-    let depth = formula_depth(formula);
-    if depth > MAX_FORMULA_DEPTH {
-        return Err(DiagnosticReport::validation_error(
-            DiagnosticCode::ESempaiSchemaInvalid,
-            format!("formula nesting depth exceeds limit of {MAX_FORMULA_DEPTH}: {depth}"),
-            rule_span.cloned(),
-            vec![],
-        ));
-    }
-    Ok(())
 }
 
 /// Compiles query plans for a single rule's languages.

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -20,7 +20,7 @@ use sempai_yaml::{Rule, RulePrincipal, parse_rule_file};
 use crate::{
     mode_validation::validate_supported_modes,
     normalize::normalize_search_principal,
-    semantic_check::{validate_formula, validate_formula_depth},
+    semantic_check::validate_formula,
 };
 
 /// A compiled query plan for one rule and target language.
@@ -120,7 +120,6 @@ impl Engine {
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
                 tracing::debug!(rule_id = rule.id(), "normalizing principal");
                 let formula = normalize_search_principal(principal, rule.rule_span());
-                validate_formula_depth(&formula, rule.rule_span())?;
 
                 tracing::debug!(rule_id = rule.id(), "validating normalized formula");
                 validate_formula(&formula)?;

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -5,14 +5,24 @@
 //! Compilation and execution are separate phases, allowing a compiled
 //! [`QueryPlan`] to be reused across multiple source files.
 
-use sempai_core::formula::{Decorated, Formula};
-use sempai_core::{DiagnosticCode, DiagnosticReport, EngineConfig, Language, Match};
+use sempai_core::{
+    DiagnosticCode,
+    DiagnosticReport,
+    EngineConfig,
+    Language,
+    Match,
+    formula::{Decorated, Formula},
+};
 use sempai_yaml::{Rule, RulePrincipal, parse_rule_file};
 
-use crate::mode_validation::validate_supported_modes;
-use crate::normalize::normalize_search_principal;
-use crate::semantic_check::validate_formula;
+use crate::{
+    mode_validation::validate_supported_modes,
+    normalize::normalize_search_principal,
+    semantic_check::validate_formula,
+};
 
+/// A compiled query plan for one rule and target language.
+#[derive(Debug)]
 pub struct QueryPlan {
     rule_id: String,
     language: Language,
@@ -21,7 +31,11 @@ pub struct QueryPlan {
 }
 
 impl QueryPlan {
-    pub(crate) fn new(rule_id: String, language: Language, formula: Decorated<Formula>) -> Self {
+    pub(crate) const fn new(
+        rule_id: String,
+        language: Language,
+        formula: Decorated<Formula>,
+    ) -> Self {
         Self {
             rule_id,
             language,
@@ -39,9 +53,7 @@ impl QueryPlan {
 
     /// Returns the normalized canonical formula.
     #[must_use]
-    pub const fn formula(&self) -> &Decorated<Formula> {
-        &self.formula
-    }
+    pub const fn formula(&self) -> &Decorated<Formula> { &self.formula }
 }
 
 /// Compiles and executes Semgrep-compatible queries on Tree-sitter syntax
@@ -59,7 +71,10 @@ impl QueryPlan {
 ///
 /// let engine = Engine::new(EngineConfig::default());
 /// // Valid YAML with rules compiles successfully
-/// let result = engine.compile_yaml("rules:\n  - id: test\n    message: test\n    languages: [rust]\n    severity: ERROR\n    pattern: foo\n");
+/// let result = engine.compile_yaml(
+///     "rules:\n  - id: test\n    message: test\n    languages: [rust]\n    severity: ERROR\n    \
+///      pattern: foo\n",
+/// );
 /// assert!(result.is_ok());
 ///
 /// // Malformed YAML returns a parser diagnostic

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -102,8 +102,10 @@ impl Engine {
     /// # Errors
     ///
     /// Returns a diagnostic report if parsing, normalization, or validation fails.
+    #[tracing::instrument(level = "info", skip_all, fields(rules = tracing::field::Empty))]
     pub fn compile_yaml(&self, yaml: &str) -> Result<Vec<QueryPlan>, DiagnosticReport> {
         let file = parse_rule_file(yaml, None)?;
+        tracing::Span::current().record("rules", file.rules().len());
         validate_supported_modes(&file)?;
 
         file.rules()
@@ -116,8 +118,17 @@ impl Engine {
                 }
             })
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
+                tracing::debug!(rule_id = rule.id(), "normalizing principal");
                 let formula = normalize_search_principal(principal, rule.rule_span());
+
+                tracing::debug!(rule_id = rule.id(), "validating normalized formula");
                 validate_formula(&formula)?;
+
+                tracing::debug!(
+                    rule_id = rule.id(),
+                    languages = ?rule.languages(),
+                    "compiling rule plans"
+                );
                 let rule_plans = compile_rule_plans(rule, formula)?;
                 plans.extend(rule_plans);
                 Ok(plans)
@@ -164,6 +175,12 @@ fn compile_rule_plans(
     rule.languages()
         .iter()
         .map(|lang_str| {
+            let _span = tracing::debug_span!(
+                "compile_rule_plan",
+                rule_id = rule.id(),
+                language = lang_str.as_str()
+            )
+            .entered();
             let language = lang_str.parse::<Language>().map_err(|e| {
                 DiagnosticReport::validation_error(
                     DiagnosticCode::ESempaiSchemaInvalid,

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -5,6 +5,8 @@
 //! Compilation and execution are separate phases, allowing a compiled
 //! [`QueryPlan`] to be reused across multiple source files.
 
+use std::sync::Arc;
+
 use sempai_core::{
     DiagnosticCode,
     DiagnosticReport,
@@ -27,14 +29,14 @@ pub struct QueryPlan {
     rule_id: String,
     language: Language,
     /// The normalized canonical formula.
-    formula: Decorated<Formula>,
+    formula: Arc<Decorated<Formula>>,
 }
 
 impl QueryPlan {
     pub(crate) const fn new(
         rule_id: String,
         language: Language,
-        formula: Decorated<Formula>,
+        formula: Arc<Decorated<Formula>>,
     ) -> Self {
         Self {
             rule_id,
@@ -53,7 +55,7 @@ impl QueryPlan {
 
     /// Returns the normalized canonical formula.
     #[must_use]
-    pub const fn formula(&self) -> &Decorated<Formula> { &self.formula }
+    pub fn formula(&self) -> &Decorated<Formula> { self.formula.as_ref() }
 }
 
 /// Compiles and executes Semgrep-compatible queries on Tree-sitter syntax
@@ -116,7 +118,7 @@ impl Engine {
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
                 let formula = normalize_search_principal(principal, rule.rule_span());
                 validate_formula(&formula)?;
-                let rule_plans = compile_rule_plans(rule, &formula)?;
+                let rule_plans = compile_rule_plans(rule, formula)?;
                 plans.extend(rule_plans);
                 Ok(plans)
             })
@@ -156,8 +158,9 @@ impl Engine {
 /// Compiles query plans for a single rule's languages.
 fn compile_rule_plans(
     rule: &Rule,
-    formula: &Decorated<Formula>,
+    formula: Decorated<Formula>,
 ) -> Result<Vec<QueryPlan>, DiagnosticReport> {
+    let shared_formula = Arc::new(formula);
     rule.languages()
         .iter()
         .map(|lang_str| {
@@ -172,7 +175,7 @@ fn compile_rule_plans(
             Ok(QueryPlan::new(
                 rule.id().to_owned(),
                 language,
-                formula.clone(),
+                Arc::clone(&shared_formula),
             ))
         })
         .collect()

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -5,51 +5,27 @@
 //! Compilation and execution are separate phases, allowing a compiled
 //! [`QueryPlan`] to be reused across multiple source files.
 
-use sempai_core::{DiagnosticReport, EngineConfig, Language, Match};
-use sempai_yaml::parse_rule_file;
+use sempai_core::formula::{Decorated, Formula};
+use sempai_core::{DiagnosticCode, DiagnosticReport, EngineConfig, Language, Match};
+use sempai_yaml::{parse_rule_file, Rule, RulePrincipal};
 
 use crate::mode_validation::validate_supported_modes;
+use crate::normalize::normalize_search_principal;
+use crate::semantic_check::validate_formula;
 
-/// A compiled query plan for one rule and one language.
-///
-/// Query plans are produced by [`Engine::compile_yaml`] or
-/// [`Engine::compile_dsl`] and can be executed against source snapshots
-/// via [`Engine::execute`].
-///
-/// # Example
-///
-/// ```
-/// use sempai::{Engine, EngineConfig, Language};
-///
-/// let engine = Engine::new(EngineConfig::default());
-/// // compile_dsl currently returns an error (not yet implemented)
-/// let result = engine.compile_dsl("rule-1", Language::Rust, "pattern(\"fn $F\")");
-/// assert!(result.is_err());
-/// ```
-#[derive(Debug, Clone)]
 pub struct QueryPlan {
     rule_id: String,
     language: Language,
-    /// Placeholder for the internal plan representation.  Will be replaced
-    /// by `sempai_core::PlanNode` once the normalization layer is built.
-    _plan: (),
+    /// The normalized canonical formula.
+    formula: Decorated<Formula>,
 }
 
 impl QueryPlan {
-    /// Creates a new query plan (crate-internal).
-    // FIXME: remove `#[cfg(test)]` when `compile_yaml` / `compile_dsl` produce
-    // real plans — https://github.com/leynos/weaver/issues/67
-    #[cfg(test)]
-    #[must_use]
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "heap types cannot be used in const contexts"
-    )]
-    pub(crate) fn new(rule_id: String, language: Language) -> Self {
+    pub(crate) fn new(rule_id: String, language: Language, formula: Decorated<Formula>) -> Self {
         Self {
             rule_id,
             language,
-            _plan: (),
+            formula,
         }
     }
 
@@ -60,6 +36,12 @@ impl QueryPlan {
     /// Returns the target language.
     #[must_use]
     pub const fn language(&self) -> Language { self.language }
+
+    /// Returns the normalized canonical formula.
+    #[must_use]
+    pub const fn formula(&self) -> &Decorated<Formula> {
+        &self.formula
+    }
 }
 
 /// Compiles and executes Semgrep-compatible queries on Tree-sitter syntax
@@ -76,9 +58,13 @@ impl QueryPlan {
 /// use sempai::{Engine, EngineConfig};
 ///
 /// let engine = Engine::new(EngineConfig::default());
-/// let result = engine.compile_yaml("rules: []");
-/// // Malformed YAML and schema errors now surface parser diagnostics.
-/// assert!(result.is_err());
+/// // Valid YAML with rules compiles successfully
+/// let result = engine.compile_yaml("rules:\n  - id: test\n    message: test\n    languages: [rust]\n    severity: ERROR\n    pattern: foo\n");
+/// assert!(result.is_ok());
+///
+/// // Malformed YAML returns a parser diagnostic
+/// let bad_result = engine.compile_yaml("{ invalid yaml");
+/// assert!(bad_result.is_err());
 /// ```
 #[derive(Debug)]
 pub struct Engine {
@@ -98,16 +84,27 @@ impl Engine {
     ///
     /// # Errors
     ///
-    /// Returns a diagnostic report if parsing or validation fails.
-    ///
-    /// Successful YAML parsing still stops at the post-parse placeholder until
-    /// rule normalization is implemented.
+    /// Returns a diagnostic report if parsing, normalization, or validation fails.
     pub fn compile_yaml(&self, yaml: &str) -> Result<Vec<QueryPlan>, DiagnosticReport> {
         let file = parse_rule_file(yaml, None)?;
         validate_supported_modes(&file)?;
-        Err(DiagnosticReport::not_implemented(
-            "compile_yaml query-plan normalization",
-        ))
+
+        file.rules()
+            .iter()
+            .filter_map(|rule| {
+                if let RulePrincipal::Search(principal) = rule.principal() {
+                    Some((rule, principal))
+                } else {
+                    None
+                }
+            })
+            .try_fold(Vec::new(), |mut plans, (rule, principal)| {
+                let formula = normalize_search_principal(principal, rule.rule_span())?;
+                validate_formula(&formula)?;
+                let rule_plans = compile_rule_plans(rule, &formula)?;
+                plans.extend(rule_plans);
+                Ok(plans)
+            })
     }
 
     /// Compiles a one-liner query DSL expression into a query plan.
@@ -139,4 +136,29 @@ impl Engine {
     ) -> Result<Vec<Match>, DiagnosticReport> {
         Err(DiagnosticReport::not_implemented("execute"))
     }
+}
+
+/// Compiles query plans for a single rule's languages.
+fn compile_rule_plans(
+    rule: &Rule,
+    formula: &Decorated<Formula>,
+) -> Result<Vec<QueryPlan>, DiagnosticReport> {
+    rule.languages()
+        .iter()
+        .map(|lang_str| {
+            let language = lang_str.parse::<Language>().map_err(|e| {
+                DiagnosticReport::validation_error(
+                    DiagnosticCode::ESempaiSchemaInvalid,
+                    format!("unsupported language '{lang_str}': {e}"),
+                    rule.rule_span().cloned(),
+                    vec![],
+                )
+            })?;
+            Ok(QueryPlan::new(
+                rule.id().to_owned(),
+                language,
+                formula.clone(),
+            ))
+        })
+        .collect()
 }

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -119,7 +119,7 @@ impl Engine {
             })
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
                 tracing::debug!(rule_id = rule.id(), "normalizing principal");
-                let formula = normalize_search_principal(principal, rule.rule_span());
+                let formula = normalize_search_principal(principal, rule.rule_span())?;
 
                 tracing::debug!(rule_id = rule.id(), "validating normalized formula");
                 validate_formula(&formula)?;

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -20,7 +20,7 @@ use sempai_yaml::{Rule, RulePrincipal, parse_rule_file};
 use crate::{
     mode_validation::validate_supported_modes,
     normalize::normalize_search_principal,
-    semantic_check::validate_formula,
+    semantic_check::{MAX_FORMULA_DEPTH, formula_depth, validate_formula},
 };
 
 /// A compiled query plan for one rule and target language.
@@ -120,6 +120,7 @@ impl Engine {
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
                 tracing::debug!(rule_id = rule.id(), "normalizing principal");
                 let formula = normalize_search_principal(principal, rule.rule_span());
+                validate_formula_depth(&formula, rule.rule_span())?;
 
                 tracing::debug!(rule_id = rule.id(), "validating normalized formula");
                 validate_formula(&formula)?;
@@ -164,6 +165,22 @@ impl Engine {
     ) -> Result<Vec<Match>, DiagnosticReport> {
         Err(DiagnosticReport::not_implemented("execute"))
     }
+}
+
+pub(crate) fn validate_formula_depth(
+    formula: &Decorated<Formula>,
+    rule_span: Option<&sempai_core::SourceSpan>,
+) -> Result<(), DiagnosticReport> {
+    let depth = formula_depth(formula);
+    if depth > MAX_FORMULA_DEPTH {
+        return Err(DiagnosticReport::validation_error(
+            DiagnosticCode::ESempaiSchemaInvalid,
+            format!("formula nesting depth exceeds limit of {MAX_FORMULA_DEPTH}: {depth}"),
+            rule_span.cloned(),
+            vec![],
+        ));
+    }
+    Ok(())
 }
 
 /// Compiles query plans for a single rule's languages.

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -37,6 +37,8 @@
 
 mod engine;
 mod mode_validation;
+mod normalize;
+mod semantic_check;
 
 // Re-export all stable types from sempai_core.
 pub use sempai_core::{

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -38,6 +38,7 @@
 mod engine;
 mod mode_validation;
 mod normalize;
+mod normalize_constraints;
 mod semantic_check;
 
 // Re-export all stable types from sempai_core.

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -37,6 +37,8 @@
 
 mod engine;
 mod mode_validation;
+mod normalize;
+mod semantic_check;
 
 // Re-export all stable types from sempai_core.
 pub use engine::{Engine, QueryPlan};

--- a/crates/sempai/src/lib.rs
+++ b/crates/sempai/src/lib.rs
@@ -39,6 +39,7 @@ mod engine;
 mod mode_validation;
 mod normalize;
 mod normalize_constraints;
+mod normalize_trace;
 mod semantic_check;
 
 // Re-export all stable types from sempai_core.

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -176,6 +176,30 @@ fn normalize_legacy_patterns(
     }
 }
 
+/// Normalizes a unary v2 match formula (Not, Inside, Anywhere).
+fn normalize_unary<F>(
+    inner: &MatchFormula,
+    fallback_span: Option<SourceSpan>,
+    wrap: F,
+) -> Decorated<Formula>
+where
+    F: FnOnce(Box<Decorated<Formula>>) -> Formula,
+{
+    let child = normalize_match(inner, fallback_span.clone());
+    bare(wrap(Box::new(child)), fallback_span)
+}
+
+/// Normalizes a list of v2 match formula branches (All, Any).
+fn normalize_branches(
+    branches: &[MatchFormula],
+    fallback_span: Option<&SourceSpan>,
+) -> Vec<Decorated<Formula>> {
+    branches
+        .iter()
+        .map(|b| normalize_match(b, fallback_span.cloned()))
+        .collect()
+}
+
 /// Normalizes a v2 match formula into canonical form.
 fn normalize_match(
     formula: &MatchFormula,
@@ -192,32 +216,17 @@ fn normalize_match(
             })),
             fallback_span,
         ),
-        MatchFormula::All(branches) => {
-            let normalized_branches = branches
-                .iter()
-                .map(|branch| normalize_match(branch, fallback_span.clone()))
-                .collect();
-            bare(Formula::And(normalized_branches), fallback_span)
-        }
-        MatchFormula::Any(branches) => {
-            let normalized_branches = branches
-                .iter()
-                .map(|branch| normalize_match(branch, fallback_span.clone()))
-                .collect();
-            bare(Formula::Or(normalized_branches), fallback_span)
-        }
-        MatchFormula::Not(inner) => {
-            let normalized_inner = normalize_match(inner, fallback_span.clone());
-            bare(Formula::Not(Box::new(normalized_inner)), fallback_span)
-        }
-        MatchFormula::Inside(inner) => {
-            let normalized_inner = normalize_match(inner, fallback_span.clone());
-            bare(Formula::Inside(Box::new(normalized_inner)), fallback_span)
-        }
-        MatchFormula::Anywhere(inner) => {
-            let normalized_inner = normalize_match(inner, fallback_span.clone());
-            bare(Formula::Anywhere(Box::new(normalized_inner)), fallback_span)
-        }
+        MatchFormula::All(branches) => bare(
+            Formula::And(normalize_branches(branches, fallback_span.as_ref())),
+            fallback_span,
+        ),
+        MatchFormula::Any(branches) => bare(
+            Formula::Or(normalize_branches(branches, fallback_span.as_ref())),
+            fallback_span,
+        ),
+        MatchFormula::Not(inner) => normalize_unary(inner, fallback_span, Formula::Not),
+        MatchFormula::Inside(inner) => normalize_unary(inner, fallback_span, Formula::Inside),
+        MatchFormula::Anywhere(inner) => normalize_unary(inner, fallback_span, Formula::Anywhere),
         MatchFormula::Decorated {
             formula: inner_formula,
             where_clauses: raw_where,

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -249,12 +249,14 @@ fn normalize_dependency_principal(
     _payload: &ProjectDependsOnPayload,
     fallback_span: Option<SourceSpan>,
 ) -> Decorated<Formula> {
-    // For now, represent as a degenerate pattern that will never match
-    // real code. This allows the rule to parse and normalize successfully
-    // without inventing execution semantics prematurely.
+    // For now, represent as a degenerate pattern that will never match real
+    // code. Use a node type that cannot exist in any Tree-sitter grammar
+    // (`__NONEXISTENT_NODE__`) so the query is guaranteed to be non-matchable;
+    // the earlier `(ERROR)` placeholder would have matched real parse-error
+    // nodes produced by Tree-sitter on malformed source.
     bare(
         Formula::Atom(Atom::TreeSitterQuery(TreeSitterQueryAtom {
-            query: String::from("(ERROR) @_dependency_check"),
+            query: String::from("(__NONEXISTENT_NODE__) @_dependency_check"),
         })),
         fallback_span,
     )

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -1,0 +1,330 @@
+//! Normalization of parsed query syntax into canonical formula model.
+//!
+//! This module provides the transformation from parsed
+//! [`SearchQueryPrincipal`] (either legacy or v2 syntax) into the canonical
+//! [`Formula`] model defined in `sempai_core::formula`.
+//!
+//! # Normalization rules
+//!
+//! Legacy-to-canonical mapping:
+//!
+//! - `pattern: "..."` → `Formula::Atom(Atom::Pattern(...))`
+//! - `pattern-regex: "..."` → `Formula::Atom(Atom::Regex(...))`
+//! - `patterns: [...]` → `Formula::And([...])`
+//! - `pattern-either: [...]` → `Formula::Or([...])`
+//! - `pattern-not: ...` → `Formula::Not(Box<...>)`
+//! - `pattern-inside: ...` → `Formula::Inside(Box<...>)`
+//! - `pattern-not-inside: ...` → `Formula::Not(Inside(...))`
+//! - `pattern-not-regex: "..."` → `Formula::Not(Atom(Regex(...)))`
+//! - `semgrep-internal-pattern-anywhere: ...` → `Formula::Anywhere(Box<...>)`
+//!
+//! v2-to-canonical mapping:
+//!
+//! - `"..."` (string shorthand) → `Formula::Atom(Atom::Pattern(...))`
+//! - `pattern: "..."` → `Formula::Atom(Atom::Pattern(...))`
+//! - `regex: "...` → `Formula::Atom(Atom::Regex(...))`
+//! - `all: [...]` → `Formula::And([...])`
+//! - `any: [...]` → `Formula::Or([...])`
+//! - `not: ...` → `Formula::Not(Box<...>)`
+//! - `inside: ...` → `Formula::Inside(Box<...>)`
+//! - `anywhere: ...` → `Formula::Anywhere(Box<...>)`
+
+use sempai_core::formula::{
+    Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause,
+};
+use sempai_core::{DiagnosticReport, SourceSpan};
+use sempai_yaml::{
+    LegacyClause, LegacyFormula, LegacyValue, MatchFormula, ProjectDependsOnPayload,
+    SearchQueryPrincipal,
+};
+
+/// Normalizes a parsed search principal into the canonical formula model.
+///
+/// # Errors
+///
+/// Returns a diagnostic report if the principal cannot be normalized
+/// (e.g., unsupported formula structure or missing required data).
+#[expect(clippy::unnecessary_wraps, reason = "future normalization steps may return errors")]
+pub(crate) fn normalize_search_principal(
+    principal: &SearchQueryPrincipal,
+    rule_span: Option<&SourceSpan>,
+) -> Result<Decorated<Formula>, DiagnosticReport> {
+    match principal {
+        SearchQueryPrincipal::Legacy(formula) => Ok(normalize_legacy(formula, rule_span.cloned())),
+        SearchQueryPrincipal::Match(formula) => Ok(normalize_match(formula, rule_span.cloned())),
+        SearchQueryPrincipal::ProjectDependsOn(payload) => {
+            Ok(normalize_dependency_principal(payload, rule_span.cloned()))
+        }
+    }
+}
+
+/// Normalizes a legacy formula into canonical form.
+#[expect(clippy::too_many_lines, reason = "formula enumeration requires exhaustive matching")]
+fn normalize_legacy(
+    formula: &LegacyFormula,
+    fallback_span: Option<SourceSpan>,
+) -> Decorated<Formula> {
+    match formula {
+        LegacyFormula::Pattern(text) => Decorated {
+            node: Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
+            where_clauses: vec![],
+            as_name: None,
+            fix: None,
+            span: fallback_span,
+        },
+        LegacyFormula::PatternRegex(pattern) => Decorated {
+            node: Formula::Atom(Atom::Regex(RegexAtom {
+                pattern: pattern.clone(),
+            })),
+            where_clauses: vec![],
+            as_name: None,
+            fix: None,
+            span: fallback_span,
+        },
+        LegacyFormula::Patterns(clauses) => normalize_legacy_patterns(clauses, fallback_span),
+        LegacyFormula::PatternEither(branches) => {
+            let normalized_branches = branches
+                .iter()
+                .map(|branch| normalize_legacy(branch, fallback_span.clone()))
+                .collect();
+            Decorated {
+                node: Formula::Or(normalized_branches),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        LegacyFormula::PatternNot(value) => {
+            let inner = normalize_legacy_value(value, fallback_span.clone());
+            Decorated {
+                node: Formula::Not(Box::new(inner)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        LegacyFormula::PatternInside(value) => {
+            let inner = normalize_legacy_value(value, fallback_span.clone());
+            Decorated {
+                node: Formula::Inside(Box::new(inner)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        LegacyFormula::PatternNotInside(value) => {
+            let inner = normalize_legacy_value(value, fallback_span.clone());
+            let inside = Decorated {
+                node: Formula::Inside(Box::new(inner)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span.clone(),
+            };
+            Decorated {
+                node: Formula::Not(Box::new(inside)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        LegacyFormula::PatternNotRegex(pattern) => {
+            let regex_atom = Decorated {
+                node: Formula::Atom(Atom::Regex(RegexAtom {
+                    pattern: pattern.clone(),
+                })),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span.clone(),
+            };
+            Decorated {
+                node: Formula::Not(Box::new(regex_atom)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        LegacyFormula::Anywhere(value) => {
+            let inner = normalize_legacy_value(value, fallback_span.clone());
+            Decorated {
+                node: Formula::Anywhere(Box::new(inner)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+    }
+}
+
+/// Normalizes a legacy value (string or formula object) into canonical form.
+fn normalize_legacy_value(
+    value: &LegacyValue,
+    fallback_span: Option<SourceSpan>,
+) -> Decorated<Formula> {
+    match value {
+        LegacyValue::String(text) => Decorated {
+            node: Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
+            where_clauses: vec![],
+            as_name: None,
+            fix: None,
+            span: fallback_span,
+        },
+        LegacyValue::Formula(formula) => normalize_legacy(formula, fallback_span),
+    }
+}
+
+/// Normalizes a legacy `patterns` array into an And formula.
+///
+/// Constraints are mapped to `where_clauses` on the enclosing And decorator.
+fn normalize_legacy_patterns(
+    clauses: &[LegacyClause],
+    fallback_span: Option<SourceSpan>,
+) -> Decorated<Formula> {
+    let mut formulas = Vec::new();
+    let mut where_clauses = Vec::new();
+
+    for clause in clauses {
+        match clause {
+            LegacyClause::Formula(formula) => {
+                formulas.push(normalize_legacy(formula, fallback_span.clone()));
+            }
+            LegacyClause::Constraint(value) => {
+                where_clauses.push(WhereClause { raw: value.clone() });
+            }
+        }
+    }
+
+    Decorated {
+        node: Formula::And(formulas),
+        where_clauses,
+        as_name: None,
+        fix: None,
+        span: fallback_span,
+    }
+}
+
+/// Normalizes a v2 match formula into canonical form.
+#[expect(clippy::too_many_lines, reason = "formula enumeration requires exhaustive matching")]
+fn normalize_match(
+    formula: &MatchFormula,
+    fallback_span: Option<SourceSpan>,
+) -> Decorated<Formula> {
+    match formula {
+        MatchFormula::Pattern(text) | MatchFormula::PatternObject(text) => Decorated {
+            node: Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
+            where_clauses: vec![],
+            as_name: None,
+            fix: None,
+            span: fallback_span,
+        },
+        MatchFormula::Regex(pattern) => Decorated {
+            node: Formula::Atom(Atom::Regex(RegexAtom {
+                pattern: pattern.clone(),
+            })),
+            where_clauses: vec![],
+            as_name: None,
+            fix: None,
+            span: fallback_span,
+        },
+        MatchFormula::All(branches) => {
+            let normalized_branches = branches
+                .iter()
+                .map(|branch| normalize_match(branch, fallback_span.clone()))
+                .collect();
+            Decorated {
+                node: Formula::And(normalized_branches),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        MatchFormula::Any(branches) => {
+            let normalized_branches = branches
+                .iter()
+                .map(|branch| normalize_match(branch, fallback_span.clone()))
+                .collect();
+            Decorated {
+                node: Formula::Or(normalized_branches),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        MatchFormula::Not(inner) => {
+            let normalized_inner = normalize_match(inner, fallback_span.clone());
+            Decorated {
+                node: Formula::Not(Box::new(normalized_inner)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        MatchFormula::Inside(inner) => {
+            let normalized_inner = normalize_match(inner, fallback_span.clone());
+            Decorated {
+                node: Formula::Inside(Box::new(normalized_inner)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        MatchFormula::Anywhere(inner) => {
+            let normalized_inner = normalize_match(inner, fallback_span.clone());
+            Decorated {
+                node: Formula::Anywhere(Box::new(normalized_inner)),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: fallback_span,
+            }
+        }
+        MatchFormula::Decorated {
+            formula: inner_formula,
+            where_clauses: raw_where,
+            as_name,
+            fix,
+        } => {
+            let mut normalized = normalize_match(inner_formula, fallback_span);
+            normalized.where_clauses = raw_where
+                .iter()
+                .map(|raw| WhereClause { raw: raw.clone() })
+                .collect();
+            normalized.as_name.clone_from(as_name);
+            normalized.fix.clone_from(fix);
+            normalized
+        }
+    }
+}
+
+/// Normalizes a dependency principal into a placeholder formula.
+///
+/// The `r2c-internal-project-depends-on` principal has no formula body,
+/// so we represent it as a degenerate pattern atom for now.
+fn normalize_dependency_principal(
+    _payload: &ProjectDependsOnPayload,
+    fallback_span: Option<SourceSpan>,
+) -> Decorated<Formula> {
+    // For now, represent as a degenerate pattern that will never match
+    // real code. This allows the rule to parse and normalize successfully
+    // without inventing execution semantics prematurely.
+    Decorated {
+        node: Formula::Atom(Atom::TreeSitterQuery(TreeSitterQueryAtom {
+            query: String::from("(ERROR) @_dependency_check"),
+        })),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: fallback_span,
+    }
+}

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -29,10 +29,10 @@
 //! - `inside: ...` → `Formula::Inside(Box<...>)`
 //! - `anywhere: ...` → `Formula::Anywhere(Box<...>)`
 
+use sempai_core::SourceSpan;
 use sempai_core::formula::{
     Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause,
 };
-use sempai_core::{DiagnosticReport, SourceSpan};
 use sempai_yaml::{
     LegacyClause, LegacyFormula, LegacyValue, MatchFormula, ProjectDependsOnPayload,
     SearchQueryPrincipal,
@@ -40,23 +40,19 @@ use sempai_yaml::{
 
 /// Normalizes a parsed search principal into the canonical formula model.
 ///
-/// # Errors
-///
-/// Returns a diagnostic report if the principal cannot be normalized
-/// (e.g., unsupported formula structure or missing required data).
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "future normalization steps may return errors"
-)]
+/// Normalization is currently infallible: every supported principal shape has
+/// a well-defined canonical mapping. If a future mapping needs to signal a
+/// structural error, switch this function's return type to
+/// `Result<Decorated<Formula>, DiagnosticReport>` at that point.
 pub(crate) fn normalize_search_principal(
     principal: &SearchQueryPrincipal,
     rule_span: Option<&SourceSpan>,
-) -> Result<Decorated<Formula>, DiagnosticReport> {
+) -> Decorated<Formula> {
     match principal {
-        SearchQueryPrincipal::Legacy(formula) => Ok(normalize_legacy(formula, rule_span.cloned())),
-        SearchQueryPrincipal::Match(formula) => Ok(normalize_match(formula, rule_span.cloned())),
+        SearchQueryPrincipal::Legacy(formula) => normalize_legacy(formula, rule_span.cloned()),
+        SearchQueryPrincipal::Match(formula) => normalize_match(formula, rule_span.cloned()),
         SearchQueryPrincipal::ProjectDependsOn(payload) => {
-            Ok(normalize_dependency_principal(payload, rule_span.cloned()))
+            normalize_dependency_principal(payload, rule_span.cloned())
         }
     }
 }

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -44,7 +44,10 @@ use sempai_yaml::{
 ///
 /// Returns a diagnostic report if the principal cannot be normalized
 /// (e.g., unsupported formula structure or missing required data).
-#[expect(clippy::unnecessary_wraps, reason = "future normalization steps may return errors")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "future normalization steps may return errors"
+)]
 pub(crate) fn normalize_search_principal(
     principal: &SearchQueryPrincipal,
     rule_span: Option<&SourceSpan>,
@@ -58,107 +61,73 @@ pub(crate) fn normalize_search_principal(
     }
 }
 
+/// Constructs a bare [`Decorated`] node with no metadata attached.
+///
+/// All metadata fields (`where_clauses`, `as_name`, `fix`) are zeroed;
+/// only the canonical `node` and its associated `span` are set.
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "Vec allocation requires runtime"
+)]
+fn bare(node: Formula, span: Option<SourceSpan>) -> Decorated<Formula> {
+    Decorated {
+        node,
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span,
+    }
+}
+
 /// Normalizes a legacy formula into canonical form.
-#[expect(clippy::too_many_lines, reason = "formula enumeration requires exhaustive matching")]
 fn normalize_legacy(
     formula: &LegacyFormula,
     fallback_span: Option<SourceSpan>,
 ) -> Decorated<Formula> {
     match formula {
-        LegacyFormula::Pattern(text) => Decorated {
-            node: Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
-            where_clauses: vec![],
-            as_name: None,
-            fix: None,
-            span: fallback_span,
-        },
-        LegacyFormula::PatternRegex(pattern) => Decorated {
-            node: Formula::Atom(Atom::Regex(RegexAtom {
+        LegacyFormula::Pattern(text) => bare(
+            Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
+            fallback_span,
+        ),
+        LegacyFormula::PatternRegex(pattern) => bare(
+            Formula::Atom(Atom::Regex(RegexAtom {
                 pattern: pattern.clone(),
             })),
-            where_clauses: vec![],
-            as_name: None,
-            fix: None,
-            span: fallback_span,
-        },
+            fallback_span,
+        ),
         LegacyFormula::Patterns(clauses) => normalize_legacy_patterns(clauses, fallback_span),
         LegacyFormula::PatternEither(branches) => {
             let normalized_branches = branches
                 .iter()
                 .map(|branch| normalize_legacy(branch, fallback_span.clone()))
                 .collect();
-            Decorated {
-                node: Formula::Or(normalized_branches),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Or(normalized_branches), fallback_span)
         }
         LegacyFormula::PatternNot(value) => {
             let inner = normalize_legacy_value(value, fallback_span.clone());
-            Decorated {
-                node: Formula::Not(Box::new(inner)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Not(Box::new(inner)), fallback_span)
         }
         LegacyFormula::PatternInside(value) => {
             let inner = normalize_legacy_value(value, fallback_span.clone());
-            Decorated {
-                node: Formula::Inside(Box::new(inner)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Inside(Box::new(inner)), fallback_span)
         }
         LegacyFormula::PatternNotInside(value) => {
             let inner = normalize_legacy_value(value, fallback_span.clone());
-            let inside = Decorated {
-                node: Formula::Inside(Box::new(inner)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span.clone(),
-            };
-            Decorated {
-                node: Formula::Not(Box::new(inside)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            let inside = bare(Formula::Inside(Box::new(inner)), fallback_span.clone());
+            bare(Formula::Not(Box::new(inside)), fallback_span)
         }
         LegacyFormula::PatternNotRegex(pattern) => {
-            let regex_atom = Decorated {
-                node: Formula::Atom(Atom::Regex(RegexAtom {
+            let regex_atom = bare(
+                Formula::Atom(Atom::Regex(RegexAtom {
                     pattern: pattern.clone(),
                 })),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span.clone(),
-            };
-            Decorated {
-                node: Formula::Not(Box::new(regex_atom)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+                fallback_span.clone(),
+            );
+            bare(Formula::Not(Box::new(regex_atom)), fallback_span)
         }
         LegacyFormula::Anywhere(value) => {
             let inner = normalize_legacy_value(value, fallback_span.clone());
-            Decorated {
-                node: Formula::Anywhere(Box::new(inner)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Anywhere(Box::new(inner)), fallback_span)
         }
     }
 }
@@ -169,13 +138,10 @@ fn normalize_legacy_value(
     fallback_span: Option<SourceSpan>,
 ) -> Decorated<Formula> {
     match value {
-        LegacyValue::String(text) => Decorated {
-            node: Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
-            where_clauses: vec![],
-            as_name: None,
-            fix: None,
-            span: fallback_span,
-        },
+        LegacyValue::String(text) => bare(
+            Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
+            fallback_span,
+        ),
         LegacyValue::Formula(formula) => normalize_legacy(formula, fallback_span),
     }
 }
@@ -211,83 +177,46 @@ fn normalize_legacy_patterns(
 }
 
 /// Normalizes a v2 match formula into canonical form.
-#[expect(clippy::too_many_lines, reason = "formula enumeration requires exhaustive matching")]
 fn normalize_match(
     formula: &MatchFormula,
     fallback_span: Option<SourceSpan>,
 ) -> Decorated<Formula> {
     match formula {
-        MatchFormula::Pattern(text) | MatchFormula::PatternObject(text) => Decorated {
-            node: Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
-            where_clauses: vec![],
-            as_name: None,
-            fix: None,
-            span: fallback_span,
-        },
-        MatchFormula::Regex(pattern) => Decorated {
-            node: Formula::Atom(Atom::Regex(RegexAtom {
+        MatchFormula::Pattern(text) | MatchFormula::PatternObject(text) => bare(
+            Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
+            fallback_span,
+        ),
+        MatchFormula::Regex(pattern) => bare(
+            Formula::Atom(Atom::Regex(RegexAtom {
                 pattern: pattern.clone(),
             })),
-            where_clauses: vec![],
-            as_name: None,
-            fix: None,
-            span: fallback_span,
-        },
+            fallback_span,
+        ),
         MatchFormula::All(branches) => {
             let normalized_branches = branches
                 .iter()
                 .map(|branch| normalize_match(branch, fallback_span.clone()))
                 .collect();
-            Decorated {
-                node: Formula::And(normalized_branches),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::And(normalized_branches), fallback_span)
         }
         MatchFormula::Any(branches) => {
             let normalized_branches = branches
                 .iter()
                 .map(|branch| normalize_match(branch, fallback_span.clone()))
                 .collect();
-            Decorated {
-                node: Formula::Or(normalized_branches),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Or(normalized_branches), fallback_span)
         }
         MatchFormula::Not(inner) => {
             let normalized_inner = normalize_match(inner, fallback_span.clone());
-            Decorated {
-                node: Formula::Not(Box::new(normalized_inner)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Not(Box::new(normalized_inner)), fallback_span)
         }
         MatchFormula::Inside(inner) => {
             let normalized_inner = normalize_match(inner, fallback_span.clone());
-            Decorated {
-                node: Formula::Inside(Box::new(normalized_inner)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Inside(Box::new(normalized_inner)), fallback_span)
         }
         MatchFormula::Anywhere(inner) => {
             let normalized_inner = normalize_match(inner, fallback_span.clone());
-            Decorated {
-                node: Formula::Anywhere(Box::new(normalized_inner)),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: fallback_span,
-            }
+            bare(Formula::Anywhere(Box::new(normalized_inner)), fallback_span)
         }
         MatchFormula::Decorated {
             formula: inner_formula,
@@ -318,13 +247,10 @@ fn normalize_dependency_principal(
     // For now, represent as a degenerate pattern that will never match
     // real code. This allows the rule to parse and normalize successfully
     // without inventing execution semantics prematurely.
-    Decorated {
-        node: Formula::Atom(Atom::TreeSitterQuery(TreeSitterQueryAtom {
+    bare(
+        Formula::Atom(Atom::TreeSitterQuery(TreeSitterQueryAtom {
             query: String::from("(ERROR) @_dependency_check"),
         })),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: fallback_span,
-    }
+        fallback_span,
+    )
 }

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -42,22 +42,115 @@ use sempai_yaml::{
     SearchQueryPrincipal,
 };
 
+trait SearchQueryPrincipalTraceExt {
+    fn discriminant_like(&self) -> &'static str;
+}
+
+impl SearchQueryPrincipalTraceExt for SearchQueryPrincipal {
+    fn discriminant_like(&self) -> &'static str {
+        match self {
+            Self::Legacy(_) => "legacy",
+            Self::Match(_) => "match",
+            Self::ProjectDependsOn(_) => "project_depends_on",
+        }
+    }
+}
+
 /// Normalizes a parsed search principal into the canonical formula model.
 ///
 /// Normalization is currently infallible: every supported principal shape has
 /// a well-defined canonical mapping. If a future mapping needs to signal a
 /// structural error, switch this function's return type to
 /// `Result<Decorated<Formula>, DiagnosticReport>` at that point.
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(kind = ?principal.discriminant_like(), has_span = rule_span.is_some())
+)]
 pub(crate) fn normalize_search_principal(
     principal: &SearchQueryPrincipal,
     rule_span: Option<&SourceSpan>,
 ) -> Decorated<Formula> {
     match principal {
-        SearchQueryPrincipal::Legacy(formula) => normalize_legacy(formula, rule_span.cloned()),
-        SearchQueryPrincipal::Match(formula) => normalize_match(formula, rule_span.cloned()),
+        SearchQueryPrincipal::Legacy(formula) => {
+            tracing::trace!(
+                pattern_len = legacy_pattern_len(formula),
+                branch_count = legacy_branch_count(formula),
+                "normalizing legacy principal"
+            );
+            normalize_legacy(formula, rule_span.cloned())
+        }
+        SearchQueryPrincipal::Match(formula) => {
+            tracing::trace!(
+                pattern_len = match_pattern_len(formula),
+                branch_count = match_branch_count(formula),
+                "normalizing match principal"
+            );
+            normalize_match(formula, rule_span.cloned())
+        }
         SearchQueryPrincipal::ProjectDependsOn(payload) => {
+            tracing::trace!(
+                namespace = payload.namespace(),
+                package = payload.package(),
+                "normalizing project dependency principal"
+            );
             normalize_dependency_principal(payload, rule_span.cloned())
         }
+    }
+}
+
+fn legacy_pattern_len(formula: &LegacyFormula) -> Option<usize> {
+    match formula {
+        LegacyFormula::Pattern(text)
+        | LegacyFormula::PatternRegex(text)
+        | LegacyFormula::PatternNotRegex(text) => Some(text.len()),
+        LegacyFormula::PatternNot(value)
+        | LegacyFormula::PatternInside(value)
+        | LegacyFormula::PatternNotInside(value)
+        | LegacyFormula::Anywhere(value) => legacy_value_pattern_len(value),
+        LegacyFormula::Patterns(_) | LegacyFormula::PatternEither(_) => None,
+    }
+}
+
+fn legacy_value_pattern_len(value: &LegacyValue) -> Option<usize> {
+    match value {
+        LegacyValue::String(text) => Some(text.len()),
+        LegacyValue::Formula(formula) => legacy_pattern_len(formula),
+    }
+}
+
+const fn legacy_branch_count(formula: &LegacyFormula) -> Option<usize> {
+    match formula {
+        LegacyFormula::Patterns(clauses) => Some(clauses.len()),
+        LegacyFormula::PatternEither(branches) => Some(branches.len()),
+        _ => None,
+    }
+}
+
+fn match_pattern_len(formula: &MatchFormula) -> Option<usize> {
+    match formula {
+        MatchFormula::Pattern(text)
+        | MatchFormula::PatternObject(text)
+        | MatchFormula::Regex(text) => Some(text.len()),
+        MatchFormula::Not(inner) | MatchFormula::Inside(inner) | MatchFormula::Anywhere(inner) => {
+            match_pattern_len(inner)
+        }
+        MatchFormula::Decorated {
+            formula: inner_formula,
+            ..
+        } => match_pattern_len(inner_formula),
+        MatchFormula::All(_) | MatchFormula::Any(_) => None,
+    }
+}
+
+fn match_branch_count(formula: &MatchFormula) -> Option<usize> {
+    match formula {
+        MatchFormula::All(branches) | MatchFormula::Any(branches) => Some(branches.len()),
+        MatchFormula::Decorated {
+            formula: inner_formula,
+            ..
+        } => match_branch_count(inner_formula),
+        _ => None,
     }
 }
 
@@ -80,6 +173,7 @@ fn bare(node: Formula, span: Option<SourceSpan>) -> Decorated<Formula> {
 }
 
 /// Normalizes a legacy formula into canonical form.
+#[tracing::instrument(level = "trace", skip_all)]
 fn normalize_legacy(
     formula: &LegacyFormula,
     fallback_span: Option<SourceSpan>,
@@ -201,6 +295,7 @@ fn normalize_branches(
 }
 
 /// Normalizes a v2 match formula into canonical form.
+#[tracing::instrument(level = "trace", skip_all)]
 fn normalize_match(
     formula: &MatchFormula,
     fallback_span: Option<SourceSpan>,

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -30,17 +30,9 @@
 //! - `anywhere: ...` → `Formula::Anywhere(Box<...>)`
 
 use sempai_core::{
+    DiagnosticReport,
     SourceSpan,
-    formula::{
-        Atom,
-        Constraint,
-        Decorated,
-        Formula,
-        PatternAtom,
-        RegexAtom,
-        TreeSitterQueryAtom,
-        WhereClause,
-    },
+    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause},
 };
 use sempai_yaml::{
     LegacyClause,
@@ -50,7 +42,8 @@ use sempai_yaml::{
     ProjectDependsOnPayload,
     SearchQueryPrincipal,
 };
-use serde_json::Value;
+
+use crate::normalize_constraints::parse_constraint;
 
 trait SearchQueryPrincipalTraceExt {
     fn discriminant_like(&self) -> &'static str;
@@ -68,10 +61,10 @@ impl SearchQueryPrincipalTraceExt for SearchQueryPrincipal {
 
 /// Normalizes a parsed search principal into the canonical formula model.
 ///
-/// Normalization is currently infallible: every supported principal shape has
-/// a well-defined canonical mapping. If a future mapping needs to signal a
-/// structural error, switch this function's return type to
-/// `Result<Decorated<Formula>, DiagnosticReport>` at that point.
+/// # Errors
+///
+/// Returns a schema diagnostic when a recognised `where` clause shape is
+/// malformed.
 #[tracing::instrument(
     level = "debug",
     skip_all,
@@ -80,7 +73,7 @@ impl SearchQueryPrincipalTraceExt for SearchQueryPrincipal {
 pub(crate) fn normalize_search_principal(
     principal: &SearchQueryPrincipal,
     rule_span: Option<&SourceSpan>,
-) -> Decorated<Formula> {
+) -> Result<Decorated<Formula>, DiagnosticReport> {
     match principal {
         SearchQueryPrincipal::Legacy(formula) => {
             tracing::trace!(
@@ -104,7 +97,7 @@ pub(crate) fn normalize_search_principal(
                 package = payload.package(),
                 "normalizing project dependency principal"
             );
-            normalize_dependency_principal(payload, rule_span)
+            Ok(normalize_dependency_principal(payload, rule_span))
         }
     }
 }
@@ -183,38 +176,38 @@ fn bare(node: Formula, span: Option<&SourceSpan>) -> Decorated<Formula> {
 fn normalize_legacy(
     formula: &LegacyFormula,
     fallback_span: Option<&SourceSpan>,
-) -> Decorated<Formula> {
+) -> Result<Decorated<Formula>, DiagnosticReport> {
     match formula {
-        LegacyFormula::Pattern(text) => bare(
+        LegacyFormula::Pattern(text) => Ok(bare(
             Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
             fallback_span,
-        ),
-        LegacyFormula::PatternRegex(pattern) => bare(
+        )),
+        LegacyFormula::PatternRegex(pattern) => Ok(bare(
             Formula::Atom(Atom::Regex(RegexAtom {
                 pattern: pattern.clone(),
             })),
             fallback_span,
-        ),
+        )),
         LegacyFormula::Patterns(clauses) => normalize_legacy_patterns(clauses, fallback_span),
         LegacyFormula::PatternEither(branches) => {
             let normalized_branches = branches
                 .iter()
                 .map(|branch| normalize_legacy(branch, fallback_span))
-                .collect();
-            bare(Formula::Or(normalized_branches), fallback_span)
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(bare(Formula::Or(normalized_branches), fallback_span))
         }
         LegacyFormula::PatternNot(value) => {
-            let inner = normalize_legacy_value(value, fallback_span);
-            bare(Formula::Not(Box::new(inner)), fallback_span)
+            let inner = normalize_legacy_value(value, fallback_span)?;
+            Ok(bare(Formula::Not(Box::new(inner)), fallback_span))
         }
         LegacyFormula::PatternInside(value) => {
-            let inner = normalize_legacy_value(value, fallback_span);
-            bare(Formula::Inside(Box::new(inner)), fallback_span)
+            let inner = normalize_legacy_value(value, fallback_span)?;
+            Ok(bare(Formula::Inside(Box::new(inner)), fallback_span))
         }
         LegacyFormula::PatternNotInside(value) => {
-            let inner = normalize_legacy_value(value, fallback_span);
+            let inner = normalize_legacy_value(value, fallback_span)?;
             let inside = bare(Formula::Inside(Box::new(inner)), fallback_span);
-            bare(Formula::Not(Box::new(inside)), fallback_span)
+            Ok(bare(Formula::Not(Box::new(inside)), fallback_span))
         }
         LegacyFormula::PatternNotRegex(pattern) => {
             let regex_atom = bare(
@@ -223,11 +216,11 @@ fn normalize_legacy(
                 })),
                 fallback_span,
             );
-            bare(Formula::Not(Box::new(regex_atom)), fallback_span)
+            Ok(bare(Formula::Not(Box::new(regex_atom)), fallback_span))
         }
         LegacyFormula::Anywhere(value) => {
-            let inner = normalize_legacy_value(value, fallback_span);
-            bare(Formula::Anywhere(Box::new(inner)), fallback_span)
+            let inner = normalize_legacy_value(value, fallback_span)?;
+            Ok(bare(Formula::Anywhere(Box::new(inner)), fallback_span))
         }
     }
 }
@@ -236,12 +229,12 @@ fn normalize_legacy(
 fn normalize_legacy_value(
     value: &LegacyValue,
     fallback_span: Option<&SourceSpan>,
-) -> Decorated<Formula> {
+) -> Result<Decorated<Formula>, DiagnosticReport> {
     match value {
-        LegacyValue::String(text) => bare(
+        LegacyValue::String(text) => Ok(bare(
             Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
             fallback_span,
-        ),
+        )),
         LegacyValue::Formula(formula) => normalize_legacy(formula, fallback_span),
     }
 }
@@ -252,30 +245,30 @@ fn normalize_legacy_value(
 fn normalize_legacy_patterns(
     clauses: &[LegacyClause],
     fallback_span: Option<&SourceSpan>,
-) -> Decorated<Formula> {
+) -> Result<Decorated<Formula>, DiagnosticReport> {
     let mut formulas = Vec::new();
     let mut where_clauses = Vec::new();
 
     for clause in clauses {
         match clause {
             LegacyClause::Formula(formula) => {
-                formulas.push(normalize_legacy(formula, fallback_span));
+                formulas.push(normalize_legacy(formula, fallback_span)?);
             }
             LegacyClause::Constraint(value) => {
                 where_clauses.push(WhereClause {
-                    constraint: parse_constraint(value),
+                    constraint: parse_constraint(value, fallback_span)?,
                 });
             }
         }
     }
 
-    Decorated {
+    Ok(Decorated {
         node: Formula::And(formulas),
         where_clauses,
         as_name: None,
         fix: None,
         span: fallback_span.cloned(),
-    }
+    })
 }
 
 /// Normalizes a unary v2 match formula (Not, Inside, Anywhere).
@@ -283,19 +276,19 @@ fn normalize_unary<F>(
     inner: &MatchFormula,
     fallback_span: Option<&SourceSpan>,
     wrap: F,
-) -> Decorated<Formula>
+) -> Result<Decorated<Formula>, DiagnosticReport>
 where
     F: FnOnce(Box<Decorated<Formula>>) -> Formula,
 {
-    let child = normalize_match(inner, fallback_span);
-    bare(wrap(Box::new(child)), fallback_span)
+    let child = normalize_match(inner, fallback_span)?;
+    Ok(bare(wrap(Box::new(child)), fallback_span))
 }
 
 /// Normalizes a list of v2 match formula branches (All, Any).
 fn normalize_branches(
     branches: &[MatchFormula],
     fallback_span: Option<&SourceSpan>,
-) -> Vec<Decorated<Formula>> {
+) -> Result<Vec<Decorated<Formula>>, DiagnosticReport> {
     branches
         .iter()
         .map(|b| normalize_match(b, fallback_span))
@@ -307,26 +300,26 @@ fn normalize_branches(
 fn normalize_match(
     formula: &MatchFormula,
     fallback_span: Option<&SourceSpan>,
-) -> Decorated<Formula> {
+) -> Result<Decorated<Formula>, DiagnosticReport> {
     match formula {
-        MatchFormula::Pattern(text) | MatchFormula::PatternObject(text) => bare(
+        MatchFormula::Pattern(text) | MatchFormula::PatternObject(text) => Ok(bare(
             Formula::Atom(Atom::Pattern(PatternAtom { text: text.clone() })),
             fallback_span,
-        ),
-        MatchFormula::Regex(pattern) => bare(
+        )),
+        MatchFormula::Regex(pattern) => Ok(bare(
             Formula::Atom(Atom::Regex(RegexAtom {
                 pattern: pattern.clone(),
             })),
             fallback_span,
-        ),
-        MatchFormula::All(branches) => bare(
-            Formula::And(normalize_branches(branches, fallback_span)),
+        )),
+        MatchFormula::All(branches) => Ok(bare(
+            Formula::And(normalize_branches(branches, fallback_span)?),
             fallback_span,
-        ),
-        MatchFormula::Any(branches) => bare(
-            Formula::Or(normalize_branches(branches, fallback_span)),
+        )),
+        MatchFormula::Any(branches) => Ok(bare(
+            Formula::Or(normalize_branches(branches, fallback_span)?),
             fallback_span,
-        ),
+        )),
         MatchFormula::Not(inner) => normalize_unary(inner, fallback_span, Formula::Not),
         MatchFormula::Inside(inner) => normalize_unary(inner, fallback_span, Formula::Inside),
         MatchFormula::Anywhere(inner) => normalize_unary(inner, fallback_span, Formula::Anywhere),
@@ -336,42 +329,20 @@ fn normalize_match(
             as_name,
             fix,
         } => {
-            let mut normalized = normalize_match(inner_formula, fallback_span);
+            let mut normalized = normalize_match(inner_formula, fallback_span)?;
             normalized.where_clauses = raw_where
                 .iter()
-                .map(|raw| WhereClause {
-                    constraint: parse_constraint(raw),
+                .map(|raw| {
+                    Ok(WhereClause {
+                        constraint: parse_constraint(raw, fallback_span)?,
+                    })
                 })
-                .collect();
+                .collect::<Result<Vec<_>, _>>()?;
             normalized.as_name.clone_from(as_name);
             normalized.fix.clone_from(fix);
-            normalized
+            Ok(normalized)
         }
     }
-}
-
-fn parse_constraint(raw: &Value) -> Constraint {
-    raw.get("metavariable-regex")
-        .and_then(parse_metavariable_regex)
-        .or_else(|| {
-            raw.get("metavariable-pattern")
-                .and_then(parse_metavariable_pattern)
-        })
-        .unwrap_or_else(|| Constraint::Other(raw.to_string()))
-}
-
-fn parse_metavariable_regex(value: &Value) -> Option<Constraint> {
-    Some(Constraint::MetavariableRegex {
-        metavariable: value.get("metavariable")?.as_str()?.to_owned(),
-        regex: value.get("regex")?.as_str()?.to_owned(),
-    })
-}
-
-fn parse_metavariable_pattern(value: &Value) -> Option<Constraint> {
-    Some(Constraint::MetavariablePattern {
-        metavariable: value.get("metavariable")?.as_str()?.to_owned(),
-        pattern: value.get("pattern")?.as_str()?.to_owned(),
-    })
 }
 
 /// Normalizes a dependency principal into a placeholder formula.

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -29,12 +29,16 @@
 //! - `inside: ...` → `Formula::Inside(Box<...>)`
 //! - `anywhere: ...` → `Formula::Anywhere(Box<...>)`
 
-use sempai_core::SourceSpan;
-use sempai_core::formula::{
-    Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause,
+use sempai_core::{
+    SourceSpan,
+    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause},
 };
 use sempai_yaml::{
-    LegacyClause, LegacyFormula, LegacyValue, MatchFormula, ProjectDependsOnPayload,
+    LegacyClause,
+    LegacyFormula,
+    LegacyValue,
+    MatchFormula,
+    ProjectDependsOnPayload,
     SearchQueryPrincipal,
 };
 

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -22,7 +22,7 @@
 //!
 //! - `"..."` (string shorthand) → `Formula::Atom(Atom::Pattern(...))`
 //! - `pattern: "..."` → `Formula::Atom(Atom::Pattern(...))`
-//! - `regex: "...` → `Formula::Atom(Atom::Regex(...))`
+//! - `regex: "..."` → `Formula::Atom(Atom::Regex(...))`
 //! - `all: [...]` → `Formula::And([...])`
 //! - `any: [...]` → `Formula::Or([...])`
 //! - `not: ...` → `Formula::Not(Box<...>)`

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -43,21 +43,16 @@ use sempai_yaml::{
     SearchQueryPrincipal,
 };
 
-use crate::normalize_constraints::parse_constraint;
-
-trait SearchQueryPrincipalTraceExt {
-    fn discriminant_like(&self) -> &'static str;
-}
-
-impl SearchQueryPrincipalTraceExt for SearchQueryPrincipal {
-    fn discriminant_like(&self) -> &'static str {
-        match self {
-            Self::Legacy(_) => "legacy",
-            Self::Match(_) => "match",
-            Self::ProjectDependsOn(_) => "project_depends_on",
-        }
-    }
-}
+use crate::{
+    normalize_constraints::parse_constraint,
+    normalize_trace::{
+        SearchQueryPrincipalTraceExt,
+        legacy_branch_count,
+        legacy_pattern_len,
+        match_branch_count,
+        match_pattern_len,
+    },
+};
 
 /// Normalizes a parsed search principal into the canonical formula model.
 ///
@@ -99,61 +94,6 @@ pub(crate) fn normalize_search_principal(
             );
             Ok(normalize_dependency_principal(payload, rule_span))
         }
-    }
-}
-
-fn legacy_pattern_len(formula: &LegacyFormula) -> Option<usize> {
-    match formula {
-        LegacyFormula::Pattern(text)
-        | LegacyFormula::PatternRegex(text)
-        | LegacyFormula::PatternNotRegex(text) => Some(text.len()),
-        LegacyFormula::PatternNot(value)
-        | LegacyFormula::PatternInside(value)
-        | LegacyFormula::PatternNotInside(value)
-        | LegacyFormula::Anywhere(value) => legacy_value_pattern_len(value),
-        LegacyFormula::Patterns(_) | LegacyFormula::PatternEither(_) => None,
-    }
-}
-
-fn legacy_value_pattern_len(value: &LegacyValue) -> Option<usize> {
-    match value {
-        LegacyValue::String(text) => Some(text.len()),
-        LegacyValue::Formula(formula) => legacy_pattern_len(formula),
-    }
-}
-
-const fn legacy_branch_count(formula: &LegacyFormula) -> Option<usize> {
-    match formula {
-        LegacyFormula::Patterns(clauses) => Some(clauses.len()),
-        LegacyFormula::PatternEither(branches) => Some(branches.len()),
-        _ => None,
-    }
-}
-
-fn match_pattern_len(formula: &MatchFormula) -> Option<usize> {
-    match formula {
-        MatchFormula::Pattern(text)
-        | MatchFormula::PatternObject(text)
-        | MatchFormula::Regex(text) => Some(text.len()),
-        MatchFormula::Not(inner) | MatchFormula::Inside(inner) | MatchFormula::Anywhere(inner) => {
-            match_pattern_len(inner)
-        }
-        MatchFormula::Decorated {
-            formula: inner_formula,
-            ..
-        } => match_pattern_len(inner_formula),
-        MatchFormula::All(_) | MatchFormula::Any(_) => None,
-    }
-}
-
-fn match_branch_count(formula: &MatchFormula) -> Option<usize> {
-    match formula {
-        MatchFormula::All(branches) | MatchFormula::Any(branches) => Some(branches.len()),
-        MatchFormula::Decorated {
-            formula: inner_formula,
-            ..
-        } => match_branch_count(inner_formula),
-        _ => None,
     }
 }
 

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -31,7 +31,16 @@
 
 use sempai_core::{
     SourceSpan,
-    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause},
+    formula::{
+        Atom,
+        Constraint,
+        Decorated,
+        Formula,
+        PatternAtom,
+        RegexAtom,
+        TreeSitterQueryAtom,
+        WhereClause,
+    },
 };
 use sempai_yaml::{
     LegacyClause,
@@ -41,6 +50,7 @@ use sempai_yaml::{
     ProjectDependsOnPayload,
     SearchQueryPrincipal,
 };
+use serde_json::Value;
 
 trait SearchQueryPrincipalTraceExt {
     fn discriminant_like(&self) -> &'static str;
@@ -256,7 +266,9 @@ fn normalize_legacy_patterns(
                 formulas.push(normalize_legacy(formula, fallback_span.clone()));
             }
             LegacyClause::Constraint(value) => {
-                where_clauses.push(WhereClause { raw: value.clone() });
+                where_clauses.push(WhereClause {
+                    constraint: parse_constraint(value),
+                });
             }
         }
     }
@@ -331,13 +343,39 @@ fn normalize_match(
             let mut normalized = normalize_match(inner_formula, fallback_span);
             normalized.where_clauses = raw_where
                 .iter()
-                .map(|raw| WhereClause { raw: raw.clone() })
+                .map(|raw| WhereClause {
+                    constraint: parse_constraint(raw),
+                })
                 .collect();
             normalized.as_name.clone_from(as_name);
             normalized.fix.clone_from(fix);
             normalized
         }
     }
+}
+
+fn parse_constraint(raw: &Value) -> Constraint {
+    raw.get("metavariable-regex")
+        .and_then(parse_metavariable_regex)
+        .or_else(|| {
+            raw.get("metavariable-pattern")
+                .and_then(parse_metavariable_pattern)
+        })
+        .unwrap_or_else(|| Constraint::Other(raw.to_string()))
+}
+
+fn parse_metavariable_regex(value: &Value) -> Option<Constraint> {
+    Some(Constraint::MetavariableRegex {
+        metavariable: value.get("metavariable")?.as_str()?.to_owned(),
+        regex: value.get("regex")?.as_str()?.to_owned(),
+    })
+}
+
+fn parse_metavariable_pattern(value: &Value) -> Option<Constraint> {
+    Some(Constraint::MetavariablePattern {
+        metavariable: value.get("metavariable")?.as_str()?.to_owned(),
+        pattern: value.get("pattern")?.as_str()?.to_owned(),
+    })
 }
 
 /// Normalizes a dependency principal into a placeholder formula.

--- a/crates/sempai/src/normalize.rs
+++ b/crates/sempai/src/normalize.rs
@@ -88,7 +88,7 @@ pub(crate) fn normalize_search_principal(
                 branch_count = legacy_branch_count(formula),
                 "normalizing legacy principal"
             );
-            normalize_legacy(formula, rule_span.cloned())
+            normalize_legacy(formula, rule_span)
         }
         SearchQueryPrincipal::Match(formula) => {
             tracing::trace!(
@@ -96,7 +96,7 @@ pub(crate) fn normalize_search_principal(
                 branch_count = match_branch_count(formula),
                 "normalizing match principal"
             );
-            normalize_match(formula, rule_span.cloned())
+            normalize_match(formula, rule_span)
         }
         SearchQueryPrincipal::ProjectDependsOn(payload) => {
             tracing::trace!(
@@ -104,7 +104,7 @@ pub(crate) fn normalize_search_principal(
                 package = payload.package(),
                 "normalizing project dependency principal"
             );
-            normalize_dependency_principal(payload, rule_span.cloned())
+            normalize_dependency_principal(payload, rule_span)
         }
     }
 }
@@ -168,17 +168,13 @@ fn match_branch_count(formula: &MatchFormula) -> Option<usize> {
 ///
 /// All metadata fields (`where_clauses`, `as_name`, `fix`) are zeroed;
 /// only the canonical `node` and its associated `span` are set.
-#[expect(
-    clippy::missing_const_for_fn,
-    reason = "Vec allocation requires runtime"
-)]
-fn bare(node: Formula, span: Option<SourceSpan>) -> Decorated<Formula> {
+fn bare(node: Formula, span: Option<&SourceSpan>) -> Decorated<Formula> {
     Decorated {
         node,
         where_clauses: vec![],
         as_name: None,
         fix: None,
-        span,
+        span: span.cloned(),
     }
 }
 
@@ -186,7 +182,7 @@ fn bare(node: Formula, span: Option<SourceSpan>) -> Decorated<Formula> {
 #[tracing::instrument(level = "trace", skip_all)]
 fn normalize_legacy(
     formula: &LegacyFormula,
-    fallback_span: Option<SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
 ) -> Decorated<Formula> {
     match formula {
         LegacyFormula::Pattern(text) => bare(
@@ -203,21 +199,21 @@ fn normalize_legacy(
         LegacyFormula::PatternEither(branches) => {
             let normalized_branches = branches
                 .iter()
-                .map(|branch| normalize_legacy(branch, fallback_span.clone()))
+                .map(|branch| normalize_legacy(branch, fallback_span))
                 .collect();
             bare(Formula::Or(normalized_branches), fallback_span)
         }
         LegacyFormula::PatternNot(value) => {
-            let inner = normalize_legacy_value(value, fallback_span.clone());
+            let inner = normalize_legacy_value(value, fallback_span);
             bare(Formula::Not(Box::new(inner)), fallback_span)
         }
         LegacyFormula::PatternInside(value) => {
-            let inner = normalize_legacy_value(value, fallback_span.clone());
+            let inner = normalize_legacy_value(value, fallback_span);
             bare(Formula::Inside(Box::new(inner)), fallback_span)
         }
         LegacyFormula::PatternNotInside(value) => {
-            let inner = normalize_legacy_value(value, fallback_span.clone());
-            let inside = bare(Formula::Inside(Box::new(inner)), fallback_span.clone());
+            let inner = normalize_legacy_value(value, fallback_span);
+            let inside = bare(Formula::Inside(Box::new(inner)), fallback_span);
             bare(Formula::Not(Box::new(inside)), fallback_span)
         }
         LegacyFormula::PatternNotRegex(pattern) => {
@@ -225,12 +221,12 @@ fn normalize_legacy(
                 Formula::Atom(Atom::Regex(RegexAtom {
                     pattern: pattern.clone(),
                 })),
-                fallback_span.clone(),
+                fallback_span,
             );
             bare(Formula::Not(Box::new(regex_atom)), fallback_span)
         }
         LegacyFormula::Anywhere(value) => {
-            let inner = normalize_legacy_value(value, fallback_span.clone());
+            let inner = normalize_legacy_value(value, fallback_span);
             bare(Formula::Anywhere(Box::new(inner)), fallback_span)
         }
     }
@@ -239,7 +235,7 @@ fn normalize_legacy(
 /// Normalizes a legacy value (string or formula object) into canonical form.
 fn normalize_legacy_value(
     value: &LegacyValue,
-    fallback_span: Option<SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
 ) -> Decorated<Formula> {
     match value {
         LegacyValue::String(text) => bare(
@@ -255,7 +251,7 @@ fn normalize_legacy_value(
 /// Constraints are mapped to `where_clauses` on the enclosing And decorator.
 fn normalize_legacy_patterns(
     clauses: &[LegacyClause],
-    fallback_span: Option<SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
 ) -> Decorated<Formula> {
     let mut formulas = Vec::new();
     let mut where_clauses = Vec::new();
@@ -263,7 +259,7 @@ fn normalize_legacy_patterns(
     for clause in clauses {
         match clause {
             LegacyClause::Formula(formula) => {
-                formulas.push(normalize_legacy(formula, fallback_span.clone()));
+                formulas.push(normalize_legacy(formula, fallback_span));
             }
             LegacyClause::Constraint(value) => {
                 where_clauses.push(WhereClause {
@@ -278,20 +274,20 @@ fn normalize_legacy_patterns(
         where_clauses,
         as_name: None,
         fix: None,
-        span: fallback_span,
+        span: fallback_span.cloned(),
     }
 }
 
 /// Normalizes a unary v2 match formula (Not, Inside, Anywhere).
 fn normalize_unary<F>(
     inner: &MatchFormula,
-    fallback_span: Option<SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
     wrap: F,
 ) -> Decorated<Formula>
 where
     F: FnOnce(Box<Decorated<Formula>>) -> Formula,
 {
-    let child = normalize_match(inner, fallback_span.clone());
+    let child = normalize_match(inner, fallback_span);
     bare(wrap(Box::new(child)), fallback_span)
 }
 
@@ -302,7 +298,7 @@ fn normalize_branches(
 ) -> Vec<Decorated<Formula>> {
     branches
         .iter()
-        .map(|b| normalize_match(b, fallback_span.cloned()))
+        .map(|b| normalize_match(b, fallback_span))
         .collect()
 }
 
@@ -310,7 +306,7 @@ fn normalize_branches(
 #[tracing::instrument(level = "trace", skip_all)]
 fn normalize_match(
     formula: &MatchFormula,
-    fallback_span: Option<SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
 ) -> Decorated<Formula> {
     match formula {
         MatchFormula::Pattern(text) | MatchFormula::PatternObject(text) => bare(
@@ -324,11 +320,11 @@ fn normalize_match(
             fallback_span,
         ),
         MatchFormula::All(branches) => bare(
-            Formula::And(normalize_branches(branches, fallback_span.as_ref())),
+            Formula::And(normalize_branches(branches, fallback_span)),
             fallback_span,
         ),
         MatchFormula::Any(branches) => bare(
-            Formula::Or(normalize_branches(branches, fallback_span.as_ref())),
+            Formula::Or(normalize_branches(branches, fallback_span)),
             fallback_span,
         ),
         MatchFormula::Not(inner) => normalize_unary(inner, fallback_span, Formula::Not),
@@ -384,7 +380,7 @@ fn parse_metavariable_pattern(value: &Value) -> Option<Constraint> {
 /// so we represent it as a degenerate pattern atom for now.
 fn normalize_dependency_principal(
     _payload: &ProjectDependsOnPayload,
-    fallback_span: Option<SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
 ) -> Decorated<Formula> {
     // For now, represent as a degenerate pattern that will never match real
     // code. Use a node type that cannot exist in any Tree-sitter grammar

--- a/crates/sempai/src/normalize_constraints.rs
+++ b/crates/sempai/src/normalize_constraints.rs
@@ -1,0 +1,50 @@
+//! Constraint parsing for canonical formula normalization.
+
+use sempai_core::{DiagnosticCode, DiagnosticReport, SourceSpan, formula::Constraint};
+use serde_json::Value;
+
+pub(crate) fn parse_constraint(
+    raw: &Value,
+    fallback_span: Option<&SourceSpan>,
+) -> Result<Constraint, DiagnosticReport> {
+    if let Some(value) = raw.get("metavariable-regex") {
+        return parse_metavariable_regex(value).ok_or_else(|| {
+            invalid_where_clause(
+                "invalid where-clause: expected {metavariable, regex} string fields",
+                fallback_span,
+            )
+        });
+    }
+    if let Some(value) = raw.get("metavariable-pattern") {
+        return parse_metavariable_pattern(value).ok_or_else(|| {
+            invalid_where_clause(
+                "invalid where-clause: expected {metavariable, pattern} string fields",
+                fallback_span,
+            )
+        });
+    }
+    Ok(Constraint::Other(raw.to_string()))
+}
+
+fn invalid_where_clause(message: &str, fallback_span: Option<&SourceSpan>) -> DiagnosticReport {
+    DiagnosticReport::validation_error(
+        DiagnosticCode::ESempaiSchemaInvalid,
+        String::from(message),
+        fallback_span.cloned(),
+        vec![],
+    )
+}
+
+fn parse_metavariable_regex(value: &Value) -> Option<Constraint> {
+    Some(Constraint::MetavariableRegex {
+        metavariable: value.get("metavariable")?.as_str()?.to_owned(),
+        regex: value.get("regex")?.as_str()?.to_owned(),
+    })
+}
+
+fn parse_metavariable_pattern(value: &Value) -> Option<Constraint> {
+    Some(Constraint::MetavariablePattern {
+        metavariable: value.get("metavariable")?.as_str()?.to_owned(),
+        pattern: value.get("pattern")?.as_str()?.to_owned(),
+    })
+}

--- a/crates/sempai/src/normalize_trace.rs
+++ b/crates/sempai/src/normalize_trace.rs
@@ -1,0 +1,72 @@
+//! Tracing helpers for formula normalization.
+
+use sempai_yaml::{LegacyFormula, LegacyValue, MatchFormula, SearchQueryPrincipal};
+
+pub(crate) trait SearchQueryPrincipalTraceExt {
+    fn discriminant_like(&self) -> &'static str;
+}
+
+impl SearchQueryPrincipalTraceExt for SearchQueryPrincipal {
+    fn discriminant_like(&self) -> &'static str {
+        match self {
+            Self::Legacy(_) => "legacy",
+            Self::Match(_) => "match",
+            Self::ProjectDependsOn(_) => "project_depends_on",
+        }
+    }
+}
+
+pub(crate) fn legacy_pattern_len(formula: &LegacyFormula) -> Option<usize> {
+    match formula {
+        LegacyFormula::Pattern(text)
+        | LegacyFormula::PatternRegex(text)
+        | LegacyFormula::PatternNotRegex(text) => Some(text.len()),
+        LegacyFormula::PatternNot(value)
+        | LegacyFormula::PatternInside(value)
+        | LegacyFormula::PatternNotInside(value)
+        | LegacyFormula::Anywhere(value) => legacy_value_pattern_len(value),
+        LegacyFormula::Patterns(_) | LegacyFormula::PatternEither(_) => None,
+    }
+}
+
+fn legacy_value_pattern_len(value: &LegacyValue) -> Option<usize> {
+    match value {
+        LegacyValue::String(text) => Some(text.len()),
+        LegacyValue::Formula(formula) => legacy_pattern_len(formula),
+    }
+}
+
+pub(crate) const fn legacy_branch_count(formula: &LegacyFormula) -> Option<usize> {
+    match formula {
+        LegacyFormula::Patterns(clauses) => Some(clauses.len()),
+        LegacyFormula::PatternEither(branches) => Some(branches.len()),
+        _ => None,
+    }
+}
+
+pub(crate) fn match_pattern_len(formula: &MatchFormula) -> Option<usize> {
+    match formula {
+        MatchFormula::Pattern(text)
+        | MatchFormula::PatternObject(text)
+        | MatchFormula::Regex(text) => Some(text.len()),
+        MatchFormula::Not(inner) | MatchFormula::Inside(inner) | MatchFormula::Anywhere(inner) => {
+            match_pattern_len(inner)
+        }
+        MatchFormula::Decorated {
+            formula: inner_formula,
+            ..
+        } => match_pattern_len(inner_formula),
+        MatchFormula::All(_) | MatchFormula::Any(_) => None,
+    }
+}
+
+pub(crate) fn match_branch_count(formula: &MatchFormula) -> Option<usize> {
+    match formula {
+        MatchFormula::All(branches) | MatchFormula::Any(branches) => Some(branches.len()),
+        MatchFormula::Decorated {
+            formula: inner_formula,
+            ..
+        } => match_branch_count(inner_formula),
+        _ => None,
+    }
+}

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -124,8 +124,20 @@ fn check_positive_term_in_and(
 
 /// Returns true if the formula is a positive match-producing term.
 ///
-/// Positive terms: `Atom`, `And`, `Or`
-/// Constraint-only terms: `Not`, `Inside`, `Anywhere`
-const fn is_positive_term(formula: &Formula) -> bool {
-    matches!(formula, Formula::Atom(_) | Formula::And(_) | Formula::Or(_))
+/// A term is positive when it ultimately produces a match location.  An `Atom`
+/// is always positive; `Not`, `Inside`, and `Anywhere` are purely
+/// constraint-style and never positive on their own.  An `And` or `Or` is
+/// positive only when at least one of its descendants is itself positive —
+/// otherwise the combinator bottoms out in constraint-only terms and cannot
+/// anchor matches.  This prevents shapes like `And[Or[Inside[Atom]]]` from
+/// sneaking past `MissingPositiveTermInAnd` on the basis of the outer shape
+/// alone.
+fn is_positive_term(formula: &Formula) -> bool {
+    match formula {
+        Formula::Atom(_) => true,
+        Formula::And(branches) | Formula::Or(branches) => {
+            branches.iter().any(|b| is_positive_term(&b.node))
+        }
+        Formula::Not(_) | Formula::Inside(_) | Formula::Anywhere(_) => false,
+    }
 }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -1,0 +1,125 @@
+//! Semantic validation of normalized formulas.
+//!
+//! This module enforces semantic constraints on normalized formulas after
+//! parsing and normalization. The constraints are defined in the Semgrep
+//! operator precedence documentation.
+//!
+//! # Semantic constraints
+//!
+//! - **`InvalidNotInOr`**: `Or` branches must not contain `Not` formulas.
+//!   Negated terms in disjunction contexts are structurally invalid.
+//! - **`MissingPositiveTermInAnd`**: `And` branches must contain at least one
+//!   positive match-producing term (not `Not`, `Inside`, or `Anywhere`).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use sempai::semantic_check::validate_formula;
+//! use sempai_core::formula::{Formula, Decorated};
+//!
+//! let formula = /* ... */;
+//! validate_formula(&formula)?;
+//! ```
+
+use sempai_core::formula::{Decorated, Formula};
+use sempai_core::{DiagnosticCode, DiagnosticReport};
+
+/// Validates semantic constraints on a normalized formula.
+///
+/// # Errors
+///
+/// Returns a diagnostic report if the formula violates semantic constraints:
+///
+/// - `E_SEMPAI_INVALID_NOT_IN_OR`: Or branch contains a Not formula
+/// - `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`: And formula has no positive terms
+pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
+    check_no_not_in_or(&formula.node, formula.span.as_ref())?;
+    check_positive_term_in_and(&formula.node, formula.span.as_ref())?;
+    Ok(())
+}
+
+/// Checks that no `Or` branch contains a `Not` formula.
+///
+/// Recursively validates all sub-formulas.
+fn check_no_not_in_or(
+    formula: &Formula,
+    span: Option<&sempai_core::SourceSpan>,
+) -> Result<(), DiagnosticReport> {
+    match formula {
+        Formula::Or(branches) => {
+            for branch in branches {
+                if matches!(branch.node, Formula::Not(_)) {
+                    return Err(DiagnosticReport::validation_error(
+                        DiagnosticCode::ESempaiInvalidNotInOr,
+                        String::from(
+                            "negated terms are not allowed inside disjunction (Or/pattern-either)",
+                        ),
+                        branch.span.clone().or_else(|| span.cloned()),
+                        vec![],
+                    ));
+                }
+                // Recursively check nested formulas
+                check_no_not_in_or(&branch.node, branch.span.as_ref().or(span))?;
+            }
+            Ok(())
+        }
+        Formula::And(branches) => {
+            for branch in branches {
+                check_no_not_in_or(&branch.node, branch.span.as_ref().or(span))?;
+            }
+            Ok(())
+        }
+        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
+            check_no_not_in_or(&inner.node, inner.span.as_ref().or(span))
+        }
+        Formula::Atom(_) => Ok(()),
+    }
+}
+
+/// Checks that every `And` formula has at least one positive term.
+///
+/// A positive term is a match-producing formula: `Atom`, `And`, or `Or`.
+/// Constraint-only formulas (`Not`, `Inside`, `Anywhere`) are not positive.
+fn check_positive_term_in_and(
+    formula: &Formula,
+    span: Option<&sempai_core::SourceSpan>,
+) -> Result<(), DiagnosticReport> {
+    match formula {
+        Formula::And(branches) => {
+            let has_positive = branches.iter().any(|branch| is_positive_term(&branch.node));
+            if !has_positive {
+                return Err(DiagnosticReport::validation_error(
+                    DiagnosticCode::ESempaiMissingPositiveTermInAnd,
+                    String::from(
+                        "conjunction (And/patterns) must contain at least one positive match term",
+                    ),
+                    span.cloned(),
+                    vec![],
+                ));
+            }
+            // Recursively check nested formulas
+            for branch in branches {
+                check_positive_term_in_and(&branch.node, branch.span.as_ref().or(span))?;
+            }
+            Ok(())
+        }
+        Formula::Or(branches) => {
+            for branch in branches {
+                check_positive_term_in_and(&branch.node, branch.span.as_ref().or(span))?;
+            }
+            Ok(())
+        }
+        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
+            check_positive_term_in_and(&inner.node, inner.span.as_ref().or(span))
+        }
+        Formula::Atom(_) => Ok(()),
+    }
+}
+
+/// Returns true if the formula is a positive match-producing term.
+///
+/// Positive terms: `Atom`, `And`, `Or`
+/// Constraint-only terms: `Not`, `Inside`, `Anywhere`
+const fn is_positive_term(formula: &Formula) -> bool {
+    matches!(formula, Formula::Atom(_) | Formula::And(_) | Formula::Or(_))
+}

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -88,12 +88,18 @@ fn check_positive_term_in_and(
         Formula::And(branches) => {
             let has_positive = branches.iter().any(|branch| is_positive_term(&branch.node));
             if !has_positive {
+                // Prefer the first branch's span for a more precise anchor; fall
+                // back to the enclosing And's span if no branch has one.
+                let error_span = branches
+                    .iter()
+                    .find_map(|branch| branch.span.clone())
+                    .or_else(|| span.cloned());
                 return Err(DiagnosticReport::validation_error(
                     DiagnosticCode::ESempaiMissingPositiveTermInAnd,
                     String::from(
                         "conjunction (And/patterns) must contain at least one positive match term",
                     ),
-                    span.cloned(),
+                    error_span,
                     vec![],
                 ));
             }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -51,23 +51,13 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
 }
 
 fn validate_formula_inner(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    let mut max_depth = 0;
     let analysis = analyze_formula_with_depth(
         formula,
         AnalysisScope {
             depth: 1,
             fallback_span: formula.span.as_ref(),
         },
-        &mut max_depth,
-    );
-    if max_depth > MAX_FORMULA_DEPTH {
-        return Err(DiagnosticReport::validation_error(
-            DiagnosticCode::ESempaiSchemaInvalid,
-            format!("formula nesting depth exceeds limit of {MAX_FORMULA_DEPTH}: {max_depth}"),
-            formula.span.clone(),
-            vec![],
-        ));
-    }
+    )?;
     if let Some(diagnostic) = analysis.invalid_not_in_or {
         return Err(DiagnosticReport::validation_error(
             DiagnosticCode::ESempaiInvalidNotInOr,
@@ -123,17 +113,15 @@ fn analyze_not_arm(
     inner: &Decorated<Formula>,
     scope: AnalysisScope<'_>,
     formula_span: Option<&SourceSpan>,
-    max_depth: &mut usize,
-) -> FormulaAnalysis {
+) -> Result<FormulaAnalysis, DiagnosticReport> {
     let mut analysis = analyze_formula_with_depth(
         inner,
         scope.child_with_fallback(formula_span.or(scope.fallback_span)),
-        max_depth,
-    );
+    )?;
     analysis.contains_not = true;
     analysis.has_positive_term = false;
     analysis.first_negation_span = formula_span.cloned().or(analysis.first_negation_span);
-    analysis
+    Ok(analysis)
 }
 
 /// Analyses an `Inside` or `Anywhere` node (no negation tracking).
@@ -141,15 +129,13 @@ fn analyze_inside_anywhere_arm(
     inner: &Decorated<Formula>,
     scope: AnalysisScope<'_>,
     formula_span: Option<&SourceSpan>,
-    max_depth: &mut usize,
-) -> FormulaAnalysis {
+) -> Result<FormulaAnalysis, DiagnosticReport> {
     let mut analysis = analyze_formula_with_depth(
         inner,
         scope.child_with_fallback(formula_span.or(scope.fallback_span)),
-        max_depth,
-    );
+    )?;
     analysis.has_positive_term = false;
-    analysis
+    Ok(analysis)
 }
 
 /// Analyses a conjunction (`And`) node and attaches a
@@ -158,13 +144,11 @@ fn analyze_and_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
     scope: AnalysisScope<'_>,
-    max_depth: &mut usize,
-) -> FormulaAnalysis {
+) -> Result<FormulaAnalysis, DiagnosticReport> {
     let mut analysis = analyze_branches(
         branches,
         scope.child_with_fallback(formula.span.as_ref().or(scope.fallback_span)),
-        max_depth,
-    );
+    )?;
     if !analysis.has_positive_term {
         analysis.missing_positive_term = Some(DiagnosticSite {
             primary_span: formula
@@ -174,7 +158,7 @@ fn analyze_and_arm(
                 .or_else(|| scope.fallback_span.cloned()),
         });
     }
-    analysis
+    Ok(analysis)
 }
 
 /// Analyses a disjunction (`Or`) node and attaches an `InvalidNotInOr` site
@@ -183,13 +167,12 @@ fn analyze_or_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
     scope: AnalysisScope<'_>,
-    max_depth: &mut usize,
-) -> FormulaAnalysis {
+) -> Result<FormulaAnalysis, DiagnosticReport> {
     let mut analysis = FormulaAnalysis::default();
     let child_fallback = formula.span.as_ref().or(scope.fallback_span);
     let child_scope = scope.child_with_fallback(child_fallback);
     for branch in branches {
-        let branch_analysis = analyze_formula_with_depth(branch, child_scope, max_depth);
+        let branch_analysis = analyze_formula_with_depth(branch, child_scope)?;
         if branch_analysis.contains_not && analysis.invalid_not_in_or.is_none() {
             analysis.invalid_not_in_or = Some(DiagnosticSite {
                 primary_span: branch_analysis
@@ -212,37 +195,48 @@ fn analyze_or_arm(
             .missing_positive_term
             .or(branch_analysis.missing_positive_term);
     }
-    analysis
+    Ok(analysis)
 }
 
 fn analyze_formula_with_depth(
     formula: &Decorated<Formula>,
     scope: AnalysisScope<'_>,
-    max_depth: &mut usize,
-) -> FormulaAnalysis {
-    *max_depth = (*max_depth).max(scope.depth);
+) -> Result<FormulaAnalysis, DiagnosticReport> {
+    if scope.depth > MAX_FORMULA_DEPTH {
+        return Err(DiagnosticReport::validation_error(
+            DiagnosticCode::ESempaiSchemaInvalid,
+            format!(
+                "formula nesting depth exceeds limit of {MAX_FORMULA_DEPTH}: {}",
+                scope.depth
+            ),
+            formula
+                .span
+                .clone()
+                .or_else(|| scope.fallback_span.cloned()),
+            vec![],
+        ));
+    }
     match &formula.node {
-        Formula::Atom(_) => FormulaAnalysis {
+        Formula::Atom(_) => Ok(FormulaAnalysis {
             has_positive_term: true,
             ..FormulaAnalysis::default()
-        },
-        Formula::Not(inner) => analyze_not_arm(inner, scope, formula.span.as_ref(), max_depth),
+        }),
+        Formula::Not(inner) => analyze_not_arm(inner, scope, formula.span.as_ref()),
         Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            analyze_inside_anywhere_arm(inner, scope, formula.span.as_ref(), max_depth)
+            analyze_inside_anywhere_arm(inner, scope, formula.span.as_ref())
         }
-        Formula::And(branches) => analyze_and_arm(formula, branches, scope, max_depth),
-        Formula::Or(branches) => analyze_or_arm(formula, branches, scope, max_depth),
+        Formula::And(branches) => analyze_and_arm(formula, branches, scope),
+        Formula::Or(branches) => analyze_or_arm(formula, branches, scope),
     }
 }
 
 fn analyze_branches(
     branches: &[Decorated<Formula>],
     scope: AnalysisScope<'_>,
-    max_depth: &mut usize,
-) -> FormulaAnalysis {
+) -> Result<FormulaAnalysis, DiagnosticReport> {
     let mut analysis = FormulaAnalysis::default();
     for branch in branches {
-        let branch_analysis = analyze_formula_with_depth(branch, scope, max_depth);
+        let branch_analysis = analyze_formula_with_depth(branch, scope)?;
         analysis.has_positive_term |= branch_analysis.has_positive_term;
         analysis.contains_not |= branch_analysis.contains_not;
         analysis.first_negation_span = analysis
@@ -255,5 +249,5 @@ fn analyze_branches(
             .missing_positive_term
             .or(branch_analysis.missing_positive_term);
     }
-    analysis
+    Ok(analysis)
 }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -42,8 +42,6 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
 }
 
 /// Checks that no `Or` branch contains a `Not` formula.
-///
-/// Recursively validates all sub-formulas.
 fn check_no_not_in_or(
     formula: &Formula,
     span: Option<&sempai_core::SourceSpan>,
@@ -51,7 +49,7 @@ fn check_no_not_in_or(
     match formula {
         Formula::Or(branches) => {
             for branch in branches {
-                if matches!(branch.node, Formula::Not(_)) {
+                if branch_contains_not(&branch.node) {
                     return Err(DiagnosticReport::validation_error(
                         DiagnosticCode::ESempaiInvalidNotInOr,
                         String::from(
@@ -76,6 +74,18 @@ fn check_no_not_in_or(
             check_no_not_in_or(&inner.node, inner.span.as_ref().or(span))
         }
         Formula::Atom(_) => Ok(()),
+    }
+}
+
+/// Returns true when a formula subtree contains a negation.
+fn branch_contains_not(formula: &Formula) -> bool {
+    match formula {
+        Formula::Not(_) => true,
+        Formula::And(branches) | Formula::Or(branches) => branches
+            .iter()
+            .any(|branch| branch_contains_not(&branch.node)),
+        Formula::Inside(inner) | Formula::Anywhere(inner) => branch_contains_not(&inner.node),
+        Formula::Atom(_) => false,
     }
 }
 

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -6,10 +6,10 @@
 //!
 //! # Semantic constraints
 //!
-//! - **`InvalidNotInOr`**: `Or` branches must not contain `Not` formulas.
-//!   Negated terms in disjunction contexts are structurally invalid.
-//! - **`MissingPositiveTermInAnd`**: `And` branches must contain at least one
-//!   positive match-producing term (not `Not`, `Inside`, or `Anywhere`).
+//! - **`InvalidNotInOr`**: `Or` branches must not contain `Not` formulas. Negated terms in
+//!   disjunction contexts are structurally invalid.
+//! - **`MissingPositiveTermInAnd`**: `And` branches must contain at least one positive
+//!   match-producing term (not `Not`, `Inside`, or `Anywhere`).
 //!
 //! # Example
 //!
@@ -21,8 +21,11 @@
 //! validate_formula(&formula)?;
 //! ```
 
-use sempai_core::formula::{Decorated, Formula};
-use sempai_core::{DiagnosticCode, DiagnosticReport};
+use sempai_core::{
+    DiagnosticCode,
+    DiagnosticReport,
+    formula::{Decorated, Formula},
+};
 
 /// Validates semantic constraints on a normalized formula.
 ///

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -97,16 +97,22 @@ fn check_positive_term_in_and(
     formula: &Formula,
     span: Option<&sempai_core::SourceSpan>,
 ) -> Result<(), DiagnosticReport> {
+    check_positive_term_in_and_with_spans(formula, span, span)
+}
+
+fn check_positive_term_in_and_with_spans(
+    formula: &Formula,
+    node_span: Option<&sempai_core::SourceSpan>,
+    fallback_span: Option<&sempai_core::SourceSpan>,
+) -> Result<(), DiagnosticReport> {
     match formula {
         Formula::And(branches) => {
             let has_positive = branches.iter().any(|branch| is_positive_term(&branch.node));
             if !has_positive {
-                // Prefer the first branch's span for a more precise anchor; fall
-                // back to the enclosing And's span if no branch has one.
-                let error_span = branches
-                    .iter()
-                    .find_map(|branch| branch.span.clone())
-                    .or_else(|| span.cloned());
+                let error_span = node_span
+                    .cloned()
+                    .or_else(|| branches.first().and_then(|branch| branch.span.clone()))
+                    .or_else(|| fallback_span.cloned());
                 return Err(DiagnosticReport::validation_error(
                     DiagnosticCode::ESempaiMissingPositiveTermInAnd,
                     String::from(
@@ -118,18 +124,30 @@ fn check_positive_term_in_and(
             }
             // Recursively check nested formulas
             for branch in branches {
-                check_positive_term_in_and(&branch.node, branch.span.as_ref().or(span))?;
+                check_positive_term_in_and_with_spans(
+                    &branch.node,
+                    branch.span.as_ref(),
+                    node_span.or(fallback_span),
+                )?;
             }
             Ok(())
         }
         Formula::Or(branches) => {
             for branch in branches {
-                check_positive_term_in_and(&branch.node, branch.span.as_ref().or(span))?;
+                check_positive_term_in_and_with_spans(
+                    &branch.node,
+                    branch.span.as_ref(),
+                    node_span.or(fallback_span),
+                )?;
             }
             Ok(())
         }
         Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            check_positive_term_in_and(&inner.node, inner.span.as_ref().or(span))
+            check_positive_term_in_and_with_spans(
+                &inner.node,
+                inner.span.as_ref(),
+                node_span.or(fallback_span),
+            )
         }
         Formula::Atom(_) => Ok(()),
     }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -40,8 +40,7 @@ pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
 /// - `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`: And formula has no positive terms
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    let result = validate_formula_depth(formula, formula.span.as_ref())
-        .and_then(|()| validate_formula_single_pass(formula));
+    let result = validate_formula_inner(formula);
     if let Err(report) = &result
         && let Some(diagnostic) = report.diagnostics().first()
     {
@@ -50,42 +49,24 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
     result
 }
 
-pub(crate) fn validate_formula_depth(
-    formula: &Decorated<Formula>,
-    fallback_span: Option<&SourceSpan>,
-) -> Result<(), DiagnosticReport> {
-    let depth = formula_depth(formula);
-    if depth > MAX_FORMULA_DEPTH {
+fn validate_formula_inner(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
+    let mut max_depth = 0;
+    let analysis = analyze_formula_with_depth(
+        formula,
+        AnalysisScope {
+            depth: 1,
+            fallback_span: formula.span.as_ref(),
+        },
+        &mut max_depth,
+    );
+    if max_depth > MAX_FORMULA_DEPTH {
         return Err(DiagnosticReport::validation_error(
             DiagnosticCode::ESempaiSchemaInvalid,
-            format!("formula nesting depth exceeds limit of {MAX_FORMULA_DEPTH}: {depth}"),
-            fallback_span.cloned(),
+            format!("formula nesting depth exceeds limit of {MAX_FORMULA_DEPTH}: {max_depth}"),
+            formula.span.clone(),
             vec![],
         ));
     }
-    Ok(())
-}
-
-pub(crate) fn formula_depth(formula: &Decorated<Formula>) -> usize {
-    let mut max_depth = 0;
-    let mut stack = vec![(formula, 1)];
-    while let Some((current, depth)) = stack.pop() {
-        max_depth = max_depth.max(depth);
-        match &current.node {
-            Formula::Atom(_) => {}
-            Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
-                stack.push((inner, depth + 1));
-            }
-            Formula::And(branches) | Formula::Or(branches) => {
-                stack.extend(branches.iter().map(|branch| (branch, depth + 1)));
-            }
-        }
-    }
-    max_depth
-}
-
-fn validate_formula_single_pass(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    let analysis = analyze_formula(formula, formula.span.as_ref());
     if let Some(diagnostic) = analysis.invalid_not_in_or {
         return Err(DiagnosticReport::validation_error(
             DiagnosticCode::ESempaiInvalidNotInOr,
@@ -121,13 +102,33 @@ struct DiagnosticSite {
     primary_span: Option<SourceSpan>,
 }
 
+#[derive(Clone, Copy)]
+struct AnalysisScope<'a> {
+    depth: usize,
+    fallback_span: Option<&'a SourceSpan>,
+}
+
+impl<'a> AnalysisScope<'a> {
+    const fn child_with_fallback(self, fallback_span: Option<&'a SourceSpan>) -> Self {
+        Self {
+            depth: self.depth + 1,
+            fallback_span,
+        }
+    }
+}
+
 /// Analyses a `Not` node, marking negation and recording the first negation span.
 fn analyze_not_arm(
     inner: &Decorated<Formula>,
+    scope: AnalysisScope<'_>,
     formula_span: Option<&SourceSpan>,
-    fallback_span: Option<&SourceSpan>,
+    max_depth: &mut usize,
 ) -> FormulaAnalysis {
-    let mut analysis = analyze_formula(inner, formula_span.or(fallback_span));
+    let mut analysis = analyze_formula_with_depth(
+        inner,
+        scope.child_with_fallback(formula_span.or(scope.fallback_span)),
+        max_depth,
+    );
     analysis.contains_not = true;
     analysis.has_positive_term = false;
     analysis.first_negation_span = formula_span.cloned().or(analysis.first_negation_span);
@@ -137,10 +138,15 @@ fn analyze_not_arm(
 /// Analyses an `Inside` or `Anywhere` node (no negation tracking).
 fn analyze_inside_anywhere_arm(
     inner: &Decorated<Formula>,
+    scope: AnalysisScope<'_>,
     formula_span: Option<&SourceSpan>,
-    fallback_span: Option<&SourceSpan>,
+    max_depth: &mut usize,
 ) -> FormulaAnalysis {
-    let mut analysis = analyze_formula(inner, formula_span.or(fallback_span));
+    let mut analysis = analyze_formula_with_depth(
+        inner,
+        scope.child_with_fallback(formula_span.or(scope.fallback_span)),
+        max_depth,
+    );
     analysis.has_positive_term = false;
     analysis
 }
@@ -150,9 +156,14 @@ fn analyze_inside_anywhere_arm(
 fn analyze_and_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
-    fallback_span: Option<&SourceSpan>,
+    scope: AnalysisScope<'_>,
+    max_depth: &mut usize,
 ) -> FormulaAnalysis {
-    let mut analysis = analyze_branches(branches, formula.span.as_ref().or(fallback_span));
+    let mut analysis = analyze_branches(
+        branches,
+        scope.child_with_fallback(formula.span.as_ref().or(scope.fallback_span)),
+        max_depth,
+    );
     analysis.has_positive_term |= has_match_producing_where_clause(&formula.where_clauses);
     if !analysis.has_positive_term {
         analysis.missing_positive_term = Some(DiagnosticSite {
@@ -160,7 +171,7 @@ fn analyze_and_arm(
                 .span
                 .clone()
                 .or_else(|| branches.first().and_then(|branch| branch.span.clone()))
-                .or_else(|| fallback_span.cloned()),
+                .or_else(|| scope.fallback_span.cloned()),
         });
     }
     analysis
@@ -171,12 +182,14 @@ fn analyze_and_arm(
 fn analyze_or_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
-    fallback_span: Option<&SourceSpan>,
+    scope: AnalysisScope<'_>,
+    max_depth: &mut usize,
 ) -> FormulaAnalysis {
     let mut analysis = FormulaAnalysis::default();
-    let child_fallback = formula.span.as_ref().or(fallback_span);
+    let child_fallback = formula.span.as_ref().or(scope.fallback_span);
+    let child_scope = scope.child_with_fallback(child_fallback);
     for branch in branches {
-        let branch_analysis = analyze_formula(branch, child_fallback);
+        let branch_analysis = analyze_formula_with_depth(branch, child_scope, max_depth);
         if branch_analysis.contains_not && analysis.invalid_not_in_or.is_none() {
             analysis.invalid_not_in_or = Some(DiagnosticSite {
                 primary_span: branch_analysis
@@ -202,31 +215,34 @@ fn analyze_or_arm(
     analysis
 }
 
-fn analyze_formula(
+fn analyze_formula_with_depth(
     formula: &Decorated<Formula>,
-    fallback_span: Option<&SourceSpan>,
+    scope: AnalysisScope<'_>,
+    max_depth: &mut usize,
 ) -> FormulaAnalysis {
+    *max_depth = (*max_depth).max(scope.depth);
     match &formula.node {
         Formula::Atom(_) => FormulaAnalysis {
             has_positive_term: true,
             ..FormulaAnalysis::default()
         },
-        Formula::Not(inner) => analyze_not_arm(inner, formula.span.as_ref(), fallback_span),
+        Formula::Not(inner) => analyze_not_arm(inner, scope, formula.span.as_ref(), max_depth),
         Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            analyze_inside_anywhere_arm(inner, formula.span.as_ref(), fallback_span)
+            analyze_inside_anywhere_arm(inner, scope, formula.span.as_ref(), max_depth)
         }
-        Formula::And(branches) => analyze_and_arm(formula, branches, fallback_span),
-        Formula::Or(branches) => analyze_or_arm(formula, branches, fallback_span),
+        Formula::And(branches) => analyze_and_arm(formula, branches, scope, max_depth),
+        Formula::Or(branches) => analyze_or_arm(formula, branches, scope, max_depth),
     }
 }
 
 fn analyze_branches(
     branches: &[Decorated<Formula>],
-    fallback_span: Option<&SourceSpan>,
+    scope: AnalysisScope<'_>,
+    max_depth: &mut usize,
 ) -> FormulaAnalysis {
     let mut analysis = FormulaAnalysis::default();
     for branch in branches {
-        let branch_analysis = analyze_formula(branch, fallback_span);
+        let branch_analysis = analyze_formula_with_depth(branch, scope, max_depth);
         analysis.has_positive_term |= branch_analysis.has_positive_term;
         analysis.contains_not |= branch_analysis.contains_not;
         analysis.first_negation_span = analysis

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -25,7 +25,7 @@ use sempai_core::{
     DiagnosticCode,
     DiagnosticReport,
     SourceSpan,
-    formula::{Constraint, Decorated, Formula, WhereClause},
+    formula::{Decorated, Formula},
 };
 
 pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
@@ -165,7 +165,6 @@ fn analyze_and_arm(
         scope.child_with_fallback(formula.span.as_ref().or(scope.fallback_span)),
         max_depth,
     );
-    analysis.has_positive_term |= has_match_producing_where_clause(&formula.where_clauses);
     if !analysis.has_positive_term {
         analysis.missing_positive_term = Some(DiagnosticSite {
             primary_span: formula
@@ -257,10 +256,4 @@ fn analyze_branches(
             .or(branch_analysis.missing_positive_term);
     }
     analysis
-}
-
-fn has_match_producing_where_clause(where_clauses: &[WhereClause]) -> bool {
-    where_clauses
-        .iter()
-        .any(|clause| matches!(clause.constraint, Constraint::MetavariablePattern { .. }))
 }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -25,7 +25,7 @@ use sempai_core::{
     DiagnosticCode,
     DiagnosticReport,
     SourceSpan,
-    formula::{Decorated, Formula},
+    formula::{Decorated, Formula, WhereClause},
 };
 
 pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
@@ -40,13 +40,30 @@ pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
 /// - `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`: And formula has no positive terms
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    let result = validate_formula_single_pass(formula);
+    let result = validate_formula_depth(formula, formula.span.as_ref())
+        .and_then(|()| validate_formula_single_pass(formula));
     if let Err(report) = &result
         && let Some(diagnostic) = report.diagnostics().first()
     {
         tracing::warn!(code = ?diagnostic.code(), "semantic validation failed");
     }
     result
+}
+
+pub(crate) fn validate_formula_depth(
+    formula: &Decorated<Formula>,
+    fallback_span: Option<&SourceSpan>,
+) -> Result<(), DiagnosticReport> {
+    let depth = formula_depth(formula);
+    if depth > MAX_FORMULA_DEPTH {
+        return Err(DiagnosticReport::validation_error(
+            DiagnosticCode::ESempaiSchemaInvalid,
+            format!("formula nesting depth exceeds limit of {MAX_FORMULA_DEPTH}: {depth}"),
+            fallback_span.cloned(),
+            vec![],
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn formula_depth(formula: &Decorated<Formula>) -> usize {
@@ -94,6 +111,7 @@ fn validate_formula_single_pass(formula: &Decorated<Formula>) -> Result<(), Diag
 struct FormulaAnalysis {
     has_positive_term: bool,
     contains_not: bool,
+    first_negation_span: Option<SourceSpan>,
     invalid_not_in_or: Option<DiagnosticSite>,
     missing_positive_term: Option<DiagnosticSite>,
 }
@@ -116,6 +134,7 @@ fn analyze_formula(
             let mut analysis = analyze_formula(inner, formula.span.as_ref().or(fallback_span));
             analysis.contains_not = true;
             analysis.has_positive_term = false;
+            analysis.first_negation_span = formula.span.clone().or(analysis.first_negation_span);
             analysis
         }
         Formula::Inside(inner) | Formula::Anywhere(inner) => {
@@ -125,6 +144,7 @@ fn analyze_formula(
         }
         Formula::And(branches) => {
             let mut analysis = analyze_branches(branches, formula.span.as_ref().or(fallback_span));
+            analysis.has_positive_term |= has_match_producing_where_clause(&formula.where_clauses);
             if !analysis.has_positive_term {
                 analysis.missing_positive_term = Some(DiagnosticSite {
                     primary_span: formula
@@ -143,7 +163,11 @@ fn analyze_formula(
                 let branch_analysis = analyze_formula(branch, child_fallback);
                 if branch_analysis.contains_not && analysis.invalid_not_in_or.is_none() {
                     analysis.invalid_not_in_or = Some(DiagnosticSite {
-                        primary_span: branch.span.clone().or_else(|| child_fallback.cloned()),
+                        primary_span: branch_analysis
+                            .first_negation_span
+                            .clone()
+                            .or_else(|| branch.span.clone())
+                            .or_else(|| child_fallback.cloned()),
                     });
                 } else {
                     analysis.invalid_not_in_or = analysis
@@ -152,6 +176,9 @@ fn analyze_formula(
                 }
                 analysis.has_positive_term |= branch_analysis.has_positive_term;
                 analysis.contains_not |= branch_analysis.contains_not;
+                analysis.first_negation_span = analysis
+                    .first_negation_span
+                    .or(branch_analysis.first_negation_span);
                 analysis.missing_positive_term = analysis
                     .missing_positive_term
                     .or(branch_analysis.missing_positive_term);
@@ -170,6 +197,9 @@ fn analyze_branches(
         let branch_analysis = analyze_formula(branch, fallback_span);
         analysis.has_positive_term |= branch_analysis.has_positive_term;
         analysis.contains_not |= branch_analysis.contains_not;
+        analysis.first_negation_span = analysis
+            .first_negation_span
+            .or(branch_analysis.first_negation_span);
         analysis.invalid_not_in_or = analysis
             .invalid_not_in_or
             .or(branch_analysis.invalid_not_in_or);
@@ -178,4 +208,10 @@ fn analyze_branches(
             .or(branch_analysis.missing_positive_term);
     }
     analysis
+}
+
+fn has_match_producing_where_clause(where_clauses: &[WhereClause]) -> bool {
+    where_clauses
+        .iter()
+        .any(|clause| clause.raw.get("metavariable-pattern").is_some())
 }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -14,8 +14,8 @@
 //! # Example
 //!
 //! ```ignore
-//! use sempai::semantic_check::validate_formula;
-//! use sempai_core::formula::{Formula, Decorated};
+//! use crate::semantic_check::validate_formula;
+//! use sempai_core::formula::{Decorated, Formula};
 //!
 //! let formula = /* ... */;
 //! validate_formula(&formula)?;
@@ -38,6 +38,7 @@ pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
 ///
 /// - `E_SEMPAI_INVALID_NOT_IN_OR`: Or branch contains a Not formula
 /// - `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`: And formula has no positive terms
+/// - `E_SEMPAI_SCHEMA_INVALID`: formula nesting exceeds the maximum safe depth
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
     let result = validate_formula_inner(formula);

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -121,6 +121,82 @@ struct DiagnosticSite {
     primary_span: Option<SourceSpan>,
 }
 
+/// Analyses a unary-wrapping formula node (`Not`, `Inside`, or `Anywhere`).
+///
+/// `marks_not` is `true` for `Not`, which sets `contains_not` and records the
+/// negation span, and `false` for `Inside`/`Anywhere`.
+fn analyze_unary(
+    inner: &Decorated<Formula>,
+    formula_span: Option<&SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
+    marks_not: bool,
+) -> FormulaAnalysis {
+    let mut analysis = analyze_formula(inner, formula_span.or(fallback_span));
+    analysis.has_positive_term = false;
+    analysis.contains_not |= marks_not;
+    if marks_not {
+        analysis.first_negation_span = formula_span.cloned().or(analysis.first_negation_span);
+    }
+    analysis
+}
+
+/// Analyses a conjunction (`And`) node and attaches a
+/// `MissingPositiveTermInAnd` site when no positive descendant is found.
+fn analyze_and(
+    formula: &Decorated<Formula>,
+    branches: &[Decorated<Formula>],
+    fallback_span: Option<&SourceSpan>,
+) -> FormulaAnalysis {
+    let mut analysis = analyze_branches(branches, formula.span.as_ref().or(fallback_span));
+    analysis.has_positive_term |= has_match_producing_where_clause(&formula.where_clauses);
+    if !analysis.has_positive_term {
+        analysis.missing_positive_term = Some(DiagnosticSite {
+            primary_span: formula
+                .span
+                .clone()
+                .or_else(|| branches.first().and_then(|branch| branch.span.clone()))
+                .or_else(|| fallback_span.cloned()),
+        });
+    }
+    analysis
+}
+
+/// Analyses a disjunction (`Or`) node and attaches an `InvalidNotInOr` site
+/// the first time a branch that contains a `Not` is found.
+fn analyze_or(
+    formula: &Decorated<Formula>,
+    branches: &[Decorated<Formula>],
+    fallback_span: Option<&SourceSpan>,
+) -> FormulaAnalysis {
+    let mut analysis = FormulaAnalysis::default();
+    let child_fallback = formula.span.as_ref().or(fallback_span);
+    for branch in branches {
+        let branch_analysis = analyze_formula(branch, child_fallback);
+        if branch_analysis.contains_not && analysis.invalid_not_in_or.is_none() {
+            analysis.invalid_not_in_or = Some(DiagnosticSite {
+                primary_span: branch_analysis
+                    .first_negation_span
+                    .clone()
+                    .or_else(|| branch.span.clone())
+                    .or_else(|| child_fallback.cloned()),
+            });
+        } else {
+            analysis.invalid_not_in_or = analysis
+                .invalid_not_in_or
+                .or(branch_analysis.invalid_not_in_or);
+        }
+        analysis.has_positive_term |= branch_analysis.has_positive_term;
+        analysis.contains_not |= branch_analysis.contains_not;
+        analysis.first_negation_span = analysis
+            .first_negation_span
+            .or(branch_analysis.first_negation_span);
+        analysis.missing_positive_term = analysis
+            .missing_positive_term
+            .or(branch_analysis.missing_positive_term);
+    }
+    analysis
+}
+
 fn analyze_formula(
     formula: &Decorated<Formula>,
     fallback_span: Option<&SourceSpan>,
@@ -130,61 +206,12 @@ fn analyze_formula(
             has_positive_term: true,
             ..FormulaAnalysis::default()
         },
-        Formula::Not(inner) => {
-            let mut analysis = analyze_formula(inner, formula.span.as_ref().or(fallback_span));
-            analysis.contains_not = true;
-            analysis.has_positive_term = false;
-            analysis.first_negation_span = formula.span.clone().or(analysis.first_negation_span);
-            analysis
-        }
+        Formula::Not(inner) => analyze_unary(inner, formula.span.as_ref(), fallback_span, true),
         Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            let mut analysis = analyze_formula(inner, formula.span.as_ref().or(fallback_span));
-            analysis.has_positive_term = false;
-            analysis
+            analyze_unary(inner, formula.span.as_ref(), fallback_span, false)
         }
-        Formula::And(branches) => {
-            let mut analysis = analyze_branches(branches, formula.span.as_ref().or(fallback_span));
-            analysis.has_positive_term |= has_match_producing_where_clause(&formula.where_clauses);
-            if !analysis.has_positive_term {
-                analysis.missing_positive_term = Some(DiagnosticSite {
-                    primary_span: formula
-                        .span
-                        .clone()
-                        .or_else(|| branches.first().and_then(|branch| branch.span.clone()))
-                        .or_else(|| fallback_span.cloned()),
-                });
-            }
-            analysis
-        }
-        Formula::Or(branches) => {
-            let mut analysis = FormulaAnalysis::default();
-            let child_fallback = formula.span.as_ref().or(fallback_span);
-            for branch in branches {
-                let branch_analysis = analyze_formula(branch, child_fallback);
-                if branch_analysis.contains_not && analysis.invalid_not_in_or.is_none() {
-                    analysis.invalid_not_in_or = Some(DiagnosticSite {
-                        primary_span: branch_analysis
-                            .first_negation_span
-                            .clone()
-                            .or_else(|| branch.span.clone())
-                            .or_else(|| child_fallback.cloned()),
-                    });
-                } else {
-                    analysis.invalid_not_in_or = analysis
-                        .invalid_not_in_or
-                        .or(branch_analysis.invalid_not_in_or);
-                }
-                analysis.has_positive_term |= branch_analysis.has_positive_term;
-                analysis.contains_not |= branch_analysis.contains_not;
-                analysis.first_negation_span = analysis
-                    .first_negation_span
-                    .or(branch_analysis.first_negation_span);
-                analysis.missing_positive_term = analysis
-                    .missing_positive_term
-                    .or(branch_analysis.missing_positive_term);
-            }
-            analysis
-        }
+        Formula::And(branches) => analyze_and(formula, branches, fallback_span),
+        Formula::Or(branches) => analyze_or(formula, branches, fallback_span),
     }
 }
 

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -91,8 +91,9 @@ fn branch_contains_not(formula: &Formula) -> bool {
 
 /// Checks that every `And` formula has at least one positive term.
 ///
-/// A positive term is a match-producing formula: `Atom`, `And`, or `Or`.
-/// Constraint-only formulas (`Not`, `Inside`, `Anywhere`) are not positive.
+/// A positive term is a match-producing formula: `Atom`, or `And`/`Or` when
+/// they contain a positive descendant. Constraint-only formulas (`Not`,
+/// `Inside`, `Anywhere`) are not positive.
 fn check_positive_term_in_and(
     formula: &Formula,
     span: Option<&sempai_core::SourceSpan>,
@@ -157,8 +158,8 @@ fn check_positive_term_in_and_with_spans(
 ///
 /// A term is positive when it ultimately produces a match location.  An `Atom`
 /// is always positive; `Not`, `Inside`, and `Anywhere` are purely
-/// constraint-style and never positive on their own.  An `And` or `Or` is
-/// positive only when at least one of its descendants is itself positive —
+/// constraint-style and never positive on their own. And/Or are positive only
+/// when at least one of their descendants is itself positive —
 /// otherwise the combinator bottoms out in constraint-only terms and cannot
 /// anchor matches.  This prevents shapes like `And[Or[Inside[Atom]]]` from
 /// sneaking past `MissingPositiveTermInAnd` on the basis of the outer shape

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -24,8 +24,11 @@
 use sempai_core::{
     DiagnosticCode,
     DiagnosticReport,
+    SourceSpan,
     formula::{Decorated, Formula},
 };
+
+pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
 
 /// Validates semantic constraints on a normalized formula.
 ///
@@ -37,8 +40,7 @@ use sempai_core::{
 /// - `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`: And formula has no positive terms
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    let result = check_no_not_in_or(&formula.node, formula.span.as_ref())
-        .and_then(|()| check_positive_term_in_and(&formula.node, formula.span.as_ref()));
+    let result = validate_formula_single_pass(formula);
     if let Err(report) = &result
         && let Some(diagnostic) = report.diagnostics().first()
     {
@@ -47,135 +49,133 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
     result
 }
 
-/// Checks that no `Or` branch contains a `Not` formula.
-fn check_no_not_in_or(
-    formula: &Formula,
-    span: Option<&sempai_core::SourceSpan>,
-) -> Result<(), DiagnosticReport> {
-    match formula {
+pub(crate) fn formula_depth(formula: &Decorated<Formula>) -> usize {
+    let mut max_depth = 0;
+    let mut stack = vec![(formula, 1)];
+    while let Some((current, depth)) = stack.pop() {
+        max_depth = max_depth.max(depth);
+        match &current.node {
+            Formula::Atom(_) => {}
+            Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
+                stack.push((inner, depth + 1));
+            }
+            Formula::And(branches) | Formula::Or(branches) => {
+                stack.extend(branches.iter().map(|branch| (branch, depth + 1)));
+            }
+        }
+    }
+    max_depth
+}
+
+fn validate_formula_single_pass(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
+    let analysis = analyze_formula(formula, formula.span.as_ref());
+    if let Some(diagnostic) = analysis.invalid_not_in_or {
+        return Err(DiagnosticReport::validation_error(
+            DiagnosticCode::ESempaiInvalidNotInOr,
+            String::from("negated terms are not allowed inside disjunction (Or/pattern-either)"),
+            diagnostic.primary_span,
+            vec![],
+        ));
+    }
+    if let Some(diagnostic) = analysis.missing_positive_term {
+        return Err(DiagnosticReport::validation_error(
+            DiagnosticCode::ESempaiMissingPositiveTermInAnd,
+            String::from(
+                "conjunction (And/patterns) must contain at least one positive match term",
+            ),
+            diagnostic.primary_span,
+            vec![],
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct FormulaAnalysis {
+    has_positive_term: bool,
+    contains_not: bool,
+    invalid_not_in_or: Option<DiagnosticSite>,
+    missing_positive_term: Option<DiagnosticSite>,
+}
+
+#[derive(Debug)]
+struct DiagnosticSite {
+    primary_span: Option<SourceSpan>,
+}
+
+fn analyze_formula(
+    formula: &Decorated<Formula>,
+    fallback_span: Option<&SourceSpan>,
+) -> FormulaAnalysis {
+    match &formula.node {
+        Formula::Atom(_) => FormulaAnalysis {
+            has_positive_term: true,
+            ..FormulaAnalysis::default()
+        },
+        Formula::Not(inner) => {
+            let mut analysis = analyze_formula(inner, formula.span.as_ref().or(fallback_span));
+            analysis.contains_not = true;
+            analysis.has_positive_term = false;
+            analysis
+        }
+        Formula::Inside(inner) | Formula::Anywhere(inner) => {
+            let mut analysis = analyze_formula(inner, formula.span.as_ref().or(fallback_span));
+            analysis.has_positive_term = false;
+            analysis
+        }
+        Formula::And(branches) => {
+            let mut analysis = analyze_branches(branches, formula.span.as_ref().or(fallback_span));
+            if !analysis.has_positive_term {
+                analysis.missing_positive_term = Some(DiagnosticSite {
+                    primary_span: formula
+                        .span
+                        .clone()
+                        .or_else(|| branches.first().and_then(|branch| branch.span.clone()))
+                        .or_else(|| fallback_span.cloned()),
+                });
+            }
+            analysis
+        }
         Formula::Or(branches) => {
+            let mut analysis = FormulaAnalysis::default();
+            let child_fallback = formula.span.as_ref().or(fallback_span);
             for branch in branches {
-                if branch_contains_not(&branch.node) {
-                    return Err(DiagnosticReport::validation_error(
-                        DiagnosticCode::ESempaiInvalidNotInOr,
-                        String::from(
-                            "negated terms are not allowed inside disjunction (Or/pattern-either)",
-                        ),
-                        branch.span.clone().or_else(|| span.cloned()),
-                        vec![],
-                    ));
+                let branch_analysis = analyze_formula(branch, child_fallback);
+                if branch_analysis.contains_not && analysis.invalid_not_in_or.is_none() {
+                    analysis.invalid_not_in_or = Some(DiagnosticSite {
+                        primary_span: branch.span.clone().or_else(|| child_fallback.cloned()),
+                    });
+                } else {
+                    analysis.invalid_not_in_or = analysis
+                        .invalid_not_in_or
+                        .or(branch_analysis.invalid_not_in_or);
                 }
-                // Recursively check nested formulas
-                check_no_not_in_or(&branch.node, branch.span.as_ref().or(span))?;
+                analysis.has_positive_term |= branch_analysis.has_positive_term;
+                analysis.contains_not |= branch_analysis.contains_not;
+                analysis.missing_positive_term = analysis
+                    .missing_positive_term
+                    .or(branch_analysis.missing_positive_term);
             }
-            Ok(())
+            analysis
         }
-        Formula::And(branches) => {
-            for branch in branches {
-                check_no_not_in_or(&branch.node, branch.span.as_ref().or(span))?;
-            }
-            Ok(())
-        }
-        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            check_no_not_in_or(&inner.node, inner.span.as_ref().or(span))
-        }
-        Formula::Atom(_) => Ok(()),
     }
 }
 
-/// Returns true when a formula subtree contains a negation.
-fn branch_contains_not(formula: &Formula) -> bool {
-    match formula {
-        Formula::Not(_) => true,
-        Formula::And(branches) | Formula::Or(branches) => branches
-            .iter()
-            .any(|branch| branch_contains_not(&branch.node)),
-        Formula::Inside(inner) | Formula::Anywhere(inner) => branch_contains_not(&inner.node),
-        Formula::Atom(_) => false,
+fn analyze_branches(
+    branches: &[Decorated<Formula>],
+    fallback_span: Option<&SourceSpan>,
+) -> FormulaAnalysis {
+    let mut analysis = FormulaAnalysis::default();
+    for branch in branches {
+        let branch_analysis = analyze_formula(branch, fallback_span);
+        analysis.has_positive_term |= branch_analysis.has_positive_term;
+        analysis.contains_not |= branch_analysis.contains_not;
+        analysis.invalid_not_in_or = analysis
+            .invalid_not_in_or
+            .or(branch_analysis.invalid_not_in_or);
+        analysis.missing_positive_term = analysis
+            .missing_positive_term
+            .or(branch_analysis.missing_positive_term);
     }
-}
-
-/// Checks that every `And` formula has at least one positive term.
-///
-/// A positive term is a match-producing formula: `Atom`, or `And`/`Or` when
-/// they contain a positive descendant. Constraint-only formulas (`Not`,
-/// `Inside`, `Anywhere`) are not positive.
-fn check_positive_term_in_and(
-    formula: &Formula,
-    span: Option<&sempai_core::SourceSpan>,
-) -> Result<(), DiagnosticReport> {
-    check_positive_term_in_and_with_spans(formula, span, span)
-}
-
-fn check_positive_term_in_and_with_spans(
-    formula: &Formula,
-    node_span: Option<&sempai_core::SourceSpan>,
-    fallback_span: Option<&sempai_core::SourceSpan>,
-) -> Result<(), DiagnosticReport> {
-    match formula {
-        Formula::And(branches) => {
-            let has_positive = branches.iter().any(|branch| is_positive_term(&branch.node));
-            if !has_positive {
-                let error_span = node_span
-                    .cloned()
-                    .or_else(|| branches.first().and_then(|branch| branch.span.clone()))
-                    .or_else(|| fallback_span.cloned());
-                return Err(DiagnosticReport::validation_error(
-                    DiagnosticCode::ESempaiMissingPositiveTermInAnd,
-                    String::from(
-                        "conjunction (And/patterns) must contain at least one positive match term",
-                    ),
-                    error_span,
-                    vec![],
-                ));
-            }
-            // Recursively check nested formulas
-            for branch in branches {
-                check_positive_term_in_and_with_spans(
-                    &branch.node,
-                    branch.span.as_ref(),
-                    node_span.or(fallback_span),
-                )?;
-            }
-            Ok(())
-        }
-        Formula::Or(branches) => {
-            for branch in branches {
-                check_positive_term_in_and_with_spans(
-                    &branch.node,
-                    branch.span.as_ref(),
-                    node_span.or(fallback_span),
-                )?;
-            }
-            Ok(())
-        }
-        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            check_positive_term_in_and_with_spans(
-                &inner.node,
-                inner.span.as_ref(),
-                node_span.or(fallback_span),
-            )
-        }
-        Formula::Atom(_) => Ok(()),
-    }
-}
-
-/// Returns true if the formula is a positive match-producing term.
-///
-/// A term is positive when it ultimately produces a match location.  An `Atom`
-/// is always positive; `Not`, `Inside`, and `Anywhere` are purely
-/// constraint-style and never positive on their own. And/Or are positive only
-/// when at least one of their descendants is itself positive —
-/// otherwise the combinator bottoms out in constraint-only terms and cannot
-/// anchor matches.  This prevents shapes like `And[Or[Inside[Atom]]]` from
-/// sneaking past `MissingPositiveTermInAnd` on the basis of the outer shape
-/// alone.
-fn is_positive_term(formula: &Formula) -> bool {
-    match formula {
-        Formula::Atom(_) => true,
-        Formula::And(branches) | Formula::Or(branches) => {
-            branches.iter().any(|b| is_positive_term(&b.node))
-        }
-        Formula::Not(_) | Formula::Inside(_) | Formula::Anywhere(_) => false,
-    }
+    analysis
 }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -170,7 +170,7 @@ fn analyze_and_arm(
             primary_span: formula
                 .span
                 .clone()
-                .or_else(|| branches.first().and_then(|branch| branch.span.clone()))
+                .or_else(|| branches.iter().find_map(|branch| branch.span.clone()))
                 .or_else(|| scope.fallback_span.cloned()),
         });
     }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -121,28 +121,33 @@ struct DiagnosticSite {
     primary_span: Option<SourceSpan>,
 }
 
-/// Analyses a unary-wrapping formula node (`Not`, `Inside`, or `Anywhere`).
-///
-/// `marks_not` is `true` for `Not`, which sets `contains_not` and records the
-/// negation span, and `false` for `Inside`/`Anywhere`.
-fn analyze_unary(
+/// Analyses a `Not` node, marking negation and recording the first negation span.
+fn analyze_not_arm(
     inner: &Decorated<Formula>,
     formula_span: Option<&SourceSpan>,
     fallback_span: Option<&SourceSpan>,
-    marks_not: bool,
+) -> FormulaAnalysis {
+    let mut analysis = analyze_formula(inner, formula_span.or(fallback_span));
+    analysis.contains_not = true;
+    analysis.has_positive_term = false;
+    analysis.first_negation_span = formula_span.cloned().or(analysis.first_negation_span);
+    analysis
+}
+
+/// Analyses an `Inside` or `Anywhere` node (no negation tracking).
+fn analyze_inside_anywhere_arm(
+    inner: &Decorated<Formula>,
+    formula_span: Option<&SourceSpan>,
+    fallback_span: Option<&SourceSpan>,
 ) -> FormulaAnalysis {
     let mut analysis = analyze_formula(inner, formula_span.or(fallback_span));
     analysis.has_positive_term = false;
-    analysis.contains_not |= marks_not;
-    if marks_not {
-        analysis.first_negation_span = formula_span.cloned().or(analysis.first_negation_span);
-    }
     analysis
 }
 
 /// Analyses a conjunction (`And`) node and attaches a
 /// `MissingPositiveTermInAnd` site when no positive descendant is found.
-fn analyze_and(
+fn analyze_and_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
     fallback_span: Option<&SourceSpan>,
@@ -162,8 +167,8 @@ fn analyze_and(
 }
 
 /// Analyses a disjunction (`Or`) node and attaches an `InvalidNotInOr` site
-/// the first time a branch that contains a `Not` is found.
-fn analyze_or(
+/// the first time a branch containing a `Not` is encountered.
+fn analyze_or_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
     fallback_span: Option<&SourceSpan>,
@@ -206,12 +211,12 @@ fn analyze_formula(
             has_positive_term: true,
             ..FormulaAnalysis::default()
         },
-        Formula::Not(inner) => analyze_unary(inner, formula.span.as_ref(), fallback_span, true),
+        Formula::Not(inner) => analyze_not_arm(inner, formula.span.as_ref(), fallback_span),
         Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            analyze_unary(inner, formula.span.as_ref(), fallback_span, false)
+            analyze_inside_anywhere_arm(inner, formula.span.as_ref(), fallback_span)
         }
-        Formula::And(branches) => analyze_and(formula, branches, fallback_span),
-        Formula::Or(branches) => analyze_or(formula, branches, fallback_span),
+        Formula::And(branches) => analyze_and_arm(formula, branches, fallback_span),
+        Formula::Or(branches) => analyze_or_arm(formula, branches, fallback_span),
     }
 }
 

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -35,10 +35,16 @@ use sempai_core::{
 ///
 /// - `E_SEMPAI_INVALID_NOT_IN_OR`: Or branch contains a Not formula
 /// - `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`: And formula has no positive terms
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    check_no_not_in_or(&formula.node, formula.span.as_ref())?;
-    check_positive_term_in_and(&formula.node, formula.span.as_ref())?;
-    Ok(())
+    let result = check_no_not_in_or(&formula.node, formula.span.as_ref())
+        .and_then(|()| check_positive_term_in_and(&formula.node, formula.span.as_ref()));
+    if let Err(report) = &result
+        && let Some(diagnostic) = report.diagnostics().first()
+    {
+        tracing::warn!(code = ?diagnostic.code(), "semantic validation failed");
+    }
+    result
 }
 
 /// Checks that no `Or` branch contains a `Not` formula.

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -25,7 +25,7 @@ use sempai_core::{
     DiagnosticCode,
     DiagnosticReport,
     SourceSpan,
-    formula::{Decorated, Formula, WhereClause},
+    formula::{Constraint, Decorated, Formula, WhereClause},
 };
 
 pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
@@ -240,5 +240,5 @@ fn analyze_branches(
 fn has_match_producing_where_clause(where_clauses: &[WhereClause]) -> bool {
     where_clauses
         .iter()
-        .any(|clause| clause.raw.get("metavariable-pattern").is_some())
+        .any(|clause| matches!(clause.constraint, Constraint::MetavariablePattern { .. }))
 }

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -2,6 +2,7 @@
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 use sempai_core::test_support::QuotedString;
 
 use crate::engine::QueryPlan;
@@ -56,7 +57,16 @@ fn when_compile_dsl(world: &mut TestWorld, dsl: QuotedString, lang: QuotedString
 #[when("a query plan is executed")]
 fn when_execute(world: &mut TestWorld) {
     let engine = world.engine.as_ref().expect("engine should be set");
-    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust);
+    let dummy_formula = Decorated {
+        node: Formula::Atom(Atom::Pattern(PatternAtom {
+            text: String::from("dummy"),
+        })),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust, dummy_formula);
     world.execute_result = Some(
         engine
             .execute(&plan, "file:///t.rs", "fn main() {}")

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -15,7 +15,7 @@ use crate::{DiagnosticReport, Engine, EngineConfig, Language};
 #[derive(Default)]
 struct TestWorld {
     engine: Option<Engine>,
-    compile_result: Option<Result<(), DiagnosticReport>>,
+    compile_result: Option<Result<Vec<QueryPlan>, DiagnosticReport>>,
     execute_result: Option<Result<(), DiagnosticReport>>,
 }
 
@@ -40,7 +40,7 @@ fn given_default_engine(world: &mut TestWorld) {
 #[when("YAML {yaml} is compiled")]
 fn when_compile_yaml(world: &mut TestWorld, yaml: QuotedString) {
     let engine = world.engine.as_ref().expect("engine should be set");
-    world.compile_result = Some(engine.compile_yaml(yaml.as_str()).map(|_| ()));
+    world.compile_result = Some(engine.compile_yaml(yaml.as_str()));
 }
 
 #[when("DSL {dsl} is compiled for language {lang}")]
@@ -50,7 +50,7 @@ fn when_compile_dsl(world: &mut TestWorld, dsl: QuotedString, lang: QuotedString
     world.compile_result = Some(
         engine
             .compile_dsl("interactive", language, dsl.as_str())
-            .map(|_| ()),
+            .map(|plan| vec![plan]),
     );
 }
 
@@ -79,8 +79,8 @@ fn when_execute(world: &mut TestWorld) {
 // ---------------------------------------------------------------------------
 
 /// Asserts that a diagnostic result contains a specific error code.
-fn assert_diagnostic_code(
-    result: Option<&Result<(), DiagnosticReport>>,
+fn assert_diagnostic_code<T: std::fmt::Debug>(
+    result: Option<&Result<T, DiagnosticReport>>,
     expected_code: &str,
     result_name: &str,
     failure_kind: &str,
@@ -133,6 +133,34 @@ fn then_first_diagnostic_message_contains(world: &mut TestWorld, snippet: Quoted
         .first()
         .expect("at least one diagnostic");
     assert!(first.message().contains(snippet.as_str()));
+}
+
+#[then("compilation succeeds with {count} query plan")]
+fn then_compilation_succeeds_with_plans(world: &mut TestWorld, count: usize) {
+    let plans = world
+        .compile_result
+        .as_ref()
+        .expect("compile result should be set")
+        .as_ref()
+        .expect("expected successful compilation");
+    assert_eq!(
+        plans.len(),
+        count,
+        "expected {count} query plan(s), got {}",
+        plans.len()
+    );
+}
+
+#[then("the first query plan has rule id {id}")]
+fn then_first_plan_rule_id(world: &mut TestWorld, id: QuotedString) {
+    let plans = world
+        .compile_result
+        .as_ref()
+        .expect("compile result should be set")
+        .as_ref()
+        .expect("expected successful compilation");
+    let first = plans.first().expect("expected at least one query plan");
+    assert_eq!(first.rule_id(), id.as_str());
 }
 
 #[then("execution fails with code {code}")]

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -2,8 +2,10 @@
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
-use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
-use sempai_core::test_support::QuotedString;
+use sempai_core::{
+    formula::{Atom, Decorated, Formula, PatternAtom},
+    test_support::QuotedString,
+};
 use weaver_test_macros::allow_fixture_expansion_lints;
 
 use crate::{DiagnosticReport, Engine, EngineConfig, Language, engine::QueryPlan};
@@ -134,6 +136,7 @@ fn then_first_diagnostic_message_contains(world: &mut TestWorld, snippet: Quoted
     assert!(first.message().contains(snippet.as_str()));
 }
 
+#[then("compilation succeeds with {count} query plan")]
 fn then_compilation_succeeds_with_plans(world: &mut TestWorld, count: usize) {
     let plans = world
         .compile_result
@@ -149,6 +152,7 @@ fn then_compilation_succeeds_with_plans(world: &mut TestWorld, count: usize) {
     );
 }
 
+#[then("the first query plan has rule id {id}")]
 fn then_first_plan_rule_id(world: &mut TestWorld, id: QuotedString) {
     let plans = world
         .compile_result
@@ -159,6 +163,8 @@ fn then_first_plan_rule_id(world: &mut TestWorld, id: QuotedString) {
     let first = plans.first().expect("expected at least one query plan");
     assert_eq!(first.rule_id(), id.as_str());
 }
+
+#[then("execution fails with code {code}")]
 fn then_execution_fails(world: &mut TestWorld, code: QuotedString) {
     assert_diagnostic_code(
         world.execute_result.as_ref(),

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -15,7 +15,7 @@ use crate::{DiagnosticReport, Engine, EngineConfig, Language, engine::QueryPlan}
 #[derive(Default)]
 struct TestWorld {
     engine: Option<Engine>,
-    compile_result: Option<Result<(), DiagnosticReport>>,
+    compile_result: Option<Result<Vec<QueryPlan>, DiagnosticReport>>,
     execute_result: Option<Result<(), DiagnosticReport>>,
 }
 
@@ -39,7 +39,7 @@ fn given_default_engine(world: &mut TestWorld) {
 #[when("YAML {yaml} is compiled")]
 fn when_compile_yaml(world: &mut TestWorld, yaml: QuotedString) {
     let engine = world.engine.as_ref().expect("engine should be set");
-    world.compile_result = Some(engine.compile_yaml(yaml.as_str()).map(|_| ()));
+    world.compile_result = Some(engine.compile_yaml(yaml.as_str()));
 }
 
 #[when("DSL {dsl} is compiled for language {lang}")]
@@ -49,7 +49,7 @@ fn when_compile_dsl(world: &mut TestWorld, dsl: QuotedString, lang: QuotedString
     world.compile_result = Some(
         engine
             .compile_dsl("interactive", language, dsl.as_str())
-            .map(|_| ()),
+            .map(|plan| vec![plan]),
     );
 }
 
@@ -78,8 +78,8 @@ fn when_execute(world: &mut TestWorld) {
 // ---------------------------------------------------------------------------
 
 /// Asserts that a diagnostic result contains a specific error code.
-fn assert_diagnostic_code(
-    result: Option<&Result<(), DiagnosticReport>>,
+fn assert_diagnostic_code<T: std::fmt::Debug>(
+    result: Option<&Result<T, DiagnosticReport>>,
     expected_code: &str,
     result_name: &str,
     failure_kind: &str,
@@ -134,7 +134,31 @@ fn then_first_diagnostic_message_contains(world: &mut TestWorld, snippet: Quoted
     assert!(first.message().contains(snippet.as_str()));
 }
 
-#[then("execution fails with code {code}")]
+fn then_compilation_succeeds_with_plans(world: &mut TestWorld, count: usize) {
+    let plans = world
+        .compile_result
+        .as_ref()
+        .expect("compile result should be set")
+        .as_ref()
+        .expect("expected successful compilation");
+    assert_eq!(
+        plans.len(),
+        count,
+        "expected {count} query plan(s), got {}",
+        plans.len()
+    );
+}
+
+fn then_first_plan_rule_id(world: &mut TestWorld, id: QuotedString) {
+    let plans = world
+        .compile_result
+        .as_ref()
+        .expect("compile result should be set")
+        .as_ref()
+        .expect("expected successful compilation");
+    let first = plans.first().expect("expected at least one query plan");
+    assert_eq!(first.rule_id(), id.as_str());
+}
 fn then_execution_fails(world: &mut TestWorld, code: QuotedString) {
     assert_diagnostic_code(
         world.execute_result.as_ref(),

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -107,6 +107,16 @@ fn assert_diagnostic_code<T: std::fmt::Debug>(
     );
 }
 
+fn first_compiled_plan(world: &TestWorld) -> &QueryPlan {
+    let plans = world
+        .compile_result
+        .as_ref()
+        .expect("compile result should be set")
+        .as_ref()
+        .expect("expected successful compilation");
+    plans.first().expect("expected at least one query plan")
+}
+
 // ---------------------------------------------------------------------------
 // Then steps
 // ---------------------------------------------------------------------------
@@ -160,14 +170,30 @@ fn then_compilation_succeeds_with_plans(world: &mut TestWorld, count: usize) {
 
 #[then("the first query plan has rule id {id}")]
 fn then_first_plan_rule_id(world: &mut TestWorld, id: QuotedString) {
-    let plans = world
-        .compile_result
-        .as_ref()
-        .expect("compile result should be set")
-        .as_ref()
-        .expect("expected successful compilation");
-    let first = plans.first().expect("expected at least one query plan");
+    let first = first_compiled_plan(world);
     assert_eq!(first.rule_id(), id.as_str());
+}
+
+#[then("the first query plan formula is pattern atom {text}")]
+fn then_first_plan_formula_is_pattern_atom(world: &mut TestWorld, text: QuotedString) {
+    let first = first_compiled_plan(world);
+    assert!(
+        matches!(&first.formula().node, Formula::Atom(Atom::Pattern(pattern)) if pattern.text == text.as_str()),
+        "expected first query plan formula to be Pattern({:?}), got {:?}",
+        text.as_str(),
+        first.formula().node
+    );
+}
+
+#[then("the first query plan formula is Tree-sitter query atom {query}")]
+fn then_first_plan_formula_is_tree_sitter_query_atom(world: &mut TestWorld, query: QuotedString) {
+    let first = first_compiled_plan(world);
+    assert!(
+        matches!(&first.formula().node, Formula::Atom(Atom::TreeSitterQuery(atom)) if atom.query == query.as_str()),
+        "expected first query plan formula to be TreeSitterQuery({:?}), got {:?}",
+        query.as_str(),
+        first.formula().node
+    );
 }
 
 #[then("execution fails with code {code}")]

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -2,6 +2,7 @@
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 use sempai_core::test_support::QuotedString;
 use weaver_test_macros::allow_fixture_expansion_lints;
 
@@ -55,7 +56,16 @@ fn when_compile_dsl(world: &mut TestWorld, dsl: QuotedString, lang: QuotedString
 #[when("a query plan is executed")]
 fn when_execute(world: &mut TestWorld) {
     let engine = world.engine.as_ref().expect("engine should be set");
-    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust);
+    let dummy_formula = Decorated {
+        node: Formula::Atom(Atom::Pattern(PatternAtom {
+            text: String::from("dummy"),
+        })),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust, dummy_formula);
     world.execute_result = Some(
         engine
             .execute(&plan, "file:///t.rs", "fn main() {}")

--- a/crates/sempai/src/tests/behaviour.rs
+++ b/crates/sempai/src/tests/behaviour.rs
@@ -1,5 +1,7 @@
 //! Behaviour-driven tests for the `sempai` engine facade.
 
+use std::sync::Arc;
+
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use sempai_core::{
@@ -67,7 +69,11 @@ fn when_execute(world: &mut TestWorld) {
         fix: None,
         span: None,
     };
-    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust, dummy_formula);
+    let plan = QueryPlan::new(
+        String::from("test-rule"),
+        Language::Rust,
+        Arc::new(dummy_formula),
+    );
     world.execute_result = Some(
         engine
             .execute(&plan, "file:///t.rs", "fn main() {}")

--- a/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
@@ -123,9 +123,13 @@ fn snapshot_diagnostic_report(
     #[case] snapshot_name: &str,
 ) {
     let report = compile_yaml_report(yaml);
-    let diagnostic = report.diagnostics().first().expect("should diagnose");
-    assert_eq!(diagnostic.code(), expected_code);
-    assert!(diagnostic.message().contains(expected_msg_fragment));
+    let first = report
+        .diagnostics()
+        .first()
+        .expect("should diagnose")
+        .clone();
+    assert_eq!(first.code(), expected_code);
+    assert!(first.message().contains(expected_msg_fragment));
 
     assert_snapshot!(snapshot_name, redacted_report_json(&report));
 }

--- a/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
@@ -2,7 +2,7 @@
 
 use insta::assert_snapshot;
 
-use crate::{DiagnosticReport, Engine, EngineConfig};
+use crate::{DiagnosticCode, DiagnosticReport, Engine, EngineConfig};
 
 fn compile_yaml_report(yaml: &str) -> DiagnosticReport {
     Engine::new(EngineConfig::default())
@@ -10,8 +10,30 @@ fn compile_yaml_report(yaml: &str) -> DiagnosticReport {
         .expect_err("YAML should fail compilation")
 }
 
-fn diagnostic_report_json(report: &DiagnosticReport) -> String {
-    serde_json::to_string_pretty(report).expect("serialize diagnostic report")
+fn redact_diagnostic_spans(diagnostic: &mut serde_json::Value) {
+    let Some(object) = diagnostic.as_object_mut() else {
+        return;
+    };
+    object.insert(
+        String::from("primary_span"),
+        serde_json::json!("<redacted-span>"),
+    );
+    if let Some(suggestions) = object.get_mut("suggestions") {
+        *suggestions = serde_json::json!("<redacted-suggestions>");
+    }
+}
+
+fn redacted_report_json(report: &DiagnosticReport) -> String {
+    let mut value = serde_json::to_value(report).expect("serialize diagnostic report");
+    if let Some(diagnostics) = value
+        .get_mut("diagnostics")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for diagnostic in diagnostics {
+            redact_diagnostic_spans(diagnostic);
+        }
+    }
+    serde_json::to_string_pretty(&value).expect("stringify diagnostic report")
 }
 
 #[test]
@@ -27,8 +49,15 @@ fn snapshot_invalid_not_in_or() {
         "      - pattern-not: bar($Y)\n",
     );
     let report = compile_yaml_report(yaml);
+    let diagnostic = report.diagnostics().first().expect("should diagnose");
+    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+    assert!(
+        diagnostic
+            .message()
+            .contains("not allowed inside disjunction")
+    );
 
-    assert_snapshot!("invalid_not_in_or", diagnostic_report_json(&report));
+    assert_snapshot!("invalid_not_in_or", redacted_report_json(&report));
 }
 
 #[test]
@@ -44,10 +73,20 @@ fn snapshot_missing_positive_term_in_and() {
         "      - pattern-inside: bar($Y)\n",
     );
     let report = compile_yaml_report(yaml);
+    let diagnostic = report.diagnostics().first().expect("should diagnose");
+    assert_eq!(
+        diagnostic.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+    assert!(
+        diagnostic
+            .message()
+            .contains("must contain at least one positive match term")
+    );
 
     assert_snapshot!(
         "missing_positive_term_in_and",
-        diagnostic_report_json(&report)
+        redacted_report_json(&report)
     );
 }
 
@@ -62,6 +101,9 @@ fn snapshot_schema_invalid_language() {
         "    pattern: foo($X)\n",
     );
     let report = compile_yaml_report(yaml);
+    let diagnostic = report.diagnostics().first().expect("should diagnose");
+    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiSchemaInvalid);
+    assert!(diagnostic.message().contains("unsupported language"));
 
-    assert_snapshot!("schema_invalid_language", diagnostic_report_json(&report));
+    assert_snapshot!("schema_invalid_language", redacted_report_json(&report));
 }

--- a/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
@@ -1,0 +1,67 @@
+//! Snapshot tests for Sempai engine diagnostic output.
+
+use insta::assert_snapshot;
+
+use crate::{DiagnosticReport, Engine, EngineConfig};
+
+fn compile_yaml_report(yaml: &str) -> DiagnosticReport {
+    Engine::new(EngineConfig::default())
+        .compile_yaml(yaml)
+        .expect_err("YAML should fail compilation")
+}
+
+fn diagnostic_report_json(report: &DiagnosticReport) -> String {
+    serde_json::to_string_pretty(report).expect("serialize diagnostic report")
+}
+
+#[test]
+fn snapshot_invalid_not_in_or() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.invalid.not.in.or\n",
+        "    message: invalid not in or\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    pattern-either:\n",
+        "      - pattern: foo($X)\n",
+        "      - pattern-not: bar($Y)\n",
+    );
+    let report = compile_yaml_report(yaml);
+
+    assert_snapshot!("invalid_not_in_or", diagnostic_report_json(&report));
+}
+
+#[test]
+fn snapshot_missing_positive_term_in_and() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.missing.positive.term.in.and\n",
+        "    message: missing positive term in and\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    patterns:\n",
+        "      - pattern-not: foo($X)\n",
+        "      - pattern-inside: bar($Y)\n",
+    );
+    let report = compile_yaml_report(yaml);
+
+    assert_snapshot!(
+        "missing_positive_term_in_and",
+        diagnostic_report_json(&report)
+    );
+}
+
+#[test]
+fn snapshot_schema_invalid_language() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.invalid.language\n",
+        "    message: invalid language\n",
+        "    languages: [cobol]\n",
+        "    severity: ERROR\n",
+        "    pattern: foo($X)\n",
+    );
+    let report = compile_yaml_report(yaml);
+
+    assert_snapshot!("schema_invalid_language", diagnostic_report_json(&report));
+}

--- a/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
+++ b/crates/sempai/src/tests/diagnostic_snapshot_tests.rs
@@ -1,6 +1,7 @@
 //! Snapshot tests for Sempai engine diagnostic output.
 
 use insta::assert_snapshot;
+use rstest::rstest;
 
 use crate::{DiagnosticCode, DiagnosticReport, Engine, EngineConfig};
 
@@ -14,12 +15,47 @@ fn redact_diagnostic_spans(diagnostic: &mut serde_json::Value) {
     let Some(object) = diagnostic.as_object_mut() else {
         return;
     };
-    object.insert(
-        String::from("primary_span"),
-        serde_json::json!("<redacted-span>"),
-    );
+    if let Some(primary_span) = object.get_mut("primary_span") {
+        redact_span_value(primary_span);
+    }
     if let Some(suggestions) = object.get_mut("suggestions") {
-        *suggestions = serde_json::json!("<redacted-suggestions>");
+        redact_sensitive_scalars(suggestions);
+    }
+}
+
+fn redact_span_value(value: &mut serde_json::Value) {
+    if value.is_null() {
+        return;
+    }
+    redact_sensitive_scalars(value);
+}
+
+fn redact_sensitive_scalars(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, field_value) in object {
+                match key.as_str() {
+                    "start" | "end" | "line_start" | "line_end" | "column_start" | "column_end"
+                    | "byte_start" | "byte_end" => {
+                        *field_value = serde_json::json!(0);
+                    }
+                    "uri" | "file" | "file_name" | "path" => redact_path_value(field_value),
+                    _ => redact_sensitive_scalars(field_value),
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                redact_sensitive_scalars(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redact_path_value(value: &mut serde_json::Value) {
+    if !value.is_null() {
+        *value = serde_json::json!("<redacted>");
     }
 }
 
@@ -36,9 +72,9 @@ fn redacted_report_json(report: &DiagnosticReport) -> String {
     serde_json::to_string_pretty(&value).expect("stringify diagnostic report")
 }
 
-#[test]
-fn snapshot_invalid_not_in_or() {
-    let yaml = concat!(
+#[rstest]
+#[case::invalid_not_in_or(
+    concat!(
         "rules:\n",
         "  - id: demo.invalid.not.in.or\n",
         "    message: invalid not in or\n",
@@ -47,22 +83,13 @@ fn snapshot_invalid_not_in_or() {
         "    pattern-either:\n",
         "      - pattern: foo($X)\n",
         "      - pattern-not: bar($Y)\n",
-    );
-    let report = compile_yaml_report(yaml);
-    let diagnostic = report.diagnostics().first().expect("should diagnose");
-    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiInvalidNotInOr);
-    assert!(
-        diagnostic
-            .message()
-            .contains("not allowed inside disjunction")
-    );
-
-    assert_snapshot!("invalid_not_in_or", redacted_report_json(&report));
-}
-
-#[test]
-fn snapshot_missing_positive_term_in_and() {
-    let yaml = concat!(
+    ),
+    DiagnosticCode::ESempaiInvalidNotInOr,
+    "not allowed inside disjunction",
+    "invalid_not_in_or",
+)]
+#[case::missing_positive_term_in_and(
+    concat!(
         "rules:\n",
         "  - id: demo.missing.positive.term.in.and\n",
         "    message: missing positive term in and\n",
@@ -71,39 +98,34 @@ fn snapshot_missing_positive_term_in_and() {
         "    patterns:\n",
         "      - pattern-not: foo($X)\n",
         "      - pattern-inside: bar($Y)\n",
-    );
-    let report = compile_yaml_report(yaml);
-    let diagnostic = report.diagnostics().first().expect("should diagnose");
-    assert_eq!(
-        diagnostic.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
-    assert!(
-        diagnostic
-            .message()
-            .contains("must contain at least one positive match term")
-    );
-
-    assert_snapshot!(
-        "missing_positive_term_in_and",
-        redacted_report_json(&report)
-    );
-}
-
-#[test]
-fn snapshot_schema_invalid_language() {
-    let yaml = concat!(
+    ),
+    DiagnosticCode::ESempaiMissingPositiveTermInAnd,
+    "must contain at least one positive match term",
+    "missing_positive_term_in_and",
+)]
+#[case::schema_invalid_language(
+    concat!(
         "rules:\n",
         "  - id: demo.invalid.language\n",
         "    message: invalid language\n",
         "    languages: [cobol]\n",
         "    severity: ERROR\n",
         "    pattern: foo($X)\n",
-    );
+    ),
+    DiagnosticCode::ESempaiSchemaInvalid,
+    "unsupported language",
+    "schema_invalid_language",
+)]
+fn snapshot_diagnostic_report(
+    #[case] yaml: &str,
+    #[case] expected_code: DiagnosticCode,
+    #[case] expected_msg_fragment: &str,
+    #[case] snapshot_name: &str,
+) {
     let report = compile_yaml_report(yaml);
     let diagnostic = report.diagnostics().first().expect("should diagnose");
-    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiSchemaInvalid);
-    assert!(diagnostic.message().contains("unsupported language"));
+    assert_eq!(diagnostic.code(), expected_code);
+    assert!(diagnostic.message().contains(expected_msg_fragment));
 
-    assert_snapshot!("schema_invalid_language", redacted_report_json(&report));
+    assert_snapshot!(snapshot_name, redacted_report_json(&report));
 }

--- a/crates/sempai/src/tests/engine_integration_tests.rs
+++ b/crates/sempai/src/tests/engine_integration_tests.rs
@@ -1,0 +1,74 @@
+//! Integration-focused tests for Sempai engine query plans.
+
+use sempai_core::formula::{Atom, Constraint, Decorated, Formula};
+
+use crate::{Engine, EngineConfig};
+
+fn compile_yaml(yaml: &str) -> Vec<crate::engine::QueryPlan> {
+    Engine::new(EngineConfig::default())
+        .compile_yaml(yaml)
+        .expect("should compile")
+}
+
+fn assert_pattern_formula(formula: &Decorated<Formula>, expected_text: &str) {
+    assert!(
+        matches!(
+            &formula.node,
+            Formula::Atom(Atom::Pattern(pattern)) if pattern.text == expected_text
+        ),
+        "expected Pattern atom with text \"{expected_text}\", got {:?}",
+        formula.node
+    );
+}
+
+#[test]
+fn compile_yaml_decorated_metadata_reaches_queryplan() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.decorated.metadata\n",
+        "    message: decorated metadata\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    match:\n",
+        "      pattern: foo($X)\n",
+        "      where:\n",
+        "        - metavariable-pattern:\n",
+        "            metavariable: $X\n",
+        "            pattern: bad\n",
+        "      as: cap\n",
+        "      fix: fixme\n",
+    );
+
+    let plans = compile_yaml(yaml);
+    let formula = plans.first().expect("should have one plan").formula();
+
+    assert_pattern_formula(formula, "foo($X)");
+    assert_eq!(formula.as_name.as_deref(), Some("cap"));
+    assert_eq!(formula.fix.as_deref(), Some("fixme"));
+    assert_eq!(
+        formula.where_clauses.first().map(|c| &c.constraint),
+        Some(&Constraint::MetavariablePattern {
+            metavariable: String::from("$X"),
+            pattern: String::from("bad"),
+        })
+    );
+}
+
+#[test]
+fn compile_yaml_arc_reuse_across_languages() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.shared.arc\n",
+        "    message: shared formula\n",
+        "    languages: [rust, python]\n",
+        "    severity: ERROR\n",
+        "    pattern: foo($X)\n",
+    );
+
+    let plans = compile_yaml(yaml);
+
+    assert_eq!(plans.len(), 2);
+    let first = plans.first().expect("expected first plan");
+    let second = plans.get(1).expect("expected second plan");
+    assert!(std::ptr::eq(first.formula(), second.formula()));
+}

--- a/crates/sempai/src/tests/engine_integration_tests.rs
+++ b/crates/sempai/src/tests/engine_integration_tests.rs
@@ -35,16 +35,16 @@ fn compile_yaml_decorated_metadata_reaches_queryplan() {
         "        - metavariable-pattern:\n",
         "            metavariable: $X\n",
         "            pattern: bad\n",
-        "      as: cap\n",
-        "      fix: fixme\n",
+        "      as: my_capture\n",
+        "      fix: replace_me\n",
     );
 
     let plans = compile_yaml(yaml);
     let formula = plans.first().expect("should have one plan").formula();
 
     assert_pattern_formula(formula, "foo($X)");
-    assert_eq!(formula.as_name.as_deref(), Some("cap"));
-    assert_eq!(formula.fix.as_deref(), Some("fixme"));
+    assert_eq!(formula.as_name.as_deref(), Some("my_capture"));
+    assert_eq!(formula.fix.as_deref(), Some("replace_me"));
     assert_eq!(
         formula.where_clauses.first().map(|c| &c.constraint),
         Some(&Constraint::MetavariablePattern {
@@ -52,6 +52,7 @@ fn compile_yaml_decorated_metadata_reaches_queryplan() {
             pattern: String::from("bad"),
         })
     );
+    assert!(formula.span.is_some());
 }
 
 #[test]

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -4,6 +4,7 @@ use crate::engine::QueryPlan;
 use crate::{
     Diagnostic, DiagnosticCode, DiagnosticReport, Engine, EngineConfig, EngineLimits, Language,
 };
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 
 fn default_engine() -> Engine {
     Engine::new(EngineConfig::default())
@@ -16,6 +17,18 @@ fn first_diagnostic_of_err<T>(result: Result<T, DiagnosticReport>) -> (Diagnosti
         .first()
         .expect("expected at least one diagnostic");
     (first.code(), first.clone())
+}
+
+fn dummy_formula() -> Decorated<Formula> {
+    Decorated {
+        node: Formula::Atom(Atom::Pattern(PatternAtom {
+            text: String::from("dummy"),
+        })),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
 }
 
 #[test]
@@ -52,18 +65,20 @@ fn compile_yaml_returns_schema_diagnostic_for_missing_rule_id() {
 }
 
 #[test]
-fn compile_yaml_returns_not_implemented_after_successful_parse() {
+fn compile_yaml_normalizes_and_returns_query_plans() {
     let engine = default_engine();
     let result = engine.compile_yaml(
         "rules:\n  - id: demo.rule\n    message: oops\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n",
     );
-    let (code, diag) = first_diagnostic_of_err(result);
-    assert_eq!(code, DiagnosticCode::NotImplemented);
-    assert!(diag.message().contains("normalization"));
+    let plans = result.expect("should successfully compile");
+    assert_eq!(plans.len(), 1);
+    let plan = plans.first().expect("should have first plan");
+    assert_eq!(plan.rule_id(), "demo.rule");
+    assert_eq!(plan.language(), Language::Rust);
 }
 
 #[test]
-fn compile_yaml_returns_not_implemented_for_project_depends_on_search_rule() {
+fn compile_yaml_normalizes_project_depends_on_search_rule() {
     let engine = default_engine();
     let result = engine.compile_yaml(concat!(
         "rules:\n",
@@ -75,9 +90,11 @@ fn compile_yaml_returns_not_implemented_for_project_depends_on_search_rule() {
         "      namespace: pypi\n",
         "      package: requests\n",
     ));
-    let (code, diag) = first_diagnostic_of_err(result);
-    assert_eq!(code, DiagnosticCode::NotImplemented);
-    assert!(diag.message().contains("normalization"));
+    let plans = result.expect("should successfully compile");
+    assert_eq!(plans.len(), 1);
+    let plan = plans.first().expect("should have first plan");
+    assert_eq!(plan.rule_id(), "demo.depends");
+    assert_eq!(plan.language(), Language::Python);
 }
 
 fn assert_compile_yaml_unsupported_mode(yaml: &str, expected_mode_fragment: &str) {
@@ -140,7 +157,7 @@ fn compile_dsl_returns_not_implemented() {
 #[test]
 fn execute_returns_not_implemented() {
     let engine = default_engine();
-    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust);
+    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust, dummy_formula());
     let result = engine.execute(&plan, "file:///test.rs", "fn main() {}");
     let (code, diag) = first_diagnostic_of_err(result);
     assert_eq!(code, DiagnosticCode::NotImplemented);

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -4,6 +4,7 @@ use crate::engine::QueryPlan;
 use crate::{
     Diagnostic, DiagnosticCode, DiagnosticReport, Engine, EngineConfig, EngineLimits, Language,
 };
+use rstest::rstest;
 use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 
 fn default_engine() -> Engine {
@@ -64,17 +65,39 @@ fn compile_yaml_returns_schema_diagnostic_for_missing_rule_id() {
     assert_eq!(code, DiagnosticCode::ESempaiSchemaInvalid);
 }
 
-#[test]
-fn compile_yaml_normalizes_and_returns_query_plans() {
+#[rstest]
+#[case::legacy_pattern(
+    "rules:\n  - id: demo.rule\n    message: oops\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n",
+    "demo.rule",
+    Language::Rust
+)]
+#[case::project_depends_on(
+    concat!(
+        "rules:\n",
+        "  - id: demo.depends\n",
+        "    message: detect vulnerable dependency\n",
+        "    languages: [python]\n",
+        "    severity: WARNING\n",
+        "    r2c-internal-project-depends-on:\n",
+        "      namespace: pypi\n",
+        "      package: requests\n",
+    ),
+    "demo.depends",
+    Language::Python,
+)]
+fn compile_yaml_normalizes_and_returns_query_plans(
+    #[case] yaml: &str,
+    #[case] expected_rule_id: &str,
+    #[case] expected_language: Language,
+) {
     let engine = default_engine();
-    let result = engine.compile_yaml(
-        "rules:\n  - id: demo.rule\n    message: oops\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n",
-    );
-    let plans = result.expect("should successfully compile");
+    let plans = engine
+        .compile_yaml(yaml)
+        .expect("should successfully compile");
     assert_eq!(plans.len(), 1);
     let plan = plans.first().expect("should have first plan");
-    assert_eq!(plan.rule_id(), "demo.rule");
-    assert_eq!(plan.language(), Language::Rust);
+    assert_eq!(plan.rule_id(), expected_rule_id);
+    assert_eq!(plan.language(), expected_language);
 }
 
 #[test]
@@ -109,26 +132,6 @@ fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
     ));
     let (code, _diag) = first_diagnostic_of_err(result);
     assert_eq!(code, DiagnosticCode::ESempaiMissingPositiveTermInAnd);
-}
-
-#[test]
-fn compile_yaml_normalizes_project_depends_on_search_rule() {
-    let engine = default_engine();
-    let result = engine.compile_yaml(concat!(
-        "rules:\n",
-        "  - id: demo.depends\n",
-        "    message: detect vulnerable dependency\n",
-        "    languages: [python]\n",
-        "    severity: WARNING\n",
-        "    r2c-internal-project-depends-on:\n",
-        "      namespace: pypi\n",
-        "      package: requests\n",
-    ));
-    let plans = result.expect("should successfully compile");
-    assert_eq!(plans.len(), 1);
-    let plan = plans.first().expect("should have first plan");
-    assert_eq!(plan.rule_id(), "demo.depends");
-    assert_eq!(plan.language(), Language::Python);
 }
 
 fn assert_compile_yaml_unsupported_mode(yaml: &str, expected_mode_fragment: &str) {

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -78,6 +78,40 @@ fn compile_yaml_normalizes_and_returns_query_plans() {
 }
 
 #[test]
+fn compile_yaml_returns_semantic_error_for_invalid_not_in_or() {
+    let engine = default_engine();
+    let result = engine.compile_yaml(concat!(
+        "rules:\n",
+        "  - id: demo.invalid.not.in.or\n",
+        "    message: invalid not in or\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    pattern-either:\n",
+        "      - pattern: foo($X)\n",
+        "      - pattern-not: bar($Y)\n",
+    ));
+    let (code, _diag) = first_diagnostic_of_err(result);
+    assert_eq!(code, DiagnosticCode::ESempaiInvalidNotInOr);
+}
+
+#[test]
+fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
+    let engine = default_engine();
+    let result = engine.compile_yaml(concat!(
+        "rules:\n",
+        "  - id: demo.missing.positive.term.in.and\n",
+        "    message: missing positive term in and\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    patterns:\n",
+        "      - pattern-not: foo($X)\n",
+        "      - pattern-inside: bar($Y)\n",
+    ));
+    let (code, _diag) = first_diagnostic_of_err(result);
+    assert_eq!(code, DiagnosticCode::ESempaiMissingPositiveTermInAnd);
+}
+
+#[test]
 fn compile_yaml_normalizes_project_depends_on_search_rule() {
     let engine = default_engine();
     let result = engine.compile_yaml(concat!(

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -102,36 +102,36 @@ fn compile_yaml_normalizes_and_returns_query_plans(
 
 #[test]
 fn compile_yaml_returns_semantic_error_for_invalid_not_in_or() {
-    let engine = default_engine();
-    let result = engine.compile_yaml(concat!(
-        "rules:\n",
-        "  - id: demo.invalid.not.in.or\n",
-        "    message: invalid not in or\n",
-        "    languages: [rust]\n",
-        "    severity: ERROR\n",
-        "    pattern-either:\n",
-        "      - pattern: foo($X)\n",
-        "      - pattern-not: bar($Y)\n",
-    ));
-    let (code, _diag) = first_diagnostic_of_err(result);
-    assert_eq!(code, DiagnosticCode::ESempaiInvalidNotInOr);
+    assert_compile_yaml_semantic_error(
+        concat!(
+            "rules:\n",
+            "  - id: demo.invalid.not.in.or\n",
+            "    message: invalid not in or\n",
+            "    languages: [rust]\n",
+            "    severity: ERROR\n",
+            "    pattern-either:\n",
+            "      - pattern: foo($X)\n",
+            "      - pattern-not: bar($Y)\n",
+        ),
+        DiagnosticCode::ESempaiInvalidNotInOr,
+    );
 }
 
 #[test]
 fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
-    let engine = default_engine();
-    let result = engine.compile_yaml(concat!(
-        "rules:\n",
-        "  - id: demo.missing.positive.term.in.and\n",
-        "    message: missing positive term in and\n",
-        "    languages: [rust]\n",
-        "    severity: ERROR\n",
-        "    patterns:\n",
-        "      - pattern-not: foo($X)\n",
-        "      - pattern-inside: bar($Y)\n",
-    ));
-    let (code, _diag) = first_diagnostic_of_err(result);
-    assert_eq!(code, DiagnosticCode::ESempaiMissingPositiveTermInAnd);
+    assert_compile_yaml_semantic_error(
+        concat!(
+            "rules:\n",
+            "  - id: demo.missing.positive.term.in.and\n",
+            "    message: missing positive term in and\n",
+            "    languages: [rust]\n",
+            "    severity: ERROR\n",
+            "    patterns:\n",
+            "      - pattern-not: foo($X)\n",
+            "      - pattern-inside: bar($Y)\n",
+        ),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd,
+    );
 }
 
 fn assert_compile_yaml_unsupported_mode(yaml: &str, expected_mode_fragment: &str) {
@@ -146,6 +146,13 @@ fn assert_compile_yaml_unsupported_mode(yaml: &str, expected_mode_fragment: &str
         diag.message(),
     );
     assert!(diag.primary_span().is_some());
+}
+
+fn assert_compile_yaml_semantic_error(yaml: &str, expected_code: DiagnosticCode) {
+    let engine = default_engine();
+    let result = engine.compile_yaml(yaml);
+    let (code, _diag) = first_diagnostic_of_err(result);
+    assert_eq!(code, expected_code);
 }
 
 #[test]

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for the `Engine` and `QueryPlan` types.
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use rstest::rstest;
 use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom, TreeSitterQueryAtom};
@@ -70,6 +70,17 @@ fn dummy_formula() -> Decorated<Formula> {
         fix: None,
         span: None,
     }
+}
+
+fn assert_pattern_formula(formula: &Decorated<Formula>, expected_text: &str) {
+    assert!(
+        matches!(
+            &formula.node,
+            Formula::Atom(Atom::Pattern(pattern)) if pattern.text == expected_text
+        ),
+        "expected Pattern atom with text \"{expected_text}\", got {:?}",
+        formula.node
+    );
 }
 
 #[test]
@@ -143,13 +154,64 @@ fn compile_yaml_plan_formula_matches_normalization() {
     let plans = engine.compile_yaml(yaml).expect("should compile");
     let plan = plans.first().expect("should have one plan");
     let formula = plan.formula();
-    assert!(
-        matches!(
-            &formula.node,
-            Formula::Atom(Atom::Pattern(p)) if p.text == "foo($X)"
-        ),
-        "expected Pattern atom with text \"foo($X)\", got {:?}",
-        formula.node
+    assert_pattern_formula(formula, "foo($X)");
+}
+
+#[test]
+fn compile_yaml_multiple_languages_yields_multiple_plans() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.multi\n",
+        "    message: multi language\n",
+        "    languages: [rust, python]\n",
+        "    severity: ERROR\n",
+        "    pattern: foo($X)\n",
+    );
+
+    let plans = compile_yaml_text(yaml).expect("should compile");
+
+    assert_eq!(plans.len(), 2);
+    let languages = plans.iter().map(QueryPlan::language).collect::<Vec<_>>();
+    assert!(languages.contains(&Language::Rust));
+    assert!(languages.contains(&Language::Python));
+    for plan in &plans {
+        assert_eq!(plan.rule_id(), "demo.multi");
+        assert_pattern_formula(plan.formula(), "foo($X)");
+    }
+}
+
+#[test]
+fn compile_yaml_multiple_rules_return_expected_plans() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.first\n",
+        "    message: first rule\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    pattern: foo($X)\n",
+        "  - id: demo.second\n",
+        "    message: second rule\n",
+        "    languages: [rust]\n",
+        "    severity: WARNING\n",
+        "    pattern: bar($Y)\n",
+    );
+
+    let plans = compile_yaml_text(yaml).expect("should compile");
+
+    assert_eq!(plans.len(), 2);
+    let mut seen = BTreeSet::new();
+    for plan in &plans {
+        assert_eq!(plan.language(), Language::Rust);
+        seen.insert(plan.rule_id().to_owned());
+        match plan.rule_id() {
+            "demo.first" => assert_pattern_formula(plan.formula(), "foo($X)"),
+            "demo.second" => assert_pattern_formula(plan.formula(), "bar($Y)"),
+            other => panic!("unexpected rule id {other}"),
+        }
+    }
+    assert_eq!(
+        seen,
+        BTreeSet::from([String::from("demo.first"), String::from("demo.second")])
     );
 }
 

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -13,6 +13,8 @@ use crate::{
     engine::QueryPlan,
 };
 
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
+
 fn default_engine() -> Engine { Engine::new(EngineConfig::default()) }
 
 fn compile_yaml_text(yaml: &str) -> Result<Vec<QueryPlan>, DiagnosticReport> {
@@ -57,7 +59,17 @@ fn first_diagnostic_of_err<T>(result: Result<T, DiagnosticReport>) -> (Diagnosti
     (first.code(), first.clone())
 }
 
-#[test]
+fn dummy_formula() -> Decorated<Formula> {
+    Decorated {
+        node: Formula::Atom(Atom::Pattern(PatternAtom {
+            text: String::from("dummy"),
+        })),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
+}
 fn engine_new_with_default_config() {
     let engine = Engine::new(EngineConfig::default());
     assert_eq!(engine.config().max_matches_per_rule(), 10_000);
@@ -69,6 +81,37 @@ fn engine_new_with_custom_config() {
     let config = EngineConfig::new(limits, true);
     let engine = Engine::new(config);
     assert!(engine.config().enable_hcl());
+}
+
+fn compile_yaml_normalizes_and_returns_query_plans() {
+    let engine = default_engine();
+    let result = engine.compile_yaml(
+        "rules:\n  - id: demo.rule\n    message: oops\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n",
+    );
+    let plans = result.expect("should successfully compile");
+    assert_eq!(plans.len(), 1);
+    let plan = plans.first().expect("should have first plan");
+    assert_eq!(plan.rule_id(), "demo.rule");
+    assert_eq!(plan.language(), Language::Rust);
+}
+
+fn compile_yaml_normalizes_project_depends_on_search_rule() {
+    let engine = default_engine();
+    let result = engine.compile_yaml(concat!(
+        "rules:\n",
+        "  - id: demo.depends\n",
+        "    message: detect vulnerable dependency\n",
+        "    languages: [python]\n",
+        "    severity: WARNING\n",
+        "    r2c-internal-project-depends-on:\n",
+        "      namespace: pypi\n",
+        "      package: requests\n",
+    ));
+    let plans = result.expect("should successfully compile");
+    assert_eq!(plans.len(), 1);
+    let plan = plans.first().expect("should have first plan");
+    assert_eq!(plan.rule_id(), "demo.depends");
+    assert_eq!(plan.language(), Language::Python);
 }
 
 #[rstest]
@@ -113,23 +156,6 @@ fn compile_yaml_returns_expected_diagnostic_for_single_rule_cases(
 }
 
 #[test]
-fn compile_yaml_returns_not_implemented_for_project_depends_on_search_rule() {
-    let engine = default_engine();
-    let result = engine.compile_yaml(concat!(
-        "rules:\n",
-        "  - id: demo.depends\n",
-        "    message: detect vulnerable dependency\n",
-        "    languages: [python]\n",
-        "    severity: WARNING\n",
-        "    r2c-internal-project-depends-on:\n",
-        "      namespace: pypi\n",
-        "      package: requests\n",
-    ));
-    let (code, diag) = first_diagnostic_of_err(result);
-    assert_eq!(code, DiagnosticCode::NotImplemented);
-    assert!(diag.message().contains("normalization"));
-}
-
 fn assert_compile_yaml_unsupported_mode(yaml: &str, expected_mode_fragment: &str) {
     let engine = default_engine();
     let result = engine.compile_yaml(yaml);
@@ -190,7 +216,7 @@ fn compile_dsl_returns_not_implemented() {
 #[test]
 fn execute_returns_not_implemented() {
     let engine = default_engine();
-    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust);
+    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust, dummy_formula());
     let result = engine.execute(&plan, "file:///test.rs", "fn main() {}");
     let (code, diag) = first_diagnostic_of_err(result);
     assert_eq!(code, DiagnosticCode::NotImplemented);

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -95,6 +95,37 @@ fn compile_yaml_normalizes_and_returns_query_plans() {
     assert_eq!(plan.language(), Language::Rust);
 }
 
+fn compile_yaml_returns_semantic_error_for_invalid_not_in_or() {
+    let engine = default_engine();
+    let result = engine.compile_yaml(concat!(
+        "rules:\n",
+        "  - id: demo.invalid.not.in.or\n",
+        "    message: invalid not in or\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    pattern-either:\n",
+        "      - pattern: foo($X)\n",
+        "      - pattern-not: bar($Y)\n",
+    ));
+    let (code, _diag) = first_diagnostic_of_err(result);
+    assert_eq!(code, DiagnosticCode::ESempaiInvalidNotInOr);
+}
+
+fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
+    let engine = default_engine();
+    let result = engine.compile_yaml(concat!(
+        "rules:\n",
+        "  - id: demo.missing.positive.term.in.and\n",
+        "    message: missing positive term in and\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    patterns:\n",
+        "      - pattern-not: foo($X)\n",
+        "      - pattern-inside: bar($Y)\n",
+    ));
+    let (code, _diag) = first_diagnostic_of_err(result);
+    assert_eq!(code, DiagnosticCode::ESempaiMissingPositiveTermInAnd);
+}
 fn compile_yaml_normalizes_project_depends_on_search_rule() {
     let engine = default_engine();
     let result = engine.compile_yaml(concat!(

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use rstest::rstest;
-use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom, TreeSitterQueryAtom};
 
 use crate::{
     Diagnostic,
@@ -90,7 +90,10 @@ fn engine_new_with_custom_config() {
 #[case::legacy_pattern(
     "rules:\n  - id: demo.rule\n    message: oops\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n",
     "demo.rule",
-    Language::Rust
+    Language::Rust,
+    Formula::Atom(Atom::Pattern(PatternAtom {
+        text: String::from("foo($X)"),
+    })),
 )]
 #[case::project_depends_on(
     concat!(
@@ -105,11 +108,15 @@ fn engine_new_with_custom_config() {
     ),
     "demo.depends",
     Language::Python,
+    Formula::Atom(Atom::TreeSitterQuery(TreeSitterQueryAtom {
+        query: String::from("(__NONEXISTENT_NODE__) @_dependency_check"),
+    })),
 )]
 fn compile_yaml_normalizes_and_returns_query_plans(
     #[case] yaml: &str,
     #[case] expected_rule_id: &str,
     #[case] expected_language: Language,
+    #[case] expected_formula: Formula,
 ) {
     let engine = default_engine();
     let plans = engine
@@ -119,6 +126,7 @@ fn compile_yaml_normalizes_and_returns_query_plans(
     let plan = plans.first().expect("should have first plan");
     assert_eq!(plan.rule_id(), expected_rule_id);
     assert_eq!(plan.language(), expected_language);
+    assert_eq!(&plan.formula().node, &expected_formula);
 }
 
 #[rstest]

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -13,7 +13,8 @@ use crate::{
     EngineConfig,
     EngineLimits,
     Language,
-    engine::QueryPlan,
+    engine::{QueryPlan, validate_formula_depth},
+    semantic_check::MAX_FORMULA_DEPTH,
 };
 
 fn default_engine() -> Engine { Engine::new(EngineConfig::default()) }
@@ -70,6 +71,20 @@ fn dummy_formula() -> Decorated<Formula> {
         fix: None,
         span: None,
     }
+}
+
+fn deeply_nested_formula(depth: usize) -> Decorated<Formula> {
+    let mut formula = dummy_formula();
+    for _ in 0..depth {
+        formula = Decorated {
+            node: Formula::Inside(Box::new(formula)),
+            where_clauses: vec![],
+            as_name: None,
+            fix: None,
+            span: None,
+        };
+    }
+    formula
 }
 
 fn assert_pattern_formula(formula: &Decorated<Formula>, expected_text: &str) {
@@ -212,6 +227,25 @@ fn compile_yaml_multiple_rules_return_expected_plans() {
     assert_eq!(
         seen,
         BTreeSet::from([String::from("demo.first"), String::from("demo.second")])
+    );
+}
+
+#[test]
+fn compile_yaml_rejects_formula_nesting_beyond_depth_limit() {
+    let formula = deeply_nested_formula(MAX_FORMULA_DEPTH);
+    let report = validate_formula_depth(&formula, None).expect_err("depth limit should fail");
+    let diagnostic = report
+        .diagnostics()
+        .first()
+        .expect("should have diagnostic");
+
+    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiSchemaInvalid);
+    assert!(
+        diagnostic
+            .message()
+            .contains("formula nesting depth exceeds limit"),
+        "unexpected diagnostic message: {}",
+        diagnostic.message()
     );
 }
 

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -122,36 +122,36 @@ fn compile_yaml_normalizes_and_returns_query_plans(
 
 #[test]
 fn compile_yaml_returns_semantic_error_for_invalid_not_in_or() {
-    let engine = default_engine();
-    let result = engine.compile_yaml(concat!(
-        "rules:\n",
-        "  - id: demo.invalid.not.in.or\n",
-        "    message: invalid not in or\n",
-        "    languages: [rust]\n",
-        "    severity: ERROR\n",
-        "    pattern-either:\n",
-        "      - pattern: foo($X)\n",
-        "      - pattern-not: bar($Y)\n",
-    ));
-    let (code, _diag) = first_diagnostic_of_err(result);
-    assert_eq!(code, DiagnosticCode::ESempaiInvalidNotInOr);
+    assert_compile_yaml_semantic_error(
+        concat!(
+            "rules:\n",
+            "  - id: demo.invalid.not.in.or\n",
+            "    message: invalid not in or\n",
+            "    languages: [rust]\n",
+            "    severity: ERROR\n",
+            "    pattern-either:\n",
+            "      - pattern: foo($X)\n",
+            "      - pattern-not: bar($Y)\n",
+        ),
+        DiagnosticCode::ESempaiInvalidNotInOr,
+    );
 }
 
 #[test]
 fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
-    let engine = default_engine();
-    let result = engine.compile_yaml(concat!(
-        "rules:\n",
-        "  - id: demo.missing.positive.term.in.and\n",
-        "    message: missing positive term in and\n",
-        "    languages: [rust]\n",
-        "    severity: ERROR\n",
-        "    patterns:\n",
-        "      - pattern-not: foo($X)\n",
-        "      - pattern-inside: bar($Y)\n",
-    ));
-    let (code, _diag) = first_diagnostic_of_err(result);
-    assert_eq!(code, DiagnosticCode::ESempaiMissingPositiveTermInAnd);
+    assert_compile_yaml_semantic_error(
+        concat!(
+            "rules:\n",
+            "  - id: demo.missing.positive.term.in.and\n",
+            "    message: missing positive term in and\n",
+            "    languages: [rust]\n",
+            "    severity: ERROR\n",
+            "    patterns:\n",
+            "      - pattern-not: foo($X)\n",
+            "      - pattern-inside: bar($Y)\n",
+        ),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd,
+    );
 }
 
 #[rstest]
@@ -201,7 +201,12 @@ fn assert_compile_yaml_unsupported_mode(yaml: &str, expected_mode_fragment: &str
     assert!(diag.primary_span().is_some());
 }
 
-#[test]
+fn assert_compile_yaml_semantic_error(yaml: &str, expected_code: DiagnosticCode) {
+    let engine = default_engine();
+    let result = engine.compile_yaml(yaml);
+    let (code, _diag) = first_diagnostic_of_err(result);
+    assert_eq!(code, expected_code);
+}
 fn compile_yaml_returns_unsupported_mode_for_extract_rules() {
     assert_compile_yaml_unsupported_mode(
         concat!(

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -13,8 +13,8 @@ use crate::{
     EngineConfig,
     EngineLimits,
     Language,
-    engine::{QueryPlan, validate_formula_depth},
-    semantic_check::MAX_FORMULA_DEPTH,
+    engine::QueryPlan,
+    semantic_check::{MAX_FORMULA_DEPTH, validate_formula_depth},
 };
 
 fn default_engine() -> Engine { Engine::new(EngineConfig::default()) }
@@ -75,7 +75,7 @@ fn dummy_formula() -> Decorated<Formula> {
 
 fn deeply_nested_formula(depth: usize) -> Decorated<Formula> {
     let mut formula = dummy_formula();
-    for _ in 0..depth {
+    for _ in 1..depth {
         formula = Decorated {
             node: Formula::Inside(Box::new(formula)),
             where_clauses: vec![],
@@ -232,7 +232,9 @@ fn compile_yaml_multiple_rules_return_expected_plans() {
 
 #[test]
 fn compile_yaml_rejects_formula_nesting_beyond_depth_limit() {
-    let formula = deeply_nested_formula(MAX_FORMULA_DEPTH);
+    assert!(validate_formula_depth(&deeply_nested_formula(MAX_FORMULA_DEPTH), None).is_ok());
+
+    let formula = deeply_nested_formula(MAX_FORMULA_DEPTH + 1);
     let report = validate_formula_depth(&formula, None).expect_err("depth limit should fail");
     let diagnostic = report
         .diagnostics()

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -129,6 +129,30 @@ fn compile_yaml_normalizes_and_returns_query_plans(
     assert_eq!(&plan.formula().node, &expected_formula);
 }
 
+#[test]
+fn compile_yaml_plan_formula_matches_normalization() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.formula.check\n",
+        "    message: check formula\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    pattern: foo($X)\n",
+    );
+    let engine = default_engine();
+    let plans = engine.compile_yaml(yaml).expect("should compile");
+    let plan = plans.first().expect("should have one plan");
+    let formula = plan.formula();
+    assert!(
+        matches!(
+            &formula.node,
+            Formula::Atom(Atom::Pattern(p)) if p.text == "foo($X)"
+        ),
+        "expected Pattern atom with text \"foo($X)\", got {:?}",
+        formula.node
+    );
+}
+
 #[rstest]
 #[case::invalid_not_in_or(
     concat!(

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -121,38 +121,35 @@ fn compile_yaml_normalizes_and_returns_query_plans(
     assert_eq!(plan.language(), expected_language);
 }
 
-#[test]
-fn compile_yaml_returns_semantic_error_for_invalid_not_in_or() {
-    assert_compile_yaml_semantic_error(
-        concat!(
-            "rules:\n",
-            "  - id: demo.invalid.not.in.or\n",
-            "    message: invalid not in or\n",
-            "    languages: [rust]\n",
-            "    severity: ERROR\n",
-            "    pattern-either:\n",
-            "      - pattern: foo($X)\n",
-            "      - pattern-not: bar($Y)\n",
-        ),
-        DiagnosticCode::ESempaiInvalidNotInOr,
-    );
-}
-
-#[test]
-fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
-    assert_compile_yaml_semantic_error(
-        concat!(
-            "rules:\n",
-            "  - id: demo.missing.positive.term.in.and\n",
-            "    message: missing positive term in and\n",
-            "    languages: [rust]\n",
-            "    severity: ERROR\n",
-            "    patterns:\n",
-            "      - pattern-not: foo($X)\n",
-            "      - pattern-inside: bar($Y)\n",
-        ),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd,
-    );
+#[rstest]
+#[case::invalid_not_in_or(
+    concat!(
+        "rules:\n",
+        "  - id: demo.invalid.not.in.or\n",
+        "    message: invalid not in or\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    pattern-either:\n",
+        "      - pattern: foo($X)\n",
+        "      - pattern-not: bar($Y)\n",
+    ),
+    DiagnosticCode::ESempaiInvalidNotInOr,
+)]
+#[case::missing_positive_term_in_and(
+    concat!(
+        "rules:\n",
+        "  - id: demo.missing.positive.term.in.and\n",
+        "    message: missing positive term in and\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    patterns:\n",
+        "      - pattern-not: foo($X)\n",
+        "      - pattern-inside: bar($Y)\n",
+    ),
+    DiagnosticCode::ESempaiMissingPositiveTermInAnd,
+)]
+fn compile_yaml_returns_semantic_error(#[case] yaml: &str, #[case] expected_code: DiagnosticCode) {
+    assert_compile_yaml_semantic_error(yaml, expected_code);
 }
 
 #[rstest]

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -14,7 +14,7 @@ use crate::{
     EngineLimits,
     Language,
     engine::QueryPlan,
-    semantic_check::{MAX_FORMULA_DEPTH, validate_formula_depth},
+    semantic_check::{MAX_FORMULA_DEPTH, validate_formula},
 };
 
 fn default_engine() -> Engine { Engine::new(EngineConfig::default()) }
@@ -232,10 +232,10 @@ fn compile_yaml_multiple_rules_return_expected_plans() {
 
 #[test]
 fn compile_yaml_rejects_formula_nesting_beyond_depth_limit() {
-    assert!(validate_formula_depth(&deeply_nested_formula(MAX_FORMULA_DEPTH), None).is_ok());
+    assert!(validate_formula(&deeply_nested_formula(MAX_FORMULA_DEPTH)).is_ok());
 
     let formula = deeply_nested_formula(MAX_FORMULA_DEPTH + 1);
-    let report = validate_formula_depth(&formula, None).expect_err("depth limit should fail");
+    let report = validate_formula(&formula).expect_err("depth limit should fail");
     let diagnostic = report
         .diagnostics()
         .first()

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the `Engine` and `QueryPlan` types.
 
+use std::sync::Arc;
+
 use rstest::rstest;
 use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 
@@ -252,7 +254,11 @@ fn compile_dsl_returns_not_implemented() {
 #[test]
 fn execute_returns_not_implemented() {
     let engine = default_engine();
-    let plan = QueryPlan::new(String::from("test-rule"), Language::Rust, dummy_formula());
+    let plan = QueryPlan::new(
+        String::from("test-rule"),
+        Language::Rust,
+        Arc::new(dummy_formula()),
+    );
     let result = engine.execute(&plan, "file:///test.rs", "fn main() {}");
     let (code, diag) = first_diagnostic_of_err(result);
     assert_eq!(code, DiagnosticCode::NotImplemented);

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the `Engine` and `QueryPlan` types.
 
 use rstest::rstest;
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 
 use crate::{
     Diagnostic,
@@ -12,8 +13,6 @@ use crate::{
     Language,
     engine::QueryPlan,
 };
-
-use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
 
 fn default_engine() -> Engine { Engine::new(EngineConfig::default()) }
 
@@ -186,7 +185,6 @@ fn compile_yaml_returns_expected_diagnostic_for_single_rule_cases(
     }
 }
 
-#[test]
 fn assert_compile_yaml_unsupported_mode(yaml: &str, expected_mode_fragment: &str) {
     let engine = default_engine();
     let result = engine.compile_yaml(yaml);
@@ -207,6 +205,8 @@ fn assert_compile_yaml_semantic_error(yaml: &str, expected_code: DiagnosticCode)
     let (code, _diag) = first_diagnostic_of_err(result);
     assert_eq!(code, expected_code);
 }
+
+#[test]
 fn compile_yaml_returns_unsupported_mode_for_extract_rules() {
     assert_compile_yaml_unsupported_mode(
         concat!(

--- a/crates/sempai/src/tests/engine_tests.rs
+++ b/crates/sempai/src/tests/engine_tests.rs
@@ -70,6 +70,8 @@ fn dummy_formula() -> Decorated<Formula> {
         span: None,
     }
 }
+
+#[test]
 fn engine_new_with_default_config() {
     let engine = Engine::new(EngineConfig::default());
     assert_eq!(engine.config().max_matches_per_rule(), 10_000);
@@ -83,18 +85,42 @@ fn engine_new_with_custom_config() {
     assert!(engine.config().enable_hcl());
 }
 
-fn compile_yaml_normalizes_and_returns_query_plans() {
+#[rstest]
+#[case::legacy_pattern(
+    "rules:\n  - id: demo.rule\n    message: oops\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n",
+    "demo.rule",
+    Language::Rust
+)]
+#[case::project_depends_on(
+    concat!(
+        "rules:\n",
+        "  - id: demo.depends\n",
+        "    message: detect vulnerable dependency\n",
+        "    languages: [python]\n",
+        "    severity: WARNING\n",
+        "    r2c-internal-project-depends-on:\n",
+        "      namespace: pypi\n",
+        "      package: requests\n",
+    ),
+    "demo.depends",
+    Language::Python,
+)]
+fn compile_yaml_normalizes_and_returns_query_plans(
+    #[case] yaml: &str,
+    #[case] expected_rule_id: &str,
+    #[case] expected_language: Language,
+) {
     let engine = default_engine();
-    let result = engine.compile_yaml(
-        "rules:\n  - id: demo.rule\n    message: oops\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n",
-    );
-    let plans = result.expect("should successfully compile");
+    let plans = engine
+        .compile_yaml(yaml)
+        .expect("should successfully compile");
     assert_eq!(plans.len(), 1);
     let plan = plans.first().expect("should have first plan");
-    assert_eq!(plan.rule_id(), "demo.rule");
-    assert_eq!(plan.language(), Language::Rust);
+    assert_eq!(plan.rule_id(), expected_rule_id);
+    assert_eq!(plan.language(), expected_language);
 }
 
+#[test]
 fn compile_yaml_returns_semantic_error_for_invalid_not_in_or() {
     let engine = default_engine();
     let result = engine.compile_yaml(concat!(
@@ -111,6 +137,7 @@ fn compile_yaml_returns_semantic_error_for_invalid_not_in_or() {
     assert_eq!(code, DiagnosticCode::ESempaiInvalidNotInOr);
 }
 
+#[test]
 fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
     let engine = default_engine();
     let result = engine.compile_yaml(concat!(
@@ -125,24 +152,6 @@ fn compile_yaml_returns_semantic_error_for_missing_positive_term_in_and() {
     ));
     let (code, _diag) = first_diagnostic_of_err(result);
     assert_eq!(code, DiagnosticCode::ESempaiMissingPositiveTermInAnd);
-}
-fn compile_yaml_normalizes_project_depends_on_search_rule() {
-    let engine = default_engine();
-    let result = engine.compile_yaml(concat!(
-        "rules:\n",
-        "  - id: demo.depends\n",
-        "    message: detect vulnerable dependency\n",
-        "    languages: [python]\n",
-        "    severity: WARNING\n",
-        "    r2c-internal-project-depends-on:\n",
-        "      namespace: pypi\n",
-        "      package: requests\n",
-    ));
-    let plans = result.expect("should successfully compile");
-    assert_eq!(plans.len(), 1);
-    let plan = plans.first().expect("should have first plan");
-    assert_eq!(plan.rule_id(), "demo.depends");
-    assert_eq!(plan.language(), Language::Python);
 }
 
 #[rstest]
@@ -162,15 +171,6 @@ fn compile_yaml_normalizes_project_depends_on_search_rule() {
         expected_code: DiagnosticCode::ESempaiSchemaInvalid,
         check_primary_span: false,
         check_message: None,
-    }
-)]
-#[case(
-    SingleRuleDiagnosticCase {
-        rule_id: Some("demo.rule"),
-        yaml_body: "pattern: foo($X)",
-        expected_code: DiagnosticCode::NotImplemented,
-        check_primary_span: false,
-        check_message: Some("normalization"),
     }
 )]
 fn compile_yaml_returns_expected_diagnostic_for_single_rule_cases(

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Unit tests for the `sempai` facade crate.
 
-mod engine_tests;
-mod reexport_tests;
-
 mod behaviour;
+mod engine_tests;
+mod normalization_tests;
+mod reexport_tests;
+mod semantic_validation_tests;

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -3,5 +3,6 @@
 mod behaviour;
 mod engine_tests;
 mod normalization_tests;
+mod property_tests;
 mod reexport_tests;
 mod semantic_validation_tests;

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -3,6 +3,7 @@
 mod behaviour;
 mod diagnostic_snapshot_tests;
 mod engine_tests;
+mod normalization_constraint_tests;
 mod normalization_tests;
 mod property_tests;
 mod reexport_tests;

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -2,8 +2,10 @@
 
 mod behaviour;
 mod diagnostic_snapshot_tests;
+mod engine_integration_tests;
 mod engine_tests;
 mod normalization_constraint_tests;
+mod normalization_metadata_tests;
 mod normalization_tests;
 mod property_tests;
 mod reexport_tests;

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Unit tests for the `sempai` facade crate.
 
 mod behaviour;
+mod diagnostic_snapshot_tests;
 mod engine_tests;
 mod normalization_tests;
 mod property_tests;

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -153,6 +153,31 @@ fn legacy_patterns_with_malformed_known_constraint_fails_normalization() {
 }
 
 #[test]
+fn legacy_patterns_with_malformed_metavariable_pattern_fails_normalization() {
+    let constraint = json!({"metavariable-pattern": {"pattern": "x"}});
+    let principal =
+        SearchQueryPrincipal::Legacy(LegacyFormula::Patterns(vec![LegacyClause::Constraint(
+            constraint,
+        )]));
+
+    let report =
+        normalize_search_principal(&principal, None).expect_err("known malformed constraint fails");
+
+    assert_eq!(
+        first_diagnostic_code(&report),
+        DiagnosticCode::ESempaiSchemaInvalid
+    );
+    assert!(
+        report
+            .diagnostics()
+            .first()
+            .expect("expected diagnostic")
+            .message()
+            .contains("expected {metavariable, pattern} string fields")
+    );
+}
+
+#[test]
 fn compile_yaml_reports_schema_invalid_for_malformed_where_clause() {
     let yaml = concat!(
         "rules:\n",

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -74,6 +74,25 @@ fn assert_missing_positive_term_in_and_for_decorated(decorated: &Decorated<Formu
     );
 }
 
+fn assert_compile_yaml_schema_invalid(yaml: &str, expected_message: &str) {
+    let report = Engine::new(EngineConfig::default())
+        .compile_yaml(yaml)
+        .expect_err("malformed known constraint should fail");
+
+    assert_eq!(
+        first_diagnostic_code(&report),
+        DiagnosticCode::ESempaiSchemaInvalid
+    );
+    assert!(
+        report
+            .diagnostics()
+            .first()
+            .expect("expected diagnostic")
+            .message()
+            .contains(expected_message)
+    );
+}
+
 #[test]
 fn legacy_patterns_propagates_constraints_to_where_clauses() {
     let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
@@ -180,9 +199,9 @@ fn legacy_patterns_with_malformed_known_constraint_fails_normalization(
     assert_schema_invalid_normalization(constraint, expected_message);
 }
 
-#[test]
-fn compile_yaml_reports_schema_invalid_for_malformed_where_clause() {
-    let yaml = concat!(
+#[rstest]
+#[case::metavariable_regex(
+    concat!(
         "rules:\n",
         "  - id: demo.invalid.where\n",
         "    message: invalid where\n",
@@ -192,29 +211,11 @@ fn compile_yaml_reports_schema_invalid_for_malformed_where_clause() {
         "      - pattern: foo($X)\n",
         "      - metavariable-regex:\n",
         "          metavariable: $X\n",
-    );
-
-    let report = Engine::new(EngineConfig::default())
-        .compile_yaml(yaml)
-        .expect_err("malformed known constraint should fail");
-
-    assert_eq!(
-        first_diagnostic_code(&report),
-        DiagnosticCode::ESempaiSchemaInvalid
-    );
-    assert!(
-        report
-            .diagnostics()
-            .first()
-            .expect("expected diagnostic")
-            .message()
-            .contains("invalid where-clause")
-    );
-}
-
-#[test]
-fn compile_yaml_reports_schema_invalid_for_malformed_metavariable_pattern_where_clause() {
-    let yaml = concat!(
+    ),
+    "invalid where-clause",
+)]
+#[case::metavariable_pattern(
+    concat!(
         "rules:\n",
         "  - id: demo.invalid.pattern.where\n",
         "    message: invalid metavariable pattern\n",
@@ -224,24 +225,14 @@ fn compile_yaml_reports_schema_invalid_for_malformed_metavariable_pattern_where_
         "      - pattern: foo($X)\n",
         "      - metavariable-pattern:\n",
         "          pattern: x\n",
-    );
-
-    let report = Engine::new(EngineConfig::default())
-        .compile_yaml(yaml)
-        .expect_err("malformed known constraint should fail");
-
-    assert_eq!(
-        first_diagnostic_code(&report),
-        DiagnosticCode::ESempaiSchemaInvalid
-    );
-    assert!(
-        report
-            .diagnostics()
-            .first()
-            .expect("expected diagnostic")
-            .message()
-            .contains("expected {metavariable, pattern} string fields")
-    );
+    ),
+    "expected {metavariable, pattern} string fields",
+)]
+fn compile_yaml_reports_schema_invalid_for_malformed_where_clause(
+    #[case] yaml: &str,
+    #[case] expected_message: &str,
+) {
+    assert_compile_yaml_schema_invalid(yaml, expected_message);
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -1,11 +1,12 @@
 //! Tests for normalized constraint metadata.
 
+use rstest::rstest;
 use sempai_core::{
     DiagnosticCode,
     formula::{Atom, Constraint, Decorated, Formula, WhereClause},
 };
 use sempai_yaml::{LegacyClause, LegacyFormula, MatchFormula, SearchQueryPrincipal};
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::{
     Engine,
@@ -30,6 +31,47 @@ fn first_diagnostic_code(report: &sempai_core::DiagnosticReport) -> DiagnosticCo
         .first()
         .expect("expected diagnostic")
         .code()
+}
+
+fn make_legacy_patterns_with_constraints(
+    constraints: impl IntoIterator<Item = Value>,
+) -> LegacyFormula {
+    LegacyFormula::Patterns(
+        constraints
+            .into_iter()
+            .map(LegacyClause::Constraint)
+            .collect(),
+    )
+}
+
+fn assert_schema_invalid_normalization(constraint: Value, expected_message: &str) {
+    let principal =
+        SearchQueryPrincipal::Legacy(make_legacy_patterns_with_constraints([constraint]));
+
+    let report =
+        normalize_search_principal(&principal, None).expect_err("known malformed constraint fails");
+
+    assert_eq!(
+        first_diagnostic_code(&report),
+        DiagnosticCode::ESempaiSchemaInvalid
+    );
+    assert!(
+        report
+            .diagnostics()
+            .first()
+            .expect("expected diagnostic")
+            .message()
+            .contains(expected_message)
+    );
+}
+
+fn assert_missing_positive_term_in_and_for_decorated(decorated: &Decorated<Formula>) {
+    let err = validate_formula(decorated).expect_err("constraint-only And should fail");
+    let first = err.diagnostics().first().expect("expected diagnostic");
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
 }
 
 #[test]
@@ -66,7 +108,7 @@ fn legacy_patterns_propagates_constraints_to_where_clauses() {
 #[test]
 fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where_clauses() {
     let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
-    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint)]);
+    let legacy = make_legacy_patterns_with_constraints([constraint]);
 
     let decorated = normalize_legacy_decorated(legacy);
 
@@ -79,18 +121,13 @@ fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where
         })
     );
 
-    let err = validate_formula(&decorated).expect_err("constraint-only And should fail");
-    let first = err.diagnostics().first().expect("expected diagnostic");
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
+    assert_missing_positive_term_in_and_for_decorated(&decorated);
 }
 
 #[test]
 fn legacy_patterns_with_only_metavariable_pattern_constraint_fails_validation() {
     let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
-    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint)]);
+    let legacy = make_legacy_patterns_with_constraints([constraint]);
     let decorated = normalize_legacy_decorated(legacy);
 
     assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
@@ -103,13 +140,7 @@ fn legacy_patterns_with_only_metavariable_pattern_constraint_fails_validation() 
             },
         }]
     );
-    let err =
-        validate_formula(&decorated).expect_err("constraint-only metavariable-pattern should fail");
-    let first = err.diagnostics().first().expect("expected diagnostic");
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
+    assert_missing_positive_term_in_and_for_decorated(&decorated);
 }
 
 #[test]
@@ -133,54 +164,20 @@ fn legacy_patterns_with_unknown_constraint_preserves_other_constraint_text() {
     }
 }
 
-#[test]
-fn legacy_patterns_with_malformed_known_constraint_fails_normalization() {
-    let constraint = json!({"metavariable-regex": {"metavariable": "$X"}});
-    let principal =
-        SearchQueryPrincipal::Legacy(LegacyFormula::Patterns(vec![LegacyClause::Constraint(
-            constraint,
-        )]));
-
-    let report =
-        normalize_search_principal(&principal, None).expect_err("known malformed constraint fails");
-
-    assert_eq!(
-        first_diagnostic_code(&report),
-        DiagnosticCode::ESempaiSchemaInvalid
-    );
-    assert!(
-        report
-            .diagnostics()
-            .first()
-            .expect("expected diagnostic")
-            .message()
-            .contains("expected {metavariable, regex} string fields")
-    );
-}
-
-#[test]
-fn legacy_patterns_with_malformed_metavariable_pattern_fails_normalization() {
-    let constraint = json!({"metavariable-pattern": {"pattern": "x"}});
-    let principal =
-        SearchQueryPrincipal::Legacy(LegacyFormula::Patterns(vec![LegacyClause::Constraint(
-            constraint,
-        )]));
-
-    let report =
-        normalize_search_principal(&principal, None).expect_err("known malformed constraint fails");
-
-    assert_eq!(
-        first_diagnostic_code(&report),
-        DiagnosticCode::ESempaiSchemaInvalid
-    );
-    assert!(
-        report
-            .diagnostics()
-            .first()
-            .expect("expected diagnostic")
-            .message()
-            .contains("expected {metavariable, pattern} string fields")
-    );
+#[rstest]
+#[case::metavariable_regex(
+    json!({"metavariable-regex": {"metavariable": "$X"}}),
+    "expected {metavariable, regex} string fields",
+)]
+#[case::metavariable_pattern(
+    json!({"metavariable-pattern": {"pattern": "x"}}),
+    "expected {metavariable, pattern} string fields",
+)]
+fn legacy_patterns_with_malformed_known_constraint_fails_normalization(
+    #[case] constraint: Value,
+    #[case] expected_message: &str,
+) {
+    assert_schema_invalid_normalization(constraint, expected_message);
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -7,16 +7,29 @@ use sempai_core::{
 use sempai_yaml::{LegacyClause, LegacyFormula, MatchFormula, SearchQueryPrincipal};
 use serde_json::json;
 
-use crate::{normalize::normalize_search_principal, semantic_check::validate_formula};
+use crate::{
+    Engine,
+    EngineConfig,
+    normalize::normalize_search_principal,
+    semantic_check::validate_formula,
+};
 
 fn normalize_legacy_decorated(formula: LegacyFormula) -> Decorated<Formula> {
     let principal = SearchQueryPrincipal::Legacy(formula);
-    normalize_search_principal(&principal, None)
+    normalize_search_principal(&principal, None).expect("legacy formula should normalize")
 }
 
 fn normalize_v2_decorated(formula: MatchFormula) -> Decorated<Formula> {
     let principal = SearchQueryPrincipal::Match(formula);
-    normalize_search_principal(&principal, None)
+    normalize_search_principal(&principal, None).expect("v2 formula should normalize")
+}
+
+fn first_diagnostic_code(report: &sempai_core::DiagnosticReport) -> DiagnosticCode {
+    report
+        .diagnostics()
+        .first()
+        .expect("expected diagnostic")
+        .code()
 }
 
 #[test]
@@ -112,6 +125,63 @@ fn legacy_patterns_with_unknown_constraint_preserves_other_constraint_text() {
         }
         other => panic!("expected unknown constraint to map to Other, got {other:?}"),
     }
+}
+
+#[test]
+fn legacy_patterns_with_malformed_known_constraint_fails_normalization() {
+    let constraint = json!({"metavariable-regex": {"metavariable": "$X"}});
+    let principal =
+        SearchQueryPrincipal::Legacy(LegacyFormula::Patterns(vec![LegacyClause::Constraint(
+            constraint,
+        )]));
+
+    let report =
+        normalize_search_principal(&principal, None).expect_err("known malformed constraint fails");
+
+    assert_eq!(
+        first_diagnostic_code(&report),
+        DiagnosticCode::ESempaiSchemaInvalid
+    );
+    assert!(
+        report
+            .diagnostics()
+            .first()
+            .expect("expected diagnostic")
+            .message()
+            .contains("expected {metavariable, regex} string fields")
+    );
+}
+
+#[test]
+fn compile_yaml_reports_schema_invalid_for_malformed_where_clause() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.invalid.where\n",
+        "    message: invalid where\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    patterns:\n",
+        "      - pattern: foo($X)\n",
+        "      - metavariable-regex:\n",
+        "          metavariable: $X\n",
+    );
+
+    let report = Engine::new(EngineConfig::default())
+        .compile_yaml(yaml)
+        .expect_err("malformed known constraint should fail");
+
+    assert_eq!(
+        first_diagnostic_code(&report),
+        DiagnosticCode::ESempaiSchemaInvalid
+    );
+    assert!(
+        report
+            .diagnostics()
+            .first()
+            .expect("expected diagnostic")
+            .message()
+            .contains("invalid where-clause")
+    );
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -216,6 +216,38 @@ fn compile_yaml_reports_schema_invalid_for_malformed_where_clause() {
 }
 
 #[test]
+fn compile_yaml_reports_schema_invalid_for_malformed_metavariable_pattern_where_clause() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.invalid.pattern.where\n",
+        "    message: invalid metavariable pattern\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    patterns:\n",
+        "      - pattern: foo($X)\n",
+        "      - metavariable-pattern:\n",
+        "          pattern: x\n",
+    );
+
+    let report = Engine::new(EngineConfig::default())
+        .compile_yaml(yaml)
+        .expect_err("malformed known constraint should fail");
+
+    assert_eq!(
+        first_diagnostic_code(&report),
+        DiagnosticCode::ESempaiSchemaInvalid
+    );
+    assert!(
+        report
+            .diagnostics()
+            .first()
+            .expect("expected diagnostic")
+            .message()
+            .contains("expected {metavariable, pattern} string fields")
+    );
+}
+
+#[test]
 fn v2_decorated_preserves_where_as_and_fix_metadata() {
     let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
     let formula = MatchFormula::Decorated {

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -107,6 +107,7 @@ fn legacy_patterns_propagates_constraints_to_where_clauses() {
         other => panic!("expected normalized legacy Patterns to be And, got {other:?}"),
     };
     assert_eq!(children.len(), 2);
+    assert_eq!(decorated.where_clauses.len(), 1);
     assert_eq!(
         decorated.where_clauses.first().map(|c| &c.constraint),
         Some(&Constraint::MetavariableRegex {
@@ -145,6 +146,7 @@ fn constraint_only_patterns_normalize_to_and_and_fail_validation(
     let decorated = normalize_legacy_decorated(legacy);
 
     assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
+    assert_eq!(decorated.where_clauses.len(), 1);
     assert_eq!(
         decorated.where_clauses.first().map(|c| &c.constraint),
         Some(&expected),
@@ -159,6 +161,7 @@ fn legacy_patterns_with_unknown_constraint_preserves_other_constraint_text() {
     let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint)]);
     let decorated = normalize_legacy_decorated(legacy);
 
+    assert_eq!(decorated.where_clauses.len(), 1);
     match &decorated
         .where_clauses
         .first()
@@ -243,6 +246,7 @@ fn v2_decorated_preserves_where_as_and_fix_metadata() {
     ));
     assert_eq!(decorated.as_name.as_deref(), Some("my_capture"));
     assert_eq!(decorated.fix.as_deref(), Some("replace_me"));
+    assert_eq!(decorated.where_clauses.len(), 1);
     assert_eq!(
         decorated.where_clauses.first().map(|c| &c.constraint),
         Some(&Constraint::MetavariablePattern {

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -3,7 +3,7 @@
 use rstest::rstest;
 use sempai_core::{
     DiagnosticCode,
-    formula::{Atom, Constraint, Decorated, Formula, WhereClause},
+    formula::{Atom, Constraint, Decorated, Formula},
 };
 use sempai_yaml::{LegacyClause, LegacyFormula, MatchFormula, SearchQueryPrincipal};
 use serde_json::{Value, json};
@@ -33,9 +33,7 @@ fn first_diagnostic_code(report: &sempai_core::DiagnosticReport) -> DiagnosticCo
         .code()
 }
 
-fn make_legacy_patterns_with_constraints(
-    constraints: impl IntoIterator<Item = Value>,
-) -> LegacyFormula {
+fn make_legacy_patterns_with_constraints<const N: usize>(constraints: [Value; N]) -> LegacyFormula {
     LegacyFormula::Patterns(
         constraints
             .into_iter()
@@ -124,40 +122,32 @@ fn legacy_patterns_propagates_constraints_to_where_clauses() {
     }
 }
 
-#[test]
-fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where_clauses() {
-    let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
-    let legacy = make_legacy_patterns_with_constraints([constraint]);
-
+#[rstest]
+#[case::metavariable_regex(
+    json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}}),
+    Constraint::MetavariableRegex {
+        metavariable: String::from("$X"),
+        regex: String::from("foo.*"),
+    },
+)]
+#[case::metavariable_pattern(
+    json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}}),
+    Constraint::MetavariablePattern {
+        metavariable: String::from("$X"),
+        pattern: String::from("bad"),
+    },
+)]
+fn constraint_only_patterns_normalize_to_and_and_fail_validation(
+    #[case] raw_constraint: Value,
+    #[case] expected: Constraint,
+) {
+    let legacy = make_legacy_patterns_with_constraints([raw_constraint]);
     let decorated = normalize_legacy_decorated(legacy);
 
     assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
     assert_eq!(
         decorated.where_clauses.first().map(|c| &c.constraint),
-        Some(&Constraint::MetavariableRegex {
-            metavariable: String::from("$X"),
-            regex: String::from("foo.*"),
-        })
-    );
-
-    assert_missing_positive_term_in_and_for_decorated(&decorated);
-}
-
-#[test]
-fn legacy_patterns_with_only_metavariable_pattern_constraint_fails_validation() {
-    let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
-    let legacy = make_legacy_patterns_with_constraints([constraint]);
-    let decorated = normalize_legacy_decorated(legacy);
-
-    assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
-    assert_eq!(
-        decorated.where_clauses,
-        vec![WhereClause {
-            constraint: Constraint::MetavariablePattern {
-                metavariable: String::from("$X"),
-                pattern: String::from("bad"),
-            },
-        }]
+        Some(&expected),
     );
     assert_missing_positive_term_in_and_for_decorated(&decorated);
 }

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -88,7 +88,7 @@ fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where
 }
 
 #[test]
-fn legacy_patterns_with_only_metavariable_pattern_constraint_validates() {
+fn legacy_patterns_with_only_metavariable_pattern_constraint_fails_validation() {
     let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
     let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint)]);
     let decorated = normalize_legacy_decorated(legacy);
@@ -103,7 +103,13 @@ fn legacy_patterns_with_only_metavariable_pattern_constraint_validates() {
             },
         }]
     );
-    assert!(validate_formula(&decorated).is_ok());
+    let err =
+        validate_formula(&decorated).expect_err("constraint-only metavariable-pattern should fail");
+    let first = err.diagnostics().first().expect("expected diagnostic");
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_constraint_tests.rs
+++ b/crates/sempai/src/tests/normalization_constraint_tests.rs
@@ -1,0 +1,142 @@
+//! Tests for normalized constraint metadata.
+
+use sempai_core::{
+    DiagnosticCode,
+    formula::{Atom, Constraint, Decorated, Formula, WhereClause},
+};
+use sempai_yaml::{LegacyClause, LegacyFormula, MatchFormula, SearchQueryPrincipal};
+use serde_json::json;
+
+use crate::{normalize::normalize_search_principal, semantic_check::validate_formula};
+
+fn normalize_legacy_decorated(formula: LegacyFormula) -> Decorated<Formula> {
+    let principal = SearchQueryPrincipal::Legacy(formula);
+    normalize_search_principal(&principal, None)
+}
+
+fn normalize_v2_decorated(formula: MatchFormula) -> Decorated<Formula> {
+    let principal = SearchQueryPrincipal::Match(formula);
+    normalize_search_principal(&principal, None)
+}
+
+#[test]
+fn legacy_patterns_propagates_constraints_to_where_clauses() {
+    let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
+    let legacy = LegacyFormula::Patterns(vec![
+        LegacyClause::Formula(LegacyFormula::Pattern(String::from("foo($X)"))),
+        LegacyClause::Formula(LegacyFormula::Pattern(String::from("bar($X)"))),
+        LegacyClause::Constraint(constraint),
+    ]);
+
+    let decorated = normalize_legacy_decorated(legacy);
+
+    let children = match &decorated.node {
+        Formula::And(children) => children,
+        other => panic!("expected normalized legacy Patterns to be And, got {other:?}"),
+    };
+    assert_eq!(children.len(), 2);
+    assert_eq!(
+        decorated.where_clauses.first().map(|c| &c.constraint),
+        Some(&Constraint::MetavariableRegex {
+            metavariable: String::from("$X"),
+            regex: String::from("foo.*"),
+        })
+    );
+    for (idx, child) in children.iter().enumerate() {
+        assert!(
+            child.where_clauses.is_empty(),
+            "expected child {idx} of And to have empty where_clauses"
+        );
+    }
+}
+
+#[test]
+fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where_clauses() {
+    let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
+    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint)]);
+
+    let decorated = normalize_legacy_decorated(legacy);
+
+    assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
+    assert_eq!(
+        decorated.where_clauses.first().map(|c| &c.constraint),
+        Some(&Constraint::MetavariableRegex {
+            metavariable: String::from("$X"),
+            regex: String::from("foo.*"),
+        })
+    );
+
+    let err = validate_formula(&decorated).expect_err("constraint-only And should fail");
+    let first = err.diagnostics().first().expect("expected diagnostic");
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+}
+
+#[test]
+fn legacy_patterns_with_only_metavariable_pattern_constraint_validates() {
+    let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
+    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint)]);
+    let decorated = normalize_legacy_decorated(legacy);
+
+    assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
+    assert_eq!(
+        decorated.where_clauses,
+        vec![WhereClause {
+            constraint: Constraint::MetavariablePattern {
+                metavariable: String::from("$X"),
+                pattern: String::from("bad"),
+            },
+        }]
+    );
+    assert!(validate_formula(&decorated).is_ok());
+}
+
+#[test]
+fn legacy_patterns_with_unknown_constraint_preserves_other_constraint_text() {
+    let constraint =
+        json!({"metavariable-comparison": {"metavariable": "$X", "comparison": "$X > 0"}});
+    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint)]);
+    let decorated = normalize_legacy_decorated(legacy);
+
+    match &decorated
+        .where_clauses
+        .first()
+        .expect("expected at least one where_clause")
+        .constraint
+    {
+        Constraint::Other(raw) => {
+            assert!(raw.contains("metavariable-comparison"));
+            assert!(raw.contains("comparison"));
+        }
+        other => panic!("expected unknown constraint to map to Other, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_decorated_preserves_where_as_and_fix_metadata() {
+    let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
+    let formula = MatchFormula::Decorated {
+        formula: Box::new(MatchFormula::Pattern(String::from("foo($X)"))),
+        where_clauses: vec![constraint],
+        as_name: Some(String::from("my_capture")),
+        fix: Some(String::from("replace_me")),
+    };
+
+    let decorated = normalize_v2_decorated(formula);
+
+    assert!(matches!(
+        &decorated.node,
+        Formula::Atom(Atom::Pattern(pat)) if pat.text == "foo($X)"
+    ));
+    assert_eq!(decorated.as_name.as_deref(), Some("my_capture"));
+    assert_eq!(decorated.fix.as_deref(), Some("replace_me"));
+    assert_eq!(
+        decorated.where_clauses.first().map(|c| &c.constraint),
+        Some(&Constraint::MetavariablePattern {
+            metavariable: String::from("$X"),
+            pattern: String::from("bad"),
+        })
+    );
+}

--- a/crates/sempai/src/tests/normalization_metadata_tests.rs
+++ b/crates/sempai/src/tests/normalization_metadata_tests.rs
@@ -191,6 +191,7 @@ fn v2_decorated_over_all_wraps_preserves_metadata() {
     let decorated =
         normalize_search_principal(&principal, None).expect("decorated formula should normalize");
 
+    assert!(decorated.span.is_none());
     assert_eq!(decorated.as_name.as_deref(), Some("cap"));
     assert_eq!(decorated.fix.as_deref(), Some("fixme"));
     assert_eq!(
@@ -205,6 +206,7 @@ fn v2_decorated_over_all_wraps_preserves_metadata() {
     let children = extract_and_branches(&decorated.node);
     assert_two_pattern_branches(children, "a", "b");
     for child in children {
+        assert!(child.span.is_none());
         assert_empty_metadata(child);
     }
 }

--- a/crates/sempai/src/tests/normalization_metadata_tests.rs
+++ b/crates/sempai/src/tests/normalization_metadata_tests.rs
@@ -35,6 +35,40 @@ fn assert_empty_metadata(formula: &Decorated<Formula>) {
     assert!(formula.fix.is_none());
 }
 
+fn assert_empty_metadata_with_span(formula: &Decorated<Formula>, expected_span: &SourceSpan) {
+    assert_eq!(formula.span.as_ref(), Some(expected_span));
+    assert_empty_metadata(formula);
+}
+
+fn decorated_match_formula(formula: MatchFormula) -> SearchQueryPrincipal {
+    SearchQueryPrincipal::Match(MatchFormula::Decorated {
+        formula: Box::new(formula),
+        where_clauses: vec![json!({
+            "metavariable-pattern": {
+                "metavariable": "$X",
+                "pattern": "bad",
+            },
+        })],
+        as_name: Some(String::from("cap")),
+        fix: Some(String::from("fixme")),
+    })
+}
+
+fn assert_decorated_metadata(formula: &Decorated<Formula>, expected_span: &SourceSpan) {
+    assert_eq!(formula.span.as_ref(), Some(expected_span));
+    assert_eq!(formula.as_name.as_deref(), Some("cap"));
+    assert_eq!(formula.fix.as_deref(), Some("fixme"));
+    assert_eq!(
+        formula.where_clauses,
+        vec![WhereClause {
+            constraint: Constraint::MetavariablePattern {
+                metavariable: String::from("$X"),
+                pattern: String::from("bad"),
+            },
+        }]
+    );
+}
+
 fn assert_span_recursive(formula: &Decorated<Formula>, expected_span: &SourceSpan) {
     assert_eq!(formula.span.as_ref(), Some(expected_span));
     match &formula.node {
@@ -47,6 +81,112 @@ fn assert_span_recursive(formula: &Decorated<Formula>, expected_span: &SourceSpa
                 assert_span_recursive(branch, expected_span);
             }
         }
+    }
+}
+
+#[test]
+fn v2_decorated_over_all_preserves_metadata_and_spans() {
+    let span = SourceSpan::new(12, 99, Some(String::from("file:///rule.yaml")));
+    let principal = decorated_match_formula(MatchFormula::All(vec![
+        MatchFormula::Pattern(String::from("a")),
+        MatchFormula::Pattern(String::from("b")),
+    ]));
+
+    let decorated =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+
+    assert_decorated_metadata(&decorated, &span);
+    match &decorated.node {
+        Formula::And(children) => {
+            assert_two_pattern_branches(children, "a", "b");
+            for child in children {
+                assert_empty_metadata_with_span(child, &span);
+            }
+        }
+        other => panic!("expected And formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_decorated_over_any_preserves_metadata_and_spans() {
+    let span = SourceSpan::new(13, 100, Some(String::from("file:///rule.yaml")));
+    let principal = decorated_match_formula(MatchFormula::Any(vec![
+        MatchFormula::Pattern(String::from("a")),
+        MatchFormula::Pattern(String::from("b")),
+    ]));
+
+    let decorated =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+
+    assert_decorated_metadata(&decorated, &span);
+    match &decorated.node {
+        Formula::Or(children) => {
+            assert_two_pattern_branches(children, "a", "b");
+            for child in children {
+                assert_empty_metadata_with_span(child, &span);
+            }
+        }
+        other => panic!("expected Or formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_decorated_over_not_preserves_metadata_and_spans() {
+    let span = SourceSpan::new(14, 101, Some(String::from("file:///rule.yaml")));
+    let principal = decorated_match_formula(MatchFormula::Not(Box::new(MatchFormula::Pattern(
+        String::from("x"),
+    ))));
+
+    let decorated =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+
+    assert_decorated_metadata(&decorated, &span);
+    match &decorated.node {
+        Formula::Not(inner) => {
+            assert_empty_metadata_with_span(inner, &span);
+            assert_wraps_pattern_atom(inner, "x");
+        }
+        other => panic!("expected Not formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_decorated_over_inside_preserves_metadata_and_spans() {
+    let span = SourceSpan::new(15, 102, Some(String::from("file:///rule.yaml")));
+    let principal = decorated_match_formula(MatchFormula::Inside(Box::new(MatchFormula::Pattern(
+        String::from("x"),
+    ))));
+
+    let decorated =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+
+    assert_decorated_metadata(&decorated, &span);
+    match &decorated.node {
+        Formula::Inside(inner) => {
+            assert_empty_metadata_with_span(inner, &span);
+            assert_wraps_pattern_atom(inner, "x");
+        }
+        other => panic!("expected Inside formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_decorated_over_anywhere_preserves_metadata_and_spans() {
+    let span = SourceSpan::new(16, 103, Some(String::from("file:///rule.yaml")));
+    let principal = decorated_match_formula(MatchFormula::Anywhere(Box::new(
+        MatchFormula::Pattern(String::from("x")),
+    )));
+
+    let decorated =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+
+    assert_decorated_metadata(&decorated, &span);
+    match &decorated.node {
+        Formula::Anywhere(inner) => {
+            assert_empty_metadata_with_span(inner, &span);
+            assert_wraps_pattern_atom(inner, "x");
+        }
+        other => panic!("expected Anywhere formula, got {other:?}"),
     }
 }
 

--- a/crates/sempai/src/tests/normalization_metadata_tests.rs
+++ b/crates/sempai/src/tests/normalization_metadata_tests.rs
@@ -1,5 +1,6 @@
 //! Tests for normalized `Decorated` metadata and span propagation.
 
+use rstest::rstest;
 use sempai_core::{
     SourceSpan,
     formula::{Atom, Constraint, Decorated, Formula, WhereClause},
@@ -54,6 +55,46 @@ fn decorated_match_formula(formula: MatchFormula) -> SearchQueryPrincipal {
     })
 }
 
+fn normalize_decorated_with(formula: MatchFormula, span: &SourceSpan) -> Decorated<Formula> {
+    let principal = decorated_match_formula(formula);
+    normalize_search_principal(&principal, Some(span)).expect("formula should normalize")
+}
+
+fn extract_and_branches(formula: &Formula) -> &[Decorated<Formula>] {
+    match formula {
+        Formula::And(branches) => branches,
+        other => panic!("expected And formula, got {other:?}"),
+    }
+}
+
+fn extract_or_branches(formula: &Formula) -> &[Decorated<Formula>] {
+    match formula {
+        Formula::Or(branches) => branches,
+        other => panic!("expected Or formula, got {other:?}"),
+    }
+}
+
+fn extract_not_inner(formula: &Formula) -> &Decorated<Formula> {
+    match formula {
+        Formula::Not(inner) => inner,
+        other => panic!("expected Not formula, got {other:?}"),
+    }
+}
+
+fn extract_inside_inner(formula: &Formula) -> &Decorated<Formula> {
+    match formula {
+        Formula::Inside(inner) => inner,
+        other => panic!("expected Inside formula, got {other:?}"),
+    }
+}
+
+fn extract_anywhere_inner(formula: &Formula) -> &Decorated<Formula> {
+    match formula {
+        Formula::Anywhere(inner) => inner,
+        other => panic!("expected Anywhere formula, got {other:?}"),
+    }
+}
+
 fn assert_decorated_metadata(formula: &Decorated<Formula>, expected_span: &SourceSpan) {
     assert_eq!(formula.span.as_ref(), Some(expected_span));
     assert_eq!(formula.as_name.as_deref(), Some("cap"));
@@ -84,110 +125,60 @@ fn assert_span_recursive(formula: &Decorated<Formula>, expected_span: &SourceSpa
     }
 }
 
-#[test]
-fn v2_decorated_over_all_preserves_metadata_and_spans() {
+#[rstest]
+#[case::all(
+    MatchFormula::All(vec![
+        MatchFormula::Pattern(String::from("a")),
+        MatchFormula::Pattern(String::from("b")),
+    ]),
+    extract_and_branches as fn(&Formula) -> &[Decorated<Formula>],
+)]
+#[case::any(
+    MatchFormula::Any(vec![
+        MatchFormula::Pattern(String::from("a")),
+        MatchFormula::Pattern(String::from("b")),
+    ]),
+    extract_or_branches as fn(&Formula) -> &[Decorated<Formula>],
+)]
+fn v2_decorated_over_branches_preserves_metadata_and_spans(
+    #[case] formula: MatchFormula,
+    #[case] extract: fn(&Formula) -> &[Decorated<Formula>],
+) {
     let span = SourceSpan::new(12, 99, Some(String::from("file:///rule.yaml")));
-    let principal = decorated_match_formula(MatchFormula::All(vec![
-        MatchFormula::Pattern(String::from("a")),
-        MatchFormula::Pattern(String::from("b")),
-    ]));
-
-    let decorated =
-        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+    let decorated = normalize_decorated_with(formula, &span);
 
     assert_decorated_metadata(&decorated, &span);
-    match &decorated.node {
-        Formula::And(children) => {
-            assert_two_pattern_branches(children, "a", "b");
-            for child in children {
-                assert_empty_metadata_with_span(child, &span);
-            }
-        }
-        other => panic!("expected And formula, got {other:?}"),
+    let children = extract(&decorated.node);
+    assert_two_pattern_branches(children, "a", "b");
+    for child in children {
+        assert_empty_metadata_with_span(child, &span);
     }
 }
 
-#[test]
-fn v2_decorated_over_any_preserves_metadata_and_spans() {
-    let span = SourceSpan::new(13, 100, Some(String::from("file:///rule.yaml")));
-    let principal = decorated_match_formula(MatchFormula::Any(vec![
-        MatchFormula::Pattern(String::from("a")),
-        MatchFormula::Pattern(String::from("b")),
-    ]));
-
-    let decorated =
-        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
-
-    assert_decorated_metadata(&decorated, &span);
-    match &decorated.node {
-        Formula::Or(children) => {
-            assert_two_pattern_branches(children, "a", "b");
-            for child in children {
-                assert_empty_metadata_with_span(child, &span);
-            }
-        }
-        other => panic!("expected Or formula, got {other:?}"),
-    }
-}
-
-#[test]
-fn v2_decorated_over_not_preserves_metadata_and_spans() {
+#[rstest]
+#[case::not(
+    MatchFormula::Not(Box::new(MatchFormula::Pattern(String::from("x")))),
+    extract_not_inner as fn(&Formula) -> &Decorated<Formula>,
+)]
+#[case::inside(
+    MatchFormula::Inside(Box::new(MatchFormula::Pattern(String::from("x")))),
+    extract_inside_inner as fn(&Formula) -> &Decorated<Formula>,
+)]
+#[case::anywhere(
+    MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(String::from("x")))),
+    extract_anywhere_inner as fn(&Formula) -> &Decorated<Formula>,
+)]
+fn v2_decorated_over_unary_preserves_metadata_and_spans(
+    #[case] formula: MatchFormula,
+    #[case] extract: fn(&Formula) -> &Decorated<Formula>,
+) {
     let span = SourceSpan::new(14, 101, Some(String::from("file:///rule.yaml")));
-    let principal = decorated_match_formula(MatchFormula::Not(Box::new(MatchFormula::Pattern(
-        String::from("x"),
-    ))));
-
-    let decorated =
-        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+    let decorated = normalize_decorated_with(formula, &span);
 
     assert_decorated_metadata(&decorated, &span);
-    match &decorated.node {
-        Formula::Not(inner) => {
-            assert_empty_metadata_with_span(inner, &span);
-            assert_wraps_pattern_atom(inner, "x");
-        }
-        other => panic!("expected Not formula, got {other:?}"),
-    }
-}
-
-#[test]
-fn v2_decorated_over_inside_preserves_metadata_and_spans() {
-    let span = SourceSpan::new(15, 102, Some(String::from("file:///rule.yaml")));
-    let principal = decorated_match_formula(MatchFormula::Inside(Box::new(MatchFormula::Pattern(
-        String::from("x"),
-    ))));
-
-    let decorated =
-        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
-
-    assert_decorated_metadata(&decorated, &span);
-    match &decorated.node {
-        Formula::Inside(inner) => {
-            assert_empty_metadata_with_span(inner, &span);
-            assert_wraps_pattern_atom(inner, "x");
-        }
-        other => panic!("expected Inside formula, got {other:?}"),
-    }
-}
-
-#[test]
-fn v2_decorated_over_anywhere_preserves_metadata_and_spans() {
-    let span = SourceSpan::new(16, 103, Some(String::from("file:///rule.yaml")));
-    let principal = decorated_match_formula(MatchFormula::Anywhere(Box::new(
-        MatchFormula::Pattern(String::from("x")),
-    )));
-
-    let decorated =
-        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
-
-    assert_decorated_metadata(&decorated, &span);
-    match &decorated.node {
-        Formula::Anywhere(inner) => {
-            assert_empty_metadata_with_span(inner, &span);
-            assert_wraps_pattern_atom(inner, "x");
-        }
-        other => panic!("expected Anywhere formula, got {other:?}"),
-    }
+    let inner = extract(&decorated.node);
+    assert_empty_metadata_with_span(inner, &span);
+    assert_wraps_pattern_atom(inner, "x");
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_metadata_tests.rs
+++ b/crates/sempai/src/tests/normalization_metadata_tests.rs
@@ -1,0 +1,160 @@
+//! Tests for normalized `Decorated` metadata and span propagation.
+
+use sempai_core::{
+    SourceSpan,
+    formula::{Atom, Constraint, Decorated, Formula, WhereClause},
+};
+use sempai_yaml::{MatchFormula, SearchQueryPrincipal};
+use serde_json::json;
+
+use crate::normalize::normalize_search_principal;
+
+fn assert_wraps_pattern_atom(inner: &Decorated<Formula>, expected_text: &str) {
+    assert!(
+        matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == expected_text),
+        "expected Pattern(\"{expected_text}\"), got {:?}",
+        inner.node
+    );
+}
+
+fn assert_two_pattern_branches(
+    branches: &[Decorated<Formula>],
+    first_text: &str,
+    second_text: &str,
+) {
+    assert_eq!(branches.len(), 2);
+    let first = branches.first().expect("expected first branch");
+    let second = branches.get(1).expect("expected second branch");
+    assert_wraps_pattern_atom(first, first_text);
+    assert_wraps_pattern_atom(second, second_text);
+}
+
+fn assert_empty_metadata(formula: &Decorated<Formula>) {
+    assert!(formula.where_clauses.is_empty());
+    assert!(formula.as_name.is_none());
+    assert!(formula.fix.is_none());
+}
+
+fn assert_span_recursive(formula: &Decorated<Formula>, expected_span: &SourceSpan) {
+    assert_eq!(formula.span.as_ref(), Some(expected_span));
+    match &formula.node {
+        Formula::Atom(_) => {}
+        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
+            assert_span_recursive(inner, expected_span);
+        }
+        Formula::And(branches) | Formula::Or(branches) => {
+            for branch in branches {
+                assert_span_recursive(branch, expected_span);
+            }
+        }
+    }
+}
+
+#[test]
+fn v2_decorated_over_all_wraps_preserves_metadata() {
+    let principal = SearchQueryPrincipal::Match(MatchFormula::Decorated {
+        formula: Box::new(MatchFormula::All(vec![
+            MatchFormula::Pattern(String::from("a")),
+            MatchFormula::Pattern(String::from("b")),
+        ])),
+        where_clauses: vec![json!({
+            "metavariable-pattern": {
+                "metavariable": "$X",
+                "pattern": "bad",
+            },
+        })],
+        as_name: Some(String::from("cap")),
+        fix: Some(String::from("fixme")),
+    });
+
+    let decorated =
+        normalize_search_principal(&principal, None).expect("decorated formula should normalize");
+
+    assert_eq!(decorated.as_name.as_deref(), Some("cap"));
+    assert_eq!(decorated.fix.as_deref(), Some("fixme"));
+    assert_eq!(
+        decorated.where_clauses,
+        vec![WhereClause {
+            constraint: Constraint::MetavariablePattern {
+                metavariable: String::from("$X"),
+                pattern: String::from("bad"),
+            },
+        }]
+    );
+    match &decorated.node {
+        Formula::And(children) => {
+            assert_two_pattern_branches(children, "a", "b");
+            for child in children {
+                assert_empty_metadata(child);
+            }
+        }
+        other => panic!("expected decorated All to normalize to And, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_decorated_nested_inside_not_preserves_metadata_and_spans() {
+    let span = SourceSpan::new(11, 37, Some(String::from("file:///rule.yaml")));
+    let principal = SearchQueryPrincipal::Match(MatchFormula::Decorated {
+        formula: Box::new(MatchFormula::Not(Box::new(MatchFormula::Inside(Box::new(
+            MatchFormula::Pattern(String::from("x")),
+        ))))),
+        where_clauses: vec![json!({
+            "metavariable-regex": {
+                "metavariable": "$X",
+                "regex": "x+",
+            },
+        })],
+        as_name: Some(String::from("cap")),
+        fix: Some(String::from("fixme")),
+    });
+
+    let decorated = normalize_search_principal(&principal, Some(&span))
+        .expect("decorated formula should normalize");
+
+    assert_eq!(decorated.span.as_ref(), Some(&span));
+    assert_eq!(decorated.as_name.as_deref(), Some("cap"));
+    assert_eq!(decorated.fix.as_deref(), Some("fixme"));
+    assert_eq!(
+        decorated.where_clauses,
+        vec![WhereClause {
+            constraint: Constraint::MetavariableRegex {
+                metavariable: String::from("$X"),
+                regex: String::from("x+"),
+            },
+        }]
+    );
+    match &decorated.node {
+        Formula::Not(not_inner) => {
+            assert_eq!(not_inner.span.as_ref(), Some(&span));
+            assert_empty_metadata(not_inner);
+            match &not_inner.node {
+                Formula::Inside(inside_inner) => {
+                    assert_eq!(inside_inner.span.as_ref(), Some(&span));
+                    assert_empty_metadata(inside_inner);
+                    assert_wraps_pattern_atom(inside_inner, "x");
+                }
+                other => panic!("expected Inside formula inside Not, got {other:?}"),
+            }
+        }
+        other => panic!("expected Not formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn rule_span_propagates_through_recursive_v2_children() {
+    let span = SourceSpan::new(13, 89, Some(String::from("file:///nested-rule.yaml")));
+    let principal = SearchQueryPrincipal::Match(MatchFormula::All(vec![
+        MatchFormula::Any(vec![
+            MatchFormula::Not(Box::new(MatchFormula::Inside(Box::new(
+                MatchFormula::Pattern(String::from("x")),
+            )))),
+            MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(String::from("y")))),
+        ]),
+        MatchFormula::Pattern(String::from("z")),
+    ]));
+    let normalized =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
+
+    assert_span_recursive(&normalized, &span);
+}

--- a/crates/sempai/src/tests/normalization_metadata_tests.rs
+++ b/crates/sempai/src/tests/normalization_metadata_tests.rs
@@ -183,20 +183,10 @@ fn v2_decorated_over_unary_preserves_metadata_and_spans(
 
 #[test]
 fn v2_decorated_over_all_wraps_preserves_metadata() {
-    let principal = SearchQueryPrincipal::Match(MatchFormula::Decorated {
-        formula: Box::new(MatchFormula::All(vec![
-            MatchFormula::Pattern(String::from("a")),
-            MatchFormula::Pattern(String::from("b")),
-        ])),
-        where_clauses: vec![json!({
-            "metavariable-pattern": {
-                "metavariable": "$X",
-                "pattern": "bad",
-            },
-        })],
-        as_name: Some(String::from("cap")),
-        fix: Some(String::from("fixme")),
-    });
+    let principal = decorated_match_formula(MatchFormula::All(vec![
+        MatchFormula::Pattern(String::from("a")),
+        MatchFormula::Pattern(String::from("b")),
+    ]));
 
     let decorated =
         normalize_search_principal(&principal, None).expect("decorated formula should normalize");
@@ -212,14 +202,10 @@ fn v2_decorated_over_all_wraps_preserves_metadata() {
             },
         }]
     );
-    match &decorated.node {
-        Formula::And(children) => {
-            assert_two_pattern_branches(children, "a", "b");
-            for child in children {
-                assert_empty_metadata(child);
-            }
-        }
-        other => panic!("expected decorated All to normalize to And, got {other:?}"),
+    let children = extract_and_branches(&decorated.node);
+    assert_two_pattern_branches(children, "a", "b");
+    for child in children {
+        assert_empty_metadata(child);
     }
 }
 

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -10,9 +10,7 @@ use crate::normalize::normalize_search_principal;
 /// Helper to normalize a legacy formula and extract the node.
 fn normalize_legacy(formula: LegacyFormula) -> Formula {
     let principal = SearchQueryPrincipal::Legacy(formula);
-    normalize_search_principal(&principal, None)
-        .expect("should normalize")
-        .node
+    normalize_search_principal(&principal, None).node
 }
 
 /// Helper to normalize a legacy formula and keep the full decorated wrapper.
@@ -21,21 +19,19 @@ fn normalize_legacy(formula: LegacyFormula) -> Formula {
 /// attached to the normalized formula.
 fn normalize_legacy_decorated(formula: LegacyFormula) -> Decorated<Formula> {
     let principal = SearchQueryPrincipal::Legacy(formula);
-    normalize_search_principal(&principal, None).expect("should normalize")
+    normalize_search_principal(&principal, None)
 }
 
 /// Helper to normalize a v2 match formula and extract the node.
 fn normalize_v2(formula: MatchFormula) -> Formula {
     let principal = SearchQueryPrincipal::Match(formula);
-    normalize_search_principal(&principal, None)
-        .expect("should normalize")
-        .node
+    normalize_search_principal(&principal, None).node
 }
 
 /// Helper to normalize a v2 match formula and keep the full decorated wrapper.
 fn normalize_v2_decorated(formula: MatchFormula) -> Decorated<Formula> {
     let principal = SearchQueryPrincipal::Match(formula);
-    normalize_search_principal(&principal, None).expect("should normalize")
+    normalize_search_principal(&principal, None)
 }
 
 #[test]
@@ -265,7 +261,7 @@ fn v2_decorated_preserves_where_as_and_fix_metadata() {
 fn span_propagates_from_search_principal_to_decorated() {
     let span = SourceSpan::new(5, 42, Some(String::from("file:///rule.yaml")));
     let principal = SearchQueryPrincipal::Match(MatchFormula::Pattern(String::from("foo($X)")));
-    let normalized = normalize_search_principal(&principal, Some(&span)).expect("should normalize");
+    let normalized = normalize_search_principal(&principal, Some(&span));
 
     assert_eq!(normalized.span, Some(span));
 }

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -5,13 +5,27 @@ use sempai_yaml::{LegacyFormula, LegacyValue, MatchFormula, SearchQueryPrincipal
 
 use crate::normalize::normalize_search_principal;
 
+/// Helper to normalize a legacy formula and extract the node.
+fn normalize_legacy(formula: LegacyFormula) -> Formula {
+    let principal = SearchQueryPrincipal::Legacy(formula);
+    normalize_search_principal(&principal, None)
+        .expect("should normalize")
+        .node
+}
+
+/// Helper to normalize a v2 match formula and extract the node.
+fn normalize_v2(formula: MatchFormula) -> Formula {
+    let principal = SearchQueryPrincipal::Match(formula);
+    normalize_search_principal(&principal, None)
+        .expect("should normalize")
+        .node
+}
+
 #[test]
 fn legacy_pattern_normalizes_to_atom() {
-    let legacy = LegacyFormula::Pattern(String::from("foo($X)"));
-    let principal = SearchQueryPrincipal::Legacy(legacy);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    let result = normalize_legacy(LegacyFormula::Pattern(String::from("foo($X)")));
     assert_eq!(
-        result.node,
+        result,
         Formula::Atom(Atom::Pattern(PatternAtom {
             text: String::from("foo($X)")
         }))
@@ -20,11 +34,9 @@ fn legacy_pattern_normalizes_to_atom() {
 
 #[test]
 fn legacy_pattern_regex_normalizes_to_regex_atom() {
-    let legacy = LegacyFormula::PatternRegex(String::from(r"foo_\d+"));
-    let principal = SearchQueryPrincipal::Legacy(legacy);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    let result = normalize_legacy(LegacyFormula::PatternRegex(String::from(r"foo_\d+")));
     assert_eq!(
-        result.node,
+        result,
         Formula::Atom(Atom::Regex(RegexAtom {
             pattern: String::from(r"foo_\d+")
         }))
@@ -33,10 +45,8 @@ fn legacy_pattern_regex_normalizes_to_regex_atom() {
 
 #[test]
 fn legacy_pattern_not_regex_normalizes_to_not_regex() {
-    let legacy = LegacyFormula::PatternNotRegex(String::from(r"bar.*"));
-    let principal = SearchQueryPrincipal::Legacy(legacy);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
-    match result.node {
+    let result = normalize_legacy(LegacyFormula::PatternNotRegex(String::from(r"bar.*")));
+    match result {
         Formula::Not(inner) => match inner.node {
             Formula::Atom(Atom::Regex(regex)) => {
                 assert_eq!(regex.pattern, r"bar.*");
@@ -49,11 +59,10 @@ fn legacy_pattern_not_regex_normalizes_to_not_regex() {
 
 #[test]
 fn legacy_pattern_not_inside_normalizes_to_not_inside() {
-    let legacy =
-        LegacyFormula::PatternNotInside(Box::new(LegacyValue::String(String::from("class Foo:"))));
-    let principal = SearchQueryPrincipal::Legacy(legacy);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
-    match result.node {
+    let result = normalize_legacy(LegacyFormula::PatternNotInside(Box::new(
+        LegacyValue::String(String::from("class Foo:")),
+    )));
+    match result {
         Formula::Not(not_inner) => match not_inner.node {
             Formula::Inside(inside_inner) => match inside_inner.node {
                 Formula::Atom(Atom::Pattern(pat)) => {
@@ -69,11 +78,9 @@ fn legacy_pattern_not_inside_normalizes_to_not_inside() {
 
 #[test]
 fn v2_pattern_shorthand_normalizes_to_atom() {
-    let v2 = MatchFormula::Pattern(String::from("bar($Y)"));
-    let principal = SearchQueryPrincipal::Match(v2);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    let result = normalize_v2(MatchFormula::Pattern(String::from("bar($Y)")));
     assert_eq!(
-        result.node,
+        result,
         Formula::Atom(Atom::Pattern(PatternAtom {
             text: String::from("bar($Y)")
         }))
@@ -82,11 +89,9 @@ fn v2_pattern_shorthand_normalizes_to_atom() {
 
 #[test]
 fn v2_regex_normalizes_to_regex_atom() {
-    let v2 = MatchFormula::Regex(String::from(r"baz_\w+"));
-    let principal = SearchQueryPrincipal::Match(v2);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    let result = normalize_v2(MatchFormula::Regex(String::from(r"baz_\w+")));
     assert_eq!(
-        result.node,
+        result,
         Formula::Atom(Atom::Regex(RegexAtom {
             pattern: String::from(r"baz_\w+")
         }))
@@ -95,65 +100,42 @@ fn v2_regex_normalizes_to_regex_atom() {
 
 #[test]
 fn v2_all_normalizes_to_and() {
-    let v2 = MatchFormula::All(vec![
+    let result = normalize_v2(MatchFormula::All(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]);
-    let principal = SearchQueryPrincipal::Match(v2);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
-    match result.node {
-        Formula::And(branches) => {
-            assert_eq!(branches.len(), 2);
-        }
-        _ => panic!("expected And formula"),
-    }
+    ]));
+    assert!(matches!(result, Formula::And(ref branches) if branches.len() == 2));
 }
 
 #[test]
 fn v2_any_normalizes_to_or() {
-    let v2 = MatchFormula::Any(vec![
+    let result = normalize_v2(MatchFormula::Any(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]);
-    let principal = SearchQueryPrincipal::Match(v2);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
-    match result.node {
-        Formula::Or(branches) => {
-            assert_eq!(branches.len(), 2);
-        }
-        _ => panic!("expected Or formula"),
-    }
+    ]));
+    assert!(matches!(result, Formula::Or(ref branches) if branches.len() == 2));
 }
 
 #[test]
 fn v2_not_normalizes_to_not() {
-    let v2 = MatchFormula::Not(Box::new(MatchFormula::Pattern(String::from("baz"))));
-    let principal = SearchQueryPrincipal::Match(v2);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
-    match result.node {
-        Formula::Not(_) => {}
-        _ => panic!("expected Not formula"),
-    }
+    let result = normalize_v2(MatchFormula::Not(Box::new(MatchFormula::Pattern(
+        String::from("baz"),
+    ))));
+    assert!(matches!(result, Formula::Not(_)));
 }
 
 #[test]
 fn v2_inside_normalizes_to_inside() {
-    let v2 = MatchFormula::Inside(Box::new(MatchFormula::Pattern(String::from("class X:"))));
-    let principal = SearchQueryPrincipal::Match(v2);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
-    match result.node {
-        Formula::Inside(_) => {}
-        _ => panic!("expected Inside formula"),
-    }
+    let result = normalize_v2(MatchFormula::Inside(Box::new(MatchFormula::Pattern(
+        String::from("class X:"),
+    ))));
+    assert!(matches!(result, Formula::Inside(_)));
 }
 
 #[test]
 fn v2_anywhere_normalizes_to_anywhere() {
-    let v2 = MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(String::from("unsafe"))));
-    let principal = SearchQueryPrincipal::Match(v2);
-    let result = normalize_search_principal(&principal, None).expect("should normalize");
-    match result.node {
-        Formula::Anywhere(_) => {}
-        _ => panic!("expected Anywhere formula"),
-    }
+    let result = normalize_v2(MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(
+        String::from("unsafe"),
+    ))));
+    assert!(matches!(result, Formula::Anywhere(_)));
 }

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -1,0 +1,159 @@
+//! Tests for formula normalization.
+
+use sempai_core::formula::{Atom, Formula, PatternAtom, RegexAtom};
+use sempai_yaml::{LegacyFormula, LegacyValue, MatchFormula, SearchQueryPrincipal};
+
+use crate::normalize::normalize_search_principal;
+
+#[test]
+fn legacy_pattern_normalizes_to_atom() {
+    let legacy = LegacyFormula::Pattern(String::from("foo($X)"));
+    let principal = SearchQueryPrincipal::Legacy(legacy);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    assert_eq!(
+        result.node,
+        Formula::Atom(Atom::Pattern(PatternAtom {
+            text: String::from("foo($X)")
+        }))
+    );
+}
+
+#[test]
+fn legacy_pattern_regex_normalizes_to_regex_atom() {
+    let legacy = LegacyFormula::PatternRegex(String::from(r"foo_\d+"));
+    let principal = SearchQueryPrincipal::Legacy(legacy);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    assert_eq!(
+        result.node,
+        Formula::Atom(Atom::Regex(RegexAtom {
+            pattern: String::from(r"foo_\d+")
+        }))
+    );
+}
+
+#[test]
+fn legacy_pattern_not_regex_normalizes_to_not_regex() {
+    let legacy = LegacyFormula::PatternNotRegex(String::from(r"bar.*"));
+    let principal = SearchQueryPrincipal::Legacy(legacy);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    match result.node {
+        Formula::Not(inner) => match inner.node {
+            Formula::Atom(Atom::Regex(regex)) => {
+                assert_eq!(regex.pattern, r"bar.*");
+            }
+            _ => panic!("expected Regex atom inside Not"),
+        },
+        _ => panic!("expected Not formula"),
+    }
+}
+
+#[test]
+fn legacy_pattern_not_inside_normalizes_to_not_inside() {
+    let legacy =
+        LegacyFormula::PatternNotInside(Box::new(LegacyValue::String(String::from("class Foo:"))));
+    let principal = SearchQueryPrincipal::Legacy(legacy);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    match result.node {
+        Formula::Not(not_inner) => match not_inner.node {
+            Formula::Inside(inside_inner) => match inside_inner.node {
+                Formula::Atom(Atom::Pattern(pat)) => {
+                    assert_eq!(pat.text, "class Foo:");
+                }
+                _ => panic!("expected Pattern atom"),
+            },
+            _ => panic!("expected Inside formula inside Not"),
+        },
+        _ => panic!("expected Not formula"),
+    }
+}
+
+#[test]
+fn v2_pattern_shorthand_normalizes_to_atom() {
+    let v2 = MatchFormula::Pattern(String::from("bar($Y)"));
+    let principal = SearchQueryPrincipal::Match(v2);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    assert_eq!(
+        result.node,
+        Formula::Atom(Atom::Pattern(PatternAtom {
+            text: String::from("bar($Y)")
+        }))
+    );
+}
+
+#[test]
+fn v2_regex_normalizes_to_regex_atom() {
+    let v2 = MatchFormula::Regex(String::from(r"baz_\w+"));
+    let principal = SearchQueryPrincipal::Match(v2);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    assert_eq!(
+        result.node,
+        Formula::Atom(Atom::Regex(RegexAtom {
+            pattern: String::from(r"baz_\w+")
+        }))
+    );
+}
+
+#[test]
+fn v2_all_normalizes_to_and() {
+    let v2 = MatchFormula::All(vec![
+        MatchFormula::Pattern(String::from("foo")),
+        MatchFormula::Pattern(String::from("bar")),
+    ]);
+    let principal = SearchQueryPrincipal::Match(v2);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    match result.node {
+        Formula::And(branches) => {
+            assert_eq!(branches.len(), 2);
+        }
+        _ => panic!("expected And formula"),
+    }
+}
+
+#[test]
+fn v2_any_normalizes_to_or() {
+    let v2 = MatchFormula::Any(vec![
+        MatchFormula::Pattern(String::from("foo")),
+        MatchFormula::Pattern(String::from("bar")),
+    ]);
+    let principal = SearchQueryPrincipal::Match(v2);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    match result.node {
+        Formula::Or(branches) => {
+            assert_eq!(branches.len(), 2);
+        }
+        _ => panic!("expected Or formula"),
+    }
+}
+
+#[test]
+fn v2_not_normalizes_to_not() {
+    let v2 = MatchFormula::Not(Box::new(MatchFormula::Pattern(String::from("baz"))));
+    let principal = SearchQueryPrincipal::Match(v2);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    match result.node {
+        Formula::Not(_) => {}
+        _ => panic!("expected Not formula"),
+    }
+}
+
+#[test]
+fn v2_inside_normalizes_to_inside() {
+    let v2 = MatchFormula::Inside(Box::new(MatchFormula::Pattern(String::from("class X:"))));
+    let principal = SearchQueryPrincipal::Match(v2);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    match result.node {
+        Formula::Inside(_) => {}
+        _ => panic!("expected Inside formula"),
+    }
+}
+
+#[test]
+fn v2_anywhere_normalizes_to_anywhere() {
+    let v2 = MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(String::from("unsafe"))));
+    let principal = SearchQueryPrincipal::Match(v2);
+    let result = normalize_search_principal(&principal, None).expect("should normalize");
+    match result.node {
+        Formula::Anywhere(_) => {}
+        _ => panic!("expected Anywhere formula"),
+    }
+}

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for formula normalization.
 
-use sempai_core::formula::{Atom, Formula, PatternAtom, RegexAtom};
-use sempai_yaml::{LegacyFormula, LegacyValue, MatchFormula, SearchQueryPrincipal};
+use sempai_core::SourceSpan;
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom};
+use sempai_yaml::{LegacyClause, LegacyFormula, LegacyValue, MatchFormula, SearchQueryPrincipal};
+use serde_json::json;
 
 use crate::normalize::normalize_search_principal;
 
@@ -13,12 +15,27 @@ fn normalize_legacy(formula: LegacyFormula) -> Formula {
         .node
 }
 
+/// Helper to normalize a legacy formula and keep the full decorated wrapper.
+///
+/// Useful for tests that need to inspect `where_clauses` or other metadata
+/// attached to the normalized formula.
+fn normalize_legacy_decorated(formula: LegacyFormula) -> Decorated<Formula> {
+    let principal = SearchQueryPrincipal::Legacy(formula);
+    normalize_search_principal(&principal, None).expect("should normalize")
+}
+
 /// Helper to normalize a v2 match formula and extract the node.
 fn normalize_v2(formula: MatchFormula) -> Formula {
     let principal = SearchQueryPrincipal::Match(formula);
     normalize_search_principal(&principal, None)
         .expect("should normalize")
         .node
+}
+
+/// Helper to normalize a v2 match formula and keep the full decorated wrapper.
+fn normalize_v2_decorated(formula: MatchFormula) -> Decorated<Formula> {
+    let principal = SearchQueryPrincipal::Match(formula);
+    normalize_search_principal(&principal, None).expect("should normalize")
 }
 
 #[test]
@@ -138,4 +155,117 @@ fn v2_anywhere_normalizes_to_anywhere() {
         String::from("unsafe"),
     ))));
     assert!(matches!(result, Formula::Anywhere(_)));
+}
+
+#[test]
+fn legacy_pattern_either_normalizes_to_or() {
+    let result = normalize_legacy(LegacyFormula::PatternEither(vec![
+        LegacyFormula::Pattern(String::from("first")),
+        LegacyFormula::Pattern(String::from("second")),
+    ]));
+    match result {
+        Formula::Or(children) => {
+            assert_eq!(children.len(), 2);
+            let mut iter = children.iter();
+            match &iter.next().expect("first child").node {
+                Formula::Atom(Atom::Pattern(pat)) => assert_eq!(pat.text, "first"),
+                _ => panic!("expected first child to be a Pattern atom"),
+            }
+            match &iter.next().expect("second child").node {
+                Formula::Atom(Atom::Pattern(pat)) => assert_eq!(pat.text, "second"),
+                _ => panic!("expected second child to be a Pattern atom"),
+            }
+        }
+        _ => panic!("expected Or formula from pattern-either"),
+    }
+}
+
+#[test]
+fn legacy_anywhere_normalizes_to_anywhere() {
+    // Corresponds to legacy `semgrep-internal-pattern-anywhere: ...`.
+    let result = normalize_legacy(LegacyFormula::Anywhere(Box::new(LegacyValue::String(
+        String::from("pattern anywhere"),
+    ))));
+    match result {
+        Formula::Anywhere(inner) => match inner.node {
+            Formula::Atom(Atom::Pattern(pat)) => assert_eq!(pat.text, "pattern anywhere"),
+            _ => panic!("expected Pattern atom inside Anywhere"),
+        },
+        _ => panic!("expected Anywhere formula from semgrep-internal-pattern-anywhere"),
+    }
+}
+
+#[test]
+fn legacy_patterns_propagates_constraints_to_where_clauses() {
+    // Build a legacy `patterns: [...]` with two pattern clauses and one
+    // constraint clause. The constraint should end up on the enclosing And.
+    let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
+    let legacy = LegacyFormula::Patterns(vec![
+        LegacyClause::Formula(LegacyFormula::Pattern(String::from("foo($X)"))),
+        LegacyClause::Formula(LegacyFormula::Pattern(String::from("bar($X)"))),
+        LegacyClause::Constraint(constraint.clone()),
+    ]);
+
+    let decorated = normalize_legacy_decorated(legacy);
+
+    // Outer node must be an `And` combining the pattern formulas.
+    let children = match &decorated.node {
+        Formula::And(children) => children,
+        other => panic!("expected normalized legacy Patterns to be And, got {other:?}"),
+    };
+    assert_eq!(children.len(), 2);
+
+    // The constraint should be attached as a where_clause on the outer And.
+    assert_eq!(decorated.where_clauses.len(), 1);
+    let clause = decorated
+        .where_clauses
+        .first()
+        .expect("expected at least one where_clause");
+    assert_eq!(clause.raw, constraint);
+
+    // Child formulas themselves must not carry any where_clauses.
+    for (idx, child) in children.iter().enumerate() {
+        assert!(
+            child.where_clauses.is_empty(),
+            "expected child {idx} of And to have empty where_clauses"
+        );
+    }
+}
+
+#[test]
+fn v2_decorated_preserves_where_as_and_fix_metadata() {
+    let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
+    let formula = MatchFormula::Decorated {
+        formula: Box::new(MatchFormula::Pattern(String::from("foo($X)"))),
+        where_clauses: vec![constraint.clone()],
+        as_name: Some(String::from("my_capture")),
+        fix: Some(String::from("replace_me")),
+    };
+
+    let decorated = normalize_v2_decorated(formula);
+
+    // The core node should be the normalized pattern atom.
+    assert!(matches!(
+        decorated.node,
+        Formula::Atom(Atom::Pattern(ref pat)) if pat.text == "foo($X)"
+    ));
+
+    // Metadata should be preserved on the Decorated wrapper.
+    assert_eq!(decorated.as_name.as_deref(), Some("my_capture"));
+    assert_eq!(decorated.fix.as_deref(), Some("replace_me"));
+    assert_eq!(decorated.where_clauses.len(), 1);
+    let clause = decorated
+        .where_clauses
+        .first()
+        .expect("expected at least one where_clause");
+    assert_eq!(clause.raw, constraint);
+}
+
+#[test]
+fn span_propagates_from_search_principal_to_decorated() {
+    let span = SourceSpan::new(5, 42, Some(String::from("file:///rule.yaml")));
+    let principal = SearchQueryPrincipal::Match(MatchFormula::Pattern(String::from("foo($X)")));
+    let normalized = normalize_search_principal(&principal, Some(&span)).expect("should normalize");
+
+    assert_eq!(normalized.span, Some(span));
 }

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -4,7 +4,7 @@ use rstest::rstest;
 use sempai_core::{
     DiagnosticCode,
     SourceSpan,
-    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom},
+    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause},
 };
 use sempai_yaml::{
     LegacyClause,
@@ -324,6 +324,20 @@ fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where
         first.code(),
         DiagnosticCode::ESempaiMissingPositiveTermInAnd
     );
+}
+
+#[test]
+fn legacy_patterns_with_only_metavariable_pattern_constraint_validates() {
+    let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
+    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint.clone())]);
+    let decorated = normalize_legacy_decorated(legacy);
+
+    assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
+    assert_eq!(
+        decorated.where_clauses,
+        vec![WhereClause { raw: constraint }]
+    );
+    assert!(validate_formula(&decorated).is_ok());
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -313,8 +313,8 @@ fn v2_decorated_preserves_where_as_and_fix_metadata() {
 
     // The core node should be the normalized pattern atom.
     assert!(matches!(
-        decorated.node,
-        Formula::Atom(Atom::Pattern(ref pat)) if pat.text == "foo($X)"
+        &decorated.node,
+        Formula::Atom(Atom::Pattern(pat)) if pat.text == "foo($X)"
     ));
 
     // Metadata should be preserved on the Decorated wrapper.

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -1,10 +1,18 @@
 //! Tests for formula normalization.
 
+use rstest::rstest;
 use sempai_core::{
     SourceSpan,
-    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom},
+    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom},
 };
-use sempai_yaml::{LegacyClause, LegacyFormula, LegacyValue, MatchFormula, SearchQueryPrincipal};
+use sempai_yaml::{
+    LegacyClause,
+    LegacyFormula,
+    LegacyValue,
+    MatchFormula,
+    ProjectDependsOnPayload,
+    SearchQueryPrincipal,
+};
 use serde_json::json;
 
 use crate::normalize::normalize_search_principal;
@@ -36,26 +44,25 @@ fn normalize_v2_decorated(formula: MatchFormula) -> Decorated<Formula> {
     normalize_search_principal(&principal, None)
 }
 
-#[test]
-fn legacy_pattern_normalizes_to_atom() {
-    let result = normalize_legacy(LegacyFormula::Pattern(String::from("foo($X)")));
-    assert_eq!(
-        result,
-        Formula::Atom(Atom::Pattern(PatternAtom {
-            text: String::from("foo($X)")
-        }))
-    );
-}
-
-#[test]
-fn legacy_pattern_regex_normalizes_to_regex_atom() {
-    let result = normalize_legacy(LegacyFormula::PatternRegex(String::from(r"foo_\d+")));
-    assert_eq!(
-        result,
-        Formula::Atom(Atom::Regex(RegexAtom {
-            pattern: String::from(r"foo_\d+")
-        }))
-    );
+#[rstest]
+#[case::pattern(
+    LegacyFormula::Pattern(String::from("foo($X)")),
+    Formula::Atom(Atom::Pattern(PatternAtom {
+        text: String::from("foo($X)")
+    }))
+)]
+#[case::pattern_regex(
+    LegacyFormula::PatternRegex(String::from(r"foo_\d+")),
+    Formula::Atom(Atom::Regex(RegexAtom {
+        pattern: String::from(r"foo_\d+")
+    }))
+)]
+fn legacy_formula_normalizes_to_expected_formula(
+    #[case] formula: LegacyFormula,
+    #[case] expected: Formula,
+) {
+    let result = normalize_legacy(formula);
+    assert_eq!(result, expected);
 }
 
 #[test]
@@ -91,68 +98,60 @@ fn legacy_pattern_not_inside_normalizes_to_not_inside() {
     }
 }
 
-#[test]
-fn v2_pattern_shorthand_normalizes_to_atom() {
-    let result = normalize_v2(MatchFormula::Pattern(String::from("bar($Y)")));
-    assert_eq!(
-        result,
-        Formula::Atom(Atom::Pattern(PatternAtom {
-            text: String::from("bar($Y)")
-        }))
-    );
+#[rstest]
+#[case::pattern_shorthand(
+    MatchFormula::Pattern(String::from("bar($Y)")),
+    Formula::Atom(Atom::Pattern(PatternAtom {
+        text: String::from("bar($Y)")
+    }))
+)]
+#[case::regex(
+    MatchFormula::Regex(String::from(r"baz_\w+")),
+    Formula::Atom(Atom::Regex(RegexAtom {
+        pattern: String::from(r"baz_\w+")
+    }))
+)]
+fn v2_atom_formula_normalizes_to_expected_formula(
+    #[case] formula: MatchFormula,
+    #[case] expected: Formula,
+) {
+    let result = normalize_v2(formula);
+    assert_eq!(result, expected);
 }
 
-#[test]
-fn v2_regex_normalizes_to_regex_atom() {
-    let result = normalize_v2(MatchFormula::Regex(String::from(r"baz_\w+")));
-    assert_eq!(
-        result,
-        Formula::Atom(Atom::Regex(RegexAtom {
-            pattern: String::from(r"baz_\w+")
-        }))
-    );
-}
-
-#[test]
-fn v2_all_normalizes_to_and() {
-    let result = normalize_v2(MatchFormula::All(vec![
+#[rstest]
+#[case::all(
+    MatchFormula::All(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]));
-    assert!(matches!(result, Formula::And(ref branches) if branches.len() == 2));
-}
-
-#[test]
-fn v2_any_normalizes_to_or() {
-    let result = normalize_v2(MatchFormula::Any(vec![
+    ]),
+    |normalised| matches!(normalised, Formula::And(branches) if branches.len() == 2)
+)]
+#[case::any(
+    MatchFormula::Any(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]));
-    assert!(matches!(result, Formula::Or(ref branches) if branches.len() == 2));
-}
-
-#[test]
-fn v2_not_normalizes_to_not() {
-    let result = normalize_v2(MatchFormula::Not(Box::new(MatchFormula::Pattern(
-        String::from("baz"),
-    ))));
-    assert!(matches!(result, Formula::Not(_)));
-}
-
-#[test]
-fn v2_inside_normalizes_to_inside() {
-    let result = normalize_v2(MatchFormula::Inside(Box::new(MatchFormula::Pattern(
-        String::from("class X:"),
-    ))));
-    assert!(matches!(result, Formula::Inside(_)));
-}
-
-#[test]
-fn v2_anywhere_normalizes_to_anywhere() {
-    let result = normalize_v2(MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(
-        String::from("unsafe"),
-    ))));
-    assert!(matches!(result, Formula::Anywhere(_)));
+    ]),
+    |normalised| matches!(normalised, Formula::Or(branches) if branches.len() == 2)
+)]
+#[case::not(
+    MatchFormula::Not(Box::new(MatchFormula::Pattern(String::from("baz")))),
+    |normalised| matches!(normalised, Formula::Not(_))
+)]
+#[case::inside(
+    MatchFormula::Inside(Box::new(MatchFormula::Pattern(String::from("class X:")))),
+    |normalised| matches!(normalised, Formula::Inside(_))
+)]
+#[case::anywhere(
+    MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(String::from("unsafe")))),
+    |normalised| matches!(normalised, Formula::Anywhere(_))
+)]
+fn v2_structural_formula_normalizes_to_expected_shape(
+    #[case] formula: MatchFormula,
+    #[case] expected_shape: fn(Formula) -> bool,
+) {
+    let result = normalize_v2(formula);
+    assert!(expected_shape(result));
 }
 
 #[test]
@@ -266,4 +265,24 @@ fn span_propagates_from_search_principal_to_decorated() {
     let normalized = normalize_search_principal(&principal, Some(&span));
 
     assert_eq!(normalized.span, Some(span));
+}
+
+#[test]
+fn project_depends_on_propagates_span_to_placeholder_formula() {
+    let span = SourceSpan::new(7, 64, Some(String::from("file:///rule.yaml")));
+    let payload = ProjectDependsOnPayload::try_from(json!({
+        "namespace": "pypi",
+        "package": "requests",
+    }))
+    .expect("valid project dependency payload");
+    let principal = SearchQueryPrincipal::ProjectDependsOn(payload);
+    let normalized = normalize_search_principal(&principal, Some(&span));
+
+    assert_eq!(normalized.span, Some(span));
+    assert_eq!(
+        normalized.node,
+        Formula::Atom(Atom::TreeSitterQuery(TreeSitterQueryAtom {
+            query: String::from("(__NONEXISTENT_NODE__) @_dependency_check"),
+        }))
+    );
 }

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -19,13 +19,17 @@ use crate::normalize::normalize_search_principal;
 /// Helper to normalize a legacy formula and extract the node.
 fn normalize_legacy(formula: LegacyFormula) -> Formula {
     let principal = SearchQueryPrincipal::Legacy(formula);
-    normalize_search_principal(&principal, None).node
+    normalize_search_principal(&principal, None)
+        .expect("legacy formula should normalize")
+        .node
 }
 
 /// Helper to normalize a v2 match formula and extract the node.
 fn normalize_v2(formula: MatchFormula) -> Formula {
     let principal = SearchQueryPrincipal::Match(formula);
-    normalize_search_principal(&principal, None).node
+    normalize_search_principal(&principal, None)
+        .expect("v2 formula should normalize")
+        .node
 }
 
 /// Asserts that a `Decorated<Formula>` wraps a `Pattern` atom with the given text.
@@ -250,7 +254,8 @@ fn legacy_anywhere_normalizes_to_anywhere() {
 fn span_propagates_from_search_principal_to_decorated() {
     let span = SourceSpan::new(5, 42, Some(String::from("file:///rule.yaml")));
     let principal = SearchQueryPrincipal::Match(MatchFormula::Pattern(String::from("foo($X)")));
-    let normalized = normalize_search_principal(&principal, Some(&span));
+    let normalized =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
 
     assert_eq!(normalized.span, Some(span));
 }
@@ -264,7 +269,8 @@ fn project_depends_on_propagates_span_to_placeholder_formula() {
     }))
     .expect("valid project dependency payload");
     let principal = SearchQueryPrincipal::ProjectDependsOn(payload);
-    let normalized = normalize_search_principal(&principal, Some(&span));
+    let normalized =
+        normalize_search_principal(&principal, Some(&span)).expect("formula should normalize");
 
     assert_eq!(normalized.span, Some(span));
     assert_eq!(

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -44,6 +44,40 @@ fn normalize_v2_decorated(formula: MatchFormula) -> Decorated<Formula> {
     normalize_search_principal(&principal, None)
 }
 
+/// Asserts that a `Decorated<Formula>` wraps a `Pattern` atom with the given text.
+///
+/// Intended for use in unary-wrapper tests (`Not`, `Inside`, `Anywhere`).
+fn assert_wraps_pattern_atom(inner: &Decorated<Formula>, expected_text: &str) {
+    assert!(
+        matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == expected_text),
+        "expected Pattern(\"{expected_text}\"), got {:?}",
+        inner.node
+    );
+}
+
+/// Asserts that a branch slice contains exactly two `Pattern` atoms with the given texts.
+///
+/// Intended for use in branch-list tests (`And`, `Or`).
+fn assert_two_pattern_branches(
+    branches: &[Decorated<Formula>],
+    first_text: &str,
+    second_text: &str,
+) {
+    assert_eq!(branches.len(), 2);
+    let first = branches.first().expect("expected first branch");
+    let second = branches.get(1).expect("expected second branch");
+    assert!(
+        matches!(&first.node, Formula::Atom(Atom::Pattern(p)) if p.text == first_text),
+        "expected first branch Pattern(\"{first_text}\"), got {:?}",
+        first.node
+    );
+    assert!(
+        matches!(&second.node, Formula::Atom(Atom::Pattern(p)) if p.text == second_text),
+        "expected second branch Pattern(\"{second_text}\"), got {:?}",
+        second.node
+    );
+}
+
 #[rstest]
 #[case::pattern(
     LegacyFormula::Pattern(String::from("foo($X)")),
@@ -126,21 +160,7 @@ fn v2_all_normalizes_to_and_with_correct_branches() {
         MatchFormula::Pattern(String::from("bar")),
     ]));
     match result {
-        Formula::And(branches) => {
-            assert_eq!(branches.len(), 2);
-            let first = branches.first().expect("expected first branch");
-            let second = branches.get(1).expect("expected second branch");
-            assert!(
-                matches!(&first.node, Formula::Atom(Atom::Pattern(p)) if p.text == "foo"),
-                "expected first branch Pattern(\"foo\"), got {:?}",
-                first.node
-            );
-            assert!(
-                matches!(&second.node, Formula::Atom(Atom::Pattern(p)) if p.text == "bar"),
-                "expected second branch Pattern(\"bar\"), got {:?}",
-                second.node
-            );
-        }
+        Formula::And(branches) => assert_two_pattern_branches(&branches, "foo", "bar"),
         other => panic!("expected And formula, got {other:?}"),
     }
 }
@@ -152,21 +172,7 @@ fn v2_any_normalizes_to_or_with_correct_branches() {
         MatchFormula::Pattern(String::from("bar")),
     ]));
     match result {
-        Formula::Or(branches) => {
-            assert_eq!(branches.len(), 2);
-            let first = branches.first().expect("expected first branch");
-            let second = branches.get(1).expect("expected second branch");
-            assert!(
-                matches!(&first.node, Formula::Atom(Atom::Pattern(p)) if p.text == "foo"),
-                "expected first branch Pattern(\"foo\"), got {:?}",
-                first.node
-            );
-            assert!(
-                matches!(&second.node, Formula::Atom(Atom::Pattern(p)) if p.text == "bar"),
-                "expected second branch Pattern(\"bar\"), got {:?}",
-                second.node
-            );
-        }
+        Formula::Or(branches) => assert_two_pattern_branches(&branches, "foo", "bar"),
         other => panic!("expected Or formula, got {other:?}"),
     }
 }
@@ -177,11 +183,7 @@ fn v2_not_normalizes_to_not_with_inner_pattern() {
         String::from("baz"),
     ))));
     match result {
-        Formula::Not(inner) => assert!(
-            matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == "baz"),
-            "expected inner Pattern(\"baz\"), got {:?}",
-            inner.node
-        ),
+        Formula::Not(inner) => assert_wraps_pattern_atom(&inner, "baz"),
         other => panic!("expected Not formula, got {other:?}"),
     }
 }
@@ -192,11 +194,7 @@ fn v2_inside_normalizes_to_inside_with_inner_pattern() {
         String::from("class X:"),
     ))));
     match result {
-        Formula::Inside(inner) => assert!(
-            matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == "class X:"),
-            "expected inner Pattern(\"class X:\"), got {:?}",
-            inner.node
-        ),
+        Formula::Inside(inner) => assert_wraps_pattern_atom(&inner, "class X:"),
         other => panic!("expected Inside formula, got {other:?}"),
     }
 }
@@ -207,11 +205,7 @@ fn v2_anywhere_normalizes_to_anywhere_with_inner_pattern() {
         String::from("unsafe"),
     ))));
     match result {
-        Formula::Anywhere(inner) => assert!(
-            matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == "unsafe"),
-            "expected inner Pattern(\"unsafe\"), got {:?}",
-            inner.node
-        ),
+        Formula::Anywhere(inner) => assert_wraps_pattern_atom(&inner, "unsafe"),
         other => panic!("expected Anywhere formula, got {other:?}"),
     }
 }

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -2,6 +2,7 @@
 
 use rstest::rstest;
 use sempai_core::{
+    DiagnosticCode,
     SourceSpan,
     formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom},
 };
@@ -15,7 +16,7 @@ use sempai_yaml::{
 };
 use serde_json::json;
 
-use crate::normalize::normalize_search_principal;
+use crate::{normalize::normalize_search_principal, semantic_check::validate_formula};
 
 /// Helper to normalize a legacy formula and extract the node.
 fn normalize_legacy(formula: LegacyFormula) -> Formula {
@@ -297,6 +298,32 @@ fn legacy_patterns_propagates_constraints_to_where_clauses() {
             "expected child {idx} of And to have empty where_clauses"
         );
     }
+}
+
+#[test]
+fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where_clauses() {
+    let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
+    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint.clone())]);
+
+    let decorated = normalize_legacy_decorated(legacy);
+
+    match &decorated.node {
+        Formula::And(children) => assert!(children.is_empty()),
+        other => panic!("expected normalized legacy Patterns to be And, got {other:?}"),
+    }
+    assert_eq!(decorated.where_clauses.len(), 1);
+    let clause = decorated
+        .where_clauses
+        .first()
+        .expect("expected at least one where_clause");
+    assert_eq!(clause.raw, constraint);
+
+    let err = validate_formula(&decorated).expect_err("constraint-only And should fail");
+    let first = err.diagnostics().first().expect("expected diagnostic");
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -78,6 +78,20 @@ fn assert_two_pattern_branches(
     );
 }
 
+fn extract_and_branches(f: Formula) -> Vec<Decorated<Formula>> {
+    match f {
+        Formula::And(b) => b,
+        other => panic!("expected And formula, got {other:?}"),
+    }
+}
+
+fn extract_or_branches(f: Formula) -> Vec<Decorated<Formula>> {
+    match f {
+        Formula::Or(b) => b,
+        other => panic!("expected Or formula, got {other:?}"),
+    }
+}
+
 #[rstest]
 #[case::pattern(
     LegacyFormula::Pattern(String::from("foo($X)")),
@@ -153,28 +167,28 @@ fn v2_atom_formula_normalizes_to_expected_formula(
     assert_eq!(result, expected);
 }
 
-#[test]
-fn v2_all_normalizes_to_and_with_correct_branches() {
-    let result = normalize_v2(MatchFormula::All(vec![
+#[rstest]
+#[case::all(
+    MatchFormula::All(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]));
-    match result {
-        Formula::And(branches) => assert_two_pattern_branches(&branches, "foo", "bar"),
-        other => panic!("expected And formula, got {other:?}"),
-    }
-}
-
-#[test]
-fn v2_any_normalizes_to_or_with_correct_branches() {
-    let result = normalize_v2(MatchFormula::Any(vec![
+    ]),
+    extract_and_branches as fn(Formula) -> Vec<Decorated<Formula>>,
+)]
+#[case::any(
+    MatchFormula::Any(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]));
-    match result {
-        Formula::Or(branches) => assert_two_pattern_branches(&branches, "foo", "bar"),
-        other => panic!("expected Or formula, got {other:?}"),
-    }
+    ]),
+    extract_or_branches as fn(Formula) -> Vec<Decorated<Formula>>,
+)]
+fn v2_branch_formula_normalizes_with_correct_branches(
+    #[case] input: MatchFormula,
+    #[case] extract: fn(Formula) -> Vec<Decorated<Formula>>,
+) {
+    let result = normalize_v2(input);
+    let branches = extract(result);
+    assert_two_pattern_branches(&branches, "foo", "bar");
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for formula normalization.
 
-use sempai_core::SourceSpan;
-use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom};
+use sempai_core::{
+    SourceSpan,
+    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom},
+};
 use sempai_yaml::{LegacyClause, LegacyFormula, LegacyValue, MatchFormula, SearchQueryPrincipal};
 use serde_json::json;
 

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -2,12 +2,10 @@
 
 use rstest::rstest;
 use sempai_core::{
-    DiagnosticCode,
     SourceSpan,
-    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom, WhereClause},
+    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom, TreeSitterQueryAtom},
 };
 use sempai_yaml::{
-    LegacyClause,
     LegacyFormula,
     LegacyValue,
     MatchFormula,
@@ -16,7 +14,7 @@ use sempai_yaml::{
 };
 use serde_json::json;
 
-use crate::{normalize::normalize_search_principal, semantic_check::validate_formula};
+use crate::normalize::normalize_search_principal;
 
 /// Helper to normalize a legacy formula and extract the node.
 fn normalize_legacy(formula: LegacyFormula) -> Formula {
@@ -24,25 +22,10 @@ fn normalize_legacy(formula: LegacyFormula) -> Formula {
     normalize_search_principal(&principal, None).node
 }
 
-/// Helper to normalize a legacy formula and keep the full decorated wrapper.
-///
-/// Useful for tests that need to inspect `where_clauses` or other metadata
-/// attached to the normalized formula.
-fn normalize_legacy_decorated(formula: LegacyFormula) -> Decorated<Formula> {
-    let principal = SearchQueryPrincipal::Legacy(formula);
-    normalize_search_principal(&principal, None)
-}
-
 /// Helper to normalize a v2 match formula and extract the node.
 fn normalize_v2(formula: MatchFormula) -> Formula {
     let principal = SearchQueryPrincipal::Match(formula);
     normalize_search_principal(&principal, None).node
-}
-
-/// Helper to normalize a v2 match formula and keep the full decorated wrapper.
-fn normalize_v2_decorated(formula: MatchFormula) -> Decorated<Formula> {
-    let principal = SearchQueryPrincipal::Match(formula);
-    normalize_search_principal(&principal, None)
 }
 
 /// Asserts that a `Decorated<Formula>` wraps a `Pattern` atom with the given text.
@@ -261,112 +244,6 @@ fn legacy_anywhere_normalizes_to_anywhere() {
         },
         _ => panic!("expected Anywhere formula from semgrep-internal-pattern-anywhere"),
     }
-}
-
-#[test]
-fn legacy_patterns_propagates_constraints_to_where_clauses() {
-    // Build a legacy `patterns: [...]` with two pattern clauses and one
-    // constraint clause. The constraint should end up on the enclosing And.
-    let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
-    let legacy = LegacyFormula::Patterns(vec![
-        LegacyClause::Formula(LegacyFormula::Pattern(String::from("foo($X)"))),
-        LegacyClause::Formula(LegacyFormula::Pattern(String::from("bar($X)"))),
-        LegacyClause::Constraint(constraint.clone()),
-    ]);
-
-    let decorated = normalize_legacy_decorated(legacy);
-
-    // Outer node must be an `And` combining the pattern formulas.
-    let children = match &decorated.node {
-        Formula::And(children) => children,
-        other => panic!("expected normalized legacy Patterns to be And, got {other:?}"),
-    };
-    assert_eq!(children.len(), 2);
-
-    // The constraint should be attached as a where_clause on the outer And.
-    assert_eq!(decorated.where_clauses.len(), 1);
-    let clause = decorated
-        .where_clauses
-        .first()
-        .expect("expected at least one where_clause");
-    assert_eq!(clause.raw, constraint);
-
-    // Child formulas themselves must not carry any where_clauses.
-    for (idx, child) in children.iter().enumerate() {
-        assert!(
-            child.where_clauses.is_empty(),
-            "expected child {idx} of And to have empty where_clauses"
-        );
-    }
-}
-
-#[test]
-fn legacy_patterns_with_only_constraints_produces_and_with_no_children_and_where_clauses() {
-    let constraint = json!({"metavariable-regex": {"metavariable": "$X", "regex": "foo.*"}});
-    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint.clone())]);
-
-    let decorated = normalize_legacy_decorated(legacy);
-
-    match &decorated.node {
-        Formula::And(children) => assert!(children.is_empty()),
-        other => panic!("expected normalized legacy Patterns to be And, got {other:?}"),
-    }
-    assert_eq!(decorated.where_clauses.len(), 1);
-    let clause = decorated
-        .where_clauses
-        .first()
-        .expect("expected at least one where_clause");
-    assert_eq!(clause.raw, constraint);
-
-    let err = validate_formula(&decorated).expect_err("constraint-only And should fail");
-    let first = err.diagnostics().first().expect("expected diagnostic");
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
-}
-
-#[test]
-fn legacy_patterns_with_only_metavariable_pattern_constraint_validates() {
-    let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
-    let legacy = LegacyFormula::Patterns(vec![LegacyClause::Constraint(constraint.clone())]);
-    let decorated = normalize_legacy_decorated(legacy);
-
-    assert!(matches!(&decorated.node, Formula::And(children) if children.is_empty()));
-    assert_eq!(
-        decorated.where_clauses,
-        vec![WhereClause { raw: constraint }]
-    );
-    assert!(validate_formula(&decorated).is_ok());
-}
-
-#[test]
-fn v2_decorated_preserves_where_as_and_fix_metadata() {
-    let constraint = json!({"metavariable-pattern": {"metavariable": "$X", "pattern": "bad"}});
-    let formula = MatchFormula::Decorated {
-        formula: Box::new(MatchFormula::Pattern(String::from("foo($X)"))),
-        where_clauses: vec![constraint.clone()],
-        as_name: Some(String::from("my_capture")),
-        fix: Some(String::from("replace_me")),
-    };
-
-    let decorated = normalize_v2_decorated(formula);
-
-    // The core node should be the normalized pattern atom.
-    assert!(matches!(
-        &decorated.node,
-        Formula::Atom(Atom::Pattern(pat)) if pat.text == "foo($X)"
-    ));
-
-    // Metadata should be preserved on the Decorated wrapper.
-    assert_eq!(decorated.as_name.as_deref(), Some("my_capture"));
-    assert_eq!(decorated.fix.as_deref(), Some("replace_me"));
-    assert_eq!(decorated.where_clauses.len(), 1);
-    let clause = decorated
-        .where_clauses
-        .first()
-        .expect("expected at least one where_clause");
-    assert_eq!(clause.raw, constraint);
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -80,6 +80,27 @@ fn extract_or_branches(f: Formula) -> Vec<Decorated<Formula>> {
     }
 }
 
+fn extract_not_inner(f: Formula) -> Box<Decorated<Formula>> {
+    match f {
+        Formula::Not(inner) => inner,
+        other => panic!("expected Not formula, got {other:?}"),
+    }
+}
+
+fn extract_inside_inner(f: Formula) -> Box<Decorated<Formula>> {
+    match f {
+        Formula::Inside(inner) => inner,
+        other => panic!("expected Inside formula, got {other:?}"),
+    }
+}
+
+fn extract_anywhere_inner(f: Formula) -> Box<Decorated<Formula>> {
+    match f {
+        Formula::Anywhere(inner) => inner,
+        other => panic!("expected Anywhere formula, got {other:?}"),
+    }
+}
+
 #[rstest]
 #[case::pattern(
     LegacyFormula::Pattern(String::from("foo($X)")),
@@ -179,37 +200,30 @@ fn v2_branch_formula_normalizes_with_correct_branches(
     assert_two_pattern_branches(&branches, "foo", "bar");
 }
 
-#[test]
-fn v2_not_normalizes_to_not_with_inner_pattern() {
-    let result = normalize_v2(MatchFormula::Not(Box::new(MatchFormula::Pattern(
-        String::from("baz"),
-    ))));
-    match result {
-        Formula::Not(inner) => assert_wraps_pattern_atom(&inner, "baz"),
-        other => panic!("expected Not formula, got {other:?}"),
-    }
-}
-
-#[test]
-fn v2_inside_normalizes_to_inside_with_inner_pattern() {
-    let result = normalize_v2(MatchFormula::Inside(Box::new(MatchFormula::Pattern(
-        String::from("class X:"),
-    ))));
-    match result {
-        Formula::Inside(inner) => assert_wraps_pattern_atom(&inner, "class X:"),
-        other => panic!("expected Inside formula, got {other:?}"),
-    }
-}
-
-#[test]
-fn v2_anywhere_normalizes_to_anywhere_with_inner_pattern() {
-    let result = normalize_v2(MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(
-        String::from("unsafe"),
-    ))));
-    match result {
-        Formula::Anywhere(inner) => assert_wraps_pattern_atom(&inner, "unsafe"),
-        other => panic!("expected Anywhere formula, got {other:?}"),
-    }
+#[rstest]
+#[case::not(
+    MatchFormula::Not(Box::new(MatchFormula::Pattern(String::from("baz")))),
+    extract_not_inner as fn(Formula) -> Box<Decorated<Formula>>,
+    "baz",
+)]
+#[case::inside(
+    MatchFormula::Inside(Box::new(MatchFormula::Pattern(String::from("class X:")))),
+    extract_inside_inner as fn(Formula) -> Box<Decorated<Formula>>,
+    "class X:",
+)]
+#[case::anywhere(
+    MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(String::from("unsafe")))),
+    extract_anywhere_inner as fn(Formula) -> Box<Decorated<Formula>>,
+    "unsafe",
+)]
+fn v2_unary_wrapper_normalizes_to_inner_pattern(
+    #[case] input: MatchFormula,
+    #[case] extract: fn(Formula) -> Box<Decorated<Formula>>,
+    #[case] expected_text: &str,
+) {
+    let result = normalize_v2(input);
+    let inner = extract(result);
+    assert_wraps_pattern_atom(&inner, expected_text);
 }
 
 #[test]

--- a/crates/sempai/src/tests/normalization_tests.rs
+++ b/crates/sempai/src/tests/normalization_tests.rs
@@ -119,39 +119,101 @@ fn v2_atom_formula_normalizes_to_expected_formula(
     assert_eq!(result, expected);
 }
 
-#[rstest]
-#[case::all(
-    MatchFormula::All(vec![
+#[test]
+fn v2_all_normalizes_to_and_with_correct_branches() {
+    let result = normalize_v2(MatchFormula::All(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]),
-    |normalised| matches!(normalised, Formula::And(branches) if branches.len() == 2)
-)]
-#[case::any(
-    MatchFormula::Any(vec![
+    ]));
+    match result {
+        Formula::And(branches) => {
+            assert_eq!(branches.len(), 2);
+            let first = branches.first().expect("expected first branch");
+            let second = branches.get(1).expect("expected second branch");
+            assert!(
+                matches!(&first.node, Formula::Atom(Atom::Pattern(p)) if p.text == "foo"),
+                "expected first branch Pattern(\"foo\"), got {:?}",
+                first.node
+            );
+            assert!(
+                matches!(&second.node, Formula::Atom(Atom::Pattern(p)) if p.text == "bar"),
+                "expected second branch Pattern(\"bar\"), got {:?}",
+                second.node
+            );
+        }
+        other => panic!("expected And formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_any_normalizes_to_or_with_correct_branches() {
+    let result = normalize_v2(MatchFormula::Any(vec![
         MatchFormula::Pattern(String::from("foo")),
         MatchFormula::Pattern(String::from("bar")),
-    ]),
-    |normalised| matches!(normalised, Formula::Or(branches) if branches.len() == 2)
-)]
-#[case::not(
-    MatchFormula::Not(Box::new(MatchFormula::Pattern(String::from("baz")))),
-    |normalised| matches!(normalised, Formula::Not(_))
-)]
-#[case::inside(
-    MatchFormula::Inside(Box::new(MatchFormula::Pattern(String::from("class X:")))),
-    |normalised| matches!(normalised, Formula::Inside(_))
-)]
-#[case::anywhere(
-    MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(String::from("unsafe")))),
-    |normalised| matches!(normalised, Formula::Anywhere(_))
-)]
-fn v2_structural_formula_normalizes_to_expected_shape(
-    #[case] formula: MatchFormula,
-    #[case] expected_shape: fn(Formula) -> bool,
-) {
-    let result = normalize_v2(formula);
-    assert!(expected_shape(result));
+    ]));
+    match result {
+        Formula::Or(branches) => {
+            assert_eq!(branches.len(), 2);
+            let first = branches.first().expect("expected first branch");
+            let second = branches.get(1).expect("expected second branch");
+            assert!(
+                matches!(&first.node, Formula::Atom(Atom::Pattern(p)) if p.text == "foo"),
+                "expected first branch Pattern(\"foo\"), got {:?}",
+                first.node
+            );
+            assert!(
+                matches!(&second.node, Formula::Atom(Atom::Pattern(p)) if p.text == "bar"),
+                "expected second branch Pattern(\"bar\"), got {:?}",
+                second.node
+            );
+        }
+        other => panic!("expected Or formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_not_normalizes_to_not_with_inner_pattern() {
+    let result = normalize_v2(MatchFormula::Not(Box::new(MatchFormula::Pattern(
+        String::from("baz"),
+    ))));
+    match result {
+        Formula::Not(inner) => assert!(
+            matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == "baz"),
+            "expected inner Pattern(\"baz\"), got {:?}",
+            inner.node
+        ),
+        other => panic!("expected Not formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_inside_normalizes_to_inside_with_inner_pattern() {
+    let result = normalize_v2(MatchFormula::Inside(Box::new(MatchFormula::Pattern(
+        String::from("class X:"),
+    ))));
+    match result {
+        Formula::Inside(inner) => assert!(
+            matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == "class X:"),
+            "expected inner Pattern(\"class X:\"), got {:?}",
+            inner.node
+        ),
+        other => panic!("expected Inside formula, got {other:?}"),
+    }
+}
+
+#[test]
+fn v2_anywhere_normalizes_to_anywhere_with_inner_pattern() {
+    let result = normalize_v2(MatchFormula::Anywhere(Box::new(MatchFormula::Pattern(
+        String::from("unsafe"),
+    ))));
+    match result {
+        Formula::Anywhere(inner) => assert!(
+            matches!(&inner.node, Formula::Atom(Atom::Pattern(p)) if p.text == "unsafe"),
+            "expected inner Pattern(\"unsafe\"), got {:?}",
+            inner.node
+        ),
+        other => panic!("expected Anywhere formula, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/sempai/src/tests/property_tests.rs
+++ b/crates/sempai/src/tests/property_tests.rs
@@ -1,0 +1,236 @@
+//! Property tests for semantic formula validation invariants.
+
+use proptest::{collection::vec, prelude::*};
+use sempai_core::{
+    DiagnosticCode,
+    SourceSpan,
+    formula::{Atom, Decorated, Formula, PatternAtom, RegexAtom},
+};
+
+use crate::semantic_check::validate_formula;
+
+const MAX_DEPTH: u32 = 4;
+const MAX_SIZE: u32 = 32;
+const MAX_BRANCHES: u32 = 3;
+
+fn decorated(node: Formula, span: Option<SourceSpan>) -> Decorated<Formula> {
+    Decorated {
+        node,
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span,
+    }
+}
+
+fn span_strategy() -> impl Strategy<Value = Option<SourceSpan>> {
+    prop_oneof![
+        Just(None),
+        (0_u32..100, 1_u32..20).prop_map(|(start, len)| {
+            Some(SourceSpan::new(start, start.saturating_add(len), None))
+        }),
+    ]
+}
+
+fn atom_strategy() -> BoxedStrategy<Decorated<Formula>> {
+    (
+        prop_oneof![Just(String::from("foo")), Just(String::from("bar"))],
+        any::<bool>(),
+        span_strategy(),
+    )
+        .prop_map(|(text, is_regex, span)| {
+            let atom = if is_regex {
+                Atom::Regex(RegexAtom { pattern: text })
+            } else {
+                Atom::Pattern(PatternAtom { text })
+            };
+            decorated(Formula::Atom(atom), span)
+        })
+        .boxed()
+}
+
+fn formula_tree() -> BoxedStrategy<Decorated<Formula>> {
+    atom_strategy()
+        .prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
+            let unary =
+                (0_u8..3, inner.clone(), span_strategy()).prop_map(|(variant, child, span)| {
+                    let node = match variant {
+                        0 => Formula::Not(Box::new(child)),
+                        1 => Formula::Inside(Box::new(child)),
+                        _ => Formula::Anywhere(Box::new(child)),
+                    };
+                    decorated(node, span)
+                });
+            let nary = (
+                any::<bool>(),
+                vec(inner, 0..=MAX_BRANCHES as usize),
+                span_strategy(),
+            )
+                .prop_map(|(is_and, branches, span)| {
+                    let node = if is_and {
+                        Formula::And(branches)
+                    } else {
+                        Formula::Or(branches)
+                    };
+                    decorated(node, span)
+                });
+            prop_oneof![unary, nary]
+        })
+        .boxed()
+}
+
+fn tree_with_not() -> BoxedStrategy<Decorated<Formula>> {
+    (formula_tree(), span_strategy())
+        .prop_map(|(child, span)| decorated(Formula::Not(Box::new(child)), span))
+        .boxed()
+}
+
+fn or_with_not_descendant() -> BoxedStrategy<Decorated<Formula>> {
+    (
+        vec(formula_tree(), 0..=2),
+        tree_with_not(),
+        vec(formula_tree(), 0..=2),
+        span_strategy(),
+    )
+        .prop_map(|(mut before, not_branch, after, span)| {
+            before.push(not_branch);
+            before.extend(after);
+            decorated(Formula::Or(before), span)
+        })
+        .boxed()
+}
+
+fn atomless_tree_without_not_in_or() -> BoxedStrategy<Decorated<Formula>> {
+    let leaf = span_strategy()
+        .prop_map(|span| decorated(Formula::And(vec![]), span))
+        .boxed();
+
+    leaf.prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
+        let unary = (0_u8..3, inner.clone(), span_strategy()).prop_map(|(variant, child, span)| {
+            let node = match variant {
+                0 => Formula::Not(Box::new(child)),
+                1 => Formula::Inside(Box::new(child)),
+                _ => Formula::Anywhere(Box::new(child)),
+            };
+            decorated(node, span)
+        });
+        let and = (vec(inner, 0..=MAX_BRANCHES as usize), span_strategy())
+            .prop_map(|(branches, span)| decorated(Formula::And(branches), span));
+        prop_oneof![unary, and]
+    })
+    .boxed()
+}
+
+fn and_without_positive_descendant() -> BoxedStrategy<Decorated<Formula>> {
+    (
+        vec(atomless_tree_without_not_in_or(), 0..=MAX_BRANCHES as usize),
+        span_strategy(),
+    )
+        .prop_map(|(branches, span)| decorated(Formula::And(branches), span))
+        .boxed()
+}
+
+fn valid_no_not_tree() -> BoxedStrategy<Decorated<Formula>> {
+    atom_strategy()
+        .prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
+            let unary = (any::<bool>(), inner.clone(), span_strategy()).prop_map(
+                |(is_inside, child, span)| {
+                    let node = if is_inside {
+                        Formula::Inside(Box::new(child))
+                    } else {
+                        Formula::Anywhere(Box::new(child))
+                    };
+                    decorated(node, span)
+                },
+            );
+            let or = (vec(inner, 0..=MAX_BRANCHES as usize), span_strategy())
+                .prop_map(|(branches, span)| decorated(Formula::Or(branches), span));
+            prop_oneof![unary, or]
+        })
+        .boxed()
+}
+
+fn positive_tree() -> BoxedStrategy<Decorated<Formula>> {
+    atom_strategy()
+        .prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
+            let constraint =
+                (0_u8..3, atom_strategy(), span_strategy()).prop_map(|(variant, child, span)| {
+                    let node = match variant {
+                        0 => Formula::Not(Box::new(child)),
+                        1 => Formula::Inside(Box::new(child)),
+                        _ => Formula::Anywhere(Box::new(child)),
+                    };
+                    decorated(node, span)
+                });
+            let and = (
+                vec(prop_oneof![inner.clone(), constraint], 0..=2),
+                inner.clone(),
+                vec(inner.clone(), 0..=2),
+                span_strategy(),
+            )
+                .prop_map(|(mut before, positive, after, span)| {
+                    before.push(positive);
+                    before.extend(after);
+                    decorated(Formula::And(before), span)
+                });
+            let or = (
+                vec(valid_no_not_tree(), 0..=2),
+                atom_strategy(),
+                vec(valid_no_not_tree(), 0..=2),
+                span_strategy(),
+            )
+                .prop_map(|(mut before, positive, after, span)| {
+                    before.push(positive);
+                    before.extend(after);
+                    decorated(Formula::Or(before), span)
+                });
+            prop_oneof![and, or, inner]
+        })
+        .boxed()
+}
+
+fn first_diagnostic_code(formula: &Decorated<Formula>) -> DiagnosticCode {
+    let err = validate_formula(formula).expect_err("formula should fail validation");
+    err.diagnostics()
+        .first()
+        .expect("should have diagnostic")
+        .code()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 32,
+        max_shrink_iters: 128,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn prop_invalid_not_in_or_rejected(formula in or_with_not_descendant()) {
+        prop_assert_eq!(
+            first_diagnostic_code(&formula),
+            DiagnosticCode::ESempaiInvalidNotInOr
+        );
+    }
+
+    #[test]
+    fn prop_missing_positive_in_and_rejected(formula in and_without_positive_descendant()) {
+        let expected_span = formula
+            .span
+            .clone()
+            .or_else(|| match &formula.node {
+                Formula::And(branches) => branches.first().and_then(|branch| branch.span.clone()),
+                _ => None,
+            });
+
+        let err = validate_formula(&formula).expect_err("formula should fail validation");
+        let first = err.diagnostics().first().expect("should have diagnostic");
+
+        prop_assert_eq!(first.code(), DiagnosticCode::ESempaiMissingPositiveTermInAnd);
+        prop_assert_eq!(first.primary_span(), expected_span.as_ref());
+    }
+
+    #[test]
+    fn prop_valid_positive_tree_ok(formula in positive_tree()) {
+        prop_assert!(validate_formula(&formula).is_ok());
+    }
+}

--- a/crates/sempai/src/tests/property_tests.rs
+++ b/crates/sempai/src/tests/property_tests.rs
@@ -219,7 +219,9 @@ proptest! {
             .span
             .clone()
             .or_else(|| match &formula.node {
-                Formula::And(branches) => branches.first().and_then(|branch| branch.span.clone()),
+                Formula::And(branches) => branches
+                    .iter()
+                    .find_map(|branch| branch.span.clone()),
                 _ => None,
             });
 

--- a/crates/sempai/src/tests/property_tests.rs
+++ b/crates/sempai/src/tests/property_tests.rs
@@ -9,7 +9,7 @@ use sempai_core::{
 
 use crate::semantic_check::validate_formula;
 
-const MAX_DEPTH: u32 = 4;
+const MAX_DEPTH: u32 = 5;
 const MAX_SIZE: u32 = 32;
 const MAX_BRANCHES: u32 = 3;
 
@@ -25,7 +25,8 @@ fn decorated(node: Formula, span: Option<SourceSpan>) -> Decorated<Formula> {
 
 fn span_strategy() -> impl Strategy<Value = Option<SourceSpan>> {
     prop_oneof![
-        Just(None),
+        7 => Just(None),
+        3 =>
         (0_u32..100, 1_u32..20).prop_map(|(start, len)| {
             Some(SourceSpan::new(start, start.saturating_add(len), None))
         }),
@@ -199,13 +200,13 @@ fn first_diagnostic_code(formula: &Decorated<Formula>) -> DiagnosticCode {
 
 proptest! {
     #![proptest_config(ProptestConfig {
-        cases: 32,
+        cases: 64,
         max_shrink_iters: 128,
         ..ProptestConfig::default()
     })]
 
     #[test]
-    fn prop_invalid_not_in_or_rejected(formula in or_with_not_descendant()) {
+    fn prop_or_branch_containing_negation_is_rejected(formula in or_with_not_descendant()) {
         prop_assert_eq!(
             first_diagnostic_code(&formula),
             DiagnosticCode::ESempaiInvalidNotInOr
@@ -213,7 +214,7 @@ proptest! {
     }
 
     #[test]
-    fn prop_missing_positive_in_and_rejected(formula in and_without_positive_descendant()) {
+    fn prop_and_with_no_positive_term_is_rejected(formula in and_without_positive_descendant()) {
         let expected_span = formula
             .span
             .clone()
@@ -230,7 +231,7 @@ proptest! {
     }
 
     #[test]
-    fn prop_valid_positive_tree_ok(formula in positive_tree()) {
+    fn prop_valid_tree_with_positive_in_every_and_is_ok(formula in positive_tree()) {
         prop_assert!(validate_formula(&formula).is_ok());
     }
 }

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -1,0 +1,139 @@
+//! Tests for semantic formula validation.
+
+use sempai_core::DiagnosticCode;
+use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
+
+use crate::semantic_check::validate_formula;
+
+fn make_pattern(text: &str) -> Decorated<Formula> {
+    Decorated {
+        node: Formula::Atom(Atom::Pattern(PatternAtom {
+            text: String::from(text),
+        })),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
+}
+
+#[test]
+fn valid_or_with_positive_branches_passes() {
+    let formula = Decorated {
+        node: Formula::Or(vec![make_pattern("foo"), make_pattern("bar")]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let result = validate_formula(&formula);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn or_with_not_branch_fails() {
+    let not_branch = Decorated {
+        node: Formula::Not(Box::new(make_pattern("baz"))),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let formula = Decorated {
+        node: Formula::Or(vec![make_pattern("foo"), not_branch]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let result = validate_formula(&formula);
+    let err = result.expect_err("should fail validation");
+    let first = err.diagnostics().first().expect("should have diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+}
+
+#[test]
+fn valid_and_with_positive_term_passes() {
+    let formula = Decorated {
+        node: Formula::And(vec![
+            make_pattern("foo"),
+            Decorated {
+                node: Formula::Not(Box::new(make_pattern("bar"))),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: None,
+            },
+        ]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let result = validate_formula(&formula);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn and_with_only_constraints_fails() {
+    let formula = Decorated {
+        node: Formula::And(vec![
+            Decorated {
+                node: Formula::Not(Box::new(make_pattern("foo"))),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: None,
+            },
+            Decorated {
+                node: Formula::Inside(Box::new(make_pattern("bar"))),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: None,
+            },
+        ]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let result = validate_formula(&formula);
+    let err = result.expect_err("should fail validation");
+    let first = err.diagnostics().first().expect("should have diagnostic");
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+}
+
+#[test]
+fn nested_or_in_and_with_not_fails() {
+    let nested_or = Decorated {
+        node: Formula::Or(vec![
+            make_pattern("a"),
+            Decorated {
+                node: Formula::Not(Box::new(make_pattern("b"))),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: None,
+            },
+        ]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let formula = Decorated {
+        node: Formula::And(vec![make_pattern("foo"), nested_or]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let result = validate_formula(&formula);
+    let err = result.expect_err("should fail validation");
+    let first = err.diagnostics().first().expect("should have diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+}

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -115,6 +115,40 @@ fn and_with_only_constraints_fails() {
 }
 
 #[test]
+fn and_with_or_containing_only_constraints_fails() {
+    // `And[Or[Inside[Atom]]]` must not pass: the Or's only branch is a
+    // constraint-only term, so the whole combinator lacks a positive term.
+    let inside_only = Decorated {
+        node: Formula::Inside(Box::new(make_pattern("ctx"))),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let or_of_constraints = Decorated {
+        node: Formula::Or(vec![inside_only]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let formula = Decorated {
+        node: Formula::And(vec![or_of_constraints]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let result = validate_formula(&formula);
+    let err = result.expect_err("should fail validation");
+    let first = err.diagnostics().first().expect("should have diagnostic");
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+}
+
+#[test]
 fn nested_or_in_and_with_not_fails() {
     let nested_or = Decorated {
         node: Formula::Or(vec![

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -18,6 +18,13 @@ fn make_pattern(text: &str) -> Decorated<Formula> {
 }
 
 #[test]
+fn single_positive_atom_passes_validation() {
+    let formula = make_pattern("foo");
+    let result = validate_formula(&formula);
+    assert!(result.is_ok());
+}
+
+#[test]
 fn valid_or_with_positive_branches_passes() {
     let formula = Decorated {
         node: Formula::Or(vec![make_pattern("foo"), make_pattern("bar")]),

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -219,6 +219,24 @@ fn invalid_not_in_or_prefers_branch_span() {
 }
 
 #[test]
+fn invalid_not_in_or_prefers_nested_not_span_over_fallback() {
+    let not_span = SourceSpan::new(90, 100, None);
+    let fallback_span = SourceSpan::new(110, 120, None);
+    let formula = with_span(
+        make_or(vec![make_inside(with_span(
+            make_not(make_pattern("bad")),
+            not_span.clone(),
+        ))]),
+        fallback_span,
+    );
+
+    let diagnostic = first_validation_diagnostic(&formula);
+
+    assert_eq!(diagnostic.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+    assert_eq!(diagnostic.primary_span(), Some(&not_span));
+}
+
+#[test]
 fn deeply_nested_or_with_negation_anywhere_fails() {
     let nested_and = make_and(vec![
         make_inside(make_pattern("x")),

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -26,119 +26,82 @@ fn assert_invalid_not_in_or(formula: &Decorated<Formula>) {
     assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
 }
 
+fn make_not(inner: Decorated<Formula>) -> Decorated<Formula> {
+    Decorated {
+        node: Formula::Not(Box::new(inner)),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
+}
+
+fn make_or(branches: Vec<Decorated<Formula>>) -> Decorated<Formula> {
+    Decorated {
+        node: Formula::Or(branches),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
+}
+
+fn make_and(branches: Vec<Decorated<Formula>>) -> Decorated<Formula> {
+    Decorated {
+        node: Formula::And(branches),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
+}
+
+fn make_inside(inner: Decorated<Formula>) -> Decorated<Formula> {
+    Decorated {
+        node: Formula::Inside(Box::new(inner)),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
+}
+
 #[test]
 fn single_positive_atom_passes_validation() {
-    let formula = make_pattern("foo");
-    let result = validate_formula(&formula);
-    assert!(result.is_ok());
+    assert!(validate_formula(&make_pattern("foo")).is_ok());
 }
 
 #[test]
 fn valid_or_with_positive_branches_passes() {
-    let formula = Decorated {
-        node: Formula::Or(vec![make_pattern("foo"), make_pattern("bar")]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
-    let result = validate_formula(&formula);
-    assert!(result.is_ok());
+    let formula = make_or(vec![make_pattern("foo"), make_pattern("bar")]);
+    assert!(validate_formula(&formula).is_ok());
 }
 
 #[test]
 fn or_with_not_branch_fails() {
-    let not_branch = Decorated {
-        node: Formula::Not(Box::new(make_pattern("baz"))),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
-    let formula = Decorated {
-        node: Formula::Or(vec![make_pattern("foo"), not_branch]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
+    let formula = make_or(vec![make_pattern("foo"), make_not(make_pattern("baz"))]);
     assert_invalid_not_in_or(&formula);
 }
 
 #[test]
 fn or_with_nested_not_branch_fails() {
-    let nested_and = Decorated {
-        node: Formula::And(vec![
-            make_pattern("foo"),
-            Decorated {
-                node: Formula::Not(Box::new(make_pattern("bar"))),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: None,
-            },
-        ]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
-    let formula = Decorated {
-        node: Formula::Or(vec![nested_and]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
+    let nested_and = make_and(vec![make_pattern("foo"), make_not(make_pattern("bar"))]);
+    let formula = make_or(vec![nested_and]);
     assert_invalid_not_in_or(&formula);
 }
 
 #[test]
 fn valid_and_with_positive_term_passes() {
-    let formula = Decorated {
-        node: Formula::And(vec![
-            make_pattern("foo"),
-            Decorated {
-                node: Formula::Not(Box::new(make_pattern("bar"))),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: None,
-            },
-        ]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
-    let result = validate_formula(&formula);
-    assert!(result.is_ok());
+    let formula = make_and(vec![make_pattern("foo"), make_not(make_pattern("bar"))]);
+    assert!(validate_formula(&formula).is_ok());
 }
 
 #[test]
 fn and_with_only_constraints_fails() {
-    let formula = Decorated {
-        node: Formula::And(vec![
-            Decorated {
-                node: Formula::Not(Box::new(make_pattern("foo"))),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: None,
-            },
-            Decorated {
-                node: Formula::Inside(Box::new(make_pattern("bar"))),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: None,
-            },
-        ]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
+    let formula = make_and(vec![
+        make_not(make_pattern("foo")),
+        make_inside(make_pattern("bar")),
+    ]);
     let result = validate_formula(&formula);
     let err = result.expect_err("should fail validation");
     let first = err.diagnostics().first().expect("should have diagnostic");
@@ -150,29 +113,7 @@ fn and_with_only_constraints_fails() {
 
 #[test]
 fn and_with_or_containing_only_constraints_fails() {
-    // `And[Or[Inside[Atom]]]` must not pass: the Or's only branch is a
-    // constraint-only term, so the whole combinator lacks a positive term.
-    let inside_only = Decorated {
-        node: Formula::Inside(Box::new(make_pattern("ctx"))),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
-    let or_of_constraints = Decorated {
-        node: Formula::Or(vec![inside_only]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
-    let formula = Decorated {
-        node: Formula::And(vec![or_of_constraints]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
+    let formula = make_and(vec![make_or(vec![make_inside(make_pattern("ctx"))])]);
     let result = validate_formula(&formula);
     let err = result.expect_err("should fail validation");
     let first = err.diagnostics().first().expect("should have diagnostic");
@@ -184,28 +125,7 @@ fn and_with_or_containing_only_constraints_fails() {
 
 #[test]
 fn nested_or_in_and_with_not_fails() {
-    let nested_or = Decorated {
-        node: Formula::Or(vec![
-            make_pattern("a"),
-            Decorated {
-                node: Formula::Not(Box::new(make_pattern("b"))),
-                where_clauses: vec![],
-                as_name: None,
-                fix: None,
-                span: None,
-            },
-        ]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
-    let formula = Decorated {
-        node: Formula::And(vec![make_pattern("foo"), nested_or]),
-        where_clauses: vec![],
-        as_name: None,
-        fix: None,
-        span: None,
-    };
+    let nested_or = make_or(vec![make_pattern("a"), make_not(make_pattern("b"))]);
+    let formula = make_and(vec![make_pattern("foo"), nested_or]);
     assert_invalid_not_in_or(&formula);
 }

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -1,5 +1,6 @@
 //! Tests for semantic formula validation.
 
+use rstest::rstest;
 use sempai_core::{
     DiagnosticCode,
     SourceSpan,
@@ -91,6 +92,39 @@ fn make_inside(inner: Decorated<Formula>) -> Decorated<Formula> {
     }
 }
 
+fn sp(uri: &str, start: usize, end: usize) -> SourceSpan {
+    let uri_opt = if uri.is_empty() {
+        None
+    } else {
+        Some(uri.to_owned())
+    };
+    SourceSpan::new(
+        u32::try_from(start).expect("span start fits u32"),
+        u32::try_from(end).expect("span end fits u32"),
+        uri_opt,
+    )
+}
+
+fn build_constraint_only_and(
+    node_span: Option<SourceSpan>,
+    children: Vec<Decorated<Formula>>,
+) -> Decorated<Formula> {
+    let formula = make_and(children);
+    match node_span {
+        Some(span) => with_span(formula, span),
+        None => formula,
+    }
+}
+
+fn assert_missing_positive_primary_span(formula: &Decorated<Formula>, expected: &SourceSpan) {
+    let first = first_validation_diagnostic(formula);
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+    assert_eq!(first.primary_span(), Some(expected));
+}
+
 #[test]
 fn single_positive_atom_passes_validation() {
     assert!(validate_formula(&make_pattern("foo")).is_ok());
@@ -143,59 +177,38 @@ fn nested_or_in_and_with_not_fails() {
     assert_invalid_not_in_or(&formula);
 }
 
-#[test]
-fn missing_positive_term_in_and_prefers_node_span() {
-    let node_span = SourceSpan::new(10, 20, None);
-    let child_span = SourceSpan::new(30, 40, None);
-    let formula = with_span(
-        make_and(vec![with_span(
-            make_inside(make_pattern("bar")),
-            child_span,
-        )]),
-        node_span.clone(),
-    );
-
-    let first = first_validation_diagnostic(&formula);
-
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
-    assert_eq!(first.primary_span(), Some(&node_span));
-}
-
-#[test]
-fn missing_positive_term_in_and_uses_first_child_span_when_node_span_none() {
-    let child_span = SourceSpan::new(30, 40, None);
-    let formula = make_and(vec![with_span(
+#[rstest]
+#[case::prefers_node_span(
+    Some(sp("", 10, 20)),
+    vec![with_span(
         make_inside(make_pattern("bar")),
-        child_span.clone(),
-    )]);
-
-    let first = first_validation_diagnostic(&formula);
-
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
-    assert_eq!(first.primary_span(), Some(&child_span));
-}
-
-#[test]
-fn missing_positive_term_in_and_uses_first_available_child_span() {
-    let later_child_span = SourceSpan::new(35, 45, None);
-    let formula = make_and(vec![
+        sp("", 30, 40),
+    )],
+    sp("", 10, 20),
+)]
+#[case::uses_first_child_span_when_node_span_none(
+    None,
+    vec![with_span(
+        make_inside(make_pattern("bar")),
+        sp("", 30, 40),
+    )],
+    sp("", 30, 40),
+)]
+#[case::uses_first_available_child_span(
+    None,
+    vec![
         make_inside(make_pattern("foo")),
-        with_span(make_not(make_pattern("bar")), later_child_span.clone()),
-    ]);
-
-    let first = first_validation_diagnostic(&formula);
-
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
-    assert_eq!(first.primary_span(), Some(&later_child_span));
+        with_span(make_not(make_pattern("bar")), sp("", 35, 45)),
+    ],
+    sp("", 35, 45),
+)]
+fn missing_positive_term_in_and_primary_span_selection(
+    #[case] node_span: Option<SourceSpan>,
+    #[case] children: Vec<Decorated<Formula>>,
+    #[case] expected_primary: SourceSpan,
+) {
+    let formula = build_constraint_only_and(node_span, children);
+    assert_missing_positive_primary_span(&formula, &expected_primary);
 }
 
 #[test]

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -19,6 +19,13 @@ fn make_pattern(text: &str) -> Decorated<Formula> {
     }
 }
 
+fn assert_invalid_not_in_or(formula: &Decorated<Formula>) {
+    let result = validate_formula(formula);
+    let err = result.expect_err("should fail validation");
+    let first = err.diagnostics().first().expect("should have diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+}
+
 #[test]
 fn single_positive_atom_passes_validation() {
     let formula = make_pattern("foo");
@@ -55,10 +62,7 @@ fn or_with_not_branch_fails() {
         fix: None,
         span: None,
     };
-    let result = validate_formula(&formula);
-    let err = result.expect_err("should fail validation");
-    let first = err.diagnostics().first().expect("should have diagnostic");
-    assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+    assert_invalid_not_in_or(&formula);
 }
 
 #[test]
@@ -86,10 +90,7 @@ fn or_with_nested_not_branch_fails() {
         fix: None,
         span: None,
     };
-    let result = validate_formula(&formula);
-    let err = result.expect_err("should fail validation");
-    let first = err.diagnostics().first().expect("should have diagnostic");
-    assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+    assert_invalid_not_in_or(&formula);
 }
 
 #[test]

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -182,6 +182,23 @@ fn missing_positive_term_in_and_uses_first_child_span_when_node_span_none() {
 }
 
 #[test]
+fn missing_positive_term_in_and_uses_first_available_child_span() {
+    let later_child_span = SourceSpan::new(35, 45, None);
+    let formula = make_and(vec![
+        make_inside(make_pattern("foo")),
+        with_span(make_not(make_pattern("bar")), later_child_span.clone()),
+    ]);
+
+    let first = first_validation_diagnostic(&formula);
+
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+    assert_eq!(first.primary_span(), Some(&later_child_span));
+}
+
+#[test]
 fn invalid_not_in_or_prefers_branch_span() {
     let branch_span = SourceSpan::new(50, 60, None);
     let branch_span_formula = make_or(vec![

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for semantic formula validation.
 
-use sempai_core::DiagnosticCode;
-use sempai_core::formula::{Atom, Decorated, Formula, PatternAtom};
+use sempai_core::{
+    DiagnosticCode,
+    formula::{Atom, Decorated, Formula, PatternAtom},
+};
 
 use crate::semantic_check::validate_formula;
 

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -62,6 +62,37 @@ fn or_with_not_branch_fails() {
 }
 
 #[test]
+fn or_with_nested_not_branch_fails() {
+    let nested_and = Decorated {
+        node: Formula::And(vec![
+            make_pattern("foo"),
+            Decorated {
+                node: Formula::Not(Box::new(make_pattern("bar"))),
+                where_clauses: vec![],
+                as_name: None,
+                fix: None,
+                span: None,
+            },
+        ]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let formula = Decorated {
+        node: Formula::Or(vec![nested_and]),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    };
+    let result = validate_formula(&formula);
+    let err = result.expect_err("should fail validation");
+    let first = err.diagnostics().first().expect("should have diagnostic");
+    assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+}
+
+#[test]
 fn valid_and_with_positive_term_passes() {
     let formula = Decorated {
         node: Formula::And(vec![

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -2,6 +2,7 @@
 
 use sempai_core::{
     DiagnosticCode,
+    SourceSpan,
     formula::{Atom, Decorated, Formula, PatternAtom},
 };
 
@@ -19,6 +20,11 @@ fn make_pattern(text: &str) -> Decorated<Formula> {
     }
 }
 
+fn with_span(mut formula: Decorated<Formula>, span: SourceSpan) -> Decorated<Formula> {
+    formula.span = Some(span);
+    formula
+}
+
 fn assert_invalid_not_in_or(formula: &Decorated<Formula>) {
     let result = validate_formula(formula);
     let err = result.expect_err("should fail validation");
@@ -34,6 +40,15 @@ fn assert_missing_positive_term_in_and(formula: &Decorated<Formula>) {
         first.code(),
         DiagnosticCode::ESempaiMissingPositiveTermInAnd
     );
+}
+
+fn first_validation_diagnostic(formula: &Decorated<Formula>) -> sempai_core::Diagnostic {
+    validate_formula(formula)
+        .expect_err("should fail validation")
+        .diagnostics()
+        .first()
+        .expect("should have diagnostic")
+        .clone()
 }
 
 fn make_not(inner: Decorated<Formula>) -> Decorated<Formula> {
@@ -126,4 +141,98 @@ fn nested_or_in_and_with_not_fails() {
     let nested_or = make_or(vec![make_pattern("a"), make_not(make_pattern("b"))]);
     let formula = make_and(vec![make_pattern("foo"), nested_or]);
     assert_invalid_not_in_or(&formula);
+}
+
+#[test]
+fn missing_positive_term_in_and_prefers_node_span() {
+    let node_span = SourceSpan::new(10, 20, None);
+    let child_span = SourceSpan::new(30, 40, None);
+    let formula = with_span(
+        make_and(vec![with_span(
+            make_inside(make_pattern("bar")),
+            child_span,
+        )]),
+        node_span.clone(),
+    );
+
+    let first = first_validation_diagnostic(&formula);
+
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+    assert_eq!(first.primary_span(), Some(&node_span));
+}
+
+#[test]
+fn missing_positive_term_in_and_uses_first_child_span_when_node_span_none() {
+    let child_span = SourceSpan::new(30, 40, None);
+    let formula = make_and(vec![with_span(
+        make_inside(make_pattern("bar")),
+        child_span.clone(),
+    )]);
+
+    let first = first_validation_diagnostic(&formula);
+
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+    assert_eq!(first.primary_span(), Some(&child_span));
+}
+
+#[test]
+fn invalid_not_in_or_prefers_branch_span() {
+    let branch_span = SourceSpan::new(50, 60, None);
+    let branch_span_formula = make_or(vec![
+        with_span(
+            make_and(vec![make_not(make_pattern("bad"))]),
+            branch_span.clone(),
+        ),
+        make_pattern("ok"),
+    ]);
+
+    let branch_span_diagnostic = first_validation_diagnostic(&branch_span_formula);
+
+    assert_eq!(
+        branch_span_diagnostic.code(),
+        DiagnosticCode::ESempaiInvalidNotInOr
+    );
+    assert_eq!(branch_span_diagnostic.primary_span(), Some(&branch_span));
+
+    let fallback_span = SourceSpan::new(70, 80, None);
+    let fallback_span_formula = with_span(
+        make_or(vec![make_not(make_pattern("bad"))]),
+        fallback_span.clone(),
+    );
+
+    let fallback_span_diagnostic = first_validation_diagnostic(&fallback_span_formula);
+
+    assert_eq!(
+        fallback_span_diagnostic.code(),
+        DiagnosticCode::ESempaiInvalidNotInOr
+    );
+    assert_eq!(
+        fallback_span_diagnostic.primary_span(),
+        Some(&fallback_span)
+    );
+}
+
+#[test]
+fn deeply_nested_or_with_negation_anywhere_fails() {
+    let nested_and = make_and(vec![
+        make_inside(make_pattern("x")),
+        make_not(make_pattern("y")),
+    ]);
+    let formula = make_or(vec![nested_and, make_pattern("z")]);
+
+    assert_invalid_not_in_or(&formula);
+}
+
+#[test]
+fn and_of_or_with_mixed_positive_and_constraints_passes() {
+    let nested_or = make_or(vec![make_pattern("a"), make_inside(make_pattern("b"))]);
+    let formula = make_and(vec![nested_or, make_not(make_pattern("c"))]);
+
+    assert!(validate_formula(&formula).is_ok());
 }

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -26,6 +26,16 @@ fn assert_invalid_not_in_or(formula: &Decorated<Formula>) {
     assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
 }
 
+fn assert_missing_positive_term_in_and(formula: &Decorated<Formula>) {
+    let result = validate_formula(formula);
+    let err = result.expect_err("should fail validation");
+    let first = err.diagnostics().first().expect("should have diagnostic");
+    assert_eq!(
+        first.code(),
+        DiagnosticCode::ESempaiMissingPositiveTermInAnd
+    );
+}
+
 fn make_not(inner: Decorated<Formula>) -> Decorated<Formula> {
     Decorated {
         node: Formula::Not(Box::new(inner)),
@@ -102,25 +112,13 @@ fn and_with_only_constraints_fails() {
         make_not(make_pattern("foo")),
         make_inside(make_pattern("bar")),
     ]);
-    let result = validate_formula(&formula);
-    let err = result.expect_err("should fail validation");
-    let first = err.diagnostics().first().expect("should have diagnostic");
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
+    assert_missing_positive_term_in_and(&formula);
 }
 
 #[test]
 fn and_with_or_containing_only_constraints_fails() {
     let formula = make_and(vec![make_or(vec![make_inside(make_pattern("ctx"))])]);
-    let result = validate_formula(&formula);
-    let err = result.expect_err("should fail validation");
-    let first = err.diagnostics().first().expect("should have diagnostic");
-    assert_eq!(
-        first.code(),
-        DiagnosticCode::ESempaiMissingPositiveTermInAnd
-    );
+    assert_missing_positive_term_in_and(&formula);
 }
 
 #[test]

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -207,8 +207,5 @@ fn nested_or_in_and_with_not_fails() {
         fix: None,
         span: None,
     };
-    let result = validate_formula(&formula);
-    let err = result.expect_err("should fail validation");
-    let first = err.diagnostics().first().expect("should have diagnostic");
-    assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+    assert_invalid_not_in_or(&formula);
 }

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__invalid_not_in_or.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__invalid_not_in_or.snap
@@ -1,0 +1,18 @@
+---
+source: crates/sempai/src/tests/diagnostic_snapshot_tests.rs
+expression: diagnostic_report_json(&report)
+---
+{
+  "diagnostics": [
+    {
+      "code": "E_SEMPAI_INVALID_NOT_IN_OR",
+      "message": "negated terms are not allowed inside disjunction (Or/pattern-either)",
+      "primary_span": {
+        "start": 0,
+        "end": 1,
+        "uri": null
+      },
+      "notes": []
+    }
+  ]
+}

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__invalid_not_in_or.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__invalid_not_in_or.snap
@@ -8,7 +8,11 @@ expression: redacted_report_json(&report)
       "code": "E_SEMPAI_INVALID_NOT_IN_OR",
       "message": "negated terms are not allowed inside disjunction (Or/pattern-either)",
       "notes": [],
-      "primary_span": "<redacted-span>"
+      "primary_span": {
+        "end": 0,
+        "start": 0,
+        "uri": null
+      }
     }
   ]
 }

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__invalid_not_in_or.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__invalid_not_in_or.snap
@@ -1,18 +1,14 @@
 ---
 source: crates/sempai/src/tests/diagnostic_snapshot_tests.rs
-expression: diagnostic_report_json(&report)
+expression: redacted_report_json(&report)
 ---
 {
   "diagnostics": [
     {
       "code": "E_SEMPAI_INVALID_NOT_IN_OR",
       "message": "negated terms are not allowed inside disjunction (Or/pattern-either)",
-      "primary_span": {
-        "start": 0,
-        "end": 1,
-        "uri": null
-      },
-      "notes": []
+      "notes": [],
+      "primary_span": "<redacted-span>"
     }
   ]
 }

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__missing_positive_term_in_and.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__missing_positive_term_in_and.snap
@@ -1,18 +1,14 @@
 ---
 source: crates/sempai/src/tests/diagnostic_snapshot_tests.rs
-expression: diagnostic_report_json(&report)
+expression: redacted_report_json(&report)
 ---
 {
   "diagnostics": [
     {
       "code": "E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND",
       "message": "conjunction (And/patterns) must contain at least one positive match term",
-      "primary_span": {
-        "start": 0,
-        "end": 1,
-        "uri": null
-      },
-      "notes": []
+      "notes": [],
+      "primary_span": "<redacted-span>"
     }
   ]
 }

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__missing_positive_term_in_and.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__missing_positive_term_in_and.snap
@@ -8,7 +8,11 @@ expression: redacted_report_json(&report)
       "code": "E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND",
       "message": "conjunction (And/patterns) must contain at least one positive match term",
       "notes": [],
-      "primary_span": "<redacted-span>"
+      "primary_span": {
+        "end": 0,
+        "start": 0,
+        "uri": null
+      }
     }
   ]
 }

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__missing_positive_term_in_and.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__missing_positive_term_in_and.snap
@@ -1,0 +1,18 @@
+---
+source: crates/sempai/src/tests/diagnostic_snapshot_tests.rs
+expression: diagnostic_report_json(&report)
+---
+{
+  "diagnostics": [
+    {
+      "code": "E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND",
+      "message": "conjunction (And/patterns) must contain at least one positive match term",
+      "primary_span": {
+        "start": 0,
+        "end": 1,
+        "uri": null
+      },
+      "notes": []
+    }
+  ]
+}

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__schema_invalid_language.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__schema_invalid_language.snap
@@ -1,18 +1,14 @@
 ---
 source: crates/sempai/src/tests/diagnostic_snapshot_tests.rs
-expression: diagnostic_report_json(&report)
+expression: redacted_report_json(&report)
 ---
 {
   "diagnostics": [
     {
       "code": "E_SEMPAI_SCHEMA_INVALID",
       "message": "unsupported language 'cobol': unknown language: cobol",
-      "primary_span": {
-        "start": 0,
-        "end": 1,
-        "uri": null
-      },
-      "notes": []
+      "notes": [],
+      "primary_span": "<redacted-span>"
     }
   ]
 }

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__schema_invalid_language.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__schema_invalid_language.snap
@@ -1,0 +1,18 @@
+---
+source: crates/sempai/src/tests/diagnostic_snapshot_tests.rs
+expression: diagnostic_report_json(&report)
+---
+{
+  "diagnostics": [
+    {
+      "code": "E_SEMPAI_SCHEMA_INVALID",
+      "message": "unsupported language 'cobol': unknown language: cobol",
+      "primary_span": {
+        "start": 0,
+        "end": 1,
+        "uri": null
+      },
+      "notes": []
+    }
+  ]
+}

--- a/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__schema_invalid_language.snap
+++ b/crates/sempai/src/tests/snapshots/sempai__tests__diagnostic_snapshot_tests__schema_invalid_language.snap
@@ -8,7 +8,11 @@ expression: redacted_report_json(&report)
       "code": "E_SEMPAI_SCHEMA_INVALID",
       "message": "unsupported language 'cobol': unknown language: cobol",
       "notes": [],
-      "primary_span": "<redacted-span>"
+      "primary_span": {
+        "end": 0,
+        "start": 0,
+        "uri": null
+      }
     }
   ]
 }

--- a/crates/sempai/tests/features/sempai_engine.feature
+++ b/crates/sempai/tests/features/sempai_engine.feature
@@ -14,17 +14,17 @@ Feature: Sempai engine facade behaviour
     When YAML "rules:\n  - message: detect foo\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n" is compiled
     Then compilation fails with code "E_SEMPAI_SCHEMA_INVALID"
 
-  Scenario: Engine compile_yaml keeps a post-parse placeholder for valid YAML
+  Scenario: Engine compile_yaml returns query plans for valid YAML
     Given an engine with default configuration
     When YAML "rules:\n  - id: demo.rule\n    message: detect foo\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n" is compiled
-    Then compilation fails with code "NOT_IMPLEMENTED"
-    And the first diagnostic message contains "normalization"
+    Then compilation succeeds with 1 query plan
+    And the first query plan has rule id "demo.rule"
 
-  Scenario: Engine compile_yaml keeps the placeholder for dependency search rules
+  Scenario: Engine compile_yaml returns a query plan for dependency search rules
     Given an engine with default configuration
     When YAML "rules:\n  - id: demo.depends\n    message: detect vulnerable dependency\n    languages: [python]\n    severity: WARNING\n    r2c-internal-project-depends-on:\n      namespace: pypi\n      package: requests\n" is compiled
-    Then compilation fails with code "NOT_IMPLEMENTED"
-    And the first diagnostic message contains "normalization"
+    Then compilation succeeds with 1 query plan
+    And the first query plan has rule id "demo.depends"
 
   Scenario: Engine compile_yaml rejects extract mode during execution gating
     Given an engine with default configuration

--- a/crates/sempai/tests/features/sempai_engine.feature
+++ b/crates/sempai/tests/features/sempai_engine.feature
@@ -19,12 +19,14 @@ Feature: Sempai engine facade behaviour
     When YAML "rules:\n  - id: demo.rule\n    message: detect foo\n    languages: [rust]\n    severity: ERROR\n    pattern: foo($X)\n" is compiled
     Then compilation succeeds with 1 query plan
     And the first query plan has rule id "demo.rule"
+    And the first query plan formula is pattern atom "foo($X)"
 
   Scenario: Engine compile_yaml returns a query plan for dependency search rules
     Given an engine with default configuration
     When YAML "rules:\n  - id: demo.depends\n    message: detect vulnerable dependency\n    languages: [python]\n    severity: WARNING\n    r2c-internal-project-depends-on:\n      namespace: pypi\n      package: requests\n" is compiled
     Then compilation succeeds with 1 query plan
     And the first query plan has rule id "demo.depends"
+    And the first query plan formula is Tree-sitter query atom "(__NONEXISTENT_NODE__) @_dependency_check"
 
   Scenario: Engine compile_yaml rejects extract mode during execution gating
     Given an engine with default configuration

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -11,6 +11,10 @@ The workspace targets `ortho_config` v0.8.0 and Rust 1.88.
 
 ## Sempai overview
 
+Sempai is Weaver's Semgrep-compatible query engine facade. It parses rule
+YAML, normalizes supported search syntax into a canonical formula model, and
+prepares per-language query plans for later execution.
+
 ## Sempai query pipeline (milestone 4.1.5)
 
 - Canonical model (`sempai_core::formula`):

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -9,6 +9,31 @@ need but operators do not. For user-facing behaviour see the
 
 The workspace targets `ortho_config` v0.8.0 and Rust 1.88.
 
+## Sempai overview
+
+## Sempai query pipeline (milestone 4.1.5)
+
+- Canonical model (`sempai_core::formula`):
+  - `Formula` enum: `Atom`, `Not`, `Inside`, `Anywhere`, `And`, `Or`
+  - `Atom` enum: `Pattern`, `Regex`, `TreeSitterQuery`
+  - `Decorated<T>` wrapper: `where_clauses`, `as_name`, `fix`, `span`
+- Normalization (`crates/sempai/src/normalize.rs`):
+  - Legacy syntax: `pattern*`, `patterns`, `pattern-either`,
+    `pattern-not`, `pattern-not-inside`, `pattern-not-regex`, and
+    `anywhere`
+  - v2 `match` syntax: `pattern`, `regex`, `all`, `any`, `not`, `inside`,
+    `anywhere`, and decorated metadata propagation
+  - Special handling: `r2c-internal-project-depends-on` lowers to
+    `(__NONEXISTENT_NODE__) @_dependency_check`
+- Semantic validation (`crates/sempai/src/semantic_check.rs`):
+  - `InvalidNotInOr`
+  - `MissingPositiveTermInAnd`
+  - Span precedence rules: node span -> first child -> fallback
+- Engine wiring (`crates/sempai/src/engine.rs`):
+  - Parse -> validate modes -> normalize -> validate semantics -> compile
+    per-language `QueryPlan`
+  - `QueryPlan::formula()` exposure for tests and integration
+
 ## Configuration framework internals
 
 ### `ortho_config` v0.8.0 integration

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -24,7 +24,7 @@ prepares per-language query plans for later execution.
 - Normalization (`crates/sempai/src/normalize.rs`):
   - Legacy syntax: `pattern*`, `patterns`, `pattern-either`,
     `pattern-not`, `pattern-not-inside`, `pattern-not-regex`, and
-    `anywhere`
+    `semgrep-internal-pattern-anywhere`
   - v2 `match` syntax: `pattern`, `regex`, `all`, `any`, `not`, `inside`,
     `anywhere`, and decorated metadata propagation
   - Special handling: `r2c-internal-project-depends-on` lowers to

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -60,10 +60,13 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
   `as`, and `fix` metadata.
 - Preserve the crate boundary split:
   - `sempai_core` owns the `Formula`, `Atom`, `Decorated`, and `WhereClause`
-    types plus semantic validation logic.
+    types. `Decorated<T>` carries the fields `node: T`, `where_clauses:
+    Vec<WhereClause>`, `as_name: Option<String>`, `fix: Option<String>`, and
+    `span: Option<SourceSpan>`.
   - `sempai_yaml` owns the parsed `LegacyFormula` and `MatchFormula` types.
   - `sempai` (facade) wires parsing → normalization → validation → plan
-    construction.
+    construction. Normalization lives in `crates/sempai/src/normalize.rs` and
+    semantic validation in `crates/sempai/src/semantic_check.rs`.
 - Maintain the stable diagnostics contract from 4.1.2:
   `code`, `message`, `primary_span`, and `notes` remain the only emitted fields.
 - Use `DiagnosticReport::validation_error(...)` for semantic constraint
@@ -212,10 +215,10 @@ pub enum Atom {
 
 pub struct Decorated<T> {
     pub node: T,
-    pub where_: Vec<WhereClause>,
-    pub as_: Option<String>,
+    pub where_clauses: Vec<WhereClause>,
+    pub as_name: Option<String>,
     pub fix: Option<String>,
-    pub span: SourceSpan,
+    pub span: Option<SourceSpan>,
 }
 ```
 
@@ -245,7 +248,11 @@ v2-to-canonical mapping:
 | `not: ...`                           | `Formula::Not(Box<...>)`            |
 | `inside: ...`                        | `Formula::Inside(Box<...>)`         |
 | `anywhere: ...`                      | `Formula::Anywhere(Box<...>)`       |
-| `Decorated { where_, as_, fix, .. }` | `Decorated<Formula>` wrapper        |
+| `Decorated { where, as, fix, .. }`   | `Decorated<Formula>` wrapper[^d]    |
+
+[^d]: The canonical `Decorated<Formula>` exposes the fields `where_clauses`,
+    `as_name`, `fix`, and `span: Option<SourceSpan>` in addition to the inner
+    `node`.
 
 ## Plan of work
 
@@ -267,8 +274,9 @@ Add a new module `crates/sempai-core/src/formula.rs` (< 200 lines) containing:
 - `PatternAtom` — wraps a pattern string (the raw host-language snippet).
 - `RegexAtom` — wraps a regex string.
 - `TreeSitterQueryAtom` — stub wrapping a query string (for escape hatch).
-- `Decorated<T>` — generic wrapper with `node: T`, `where_: Vec<WhereClause>`,
-  `as_: Option<String>`, `fix: Option<String>`, `span: SourceSpan`.
+- `Decorated<T>` — generic wrapper with `node: T`, `where_clauses:
+  Vec<WhereClause>`, `as_name: Option<String>`, `fix: Option<String>`, `span:
+  Option<SourceSpan>`.
 - `WhereClause` — initially wraps `serde_json::Value` for opaque constraint
   storage; later milestones interpret specific clause types.
 

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -1,0 +1,627 @@
+# 4.1.5 Implement normalization into canonical Formula model
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+After this change, Sempai will normalize both legacy `pattern*` syntax and v2
+`match` syntax into a single canonical `Formula` model defined in
+`sempai_core`.  Semantic constraint checks will reject structurally invalid
+formulas — specifically `InvalidNotInOr` (negated branches inside disjunction)
+and `MissingPositiveTermInAnd` (conjunctions with no positive match-producing
+term) — with deterministic diagnostics using the existing `E_SEMPAI_*` error
+codes.
+
+Observable user-facing behaviour after implementation:
+
+- `sempai::Engine::compile_yaml` no longer returns `NOT_IMPLEMENTED` for valid
+  search-mode rules.  Instead, it returns `Vec<QueryPlan>` containing the
+  normalized canonical formula for each rule.
+- Paired legacy and v2 rule fixtures that express the same logical query
+  normalize to structurally equivalent `Formula` values.
+- Semantically invalid formulas (negated terms in `pattern-either`/`any`,
+  conjunctions without positive terms in `patterns`/`all`) emit deterministic
+  `E_SEMPAI_INVALID_NOT_IN_OR` or `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`
+  diagnostics with accurate `primary_span` locations.
+- `r2c-internal-project-depends-on` rules continue to parse successfully
+  without normalization failure (they produce a degenerate formula or are gated
+  appropriately).
+
+Observable completion evidence:
+
+```plaintext
+set -o pipefail; cargo test -p sempai_core 2>&1 | tee /tmp/4-1-5-sempai-core-test.log
+set -o pipefail; cargo test -p sempai_yaml 2>&1 | tee /tmp/4-1-5-sempai-yaml-test.log
+set -o pipefail; cargo test -p sempai 2>&1 | tee /tmp/4-1-5-sempai-test.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/4-1-5-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/4-1-5-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/4-1-5-make-test.log
+```
+
+Because this milestone updates Markdown documentation:
+
+```plaintext
+set -o pipefail; make fmt 2>&1 | tee /tmp/4-1-5-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/4-1-5-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
+```
+
+## Constraints
+
+- Align with the canonical formula model specified in
+  `docs/sempai-query-language-design.md` §"Normalised formula model":
+  `Formula::Atom`, `Formula::Not`, `Formula::Inside`, `Formula::Anywhere`,
+  `Formula::And`, `Formula::Or`, with `Decorated<T>` wrapper carrying `where`,
+  `as`, and `fix` metadata.
+- Preserve the crate boundary split:
+  - `sempai_core` owns the `Formula`, `Atom`, `Decorated`, and `WhereClause`
+    types plus semantic validation logic.
+  - `sempai_yaml` owns the parsed `LegacyFormula` and `MatchFormula` types.
+  - `sempai` (facade) wires parsing → normalization → validation → plan
+    construction.
+- Maintain the stable diagnostics contract from 4.1.2:
+  `code`, `message`, `primary_span`, and `notes` remain the only emitted fields.
+- Use `DiagnosticReport::validation_error(...)` for semantic constraint
+  violations.
+- Enforce `InvalidNotInOr` and `MissingPositiveTermInAnd` as documented in
+  `docs/semgrep-language-reference/semgrep-operator-precedence.md`.
+- Do not implement pattern atom compilation, Tree-sitter matching, or DSL
+  parsing as part of this work (those belong to 4.1.6+ and 4.2.x).
+- Do not modify the public signature of `sempai_yaml::parse_rule_file`.
+- Keep files below 400 lines.
+- Every new module must begin with a `//!` module comment.
+- New public items must carry Rustdoc with examples where feasible.
+- Tests must use `rstest-bdd` v0.5.0 for BDD scenarios covering happy,
+  unhappy, and edge paths.
+- Record design decisions in
+  `docs/sempai-query-language-design.md`.
+- Update `docs/users-guide.md` with any user-visible behaviour change.
+- Mark roadmap item 4.1.5 done in `docs/roadmap.md` only after all gates pass.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires more than 18 net file touches outside the
+  `crates/sempai*` directories and the three required docs (`roadmap.md`,
+  `users-guide.md`, `sempai-query-language-design.md`), stop and escalate.
+- Interface: if normalization requires a breaking change to the public
+  signature of `sempai::Engine::compile_yaml` (beyond replacing the
+  `NOT_IMPLEMENTED` stub with a real return), stop and escalate.
+- Dependencies: if a new external crate dependency beyond what is already in
+  the workspace is required, stop and escalate.
+- Iterations: if tests still fail after 5 attempts at a given fix, stop and
+  escalate.
+- Ambiguity: if multiple valid interpretations of the normalization rules
+  exist for a concrete fixture and the choice materially affects downstream
+  behaviour, stop and present options with trade-offs.
+
+## Risks
+
+- Risk: The `where` clause in `MatchFormula::Decorated` is currently stored as
+  raw `serde_json::Value`.  Normalization must interpret this structure without
+  full schema coverage, which could lead to incomplete handling. Severity:
+  medium Likelihood: medium Mitigation: Preserve `where_clauses` as opaque
+  `Value` slices inside `Decorated<Formula>` initially.  Only interpret
+  `focus`, `metavariable-regex`, and `metavariable-pattern` when they are
+  encountered.  All other clauses are stored verbatim and validated later in
+  4.2.x.
+
+- Risk: The `LegacyClause::Constraint(Value)` variant in `patterns` arrays
+  carries metavariable constraints that are not formula nodes.  Normalization
+  must distinguish formula items from constraint items. Severity: low
+  Likelihood: high Mitigation: Map `LegacyClause::Constraint` to `WhereClause`
+  entries attached to the enclosing `And` formula's `Decorated` wrapper,
+  preserving them as opaque JSON for later semantic interpretation.
+
+- Risk: Span propagation from parsed models to the canonical formula may be
+  lossy if `LegacyFormula` and `MatchFormula` do not carry spans today.
+  Severity: low Likelihood: medium Mitigation: Where spans are not available
+  from the parser, use the enclosing rule span as a fallback.  Add a design-doc
+  note that span precision will improve when the parser propagates spans to
+  individual formula nodes.
+
+- Risk: `r2c-internal-project-depends-on` rules have no formula body and cannot
+  meaningfully normalize. Severity: low Likelihood: certain Mitigation:
+  Represent as a dedicated `Formula::Atom(Atom::DependencyCheck)` variant or
+  skip normalization for these rules and emit a degenerate plan. Decision to be
+  taken in Stage B.
+
+## Progress
+
+- [ ] Stage A: Research and specification (no code changes).
+- [ ] Stage B: Define `Formula`, `Atom`, `Decorated`, `WhereClause` types in
+      `sempai_core`.
+- [ ] Stage C: Implement normalization functions `normalize_legacy` and
+      `normalize_match`.
+- [ ] Stage D: Implement semantic validation (`InvalidNotInOr`,
+      `MissingPositiveTermInAnd`).
+- [ ] Stage E: Wire normalization into `Engine::compile_yaml` and produce real
+      `QueryPlan` values.
+- [ ] Stage F: Add unit tests, BDD scenarios, and paired legacy/v2 fixture
+      coverage.
+- [ ] Stage G: Update documentation, roadmap, and user's guide.
+- [ ] Stage H: Run all quality gates and finalize.
+
+## Surprises & discoveries
+
+(None yet.)
+
+## Decision log
+
+(None yet.)
+
+## Outcomes & retrospective
+
+(To be completed after implementation.)
+
+## Context and orientation
+
+The Sempai query pipeline currently stops at a `NOT_IMPLEMENTED` placeholder
+after successfully parsing and mode-validating a YAML rule file.  The parser
+produces `LegacyFormula` and `MatchFormula` ASTs in `sempai_yaml`, which are
+structurally distinct but semantically equivalent for the subset they share.
+
+The normalisation step must lower both representations into the design
+document's canonical `Formula` enum, then run semantic constraint checks before
+constructing a `QueryPlan`.
+
+### Key files and modules
+
+- `crates/sempai-core/src/lib.rs` — exports `DiagnosticReport`, `SourceSpan`,
+  `DiagnosticCode`, etc.
+- `crates/sempai-core/src/diagnostic.rs` — diagnostic types and constructors.
+- `crates/sempai-yaml/src/model.rs` — `LegacyFormula`, `MatchFormula`,
+  `LegacyClause`, `LegacyValue`, `SearchQueryPrincipal`, `Rule`.
+- `crates/sempai-yaml/src/lib.rs` — public re-exports and `parse_rule_file`.
+- `crates/sempai/src/engine.rs` — `Engine::compile_yaml` with the
+  `NOT_IMPLEMENTED` placeholder.
+- `crates/sempai/src/mode_validation.rs` — mode-gating pass.
+- `crates/sempai/src/tests/behaviour.rs` — existing BDD test world.
+- `crates/sempai/tests/features/sempai_engine.feature` — existing BDD
+  scenarios.
+- `docs/sempai-query-language-design.md` — canonical `Formula` specification.
+- `docs/semgrep-language-reference/semgrep-operator-precedence.md` — semantic
+  constraint definitions.
+- `docs/semgrep-language-reference/semgrep-legacy-vs-v2-guidance.md` —
+  normalization guidance ("Option B: Compatibility parser").
+
+### Mapping from parsed types to canonical Formula
+
+The design document specifies these constructors:
+
+```rust
+pub enum Formula {
+    Atom(Atom),
+    Not(Box<Decorated<Formula>>),
+    Inside(Box<Decorated<Formula>>),
+    Anywhere(Box<Decorated<Formula>>),
+    And(Vec<Decorated<Formula>>),
+    Or(Vec<Decorated<Formula>>),
+}
+
+pub enum Atom {
+    Pattern(PatternAtom),
+    Regex(RegexAtom),
+    TreeSitterQuery(TreeSitterQueryAtom),
+}
+
+pub struct Decorated<T> {
+    pub node: T,
+    pub where_: Vec<WhereClause>,
+    pub as_: Option<String>,
+    pub fix: Option<String>,
+    pub span: SourceSpan,
+}
+```
+
+Legacy-to-canonical mapping:
+
+| Legacy                                   | Canonical                           |
+| ---------------------------------------- | ----------------------------------- |
+| `pattern: "..."` (string)                | `Formula::Atom(Atom::Pattern(...))` |
+| `pattern-regex: "..."`                   | `Formula::Atom(Atom::Regex(...))`   |
+| `patterns: [...]`                        | `Formula::And([...])`               |
+| `pattern-either: [...]`                  | `Formula::Or([...])`                |
+| `pattern-not: ...`                       | `Formula::Not(Box<...>)`            |
+| `pattern-inside: ...`                    | `Formula::Inside(Box<...>)`         |
+| `pattern-not-inside: ...`                | `Formula::Not(Inside(...))`         |
+| `pattern-not-regex: "..."`               | `Formula::Not(Atom(Regex(...)))`    |
+| `semgrep-internal-pattern-anywhere: ...` | `Formula::Anywhere(Box<...>)`       |
+
+v2-to-canonical mapping:
+
+| v2 (`match`)                         | Canonical                           |
+| ------------------------------------ | ----------------------------------- |
+| `"..."` (string shorthand)           | `Formula::Atom(Atom::Pattern(...))` |
+| `pattern: "..."`                     | `Formula::Atom(Atom::Pattern(...))` |
+| `regex: "..."`                       | `Formula::Atom(Atom::Regex(...))`   |
+| `all: [...]`                         | `Formula::And([...])`               |
+| `any: [...]`                         | `Formula::Or([...])`                |
+| `not: ...`                           | `Formula::Not(Box<...>)`            |
+| `inside: ...`                        | `Formula::Inside(Box<...>)`         |
+| `anywhere: ...`                      | `Formula::Anywhere(Box<...>)`       |
+| `Decorated { where_, as_, fix, .. }` | `Decorated<Formula>` wrapper        |
+
+## Plan of work
+
+### Stage A: Research and specification (no code changes)
+
+Review the current crate boundaries and confirm that the formula types belong
+in `sempai_core`.  Confirm the exact atom types needed for this milestone
+(pattern string and regex string; `TreeSitterQuery` can remain as a stub).
+
+Go/no-go: understanding is sufficient to define types with confidence.
+
+### Stage B: Define canonical Formula types in `sempai_core`
+
+Add a new module `crates/sempai-core/src/formula.rs` (< 200 lines) containing:
+
+- `Formula` enum — `Atom`, `Not`, `Inside`, `Anywhere`, `And`, `Or`.
+- `Atom` enum — `Pattern(PatternAtom)`, `Regex(RegexAtom)`,
+  `TreeSitterQuery(TreeSitterQueryAtom)`.
+- `PatternAtom` — wraps a pattern string (the raw host-language snippet).
+- `RegexAtom` — wraps a regex string.
+- `TreeSitterQueryAtom` — stub wrapping a query string (for escape hatch).
+- `Decorated<T>` — generic wrapper with `node: T`, `where_: Vec<WhereClause>`,
+  `as_: Option<String>`, `fix: Option<String>`, `span: SourceSpan`.
+- `WhereClause` — initially wraps `serde_json::Value` for opaque constraint
+  storage; later milestones interpret specific clause types.
+
+Add `pub mod formula;` and re-export from `crates/sempai-core/src/lib.rs`.
+
+Go/no-go: `cargo doc -p sempai_core` builds, and `make lint` passes.
+
+### Stage C: Implement normalization functions
+
+Add a new module `crates/sempai/src/normalize.rs` (or split into
+`normalize/legacy.rs` and `normalize/match_v2.rs` if size requires) with:
+
+- `pub(crate) fn normalize_search_principal(principal: &SearchQueryPrincipal)
+  -> Result<Decorated<Formula>, DiagnosticReport>`
+- Internal helpers:
+  - `fn normalize_legacy(formula: &LegacyFormula) -> Decorated<Formula>`
+  - `fn normalize_legacy_clause(clause: &LegacyClause) -> ...`
+  - `fn normalize_match(formula: &MatchFormula) -> Decorated<Formula>`
+
+The normalization must handle:
+
+1. Atomic patterns and regex strings → `Atom::Pattern` / `Atom::Regex`.
+2. `pattern-not-inside` → `Not(Inside(...))` composite.
+3. `pattern-not-regex` → `Not(Atom(Regex(...)))` composite.
+4. `LegacyClause::Constraint(Value)` → `WhereClause` entries attached to the
+   enclosing `And`'s `Decorated` wrapper.
+5. `MatchFormula::Decorated` → `Decorated<Formula>` with `where_clauses`,
+   `as_name`, and `fix` mapped through.
+6. `SearchQueryPrincipal::ProjectDependsOn` → produce a placeholder
+   `Formula::Atom(Atom::Pattern(...))` or a new `Atom::DependencyCheck` variant
+   (decision to be taken here and recorded in the decision log).
+
+Go/no-go: unit tests show that paired legacy and v2 YAML fixtures produce
+structurally equivalent `Formula` values.
+
+### Stage D: Implement semantic validation
+
+Add a new module `crates/sempai/src/semantic_check.rs` (< 200 lines) with:
+
+- `pub(crate) fn validate_formula(formula: &Decorated<Formula>)
+  -> Result<(), DiagnosticReport>`
+- Internal checks:
+  - `check_no_not_in_or(formula)` — walks `Or` branches and rejects any
+    that are `Formula::Not`.  Emits `E_SEMPAI_INVALID_NOT_IN_OR`.
+  - `check_positive_term_in_and(formula)` — walks `And` branches and
+    ensures at least one is a positive term (not `Not`, `Inside`, or
+    `Anywhere`).  Emits `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`.
+
+Both checks must be recursive: they apply to nested sub-formulas as well.
+
+Go/no-go: semantically invalid fixtures produce the correct diagnostic codes,
+and valid fixtures pass without error.
+
+### Stage E: Wire normalization into Engine::compile_yaml
+
+Modify `crates/sempai/src/engine.rs`:
+
+1. After `validate_supported_modes(&file)?`, iterate search rules.
+2. For each rule, call `normalize_search_principal(rule.principal())`.
+3. Call `validate_formula(...)` on the normalized result.
+4. Construct a `QueryPlan` containing the normalized formula and rule metadata.
+5. Return `Ok(plans)` instead of `Err(DiagnosticReport::not_implemented(...))`.
+
+Update `QueryPlan` to hold the `Decorated<Formula>` (replace the `_plan: ()`
+placeholder).
+
+Go/no-go: existing BDD scenario "Engine compile_yaml keeps a post-parse
+placeholder for valid YAML" must be updated to expect success (or a new
+behaviour) instead of `NOT_IMPLEMENTED`.
+
+### Stage F: Add tests
+
+Unit tests in `crates/sempai-core/src/tests/`:
+
+- `formula_tests.rs` — construction and equality of Formula variants.
+- Structural equivalence assertion helpers.
+
+Unit tests in `crates/sempai/src/tests/`:
+
+- `normalize_tests.rs` — paired legacy/v2 YAML inputs that must produce
+  equivalent Formula outputs.
+- `semantic_check_tests.rs` — fixtures for `InvalidNotInOr` and
+  `MissingPositiveTermInAnd` with nested and non-nested variants.
+
+BDD scenarios in `crates/sempai/tests/features/sempai_engine.feature`:
+
+- Happy path: valid legacy search rule normalizes and compiles successfully.
+- Happy path: valid v2 match search rule normalizes and compiles successfully.
+- Happy path: paired legacy and v2 rules produce equivalent plans.
+- Unhappy path: `pattern-either` with negated branch emits
+  `E_SEMPAI_INVALID_NOT_IN_OR`.
+- Unhappy path: `patterns` with only constraints (no positive term) emits
+  `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`.
+- Unhappy path: `any` with `not` branch emits `E_SEMPAI_INVALID_NOT_IN_OR`.
+- Unhappy path: `all` with no positive term emits
+  `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`.
+- Edge: dependency-only rule compiles without normalization error.
+- Edge: deeply nested formula normalizes without stack overflow or error.
+- Edge: v2 `Decorated` formula preserves `where`, `as`, and `fix` metadata.
+
+Go/no-go: `cargo test -p sempai_core`, `cargo test -p sempai` both pass.
+
+### Stage G: Update documentation
+
+1. `docs/sempai-query-language-design.md` — add implementation note recording
+   that normalization is now live, noting the decision on `WhereClause`
+   representation and `ProjectDependsOn` handling.
+2. `docs/users-guide.md` — update the Sempai section to reflect that
+   `compile_yaml` now returns compiled plans for valid search rules instead of
+   `NOT_IMPLEMENTED`.
+3. `docs/roadmap.md` — mark item 4.1.5 as `[x]` done.
+
+Go/no-go: `make markdownlint`, `make fmt`, and `make nixie` pass.
+
+### Stage H: Final quality gates
+
+Run the full quality gate suite:
+
+```plaintext
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/4-1-5-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/4-1-5-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/4-1-5-make-test.log
+```
+
+Go/no-go: all three pass with zero warnings or failures.
+
+## Concrete steps
+
+Working directory: `/home/user/project`
+
+### Stage B commands
+
+```sh
+# After creating formula.rs and updating lib.rs:
+set -o pipefail; cargo doc -p sempai_core 2>&1 | tee /tmp/4-1-5-cargo-doc.log
+set -o pipefail; make lint 2>&1 | tee /tmp/4-1-5-stage-b-lint.log
+```
+
+Expected: zero warnings, documentation builds cleanly.
+
+### Stage C–D commands
+
+```sh
+# After implementing normalization and semantic checks:
+set -o pipefail; cargo test -p sempai 2>&1 | tee /tmp/4-1-5-stage-cd-test.log
+```
+
+Expected: all new tests pass; existing tests either pass or are updated.
+
+### Stage E commands
+
+```sh
+# After wiring into engine:
+set -o pipefail; cargo test -p sempai 2>&1 | tee /tmp/4-1-5-stage-e-test.log
+set -o pipefail; cargo test -p sempai_core 2>&1 | tee /tmp/4-1-5-stage-e-core.log
+```
+
+Expected: existing BDD scenarios updated, all pass.
+
+### Stage H commands
+
+```sh
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/4-1-5-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/4-1-5-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/4-1-5-make-test.log
+set -o pipefail; make fmt 2>&1 | tee /tmp/4-1-5-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/4-1-5-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
+```
+
+Expected: all pass cleanly.
+
+## Validation and acceptance
+
+Acceptance is proven when:
+
+1. Running `make test` passes, including new tests in `sempai_core` and
+   `sempai`.
+2. A paired fixture demonstrates that legacy `patterns: [...]` with
+   `pattern-inside` normalizes to the same `Formula` shape as v2
+   `match: { all: [...], inside: ... }`.
+3. A fixture with `pattern-either: [pattern-not: ...]` emits
+   `E_SEMPAI_INVALID_NOT_IN_OR`.
+4. A fixture with `patterns: [pattern-not: ..., metavariable-regex: ...]`
+   (only constraints, no positive pattern) emits
+   `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`.
+5. A valid rule file with a single search rule returns `Ok(Vec<QueryPlan>)`
+   with `len() == 1` from `Engine::compile_yaml`.
+6. `make check-fmt`, `make lint`, `make markdownlint`, and `make nixie` all
+   pass.
+
+Quality criteria:
+
+- Tests: `make test` — all workspace tests pass (including new normalization
+  tests).
+- Lint/typecheck: `make check-fmt && make lint` — zero warnings.
+- Documentation: `make markdownlint && make nixie` — zero errors.
+
+Quality method:
+
+- Run the commands listed in "Concrete steps" Stage H.
+- Verify that the BDD feature file contains at minimum 10 scenarios covering
+  the happy, unhappy, and edge paths described above.
+
+## Idempotence and recovery
+
+All steps are idempotent.  Re-running `make test` after implementation produces
+the same results.  No destructive filesystem operations are performed.  If a
+stage fails partway through, the previous successful stage's state remains
+intact and the failed stage can be retried.
+
+## Artifacts and notes
+
+Key paired fixture example (to be created):
+
+```yaml
+# Legacy form
+rules:
+  - id: paired.legacy
+    message: find foo inside bar
+    languages: [python]
+    severity: WARNING
+    patterns:
+      - pattern: foo($X)
+      - pattern-inside: |
+          def bar():
+              ...
+```
+
+```yaml
+# v2 form (equivalent)
+rules:
+  - id: paired.v2
+    message: find foo inside bar
+    languages: [python]
+    severity: WARNING
+    match:
+      all:
+        - pattern: foo($X)
+        - inside:
+            pattern: |
+              def bar():
+                  ...
+```
+
+Both must normalize to:
+
+```plaintext
+Formula::And([
+    Decorated { node: Formula::Atom(Atom::Pattern("foo($X)")), ... },
+    Decorated { node: Formula::Inside(
+        Box(Decorated { node: Formula::Atom(Atom::Pattern("def bar():\n    ...")), ... })
+    ), ... },
+])
+```
+
+## Interfaces and dependencies
+
+### New types in `crates/sempai-core/src/formula.rs`
+
+```rust
+/// Canonical normalized query formula.
+///
+/// All legacy and v2 syntaxes are lowered into this shared representation
+/// before semantic validation and plan compilation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Formula {
+    /// A leaf pattern or regex atom.
+    Atom(Atom),
+    /// Negation: the inner formula must not match.
+    Not(Box<Decorated<Formula>>),
+    /// Context constraint: the anchor must be inside a match of the inner.
+    Inside(Box<Decorated<Formula>>),
+    /// Context constraint: the inner must match somewhere in scope.
+    Anywhere(Box<Decorated<Formula>>),
+    /// Conjunction: all branches must match.
+    And(Vec<Decorated<Formula>>),
+    /// Disjunction: at least one branch must match.
+    Or(Vec<Decorated<Formula>>),
+}
+
+/// A leaf atom in the formula tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Atom {
+    /// A host-language pattern snippet.
+    Pattern(PatternAtom),
+    /// A regex pattern.
+    Regex(RegexAtom),
+    /// A raw Tree-sitter query (escape hatch).
+    TreeSitterQuery(TreeSitterQueryAtom),
+}
+
+/// A pattern snippet atom containing a host-language code fragment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatternAtom {
+    pub text: String,
+}
+
+/// A regex atom.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegexAtom {
+    pub pattern: String,
+}
+
+/// A raw Tree-sitter query atom (stub for 4.2.x).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeSitterQueryAtom {
+    pub query: String,
+}
+
+/// Wraps a formula node with optional decorator metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Decorated<T> {
+    /// The core formula or atom.
+    pub node: T,
+    /// Optional `where` constraint clauses.
+    pub where_clauses: Vec<WhereClause>,
+    /// Optional alias binding name.
+    pub as_name: Option<String>,
+    /// Optional fix template text.
+    pub fix: Option<String>,
+    /// Source span for diagnostic anchoring.
+    pub span: Option<SourceSpan>,
+}
+
+/// An opaque `where` constraint clause preserved for later interpretation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhereClause {
+    /// The raw JSON value of the constraint.
+    pub raw: serde_json::Value,
+}
+```
+
+### New functions in `crates/sempai/src/normalize.rs`
+
+```rust
+/// Normalizes a parsed search principal into the canonical formula model.
+pub(crate) fn normalize_search_principal(
+    principal: &SearchQueryPrincipal,
+    rule_span: Option<&SourceSpan>,
+) -> Result<Decorated<Formula>, DiagnosticReport>;
+```
+
+### New functions in `crates/sempai/src/semantic_check.rs`
+
+```rust
+/// Validates semantic constraints on a normalized formula.
+pub(crate) fn validate_formula(
+    formula: &Decorated<Formula>,
+) -> Result<(), DiagnosticReport>;
+```
+
+### Dependencies
+
+No new external crate dependencies are required.  `serde_json` (already a
+workspace dependency) is needed in `sempai_core` for `WhereClause::raw`. This
+requires adding `serde_json` to `sempai_core`'s `[dependencies]` section.

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -162,10 +162,11 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
 
 The Sempai query pipeline currently stops at a `NOT_IMPLEMENTED` placeholder
 after successfully parsing and mode-validating a YAML rule file.  The parser
-produces `LegacyFormula` and `MatchFormula` ASTs in `sempai_yaml`, which are
-structurally distinct but semantically equivalent for the subset they share.
+produces `LegacyFormula` and `MatchFormula` abstract syntax trees (ASTs) in
+`sempai_yaml`, which are structurally distinct but semantically equivalent for
+the subset they share.
 
-The normalisation step must lower both representations into the design
+The normalization step must lower both representations into the design
 document's canonical `Formula` enum, then run semantic constraint checks before
 constructing a `QueryPlan`.
 

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -316,9 +316,18 @@ Add a new module `crates/sempai/src/normalize.rs` (or split into
     rule_span: Option<&SourceSpan>,
   ) -> Decorated<Formula>`
 - Internal helpers:
-  - `fn normalize_legacy(formula: &LegacyFormula) -> Decorated<Formula>`
-  - `fn normalize_legacy_clause(clause: &LegacyClause) -> ...`
-  - `fn normalize_match(formula: &MatchFormula) -> Decorated<Formula>`
+  - `fn normalize_legacy(
+      formula: &LegacyFormula,
+      fallback_span: Option<SourceSpan>,
+    ) -> Decorated<Formula>`
+  - `fn normalize_legacy_value(
+      value: &LegacyValue,
+      fallback_span: Option<SourceSpan>,
+    ) -> Decorated<Formula>`
+  - `fn normalize_match(
+      formula: &MatchFormula,
+      fallback_span: Option<SourceSpan>,
+    ) -> Decorated<Formula>`
 
 The normalization must handle:
 

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -223,7 +223,7 @@ pub struct Decorated<T> {
 }
 ```
 
-Legacy-to-canonical mapping:
+Legacy configuration keys mapped to Canonical Formula types:
 
 | Legacy                                   | Canonical                           |
 | ---------------------------------------- | ----------------------------------- |
@@ -237,7 +237,7 @@ Legacy-to-canonical mapping:
 | `pattern-not-regex: "..."`               | `Formula::Not(Atom(Regex(...)))`    |
 | `semgrep-internal-pattern-anywhere: ...` | `Formula::Anywhere(Box<...>)`       |
 
-v2-to-canonical mapping:
+v2 `match` keys mapped to Canonical Formula types:
 
 | v2 (`match`)                         | Canonical                           |
 | ------------------------------------ | ----------------------------------- |
@@ -249,9 +249,9 @@ v2-to-canonical mapping:
 | `not: ...`                           | `Formula::Not(Box<...>)`            |
 | `inside: ...`                        | `Formula::Inside(Box<...>)`         |
 | `anywhere: ...`                      | `Formula::Anywhere(Box<...>)`       |
-| `Decorated { where, as, fix, .. }`   | `Decorated<Formula>` wrapper[^d]    |
+| `Decorated { where, as, fix, .. }`   | `Decorated<Formula>` wrapper[^1]    |
 
-[^d]: The canonical `Decorated<Formula>` exposes the fields `where_clauses`,
+[^1]: The canonical `Decorated<Formula>` exposes the fields `where_clauses`,
     `as_name`, `fix`, and `span: Option<SourceSpan>` in addition to the inner
     `node`.
 

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -54,7 +54,7 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
 ## Constraints
 
 - Align with the canonical formula model specified in
-  `docs/sempai-query-language-design.md` §"Normalised formula model":
+  `docs/sempai-query-language-design.md` §"Normalized formula model":
   `Formula::Atom`, `Formula::Not`, `Formula::Inside`, `Formula::Anywhere`,
   `Formula::And`, `Formula::Or`, with `Decorated<T>` wrapper carrying `where`,
   `as`, and `fix` metadata.

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -179,15 +179,17 @@ with stable `E_SEMPAI_*` diagnostics before plan construction.
 
 ## Context and orientation
 
-The Sempai query pipeline currently stops at a `NOT_IMPLEMENTED` placeholder
-after successfully parsing and mode-validating a YAML rule file.  The parser
+The Sempai query pipeline now parses and mode-validates a YAML rule file, then
+normalizes search principals before constructing query plans. The parser
 produces `LegacyFormula` and `MatchFormula` abstract syntax trees (ASTs) in
 `sempai_yaml`, which are structurally distinct but semantically equivalent for
 the subset they share.
 
-The normalization step must lower both representations into the design
-document's canonical `Formula` enum, then run semantic constraint checks before
-constructing a `QueryPlan`.
+`Engine::compile_yaml` lowers both representations into the design document's
+canonical `Formula` enum, runs semantic constraint checks, and constructs a
+`QueryPlan` carrying the normalized formula. Historically, the pipeline stopped
+at a `NOT_IMPLEMENTED` placeholder after parsing and mode validation; that
+placeholder has been replaced for valid search-mode rules.
 
 ### Key files and modules
 
@@ -197,8 +199,8 @@ constructing a `QueryPlan`.
 - `crates/sempai-yaml/src/model.rs` — `LegacyFormula`, `MatchFormula`,
   `LegacyClause`, `LegacyValue`, `SearchQueryPrincipal`, `Rule`.
 - `crates/sempai-yaml/src/lib.rs` — public re-exports and `parse_rule_file`.
-- `crates/sempai/src/engine.rs` — `Engine::compile_yaml` with the
-  `NOT_IMPLEMENTED` placeholder.
+- `crates/sempai/src/engine.rs` — `Engine::compile_yaml` parsing,
+  normalization, semantic validation, and `QueryPlan` construction.
 - `crates/sempai/src/mode_validation.rs` — mode-gating pass.
 - `crates/sempai/src/tests/behaviour.rs` — existing BDD test world.
 - `crates/sempai/tests/features/sempai_engine.feature` — existing BDD
@@ -358,8 +360,9 @@ and valid fixtures pass without error.
 Modify `crates/sempai/src/engine.rs`:
 
 1. After `validate_supported_modes(&file)?`, iterate search rules.
-2. For each rule, call `normalize_search_principal(rule.principal())`.
-3. Call `validate_formula(...)` on the normalized result.
+2. For each rule, call
+   `normalize_search_principal(rule.principal(), rule.rule_span())`.
+3. Pass the normalized result to `validate_formula(...)`.
 4. Construct a `QueryPlan` containing the normalized formula and rule metadata.
 5. Return `Ok(plans)` instead of `Err(DiagnosticReport::not_implemented(...))`.
 

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -290,8 +290,10 @@ Go/no-go: `cargo doc -p sempai_core` builds, and `make lint` passes.
 Add a new module `crates/sempai/src/normalize.rs` (or split into
 `normalize/legacy.rs` and `normalize/match_v2.rs` if size requires) with:
 
-- `pub(crate) fn normalize_search_principal(principal: &SearchQueryPrincipal)
-  -> Result<Decorated<Formula>, DiagnosticReport>`
+- `pub(crate) fn normalize_search_principal(
+    principal: &SearchQueryPrincipal,
+    rule_span: Option<&SourceSpan>,
+  ) -> Decorated<Formula>`
 - Internal helpers:
   - `fn normalize_legacy(formula: &LegacyFormula) -> Decorated<Formula>`
   - `fn normalize_legacy_clause(clause: &LegacyClause) -> ...`
@@ -544,7 +546,7 @@ Formula::And([
 ///
 /// All legacy and v2 syntaxes are lowered into this shared representation
 /// before semantic validation and plan compilation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Formula {
     /// A leaf pattern or regex atom.
     Atom(Atom),
@@ -590,7 +592,7 @@ pub struct TreeSitterQueryAtom {
 }
 
 /// Wraps a formula node with optional decorator metadata.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Decorated<T> {
     /// The core formula or atom.
     pub node: T,
@@ -605,7 +607,7 @@ pub struct Decorated<T> {
 }
 
 /// An opaque `where` constraint clause preserved for later interpretation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhereClause {
     /// The raw JSON value of the constraint.
     pub raw: serde_json::Value,
@@ -619,7 +621,7 @@ pub struct WhereClause {
 pub(crate) fn normalize_search_principal(
     principal: &SearchQueryPrincipal,
     rule_span: Option<&SourceSpan>,
-) -> Result<Decorated<Formula>, DiagnosticReport>;
+) -> Decorated<Formula>;
 ```
 
 ### New functions in `crates/sempai/src/semantic_check.rs`

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -28,9 +28,10 @@ Observable user-facing behaviour after implementation:
   conjunctions without positive terms in `patterns`/`all`) emit deterministic
   `E_SEMPAI_INVALID_NOT_IN_OR` or `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`
   diagnostics with accurate `primary_span` locations.
-- `r2c-internal-project-depends-on` rules continue to parse successfully
-  without normalization failure (they produce a degenerate formula or are gated
-  appropriately).
+- `r2c-internal-project-depends-on` principals continue to parse successfully
+  without normalization failure by lowering to the degenerate
+  `TreeSitterQuery` atom described below, using the exact placeholder query
+  `(__NONEXISTENT_NODE__) @_dependency_check`.
 
 Observable completion evidence:
 
@@ -225,6 +226,8 @@ pub struct Decorated<T> {
 
 Legacy configuration keys mapped to Canonical Formula types:
 
+Table: Legacy configuration keys mapped to Canonical Formula types
+
 | Legacy                                   | Canonical                           |
 | ---------------------------------------- | ----------------------------------- |
 | `pattern: "..."` (string)                | `Formula::Atom(Atom::Pattern(...))` |
@@ -238,6 +241,8 @@ Legacy configuration keys mapped to Canonical Formula types:
 | `semgrep-internal-pattern-anywhere: ...` | `Formula::Anywhere(Box<...>)`       |
 
 v2 `match` keys mapped to Canonical Formula types:
+
+Table: v2 `match` keys mapped to Canonical Formula types
 
 | v2 (`match`)                         | Canonical                           |
 | ------------------------------------ | ----------------------------------- |

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -128,10 +128,11 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
   individual formula nodes.
 
 - Risk: `r2c-internal-project-depends-on` rules have no formula body and cannot
-  meaningfully normalize. Severity: low Likelihood: certain Mitigation:
-  Represent as a dedicated `Formula::Atom(Atom::DependencyCheck)` variant or
-  skip normalization for these rules and emit a degenerate plan. Decision to be
-  taken in Stage B.
+  normalize into the existing `Atom` variants (`Pattern`, `Regex`,
+  `TreeSitterQuery`) as a real code-matching query. Severity: low Likelihood:
+  certain Mitigation: model them as a distinct handling path in the ExecPlan by
+  emitting a degenerate, non-matchable `TreeSitterQuery` placeholder for now,
+  while preserving the dependency payload for later execution work.
 
 ## Progress
 
@@ -305,9 +306,10 @@ The normalization must handle:
    enclosing `And`'s `Decorated` wrapper.
 5. `MatchFormula::Decorated` → `Decorated<Formula>` with `where_clauses`,
    `as_name`, and `fix` mapped through.
-6. `SearchQueryPrincipal::ProjectDependsOn` → produce a placeholder
-   `Formula::Atom(Atom::Pattern(...))` or a new `Atom::DependencyCheck` variant
-   (decision to be taken here and recorded in the decision log).
+6. `SearchQueryPrincipal::ProjectDependsOn` → produce a degenerate
+   `Formula::Atom(Atom::TreeSitterQuery(...))` placeholder that cannot match
+   real code, preserving dependency-rule compilation without inventing a
+   speculative `Atom` variant.
 
 Go/no-go: unit tests show that paired legacy and v2 YAML fixtures produce
 structurally equivalent `Formula` values.

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -5,7 +5,8 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETED - shipped canonical formula normalization, semantic
+validation, and `compile_yaml` query-plan construction.
 
 ## Purpose / big picture
 
@@ -29,8 +30,8 @@ Observable user-facing behaviour after implementation:
   `E_SEMPAI_INVALID_NOT_IN_OR` or `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`
   diagnostics with accurate `primary_span` locations.
 - `r2c-internal-project-depends-on` principals continue to parse successfully
-  without normalization failure by lowering to the degenerate
-  `TreeSitterQuery` atom described below, using the exact placeholder query
+  without normalization failure by lowering to the degenerate `TreeSitterQuery`
+  atom described below, using the exact placeholder query
   `(__NONEXISTENT_NODE__) @_dependency_check`.
 
 Observable completion evidence:
@@ -137,31 +138,44 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
 
 ## Progress
 
-- [ ] Stage A: Research and specification (no code changes).
-- [ ] Stage B: Define `Formula`, `Atom`, `Decorated`, `WhereClause` types in
+- [x] Stage A: Research and specification (no code changes).
+- [x] Stage B: Define `Formula`, `Atom`, `Decorated`, `WhereClause` types in
       `sempai_core`.
-- [ ] Stage C: Implement normalization functions `normalize_legacy` and
+- [x] Stage C: Implement normalization functions `normalize_legacy` and
       `normalize_match`.
-- [ ] Stage D: Implement semantic validation (`InvalidNotInOr`,
+- [x] Stage D: Implement semantic validation (`InvalidNotInOr`,
       `MissingPositiveTermInAnd`).
-- [ ] Stage E: Wire normalization into `Engine::compile_yaml` and produce real
+- [x] Stage E: Wire normalization into `Engine::compile_yaml` and produce real
       `QueryPlan` values.
-- [ ] Stage F: Add unit tests, BDD scenarios, and paired legacy/v2 fixture
+- [x] Stage F: Add unit tests, BDD scenarios, and paired legacy/v2 fixture
       coverage.
-- [ ] Stage G: Update documentation, roadmap, and user's guide.
-- [ ] Stage H: Run all quality gates and finalize.
+- [x] Stage G: Update documentation, roadmap, and user's guide.
+- [x] Stage H: Run all quality gates and finalize.
+
+Completed note: this ExecPlan is archived as shipped. Later execution semantics
+for `TreeSitterQuery` matching and dependency rules are tracked by downstream
+milestones.
 
 ## Surprises & discoveries
 
-(None yet.)
+- `r2c-internal-project-depends-on` has no source-code formula body, so the
+  shipped path lowers it to a degenerate, non-matchable `TreeSitterQuery` atom
+  instead of inventing a speculative dependency atom.
 
 ## Decision log
 
-(None yet.)
+- Use `serde_json::Value` inside `WhereClause` so normalization preserves
+  constraints losslessly while later milestones decide how each clause is
+  interpreted.
+- Make `normalize_search_principal` infallible because all supported search
+  principals can be lowered into a canonical placeholder or formula shape.
 
 ## Outcomes & retrospective
 
-(To be completed after implementation.)
+Implemented. `sempai::Engine::compile_yaml` now returns query plans for valid
+search rules, with normalized formula payloads available through
+`QueryPlan::formula()`. Semantic validation rejects unsupported formula shapes
+with stable `E_SEMPAI_*` diagnostics before plan construction.
 
 ## Context and orientation
 
@@ -244,17 +258,17 @@ v2 `match` keys mapped to Canonical Formula types:
 
 Table: v2 `match` keys mapped to Canonical Formula types
 
-| v2 (`match`)                         | Canonical                           |
-| ------------------------------------ | ----------------------------------- |
-| `"..."` (string shorthand)           | `Formula::Atom(Atom::Pattern(...))` |
-| `pattern: "..."`                     | `Formula::Atom(Atom::Pattern(...))` |
-| `regex: "..."`                       | `Formula::Atom(Atom::Regex(...))`   |
-| `all: [...]`                         | `Formula::And([...])`               |
-| `any: [...]`                         | `Formula::Or([...])`                |
-| `not: ...`                           | `Formula::Not(Box<...>)`            |
-| `inside: ...`                        | `Formula::Inside(Box<...>)`         |
-| `anywhere: ...`                      | `Formula::Anywhere(Box<...>)`       |
-| `Decorated { where, as, fix, .. }`   | `Decorated<Formula>` wrapper[^1]    |
+| v2 (`match`)                       | Canonical                           |
+| ---------------------------------- | ----------------------------------- |
+| `"..."` (string shorthand)         | `Formula::Atom(Atom::Pattern(...))` |
+| `pattern: "..."`                   | `Formula::Atom(Atom::Pattern(...))` |
+| `regex: "..."`                     | `Formula::Atom(Atom::Regex(...))`   |
+| `all: [...]`                       | `Formula::And([...])`               |
+| `any: [...]`                       | `Formula::Or([...])`                |
+| `not: ...`                         | `Formula::Not(Box<...>)`            |
+| `inside: ...`                      | `Formula::Inside(Box<...>)`         |
+| `anywhere: ...`                    | `Formula::Anywhere(Box<...>)`       |
+| `Decorated { where, as, fix, .. }` | `Decorated<Formula>` wrapper[^1]    |
 
 [^1]: The canonical `Decorated<Formula>` exposes the fields `where_clauses`,
     `as_name`, `fix`, and `span: Option<SourceSpan>` in addition to the inner

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -353,11 +353,14 @@ Add a new module `crates/sempai/src/semantic_check.rs` (< 200 lines) with:
 - `pub(crate) fn validate_formula(formula: &Decorated<Formula>)
   -> Result<(), DiagnosticReport>`
 - Internal checks:
-  - `check_no_not_in_or(formula)` — walks `Or` branches and rejects any
-    that are `Formula::Not`.  Emits `E_SEMPAI_INVALID_NOT_IN_OR`.
-  - `check_positive_term_in_and(formula)` — walks `And` branches and
-    ensures at least one is a positive term (not `Not`, `Inside`, or
-    `Anywhere`).  Emits `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`.
+  - `check_no_not_in_or(formula)` — walks every `Or` branch subtree and
+    rejects any branch whose subtree contains a `Formula::Not`. Emits
+    `E_SEMPAI_INVALID_NOT_IN_OR`.
+  - `check_positive_term_in_and(formula)` — walks `And` branches and treats
+    `And`/`Or` as positive only when they contain at least one positive
+    descendant term, meaning a descendant that is not `Not`, `Inside`, or
+    `Anywhere`. Emits `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND` when no positive
+    descendant exists.
 
 Both checks must be recursive: they apply to nested sub-formulas as well.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -424,7 +424,7 @@ phase* *with explicit parser, backend, and Weaver-integration milestones.*
   - Acceptance criteria: unsupported execution modes return deterministic
     `UnsupportedMode` diagnostics, and search mode validation enforces required
     key combinations.
-- [ ] 4.1.5. Implement legacy and v2 normalization into one canonical
+- [x] 4.1.5. Implement legacy and v2 normalization into one canonical
       `Formula` model with semantic constraint checks. Requires 4.1.3.
   - Acceptance criteria: paired legacy and v2 fixtures normalize to equivalent
     formulas, and semantic invalid states emit deterministic rule diagnostics.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -445,7 +445,7 @@ phase* *with explicit parser, backend, and Weaver-integration milestones.*
   - Acceptance criteria: unsupported execution modes return deterministic
     `UnsupportedMode` diagnostics, and search mode validation enforces required
     key combinations.
-- [ ] 4.1.5. Implement legacy and v2 normalization into one canonical
+- [x] 4.1.5. Implement legacy and v2 normalization into one canonical
       `Formula` model with semantic constraint checks. Requires 4.1.3.
   - Acceptance criteria: paired legacy and v2 fixtures normalize to equivalent
     formulas, and semantic invalid states emit deterministic rule diagnostics.

--- a/docs/sempai-query-language-design.md
+++ b/docs/sempai-query-language-design.md
@@ -434,6 +434,18 @@ with `E_SEMPAI_UNSUPPORTED_MODE`. The first unsupported rule in source order is
 reported, and its `primary_span` prefers the `mode` field span before falling
 back to the enclosing rule span.
 
+Implementation note (2026-04-11): Normalization into the canonical `Formula`
+model is now implemented in `crates/sempai/src/normalize.rs`. Both legacy
+(`pattern*`) and v2 (`match`) syntaxes are lowered into the shared `Formula`
+enum defined in `sempai_core::formula`. Semantic validation
+(`E_SEMPAI_INVALID_NOT_IN_OR` and `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`) is
+enforced in `crates/sempai/src/semantic_check.rs`. The
+`r2c-internal-project-depends-on` principal normalizes to a degenerate
+Tree-sitter query atom that will never match real code, preserving forward
+compatibility without inventing execution semantics. `WhereClause` values are
+stored as opaque `serde_json::Value` and will be interpreted semantically in
+future milestones.
+
 Extract mode rules require legacy query keys, not `match`.[^1]
 
 ### Sempai extensions for Tree-sitter queries

--- a/docs/sempai-query-language-design.md
+++ b/docs/sempai-query-language-design.md
@@ -419,32 +419,22 @@ Search mode rules require:
   - `pattern-either`
   - `pattern-regex`
   - `match`
-  - `r2c-internal-project-depends-on` (parsed but ignored by Sempai).[^1]
+  - `r2c-internal-project-depends-on` (normalized to a degenerate
+    Tree-sitter query atom for now).[^1]
 
-Implementation note (2026-03-29): `sempai_yaml` now preserves
-`r2c-internal-project-depends-on` as an opaque search principal so the parser
-accepts Semgrep-compatible dependency rules without inventing execution
-semantics early.
-
-Implementation note (2026-03-29): `sempai::Engine::compile_yaml` now applies a
-mode-aware validation pass after parsing. Search rules continue to the
-deliberate `NOT_IMPLEMENTED` normalization placeholder, while `extract`,
-`taint`, `join`, and forward-compatible unknown modes fail deterministically
-with `E_SEMPAI_UNSUPPORTED_MODE`. The first unsupported rule in source order is
-reported, and its `primary_span` prefers the `mode` field span before falling
+Implementation note (2026-04-11): `sempai::Engine::compile_yaml` now parses
+YAML rules, applies mode-aware validation, and lowers valid search rules
+through canonical `Formula` normalization in `crates/sempai/src/normalize.rs`.
+Legacy (`pattern*`) and v2 (`match`) syntaxes lower into the shared
+`sempai_core::formula::Formula` enum, while `r2c-internal-project-depends-on`
+is preserved as an opaque search principal and normalizes to a degenerate
+Tree-sitter query atom that cannot match real code. Semantic checks for
+`E_SEMPAI_INVALID_NOT_IN_OR` and `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND` live
+in `crates/sempai/src/semantic_check.rs`. `WhereClause` values are stored as
+opaque `serde_json::Value` values and interpreted later. `extract`, `taint`,
+`join`, and forward-compatible unknown modes still fail deterministically with
+`E_SEMPAI_UNSUPPORTED_MODE`, preferring the `mode` field span before falling
 back to the enclosing rule span.
-
-Implementation note (2026-04-11): Normalization into the canonical `Formula`
-model is now implemented in `crates/sempai/src/normalize.rs`. Both legacy
-(`pattern*`) and v2 (`match`) syntaxes are lowered into the shared `Formula`
-enum defined in `sempai_core::formula`. Semantic validation
-(`E_SEMPAI_INVALID_NOT_IN_OR` and `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`) is
-enforced in `crates/sempai/src/semantic_check.rs`. The
-`r2c-internal-project-depends-on` principal normalizes to a degenerate
-Tree-sitter query atom that will never match real code, preserving forward
-compatibility without inventing execution semantics. `WhereClause` values are
-stored as opaque `serde_json::Value` and will be interpreted semantically in
-future milestones.
 
 Extract mode rules require legacy query keys, not `match`.[^1]
 

--- a/docs/sempai-v0.1-to-v0.2-migration-guide.md
+++ b/docs/sempai-v0.1-to-v0.2-migration-guide.md
@@ -1,0 +1,89 @@
+# Sempai v0.1 → v0.2 migration guide
+
+## Summary of breaking change
+
+- `Engine::compile_yaml` now returns `Ok(Vec<QueryPlan>)` for valid search
+  rules instead of a `NOT_IMPLEMENTED` diagnostic.
+- Semantic validation now surfaces deterministic `E_SEMPAI_*` diagnostics.
+
+## Before (v0.1)
+
+```rust
+let result = engine.compile_yaml(yaml);
+let err = result.expect_err("normalization not implemented");
+assert_eq!(err.diagnostics()[0].code(), DiagnosticCode::NotImplemented);
+```
+
+## After (v0.2)
+
+```rust
+let plans = engine.compile_yaml(yaml)?; // Ok(Vec<QueryPlan>)
+let plan = &plans[0];
+let formula = plan.formula(); // &Decorated<Formula>
+```
+
+## New failure modes
+
+- `E_SEMPAI_YAML_PARSE` — malformed YAML
+- `E_SEMPAI_SCHEMA_INVALID` — invalid rule schema, such as an unsupported
+  language
+- `E_SEMPAI_INVALID_NOT_IN_OR` — negated branch inside disjunction
+- `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND` — conjunction lacks a positive term
+- `E_SEMPAI_UNSUPPORTED_MODE` — extract, taint, join, or unknown modes
+
+## Code updates checklist
+
+- Replace tests expecting `NotImplemented` with success-path assertions over
+  `plan.formula()`.
+- Assert explicit `DiagnosticCode` values on failures.
+
+## Examples
+
+Minimal success-path assertion:
+
+```rust
+use sempai::{Engine, EngineConfig};
+use sempai_core::formula::{Atom, Formula};
+
+let yaml = concat!(
+    "rules:\n",
+    "  - id: demo.rule\n",
+    "    message: demo\n",
+    "    languages: [rust]\n",
+    "    severity: ERROR\n",
+    "    pattern: foo($X)\n",
+);
+
+let engine = Engine::new(EngineConfig::default());
+let plans = engine.compile_yaml(yaml)?;
+let plan = plans.first().expect("expected one query plan");
+let formula = plan.formula();
+
+assert!(
+    matches!(&formula.node, Formula::Atom(Atom::Pattern(p)) if p.text == "foo($X)")
+);
+# Ok::<(), sempai::DiagnosticReport>(())
+```
+
+Negated disjunction branch failure:
+
+```rust
+use sempai::{DiagnosticCode, Engine, EngineConfig};
+
+let yaml = concat!(
+    "rules:\n",
+    "  - id: demo.invalid.not.in.or\n",
+    "    message: invalid not in or\n",
+    "    languages: [rust]\n",
+    "    severity: ERROR\n",
+    "    pattern-either:\n",
+    "      - pattern: foo($X)\n",
+    "      - pattern-not: bar($Y)\n",
+);
+
+let engine = Engine::new(EngineConfig::default());
+let err = engine.compile_yaml(yaml).expect_err("semantic validation should fail");
+let first = err.diagnostics().first().expect("expected diagnostic");
+
+assert_eq!(first.code(), DiagnosticCode::ESempaiInvalidNotInOr);
+```

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1373,19 +1373,26 @@ failures such as missing required rule keys return `E_SEMPAI_SCHEMA_INVALID`,
 both using the shared structured diagnostic payload with `primary_span`
 locations when available.
 
-After parsing succeeds, `compile_yaml(yaml)` now distinguishes parseable rules
-from executable ones:
+After parsing succeeds, `compile_yaml(yaml)` normalizes search rules into
+canonical query plans:
 
-- Valid `search` rules, including compatibility-only
-  `r2c-internal-project-depends-on` rules, continue to the existing
-  `NOT_IMPLEMENTED` normalization placeholder.
-- Valid `extract`, `taint`, `join`, and unknown future mode strings now fail
-  deterministically with `E_SEMPAI_UNSUPPORTED_MODE` instead of falling through
-  to the generic placeholder.
+- Valid `search` rules are normalized into the canonical `Formula` model
+  defined in `sempai_core::formula`. Both legacy (`pattern*`) and v2 (`match`)
+  syntaxes are lowered into a shared representation.
+- Normalized formulas are validated for semantic correctness:
+  `E_SEMPAI_INVALID_NOT_IN_OR` is emitted when negated terms appear in
+  disjunction branches, and `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND` is emitted
+  when conjunctions contain only constraint formulas.
+- For each valid search rule and declared language, a `QueryPlan` is returned
+  containing the normalized formula and metadata.
+- Valid `extract`, `taint`, `join`, and unknown future mode strings fail
+  deterministically with `E_SEMPAI_UNSUPPORTED_MODE`.
+- Compatibility-only `r2c-internal-project-depends-on` rules normalize to a
+  degenerate formula that will never match real code.
 
 Unsupported-mode diagnostics point at the rule's `mode` field when that span is
-available, which makes whole-document failures deterministic even though the
-execution backend is still pending.
+available. Semantic validation errors include accurate `primary_span` locations
+when available from the parser.
 
 `compile_dsl(...)` and `execute(...)` still return "not implemented"
 diagnostics. They will be wired to the DSL parser and Tree-sitter backend as

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1518,19 +1518,26 @@ failures such as missing required rule keys return `E_SEMPAI_SCHEMA_INVALID`,
 both using the shared structured diagnostic payload with `primary_span`
 locations when available.
 
-After parsing succeeds, `compile_yaml(yaml)` now distinguishes parseable rules
-from executable ones:
+After parsing succeeds, `compile_yaml(yaml)` normalizes search rules into
+canonical query plans:
 
-- Valid `search` rules, including compatibility-only
-  `r2c-internal-project-depends-on` rules, continue to the existing
-  `NOT_IMPLEMENTED` normalization placeholder.
-- Valid `extract`, `taint`, `join`, and unknown future mode strings now fail
-  deterministically with `E_SEMPAI_UNSUPPORTED_MODE` instead of falling through
-  to the generic placeholder.
+- Valid `search` rules are normalized into the canonical `Formula` model
+  defined in `sempai_core::formula`. Both legacy (`pattern*`) and v2 (`match`)
+  syntaxes are lowered into a shared representation.
+- Normalized formulas are validated for semantic correctness:
+  `E_SEMPAI_INVALID_NOT_IN_OR` is emitted when negated terms appear in
+  disjunction branches, and `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND` is emitted
+  when conjunctions contain only constraint formulas.
+- For each valid search rule and declared language, a `QueryPlan` is returned
+  containing the normalized formula and metadata.
+- Valid `extract`, `taint`, `join`, and unknown future mode strings fail
+  deterministically with `E_SEMPAI_UNSUPPORTED_MODE`.
+- Compatibility-only `r2c-internal-project-depends-on` rules normalize to a
+  degenerate formula that will never match real code.
 
 Unsupported-mode diagnostics point at the rule's `mode` field when that span is
-available, which makes whole-document failures deterministic even though the
-execution backend is still pending.
+available. Semantic validation errors include accurate `primary_span` locations
+when available from the parser.
 
 `compile_dsl(...)` and `execute(...)` still return "not implemented"
 diagnostics. They will be wired to the DSL parser and Tree-sitter backend as

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1539,6 +1539,11 @@ Unsupported-mode diagnostics point at the rule's `mode` field when that span is
 available. Semantic validation errors include accurate `primary_span` locations
 when available from the parser.
 
+### Migration notes
+
+Upgrading from v0.1? See the
+[Sempai v0.1→v0.2 migration guide](sempai-v0.1-to-v0.2-migration-guide.md).
+
 `compile_dsl(...)` and `execute(...)` still return "not implemented"
 diagnostics. They will be wired to the DSL parser and Tree-sitter backend as
 those components are delivered in subsequent roadmap phases.


### PR DESCRIPTION
## Summary
- Introduces a canonical Formula model in sempai-core and a normalization pipeline to unify legacy `pattern*` syntax and v2 `match` syntax into a single representation in sempai_core.
- Adds semantic validation for invalid constructs (e.g. InvalidNotInOr, MissingPositiveTermInAnd).
- Replaces the NOT_IMPLEMENTED placeholder in Engine::compile_yaml with real normalization, validation, and QueryPlan construction.
- Aligns tooling, tests, and docs toward a live normalization path across core, YAML parsing, and engine layers.

## Changes
### Core modelling
- Add canonical Formula types in sempai-core:
  - `Formula` enum with variants: `Atom`, `Not`, `Inside`, `Anywhere`, `And`, `Or`.
  - `Atom` enum: `Pattern`, `Regex`, `TreeSitterQuery`.
  - Lightweight leaf wrappers: `PatternAtom`, `RegexAtom`, `TreeSitterQueryAtom`.
  - `Decorated<T>` wrapper carrying `where_clauses`, `as_name`, `fix`, and `span`.
  - `WhereClause` as an opaque container (initially storing a raw JSON value).
- Expose and re-export new types from public API (e.g. `pub mod formula;` and re-export from `sempai-core` lib).

### Normalization layer
- Introduce normalization entry points to convert both legacy formulas and v2 match formulas into `Decorated<Formula>`:
  - Legacy normalization maps `pattern`, `pattern-regex`, `patterns`, `pattern-either`, `pattern-inside`, etc. to canonical `Formula` structures.
  - v2 normalization maps `match` forms (`all`, `any`, `not`, `inside`, `anywhere`, etc.) to canonical shapes.
  - Attach `WhereClause`s to the enclosing `Decorated<Formula>` for constraints carried over from legacy forms.
  - Propagate `Decorated` metadata (`where`, `as`, `fix`) during normalization.

### Semantic validation
- Add semantic checks for canonical formulas:
  - `InvalidNotInOr`: reject negated branches inside disjunctions.
  - `MissingPositiveTermInAnd`: require at least one positive term in an `And`.
- Implement recursive validation across nested formula trees and emit deterministic diagnostics (codes like `E_SEMPAI_INVALID_NOT_IN_OR`, `E_SEMPAI_MISSING_POSITIVE_TERM_IN_AND`).

### Engine integration
- Wire normalization into `Engine::compile_yaml`:
  1) Parse rules as before.
  2) For each rule, normalize its principal into `Decorated<Formula>`.
  3) Run semantic validation on the normalized formula.
  4) Build and return a `QueryPlan` containing the normalized formula and rule metadata.
- Update `QueryPlan` to store the `Decorated<Formula>` instead of the prior placeholder.

### Testing
- Add unit tests in:
  - `sempai-core` for construction and equality of `Formula` variants.
  - `sempai` for normalization and semantic validation scenarios.
- Extend/align BDD tests to cover happy paths, negative paths (invalid-not-in-or, missing-positive-term-in-and), and parity between legacy and v2 fixtures.

### Documentation
- Documentation updates to reflect normalization as the live path:
  - `docs/sempai-query-language-design.md` (note canonical `Formula` model and `WhereClause` handling).
  - `docs/users-guide.md` (update to reflect `compile_yaml` returning compiled plans for valid rules).
  - `docs/roadmap.md` (mark 4.1.5 as done).

## Validation and acceptance criteria
- [x] `Engine::compile_yaml` returns `QueryPlan`s with normalized `Decorated<Formula>` for valid rules (no more `NOT_IMPLEMENTED`).
- [x] Legacy and v2 fixtures normalize to structurally equivalent `Formula` values.
- [x] Semantic diagnostics are emitted for invalid forms (e.g. invalid not-in-or, missing positive term).
- [x] Tests pass for new normalization and semantic checks; existing tests adapt to new behavior where necessary.
- [x] Documentation and roadmap reflect the completed milestone.

## How to test locally
- Build docs and run checks:
  - cargo doc -p sempai_core
  - make lint
  - make check-fmt
  - make markdownlint
- Run tests:
  - cargo test -p sempai_core
  - cargo test -p sempai
  - cargo test -p sempai_yaml
- Exercise engine path:
  - cargo test -p sempai

## Notes on compatibility and scope
- Public API changes are limited to internal canonical-form representations; the existing `sempai_yaml::parse_rule_file` signature remains unchanged.
- The new modules are designed to be incremental (Stage B–D) with Stage E–H focused on wiring, testing, and documentation.
- New functionality should be covered by targeted tests and BDD scenarios before release.



📎 **Task**: https://www.devboxer.com/task/795de59f-09d8-463e-9ef9-350b92fa57be