### PR TITLE
Overhaul Weaver CLI roadmap and adapter policy (13.1.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Weaver
 
-A semantics-aware command-line tool for AI coding agents.
+A human-friendly, agent-native semantic command-line tool.
 
 Weaver is your AI agent's best friend when it comes to understanding and
 modifying code. We believe the shell should speak the language of semantics—not
@@ -11,8 +11,8 @@ to your terminal.
 
 Weaver is a Rust-based CLI tool that provides semantic operations on codebases
 through a simple, composable interface. It follows the UNIX philosophy: small,
-focused tools that communicate via JSON Lines (JSONL) and play nicely with your
-existing shell utilities like `jq`, `xargs`, and `find`.
+focused tools that communicate clearly and play nicely with existing shell
+utilities like `jq`, `xargs`, and `find`.
 
 Under the bonnet, Weaver runs a daemon (`weaverd`) that orchestrates language
 servers, syntax analysers, and specialised plugins—all sandboxed for
@@ -22,22 +22,26 @@ tricky rename, Weaver gives you the semantic primitives you need.
 
 ## Status
 
-Weaver is in active early development (v0.1.0). We've completed the core
-foundation—the CLI/daemon architecture, LSP integration for Rust, Python, and
-TypeScript, and the security sandbox—but there's more to come. Check out our
-[roadmap](docs/roadmap.md) to see what we're working on next.
+Weaver is in active early development before the first v0.1.0 release. The
+repository already contains the CLI/daemon architecture, shared configuration,
+Language Server Protocol (LSP) hosting, Tree-sitter syntax support, graph and
+card foundations, plugin infrastructure, sandboxing, and write-operation safety
+harness work. The public command surface is now being reset around
+[ADR 007](docs/adr-007-agent-native-command-surface.md), which makes the 0.1.0
+target human-friendly and agent-native without preserving compatibility with
+the prototype `observe` / `act` / `verify` grammar.
 
-> **Note:** The "Double-Lock" safety harness for write operations is still under
-> development. We recommend caution when using `act` commands until this is
-> complete.
+Check the [roadmap](docs/roadmap.md) for the current build sequence and the
+[user's guide](docs/users-guide.md) for the split between current prototype
+commands and the 0.1.0 target contract.
 
 ## Key features
 
-- **Semantic operations as shell verbs** — Commands like
-  `observe get-definition` and `act rename-symbol` bring IDE-level intelligence
-  to your terminal.
-- **JSONL-native protocol** — Every request and response is a JSON object,
-  making integration with other tools trivial.
+- **Semantic operations as shell verbs** — Current prototype commands expose
+  code intelligence today; the 0.1.0 target moves to resource-first commands
+  such as `definitions get`, `references list`, and `symbols rename`.
+- **Agent-native output contracts** — The target surface keeps readable human
+  defaults while making `--json` the stable machine-readable path.
 - **Multi-layer fusion** — Combines Language Server Protocol (LSP), Tree-sitter
   parsing, and call graph analysis for comprehensive code understanding.
 - **Zero-trust sandboxing** — External tools run in isolated environments using
@@ -47,15 +51,11 @@ TypeScript, and the security sandbox—but there's more to come. Check out our
 
 ## Components
 
-Weaver is organised as a Cargo workspace with five crates:
-
-| Crate             | Description                                                      |
-| ----------------- | ---------------------------------------------------------------- |
-| `weaver-cli`      | Thin CLI client that serialises commands into JSONL              |
-| `weaverd`         | Daemon broker that orchestrates backends and verifies operations |
-| `weaver-config`   | Shared configuration management via `ortho-config`               |
-| `weaver-lsp-host` | Language Server Protocol host with capability detection          |
-| `weaver-sandbox`  | Security sandbox wrapper around `birdcage`                       |
+Weaver is organized as a Cargo workspace with dedicated crates for the CLI,
+daemon, configuration, LSP hosting, syntax parsing, graph support, cards,
+plugins, sandboxing, Sempai query planning, build utilities, and end-to-end
+tests. See [the repository layout](docs/repository-layout.md) for the current
+crate map and planned component ownership.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Here's the quickest path to your first Weaver command:
 weaver daemon start
 
 # Query a symbol definition
-weaver observe get-definition --uri file:///path/to/main.rs --position 42:17
+weaver definitions get --uri file:///path/to/main.rs --position 42:17
 
 # Check daemon status
 weaver daemon status

--- a/crates/weaver-cli/src/cli.rs
+++ b/crates/weaver-cli/src/cli.rs
@@ -3,7 +3,7 @@
 //! This module defines the command-line interface structure used by
 //! both the runtime parser and the build script for manpage generation.
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 /// Output format selection for domain command responses.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
@@ -34,7 +34,7 @@ pub enum OutputFormat {
         "\n",
         "Quick start:\n",
         "\n",
-        "  weaver observe get-definition \\\n",
+        "  weaver definitions get \\\n",
         "    --uri file:///src/main.rs --position 10:5\n",
         "  weaver act apply-patch < changes.patch\n",
         "  weaver daemon status\n",
@@ -87,12 +87,36 @@ pub(crate) struct Cli {
 /// Structured subcommands for the Weaver CLI.
 #[derive(Subcommand, Debug, Clone)]
 pub(crate) enum CliCommand {
+    /// Query symbol definitions.
+    Definitions {
+        /// The definition operation to perform.
+        #[command(subcommand)]
+        action: DefinitionsAction,
+    },
     /// Runs daemon lifecycle commands.
     Daemon {
         /// The lifecycle action to perform.
         #[command(subcommand)]
         action: DaemonAction,
     },
+}
+
+/// Resource-first definition commands.
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum DefinitionsAction {
+    /// Returns the definition location for a source position.
+    Get(DefinitionGetArgs),
+}
+
+/// Arguments for `weaver definitions get`.
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DefinitionGetArgs {
+    /// The document URI containing the reference position.
+    #[arg(long)]
+    pub(crate) uri: String,
+    /// The 1-indexed line:column position to resolve.
+    #[arg(long)]
+    pub(crate) position: String,
 }
 
 /// Daemon lifecycle actions.

--- a/crates/weaver-cli/src/command.rs
+++ b/crates/weaver-cli/src/command.rs
@@ -125,12 +125,8 @@ impl CommandInvocation {
 impl CommandRequest {
     pub(crate) fn with_patch(invocation: CommandInvocation, patch: String) -> Self {
         Self {
-            command: CommandDescriptor {
-                domain: invocation.domain,
-                operation: invocation.operation,
-            },
-            arguments: invocation.arguments,
             patch: Some(patch),
+            ..Self::from(invocation)
         }
     }
 

--- a/crates/weaver-cli/src/command.rs
+++ b/crates/weaver-cli/src/command.rs
@@ -14,7 +14,7 @@ use crate::{
     CliCommand,
     DefinitionsAction,
     cli::DefinitionGetArgs,
-    command_surface::{CommandSurfaceRecord, find_read_only_command},
+    command_surface::{CommandSurfaceRecord, DEFINITIONS_GET, find_read_only_command},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -58,12 +58,13 @@ impl CommandInvocation {
             CliCommand::Definitions {
                 action: DefinitionsAction::Get(args),
             } => {
-                let record = find_read_only_command(&["definitions"], "get").ok_or_else(|| {
-                    AppError::MissingCommandSurfaceRecord {
-                        resource: String::from("definitions"),
-                        verb: String::from("get"),
-                    }
-                })?;
+                let adapter_record = &DEFINITIONS_GET;
+                let record =
+                    find_read_only_command(adapter_record.resource_path, adapter_record.verb)
+                        .ok_or_else(|| AppError::MissingCommandSurfaceRecord {
+                            resource: adapter_record.resource_path.join(" "),
+                            verb: String::from(adapter_record.verb),
+                        })?;
                 Ok(definition_get_invocation(record, args))
             }
             CliCommand::Daemon { .. } => Err(AppError::MissingDomain),

--- a/crates/weaver-cli/src/command.rs
+++ b/crates/weaver-cli/src/command.rs
@@ -8,9 +8,16 @@ use std::io::Write;
 
 use serde::Serialize;
 
-use crate::{AppError, Cli};
+use crate::{
+    AppError,
+    Cli,
+    CliCommand,
+    DefinitionsAction,
+    cli::DefinitionGetArgs,
+    command_surface::{CommandSurfaceRecord, find_read_only_command},
+};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct CommandInvocation {
     pub(crate) domain: String,
     pub(crate) operation: String,
@@ -21,6 +28,10 @@ impl TryFrom<Cli> for CommandInvocation {
     type Error = AppError;
 
     fn try_from(cli: Cli) -> Result<Self, Self::Error> {
+        if let Some(command) = cli.command {
+            return Self::try_from_structured_command(command);
+        }
+
         let domain = cli.domain.ok_or(AppError::MissingDomain)?.trim().to_owned();
         let operation = cli
             .operation
@@ -38,6 +49,41 @@ impl TryFrom<Cli> for CommandInvocation {
             operation,
             arguments: cli.arguments,
         })
+    }
+}
+
+impl CommandInvocation {
+    fn try_from_structured_command(command: CliCommand) -> Result<Self, AppError> {
+        match command {
+            CliCommand::Definitions {
+                action: DefinitionsAction::Get(args),
+            } => {
+                let record = find_read_only_command(&["definitions"], "get").ok_or_else(|| {
+                    AppError::MissingCommandSurfaceRecord {
+                        resource: String::from("definitions"),
+                        verb: String::from("get"),
+                    }
+                })?;
+                Ok(definition_get_invocation(record, args))
+            }
+            CliCommand::Daemon { .. } => Err(AppError::MissingDomain),
+        }
+    }
+}
+
+fn definition_get_invocation(
+    record: &CommandSurfaceRecord,
+    args: DefinitionGetArgs,
+) -> CommandInvocation {
+    CommandInvocation {
+        domain: record.daemon_domain.to_string(),
+        operation: record.daemon_operation.to_string(),
+        arguments: vec![
+            String::from("--uri"),
+            args.uri,
+            String::from("--position"),
+            args.position,
+        ],
     }
 }
 

--- a/crates/weaver-cli/src/command_surface.rs
+++ b/crates/weaver-cli/src/command_surface.rs
@@ -5,6 +5,14 @@
 //! CLI policy out of this module; it only records Weaver resource paths,
 //! capabilities, selector forms, and the legacy daemon operation used during
 //! the 0.1.0 command reset.
+//!
+//! Removal policy: replace `CommandSurfaceRecord` with OrthoConfig 6.1
+//! recursive command metadata and OrthoConfig 7.2.7 generic
+//! capability/provenance metadata once those contracts can carry the
+//! Weaver-specific fields below. Replace the read-only catalogue and lookup
+//! helpers with the OrthoConfig 6.1 generated command registry, and use
+//! OrthoConfig 6.2/6.3 output for context and skill surfaces. ADR 007 records
+//! the same policy for reviewers.
 
 /// A public selector form accepted by a command-surface record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +43,9 @@ pub(crate) enum ProviderPolicy {
 }
 
 /// Metadata for one resource-first command.
+///
+/// Temporary adapter: replaced by OrthoConfig 6.1 command metadata plus
+/// OrthoConfig 7.2.7 capability/provenance metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CommandSurfaceRecord {
     pub(crate) resource_path: &'static [&'static str],
@@ -90,9 +101,15 @@ pub(crate) const REFERENCES_LIST: CommandSurfaceRecord = CommandSurfaceRecord {
 };
 
 /// Pilot read-only records owned by the local adapter.
+///
+/// Temporary adapter: replaced by generated OrthoConfig 6.1 metadata once the
+/// same records can feed routing, context, and skills.
 pub(crate) const READ_ONLY_COMMANDS: &[CommandSurfaceRecord] = &[DEFINITIONS_GET, REFERENCES_LIST];
 
 /// Finds a read-only resource command by canonical path and verb.
+///
+/// Temporary adapter: replaced by the OrthoConfig 6.1 generated command
+/// registry lookup.
 pub(crate) fn find_read_only_command(
     resource_path: &[&str],
     verb: &str,

--- a/crates/weaver-cli/src/command_surface.rs
+++ b/crates/weaver-cli/src/command_surface.rs
@@ -1,0 +1,131 @@
+//! Temporary command-surface metadata for resource-first Weaver commands.
+//!
+//! This adapter captures Weaver-owned semantic command metadata until the
+//! reusable OrthoConfig command-contract machinery is available. Keep generic
+//! CLI policy out of this module; it only records Weaver resource paths,
+//! capabilities, selector forms, and the legacy daemon operation used during
+//! the 0.1.0 command reset.
+
+/// A public selector form accepted by a command-surface record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelectorForm {
+    /// Editor-style `--uri` plus `--position` selection.
+    Position,
+}
+
+/// Whether the command can mutate the workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Mutability {
+    /// Read-only commands observe code and do not propose edits.
+    ReadOnly,
+}
+
+/// Whether a command completes synchronously or submits recoverable work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AsyncClass {
+    /// The command completes in the foreground without job-ledger recovery.
+    Synchronous,
+}
+
+/// How Weaver should choose implementation providers for a capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderPolicy {
+    /// Let Weaver choose the provider through deterministic capability routing.
+    Auto,
+}
+
+/// Metadata for one resource-first command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CommandSurfaceRecord {
+    pub(crate) resource_path: &'static [&'static str],
+    pub(crate) verb: &'static str,
+    pub(crate) capability_id: &'static str,
+    pub(crate) selector_forms: &'static [SelectorForm],
+    pub(crate) output_schema: &'static str,
+    pub(crate) error_schema: &'static str,
+    pub(crate) mutability: Mutability,
+    pub(crate) async_class: AsyncClass,
+    pub(crate) provider_policy: ProviderPolicy,
+    pub(crate) daemon_domain: &'static str,
+    pub(crate) daemon_operation: &'static str,
+    pub(crate) examples: &'static [&'static str],
+    pub(crate) skill_refs: &'static [&'static str],
+}
+
+const POSITION_SELECTOR: &[SelectorForm] = &[SelectorForm::Position];
+
+/// Command-surface record for `weaver definitions get`.
+pub(crate) const DEFINITIONS_GET: CommandSurfaceRecord = CommandSurfaceRecord {
+    resource_path: &["definitions"],
+    verb: "get",
+    capability_id: "definition.get",
+    selector_forms: POSITION_SELECTOR,
+    output_schema: "weaver.definition.locations.v1",
+    error_schema: "weaver.error.v1",
+    mutability: Mutability::ReadOnly,
+    async_class: AsyncClass::Synchronous,
+    provider_policy: ProviderPolicy::Auto,
+    daemon_domain: "observe",
+    daemon_operation: "get-definition",
+    examples: &["weaver definitions get --uri file:///src/main.rs --position 10:5"],
+    skill_refs: &["code-reading-loop"],
+};
+
+/// Metadata-only sibling that proves the read command family can grow without
+/// a second adapter shape.
+pub(crate) const REFERENCES_LIST: CommandSurfaceRecord = CommandSurfaceRecord {
+    resource_path: &["references"],
+    verb: "list",
+    capability_id: "references.list",
+    selector_forms: POSITION_SELECTOR,
+    output_schema: "weaver.reference.locations.v1",
+    error_schema: "weaver.error.v1",
+    mutability: Mutability::ReadOnly,
+    async_class: AsyncClass::Synchronous,
+    provider_policy: ProviderPolicy::Auto,
+    daemon_domain: "observe",
+    daemon_operation: "find-references",
+    examples: &["weaver references list --uri file:///src/main.rs --position 10:5"],
+    skill_refs: &["code-reading-loop"],
+};
+
+/// Pilot read-only records owned by the local adapter.
+pub(crate) const READ_ONLY_COMMANDS: &[CommandSurfaceRecord] = &[DEFINITIONS_GET, REFERENCES_LIST];
+
+/// Finds a read-only resource command by canonical path and verb.
+pub(crate) fn find_read_only_command(
+    resource_path: &[&str],
+    verb: &str,
+) -> Option<&'static CommandSurfaceRecord> {
+    READ_ONLY_COMMANDS
+        .iter()
+        .find(|record| record.resource_path == resource_path && record.verb == verb)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the temporary command-surface metadata adapter.
+
+    use super::*;
+
+    #[test]
+    fn pilot_records_cover_definition_and_reference_capabilities() {
+        let capabilities: Vec<&str> = READ_ONLY_COMMANDS
+            .iter()
+            .map(|record| record.capability_id)
+            .collect();
+
+        assert_eq!(capabilities, vec!["definition.get", "references.list"]);
+    }
+
+    #[test]
+    fn definitions_record_maps_to_existing_daemon_operation() {
+        assert_eq!(DEFINITIONS_GET.resource_path, ["definitions"]);
+        assert_eq!(DEFINITIONS_GET.verb, "get");
+        assert_eq!(DEFINITIONS_GET.selector_forms, [SelectorForm::Position]);
+        assert_eq!(DEFINITIONS_GET.daemon_domain, "observe");
+        assert_eq!(DEFINITIONS_GET.daemon_operation, "get-definition");
+        assert_eq!(DEFINITIONS_GET.mutability, Mutability::ReadOnly);
+        assert_eq!(DEFINITIONS_GET.provider_policy, ProviderPolicy::Auto);
+    }
+}

--- a/crates/weaver-cli/src/errors.rs
+++ b/crates/weaver-cli/src/errors.rs
@@ -16,6 +16,8 @@ pub(crate) enum AppError {
     MissingDomain,
     #[error("the command operation must be provided")]
     MissingOperation,
+    #[error("command-surface record missing for {resource} {verb}")]
+    MissingCommandSurfaceRecord { resource: String, verb: String },
     #[error("failed to emit bare help: {0}")]
     EmitBareHelp(io::Error),
     #[error("failed to emit clap help: {0}")]

--- a/crates/weaver-cli/src/lib.rs
+++ b/crates/weaver-cli/src/lib.rs
@@ -17,6 +17,7 @@ use ortho_config::Localizer;
 mod actionable_guidance;
 mod cli;
 mod command;
+mod command_surface;
 mod config;
 mod daemon_output;
 mod discoverability;
@@ -44,10 +45,12 @@ pub const SHARED_CONFIG_HELP_FLAGS: &[&str] = &[
 ];
 
 pub use cli::OutputFormat;
-pub(crate) use cli::{Cli, CliCommand, DaemonAction};
+pub(crate) use cli::{Cli, CliCommand, DaemonAction, DefinitionsAction};
 #[cfg(test)]
 pub(crate) use command::CommandDescriptor;
 pub(crate) use command::{CommandInvocation, CommandRequest};
+#[cfg(test)]
+pub(crate) use command_surface::READ_ONLY_COMMANDS;
 use config::prepare_cli_arguments;
 pub(crate) use config::{ConfigLoader, OrthoConfigLoader, split_config_arguments};
 #[cfg(test)]

--- a/crates/weaver-cli/src/tests/unit.rs
+++ b/crates/weaver-cli/src/tests/unit.rs
@@ -391,6 +391,7 @@ mod actionable_guidance;
 mod after_help;
 mod auto_start;
 mod bare_invocation;
+mod command_surface;
 mod discoverability;
 mod help_output;
 mod missing_operation_guidance;

--- a/crates/weaver-cli/src/tests/unit/command_surface.rs
+++ b/crates/weaver-cli/src/tests/unit/command_surface.rs
@@ -1,0 +1,51 @@
+//! Unit tests for resource-first command-surface adapter behaviour.
+
+use clap::Parser;
+
+use crate::{Cli, CommandInvocation, READ_ONLY_COMMANDS};
+
+#[test]
+fn structured_definitions_get_uses_command_surface_adapter() {
+    let cli = Cli::try_parse_from([
+        "weaver",
+        "definitions",
+        "get",
+        "--uri",
+        "file:///src/main.rs",
+        "--position",
+        "10:5",
+    ])
+    .expect("parse definitions get");
+
+    let invocation = CommandInvocation::try_from(cli).expect("map structured command");
+
+    assert_eq!(
+        invocation,
+        CommandInvocation {
+            domain: String::from("observe"),
+            operation: String::from("get-definition"),
+            arguments: vec![
+                String::from("--uri"),
+                String::from("file:///src/main.rs"),
+                String::from("--position"),
+                String::from("10:5"),
+            ],
+        }
+    );
+}
+
+#[test]
+fn read_only_command_surface_metadata_keeps_family_shape() {
+    let records: Vec<(&[&str], &str, &str)> = READ_ONLY_COMMANDS
+        .iter()
+        .map(|record| (record.resource_path, record.verb, record.capability_id))
+        .collect();
+
+    assert_eq!(
+        records,
+        vec![
+            (&["definitions"][..], "get", "definition.get"),
+            (&["references"][..], "list", "references.list"),
+        ]
+    );
+}

--- a/crates/weaver-cli/src/tests/unit/snapshots/weaver_cli__tests__unit__help_output__top_level_augmented_help.snap
+++ b/crates/weaver-cli/src/tests/unit/snapshots/weaver_cli__tests__unit__help_output__top_level_augmented_help.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/weaver-cli/src/tests/unit/help_output.rs
-assertion_line: 58
+assertion_line: 68
 expression: rendered
 ---
 Semantic code intelligence tool for observing, acting on, and verifying code.
 
 Quick start:
 
-  weaver observe get-definition \
+  weaver definitions get \
     --uri file:///src/main.rs --position 10:5
   weaver act apply-patch < changes.patch
   weaver daemon status
@@ -19,7 +19,8 @@ Usage: weaver [OPTIONS] [DOMAIN] [OPERATION] [ARG]...
        weaver [OPTIONS] [DOMAIN] [OPERATION] [ARG]... <COMMAND>
 
 Commands:
-  daemon  Runs daemon lifecycle commands
+  definitions  Query symbol definitions
+  daemon       Runs daemon lifecycle commands
 
 Arguments:
   [DOMAIN]

--- a/crates/weaver-cli/src/tests/unit/version_output.rs
+++ b/crates/weaver-cli/src/tests/unit/version_output.rs
@@ -102,7 +102,7 @@ fn help_output_contains_quick_start_example() {
         "help output missing quick-start block"
     );
     assert!(
-        stdout.contains("weaver observe get-definition"),
+        stdout.contains("weaver definitions get"),
         "help output missing runnable example"
     );
 }

--- a/crates/weaver-cli/tests/features/weaver_cli.feature
+++ b/crates/weaver-cli/tests/features/weaver_cli.feature
@@ -8,6 +8,14 @@ Feature: Weaver CLI behaviour
     And stderr is "daemon complains"
     And the CLI exits with code 17
 
+  Scenario: Streaming a resource-first definition request to the daemon
+    Given a running fake daemon
+    When the operator runs "definitions get --uri file:///src/main.rs --position 10:5"
+    Then the daemon receives "request_definitions_get.jsonl"
+    And stdout is "daemon says hello"
+    And stderr is "daemon complains"
+    And the CLI exits with code 17
+
   Scenario: Streaming an apply-patch request with stdin
     Given a running fake daemon
     And patch input is available

--- a/crates/weaver-cli/tests/golden/request_definitions_get.jsonl
+++ b/crates/weaver-cli/tests/golden/request_definitions_get.jsonl
@@ -1,0 +1,1 @@
+{"command":{"domain":"observe","operation":"get-definition"},"arguments":["--uri","file:///src/main.rs","--position","10:5"]}

--- a/crates/weaver-cli/tests/main_entry.rs
+++ b/crates/weaver-cli/tests/main_entry.rs
@@ -143,7 +143,7 @@ fn help_flag_exits_successfully_with_quick_start() {
         .assert()
         .success()
         .stdout(contains("Quick start:"))
-        .stdout(contains("weaver observe get-definition"));
+        .stdout(contains("weaver definitions get"));
 }
 
 #[test]

--- a/docs/adr-007-agent-native-command-surface.md
+++ b/docs/adr-007-agent-native-command-surface.md
@@ -95,6 +95,12 @@ Canonical verbs include `get`, `list`, `create`, `update`, `delete`, `apply`,
 policy must include every verb used by target examples and planned resource
 commands before vocabulary linting is enabled.
 
+In this public grammar, `weaver symbols move` is the resource-first form of the
+internal `extricate-symbol` capability: it moves a selected symbol to another
+module or file while preserving meaning. It is not an alias for
+`extract-method`, which extracts a selected code region into a new callable and
+must remain a separate capability and roadmap slice if it graduates later.
+
 ## OrthoConfig dependencies
 
 Weaver will not implement a second generic command-contract framework unless a

--- a/docs/adr-007-agent-native-command-surface.md
+++ b/docs/adr-007-agent-native-command-surface.md
@@ -1,0 +1,288 @@
+# Architectural decision record (ADR) 007: Agent-native command surface
+
+## Status
+
+Proposed.
+
+## Date
+
+2026-05-11.
+
+## Context and problem statement
+
+Weaver is still pre-0.1.0. That gives the project room to replace prototype
+public command grammar before users or agents depend on it as a stable
+contract. The current documentation and code contain valuable foundations:
+daemon JSON Lines (JSONL), localized prose, capability-routed plugins,
+deterministic provider refusal, broker-owned plugin execution, and the
+safety-harness commit path. They also contain prototype surfaces that are not
+the right 0.1.0 product contract: public `observe` / `act` / `verify` domains,
+root `--output auto|human|json`, operation-local `--format`, root
+`--capabilities`, provider-required `act refactor`, hand-maintained command
+catalogues, and inconsistent future naming.
+
+The design goal is not to turn Weaver into an agent-only JSON appliance. Weaver
+must remain friendly for humans at a terminal: localized help, readable default
+output, shell completions, manpages, accessible plain output,
+terminal-width-aware layouts, and explicit interactive review workflows remain
+product requirements. The redesign instead makes agent usability a first-class
+constraint at every layer by giving humans and agents one command truth with
+two generated renderers.
+
+The broader reusable machinery for that command truth belongs in OrthoConfig
+where the OrthoConfig roadmap already assigns it. Weaver should consume those
+contracts and provide only Weaver-specific semantic editing metadata,
+capability routing, provider orchestration, safety integration, selectors, and
+resource grammar.
+
+## Decision drivers
+
+- Use pre-0.1.0 freedom to remove accidental prototype grammar.
+- Preserve a high-quality human terminal interface.
+- Make `--json` the one canonical machine output switch.
+- Keep community command-line conventions and common verbs visible.
+- Keep Sempai one-liner queries as first-class symbol selectors.
+- Preserve UNIX composition between observe-style resource commands, filters,
+  pagers, and act-style mutation commands.
+- Keep capability as the public abstraction and provider names as
+  implementation provenance.
+- Avoid duplicating reusable OrthoConfig command-contract work.
+- Preserve existing completed Weaver roadmap work as future foundation.
+- Enforce command-surface consistency mechanically rather than by review alone.
+
+## Decision outcome
+
+Adopt an agent-native, human-friendly 0.1.0 command-surface reset.
+
+Weaver's public command surface will be generated or validated from one
+schema-backed command contract. That contract has two first-class renderers: a
+localized human renderer used by default, and a stable machine renderer
+selected with `--json`. Internal daemon and plugin transports may continue to
+use JSONL envelopes. Public CLI JSON mode must expose operation result schemas
+on stdout for success and structured error schemas on stderr for failure.
+
+Weaver will depend on OrthoConfig for reusable command-contract,
+documentation-intermediate-representation, agent-context, policy, renderer,
+profile, delivery, feedback, and execution-ledger contracts wherever the
+OrthoConfig roadmap provides them. Weaver owns the application adapter:
+resource paths, verbs, capability IDs, mutability classes, async classes,
+selector forms, stream input support, provider selection policy, safety class,
+transaction behaviour, examples, output schemas, error schemas, and skill
+references.
+
+The 0.1.0 public grammar will be resource-first. Target examples include:
+
+```sh
+weaver definitions get --uri file:///src/main.rs --position 10:5
+weaver references list --uri file:///src/main.rs --position 10:5
+weaver diagnostics list --workspace .
+weaver cards get --uri file:///src/main.rs --position 10:5
+weaver graph-slices get --uri file:///src/main.rs --position 10:5
+weaver symbols list --query 'fn $name(...)'
+weaver symbols rename --query 'fn process_request(...)' --new-name run_request
+weaver symbols rename --uri file:///src/main.rs --position 10:5 --new-name run
+weaver symbols move --uri file:///src/main.rs --position 10:5 --to src/runner.rs
+weaver patches apply --file changes.patch --dry-run
+weaver context --json
+weaver capabilities list --json
+weaver jobs list --json
+weaver profiles list --json
+weaver feedback create "the enum error did not list valid values"
+```
+
+Canonical verbs include `get`, `list`, `create`, `update`, `delete`, `apply`,
+`run`, `prune`, `save`, `show`, `rename`, `move`, and `send`. The vocabulary
+policy must include every verb used by target examples and planned resource
+commands before vocabulary linting is enabled.
+
+## OrthoConfig dependencies
+
+Weaver will not implement a second generic command-contract framework unless a
+future ADR records a temporary adapter with a removal path. The known external
+dependencies are:
+
+| OrthoConfig task    | Weaver dependency                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 5.2.3               | Downstream boundary: OrthoConfig owns reusable command-contract machinery; Weaver owns semantic code editing and execution. |
+| 6.1                 | Recursive command and subcommand metadata.                                                                                  |
+| 6.2.1 and 6.2.2     | Compact agent-context generation and schema stability.                                                                      |
+| 6.2.3               | Public downstream context command naming, including `weaver context --json`.                                                |
+| 6.3                 | Skill manifest metadata and validation against real command paths and flags.                                                |
+| 7.1                 | Canonical vocabulary policy and linting.                                                                                    |
+| 7.2.1 through 7.2.7 | Non-interactive, mutation, renderer, JSON stream, exit-code, bounded-list, and generic capability/provenance metadata.      |
+| 8.1                 | Reference CLI proving `--json` and enumerating error behaviour.                                                             |
+| 9.1                 | Profile contracts and redaction metadata.                                                                                   |
+| 9.2                 | Delivery and feedback contracts.                                                                                            |
+| 9.3                 | Execution-ledger contracts.                                                                                                 |
+
+If an OrthoConfig dependency is not yet available when Weaver needs a vertical
+slice, Weaver may add a narrow local adapter. The adapter must be documented as
+temporary, covered by tests, and removed or replaced once the upstream
+OrthoConfig contract is available.
+
+## Human renderer contract
+
+The default renderer is for humans. It emits localized, readable output with
+stable section headings, examples, and recovery guidance. It never relies on
+colour alone. It disables ANSI styling when colour is unavailable, when
+`NO_COLOR` is set, when `--color=never` is supplied, or when output is not a
+terminal. It supports `--plain` for screen-reader-friendly and log-friendly
+output.
+
+Human rendering flags include:
+
+```plaintext
+--plain
+--color auto|always|never
+--no-pager
+--width <columns>
+--locale <tag>
+```
+
+Progress, diagnostics, warnings, and prompts go to stderr. Primary command
+results go to stdout. Spinners and pagers are only allowed in terminal
+contexts. Tables need headings, narrow-width fallbacks, and ASCII fallbacks for
+Unicode decoration. Interactive behaviour requires `--interactive` or a
+dedicated review command and must fail fast when stdin is not a terminal.
+
+## Machine renderer contract
+
+Every data-returning command accepts `--json`. In JSON mode, stdout contains
+only the operation result on success. On failure, stderr contains a structured
+error object and the process exits with a stable non-zero exit class.
+
+JSON field names, schema versions, error codes, enum values, capability IDs,
+and exit classes are protocol identifiers and are not localized. Human-readable
+message fields may be localized only when the schema marks them as optional
+prose. Agents and scripts must be able to decide the next action without
+parsing localized text.
+
+Root `--output auto|human|json` and operation-local `--format` are not part of
+the 0.1.0 target. The canonical machine switch is `--json`.
+
+## Selector and pipeline contract
+
+Selectors are first-class inputs. A selector is a stable way to identify one
+symbol or a collection of symbols. The initial selector forms are:
+
+- Sempai one-liner queries with a canonical flag such as
+  `--query <sempai-one-liner>`.
+- Position references using `--uri` and `--position`.
+- Structured selector streams from stdin when `--from-stdin` or the final
+  canonical stream flag is present.
+
+Sempai one-liners are a peer to position references, not a secondary search
+feature. Any command that acts on one or more symbols must state which selector
+forms it accepts and how it handles zero, one, and many matches.
+
+Observe-style resource commands must emit selector records that act-style
+mutation commands can consume directly or after ordinary UNIX filtering:
+
+```sh
+weaver symbols list --query 'fn $name(...)' --json \
+  | weaver symbols rename --from-stdin --suffix _renamed
+
+weaver symbols list --query 'fn $name(...)' --json \
+  | jq 'select(.name | startswith("old_"))' \
+  | weaver symbols rename --from-stdin --replace-prefix old_ --with-prefix new_
+
+weaver symbols list --query 'class $name' --json | less
+```
+
+The pipeline contract is part of the product surface. It must remain useful to
+agents, scripts, and humans composing ordinary shell tools.
+
+## Capability, perceptor, actuator, and provider
+
+A capability is a stable semantic contract, such as `definition.get`,
+`references.list`, `diagnostics.list`, `symbol.rename`, `symbol.move`, or
+`patch.apply`.
+
+A perceptor is a read-only provider that observes the codebase and returns
+facts, diagnostics, cards, graph slices, matches, selector records, or
+provenance.
+
+An actuator is a mutation-planning provider that returns edits, diffs, patches,
+plans, or workspace-change proposals. It never commits directly. Every actuator
+result passes through Weaver-owned transaction, safety, Double-Lock,
+idempotency, rollback, and atomic-write machinery.
+
+A provider is an implementation of one or more capabilities, such as Rope,
+rust-analyzer, Tree-sitter, an LSP server, Sempai, or a Weaver built-in.
+
+The ordinary public command path is capability-first:
+
+```sh
+weaver symbols rename --uri file:///src/lib.rs --position 42:9 --new-name run
+```
+
+It is not provider-first:
+
+```sh
+weaver act refactor --provider rust-analyzer --refactoring rename ...
+```
+
+Provider selection is deterministic:
+
+1. explicit CLI override,
+2. selected profile policy,
+3. environment or configuration policy,
+4. workspace policy,
+5. provider priority from manifests,
+6. deterministic tie-breaker,
+7. structured refusal if no provider qualifies.
+
+Provider names remain available in diagnostics, provenance, `--verbose` human
+output, JSON output, `context --json`, and expert policy overrides. They are
+not the normal user workflow.
+
+## Prototype surfaces superseded for 0.1.0
+
+The following prototype surfaces are superseded by this ADR for the 0.1.0
+target:
+
+- public `observe` / `act` / `verify` domain grammar,
+- root `--output auto|human|json`,
+- operation-local `--format`,
+- root `--capabilities`,
+- provider-required `act refactor`,
+- provider-specific public commands such as `weaver rope rename`,
+- hand-maintained command catalogues,
+- implicit prompts,
+- unbounded list output.
+
+Existing implementations remain useful evidence and foundation. The roadmap
+must preserve completed work and migrate still-relevant planned work under the
+new grammar. Any removed roadmap item must be marked superseded with a short
+rationale.
+
+## Relationship to previous ADRs
+
+ADR 001 already establishes the capability-first plugin direction: user intent
+is represented by stable capability IDs, provider choice is resolved
+internally, and final edits flow through the safety harness. This ADR
+generalizes that model from `act extricate` into the whole 0.1.0 public surface.
+
+ADR 004 already requires deterministic routing and structured refusal
+diagnostics. This ADR makes those properties part of the generated public
+command contract and the machine renderer.
+
+ADR 006 already keeps plugin execution one-shot and broker-owned. This ADR
+preserves that boundary while separating internal JSONL plugin transport from
+public `--json` command output.
+
+## Consequences
+
+Documentation and implementation work must be sequenced so the command-surface
+reset lands before further Sempai, plugin, graph, or workflow command growth.
+Future commands must declare their resource path, canonical verb, capability
+ID, selector forms, mutability class, async class, pagination behaviour,
+renderer contracts, error schemas, provenance, and drift gates.
+
+The design raises the consistency bar. Command names, help, manpages, shell
+completions, docs snippets, `context --json`, skill manifests, router metadata,
+and tests must be generated from or validated against the same contract. Manual
+review is no longer sufficient as the primary consistency mechanism.
+
+The human interface remains first-class. The reset removes accidental prototype
+grammar and drift; it does not remove friendly terminal behaviour.

--- a/docs/adr-007-agent-native-command-surface.md
+++ b/docs/adr-007-agent-native-command-surface.md
@@ -120,6 +120,26 @@ slice, Weaver may add a narrow local adapter. The adapter must be documented as
 temporary, covered by tests, and removed or replaced once the upstream
 OrthoConfig contract is available.
 
+## Temporary adapter removal policy
+
+Temporary Weaver adapters are allowed only as vertical-slice scaffolding. Each
+adapter must name the OrthoConfig task that replaces it, keep its scope limited
+to Weaver-owned semantic metadata, and have tests that prove the temporary
+shape is stable enough to migrate.
+
+The first local adapter is `crates/weaver-cli/src/command_surface.rs`. Its
+removal policy is:
+
+| Local helper             | Replacement dependency          | Removal gate                                                                                                                                                                                                                                                                                   |
+| ------------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CommandSurfaceRecord`   | OrthoConfig 6.1 and 7.2.7       | Replace with OrthoConfig recursive command metadata plus generic capability/provenance metadata once those records can express Weaver resource paths, capability IDs, selector forms, output schemas, error schemas, mutability, async class, provider policy, examples, and skill references. |
+| `READ_ONLY_COMMANDS`     | OrthoConfig 6.1, 6.2.1, and 6.3 | Replace with generated command metadata once the same source can drive runtime routing, `weaver context --json`, and skill validation for the pilot read command family.                                                                                                                       |
+| `find_read_only_command` | OrthoConfig 6.1                 | Replace with the generated command registry lookup once structured command parsing and daemon routing can resolve `definitions get` and `references list` without a Weaver-specific array scan.                                                                                                |
+
+Any local helper that survives after those OrthoConfig tasks are available must
+record a permanent divergence in this ADR before it can remain in the
+implementation.
+
 ## Human renderer contract
 
 The default renderer is for humans. It emits localized, readable output with

--- a/docs/archive/prototype-roadmap.md
+++ b/docs/archive/prototype-roadmap.md
@@ -47,6 +47,61 @@ commands, canonical `--json`, `weaver context --json`,
 `weaver capabilities list --json`, capability-routed providers, and selector
 pipelines in the live roadmap.
 
+### Relevance matrix
+
+The table below records the archive assessment at step level. "Foundation"
+means completed work remains implementation evidence. "Migrated" means the
+unfinished product intent is active in `docs/roadmap.md`. "Superseded" means
+the historical spelling or implementation path is not part of the current
+product plan, but any still-useful behaviour has been re-expressed elsewhere.
+
+| Archive step | Disposition                         | Live destination or reason                                                                                                   |
+| ------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 1.1          | Foundation                          | Repository and documentation baseline retained as product history.                                                           |
+| 2.1          | Foundation                          | Daemon, JSONL transport, LSP host, sandbox, Double-Lock, and atomic-edit work underpins phases 13, 14, 16, and 19.           |
+| 2.2          | Foundation, then superseded grammar | Discoverability lessons carry into phase 13; public `observe` / `act` / `verify` examples are provenance only.               |
+| 2.3          | Foundation, then superseded grammar | Enumerating errors carry into 13.2 and 13.3; `act refactor` wording is replaced by capability-routed resource commands.      |
+| 3.1          | Foundation                          | Syntax, syntactic-lock, document-sync, and graph crates feed phases 14, 15, 16, and 17.                                      |
+| 3.2          | Migrated                            | Help, command metadata, and manpage work moves to 13.2 and 13.3, with OrthoConfig dependencies instead of local duplication. |
+| 3.3          | Migrated                            | Locale bootstrap, localized help, catalogues, and generated references move to 13.2 and 13.3.                                |
+| 4.1          | Foundation and migrated             | Completed Sempai facade and YAML normalization remain foundation; one-liner parser and recovery move to 15.1.                |
+| 4.2          | Migrated                            | Tree-sitter profiles, rewriting, matching, formula execution, and safety controls move to 15.2.                              |
+| 4.3          | Migrated, renamed                   | `observe query` becomes `symbols list --query` and selector-stream integration in 15.3.                                      |
+| 5.1          | Foundation                          | Plugin platform foundation remains provider infrastructure for phases 16 and 18.                                             |
+| 5.2          | Foundation and migrated             | Completed rename capability work supports 16.2; migration notes and capability discoverability move to 18.2.                 |
+| 5.3          | Migrated, renamed                   | `act extricate` becomes the `symbol.move` or `symbol.extract` validation slice in 16.3.                                      |
+| 5.4          | Migrated, renamed                   | Rust extrication work moves to the move/extract viability decision in 16.3.                                                  |
+| 5.5          | Migrated                            | `srgn` becomes an optional provider experiment in 18.1.                                                                      |
+| 5.6          | Migrated                            | `jedi` becomes the first specialist perceptor experiment in 18.1.                                                            |
+| 5.7          | Migrated                            | Plugin introspection and capability probe work becomes `capabilities list` and `context --json` in 13.3 and 18.2.            |
+| 5.8          | Migrated                            | Graceful degradation guidance moves to provider failure handling in 18.1 and 18.2.                                           |
+| 5.9          | Migrated                            | Static-analysis graph edges move to 17.1.                                                                                    |
+| 6.1          | Foundation and migrated             | Completed patch application is re-surfaced as `patches apply` in 16.1.                                                       |
+| 6.2          | Migrated and partly deferred        | Onboarding and explicit interaction move to 19.2; dynamic-analysis ingestion is validated or deferred by 19.2.3.             |
+| 7.1          | Foundation and migrated             | Completed card schemas, extraction, enrichment, and cache work moves to `cards get` in 14.2.                                 |
+| 7.2          | Foundation and migrated             | Completed graph-slice schema is retained; traversal and edge work moves to 17.1.                                             |
+| 7.3          | Migrated                            | Graph history moves to 17.2 after bounded graph slices prove value.                                                          |
+| 7.4          | Migrated                            | Probabilistic matching moves to 17.3 and remains conditional on history needs.                                               |
+| 7.5          | Deferred decision                   | Ledger caching is reconsidered only after 17.2.3 supplies performance evidence.                                              |
+| 8.1          | Migrated                            | Formal tooling setup moves to 19.3 after safety-critical command paths exist.                                                |
+| 8.2          | Migrated                            | Proof contracts and trust boundary move to 19.3.                                                                             |
+| 8.3          | Migrated                            | Transaction and patch Kani checks move to 19.3.                                                                              |
+| 8.4          | Migrated                            | Capability-routing checks move to 19.3.                                                                                      |
+| 8.5          | Migrated                            | Proof-only Verus kernels move to 19.3 after stable abstractions exist.                                                       |
+| 8.6          | Migrated, conditional               | Later graph, matching, and Sempai checks are folded into 19.3 only after their product slices survive.                       |
+| 9.1          | Migrated, narrowed                  | Minimal Sempai execution is recast as one-liner selector validation in 15.1 and 15.2.                                        |
+| 9.2          | Migrated, renamed                   | Symbol-first card retrieval becomes selector-aware `cards get` in 14.2 and 15.3.                                             |
+| 9.3          | Migrated                            | One-hop relation traversal moves to card summaries and selector-to-context workflows in 14.2 and 15.3.                       |
+| 10.1         | Migrated, renamed                   | `observe find-references` becomes `references list` in 14.1.                                                                 |
+| 10.2         | Migrated, renamed                   | `observe show` becomes selector-aware `cards get` and relation summaries in 14.2 and 15.3.                                   |
+| 10.3         | Migrated, renamed                   | `observe call-hierarchy` becomes bounded graph slices and card relation summaries in 14.2 and 17.1.                          |
+| 10.4         | Migrated, conditional               | `observe grep` becomes a `symbols list --pattern` decision in 14.3, or folds into Sempai selectors.                          |
+| 10.5         | Migrated, renamed                   | `act rename-symbol` becomes `symbols rename` in 16.2.                                                                        |
+| 11.1         | Migrated, renamed                   | `observe graph-slice` becomes `graph-slices get` in 17.1.                                                                    |
+| 11.2         | Migrated                            | Card-driven traversal becomes one-hop cards plus graph-slice expansion in 14.2 and 17.1.                                     |
+| 11.3         | Migrated                            | Agent-grade stdout/stderr, schema, exit-code, and compact-output contracts move to 13.2 and 13.3.                            |
+| 11.4         | Migrated                            | Visible safety-harness metadata moves to `patches apply`, mutation metadata, and user documentation in 16.1.                 |
+
 ## 1. Foundation & tooling (complete)
 
 ### 1.1. Establish foundation and documentation baseline

--- a/docs/archive/prototype-roadmap.md
+++ b/docs/archive/prototype-roadmap.md
@@ -66,7 +66,7 @@ product plan, but any still-useful behaviour has been re-expressed elsewhere.
 | 3.3          | Migrated                            | Locale bootstrap, localized help, catalogues, and generated references move to 13.2 and 13.3.                                       |
 | 4.1          | Foundation and migrated             | Completed Sempai facade and YAML normalization remain foundation; one-liner parser and recovery move to 15.1.                       |
 | 4.2          | Migrated                            | Tree-sitter profiles, rewriting, matching, formula execution, and safety controls move to 15.2.                                     |
-| 4.3          | Migrated, renamed                   | `observe query` becomes `symbols list --query` and selector-stream integration in 15.3.                                             |
+| 4.3          | Migrated, renamed                   | `observe query` becomes `symbols list --query` in 15.3, with selector-stream and context composition in 15.4.                       |
 | 5.1          | Foundation                          | Plugin platform foundation remains provider infrastructure for phases 16 and 18.                                                    |
 | 5.2          | Foundation and migrated             | Completed rename capability work supports 16.2; migration notes and capability discoverability move to 18.2.                        |
 | 5.3          | Migrated, renamed                   | `act extricate` becomes `weaver symbols move` backed by `extricate-symbol` in 16.3; `extract-method` remains a separate capability. |

--- a/docs/archive/prototype-roadmap.md
+++ b/docs/archive/prototype-roadmap.md
@@ -1,0 +1,1612 @@
+# Prototype roadmap archive
+
+This archive preserves the pre-ADR-007 Weaver roadmap ledger. Its phase, step,
+and task numbers remain in the overall roadmap sequence as historical numbers
+`1` through `11`, so existing ExecPlans and completed implementation records
+remain uniquely addressable. The live forward roadmap starts at phase `12` in
+[`../roadmap.md`](../roadmap.md).
+
+Entries below are historical provenance. Unchecked work that remains relevant
+to Weaver after the 0.1.0 command-surface reset is re-expressed in the live
+roadmap under resource-first command names. Prototype `observe`, `act`, and
+`verify` spellings are not future public grammar unless a live roadmap task
+explicitly reintroduces them.
+
+## 1. Foundation & tooling (complete)
+
+### 1.1. Establish foundation and documentation baseline
+
+- [x] 1.1.1. Set up the project workspace, Continuous Integration and
+      Continuous Deployment (CI/CD) pipeline, and core
+      dependencies.
+- [x] 1.1.2. Normalize parser and Semgrep documentation style and navigation,
+      including
+      `docs/contents.md` and `docs/repository-layout.md`, as delivered in
+      `docs/execplans/sempai-design.md`.
+
+## 2. Core MVP & safety harness foundation
+
+*Goal: Establish the core client/daemon architecture, basic LSP integration,
+and the foundational security and verification mechanisms. The MVP must be safe
+for write operations from day one.*
+
+### 2.1. Deliver CLI and daemon foundation
+
+*Outcome: Ship a pair of crates (`weaver-cli`, `weaverd`) that honour the
+design contract in `docs/weaver-design.md` and expose the lifecycle expected by
+`docs/documentation-style-guide.md`.*
+
+- [x] 2.1.1. Define the shared configuration schema for `weaver-cli` and
+      `weaverd`
+      in `weaver-config`, using `ortho-config` to merge config files,
+      environment overrides, and CLI flags for daemon sockets, logging, and the
+      capability matrix defaults.
+      - Acceptance criteria: Schema documented in crate docs, integration tests
+        demonstrate precedence order (file < env < CLI), and default sockets
+        align with the design doc.
+- [x] 2.1.2. Implement the `weaver-cli` executable as the thin JSON Lines
+      (JSONL)
+      client that
+      initializes configuration via `ortho-config`, exposes the
+      `--capabilities` probe, and streams requests to a running daemon over
+      standard IO.
+      - Acceptance criteria: CLI command surface mirrors the design table,
+        capability probe outputs the negotiated matrix, and JSONL framing is
+        validated with golden tests.
+- [x] 2.1.3. Implement the `weaverd` daemon bootstrap that consumes the shared
+      configuration, starts the Semantic Fusion backends lazily, and supervises
+      them with structured logging and error reporting.
+      - Acceptance criteria: Bootstrap performs health reporting hooks,
+        backends start only on demand, and failures propagate as structured
+        events.
+- [x] 2.1.4. Implement robust daemonization and process management for
+      `weaverd`,
+      including backgrounding with `daemonize-me`, PID/lock file handling,
+      health checks, and graceful shutdown on signals.
+      - Acceptance criteria: Background start creates PID and lock files,
+        duplicate starts fail fast, and signal handling shuts down within the
+        timeout budget.
+- [x] 2.1.5. Provide lifecycle commands in `weaver-cli` (for example,
+      `daemon start`,
+      `daemon stop`, `daemon status`) that manage the daemon process, verify
+      socket availability, and surface actionable errors when start-up fails.
+      - Acceptance criteria: Lifecycle commands call into shared helper logic,
+        refuse to start when sockets are bound, and emit recovery guidance for
+        the operator.
+
+- [x] 2.1.6. Implement the socket listener in `weaverd` to accept client
+      connections
+      on the configured Unix domain socket (or TCP socket on non-Unix
+      platforms).
+      - Acceptance criteria: Daemon binds to the socket path from configuration,
+        accepts concurrent connections, and gracefully handles connection errors
+        without crashing the daemon.
+
+- [x] 2.1.7. Implement the JSONL request dispatch loop in `weaverd` that reads
+      `CommandRequest` messages from connected clients, routes them to the
+      appropriate domain handler, and streams `CommandResponse` messages back.
+      - Acceptance criteria: Request parsing rejects malformed JSONL with
+        structured errors, domain routing covers `observe` and `act` commands,
+        and responses include the terminal `exit` message with appropriate
+        status codes.
+
+- [x] 2.1.8. Wire end-to-end domain command execution from CLI through daemon to
+      backend, starting with `observe get-definition` as the first complete
+      path.
+      - Acceptance criteria: `weaver observe get-definition` with a running
+        daemon returns LSP definition results, errors propagate with structured
+        messages, and the CLI exits with the daemon-provided status code.
+
+- [x] 2.1.9. Deliver the `weaver-lsp-host` crate with language-server
+    initialization, capability detection, and core Language Server Protocol
+    (LSP) operations for Rust, Python, and TypeScript.
+  - Acceptance criteria: `weaver-lsp-host` initializes and advertises
+    capabilities for all three languages; definition, references, and
+    diagnostics requests return structured success responses on valid inputs;
+    unsupported or pre-initialization requests return deterministic errors; and
+    integration tests cover one success case and one failure case per feature.
+
+- [x] 2.1.10. Implement process-based language server adapters for
+      `weaver-lsp-host`.
+    The `LspHost` currently requires external callers to register
+    `LanguageServer` implementations via `register_language()`. This step adds
+    concrete adapters that spawn real language server processes (e.g.,
+    `rust-analyzer`, `pyrefly`, `tsgo`).
+  - Acceptance criteria: `SemanticBackendProvider::start_backend()` registers
+    adapters for configured languages, adapters spawn server processes and
+    communicate via stdio, server shutdown is handled gracefully on daemon
+    stop, and missing server binaries produce clear diagnostic errors.
+
+- [x] 2.1.11. Add human-readable output rendering for commands that return code
+    locations or diagnostics, using `miette` or a compatible renderer to
+    show context blocks.
+  - Acceptance criteria: Definition, reference, diagnostics, and safety
+    harness failure outputs include file headers, line-numbered source
+    context, and caret spans in human-readable mode; JSONL output remains
+    unchanged; missing source content falls back to path-and-range with a
+    clear explanation.
+
+- [x] 2.1.12. Deliver the initial `weaver-sandbox` crate with enforced process
+    isolation for external tool execution.
+  - Acceptance criteria: Linux sandboxing enforces namespaces and seccomp-bpf
+    policies via `birdcage`; platform support matrix is documented for Linux
+    and non-Linux behaviour; forbidden syscalls and filesystem escapes are
+    rejected in tests; and sandbox validation tests run under `make test`.
+
+- [x] 2.1.13. Implement the full "Double-Lock" safety harness logic in
+      `weaverd`.
+    This is a critical, non-negotiable feature for the MVP. All `act` commands
+    must pass through this verification layer before committing to the
+    filesystem.
+  - Acceptance criteria: Edit transactions pass through syntactic and semantic
+    lock validation before commit, failures leave the filesystem untouched,
+    and behaviour-driven development (BDD) scenarios cover success, syntactic
+    failure, semantic failure, and backend unavailable error paths.
+
+- [x] 2.1.14. Implement atomic edits to ensure that multi-file changes either
+      succeed
+    or fail as a single transaction.
+  - Acceptance criteria: Two-phase commit with prepare (temp files) and commit
+    (atomic renames) phases, rollback restores original content on partial
+    failure, and new file creation properly tracks file existence for
+    rollback.
+
+### 2.2. Deliver baseline command-line interface (CLI) discoverability
+
+*Outcome: Ship baseline guidance in the MVP so first-use command discovery
+does* *not require source inspection or external runbooks.*
+
+- [x] 2.2.1. Show short help when `weaver` is invoked without arguments.
+      See
+      [Level 0](ui-gap-analysis.md#level-0--bare-invocation-weaver)
+      and
+      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
+      (10d).
+  - [x] Replace bare missing-domain output with short help and a clear next
+        step.
+  - [x] Acceptance criteria: `weaver` with no arguments exits non-zero, prints
+        a `Usage:` line, lists the three valid domains (`observe`, `act`,
+        `verify`), and includes exactly one pointer to `weaver --help`.
+- [x] 2.2.2. List all domains and operations in top-level help output.
+      See
+      [Gap 1a](ui-gap-analysis.md#gap-1a--domains-not-enumerated)
+      and
+      [Gap 1b](ui-gap-analysis.md#gap-1b--operations-not-enumerated).
+  - [x] Add an `after_help` catalogue covering `observe`, `act`, and `verify`
+        operations.
+  - [x] Acceptance criteria: `weaver --help` lists all three domains and every
+        CLI-supported operation for each domain, and completes without daemon
+        startup or socket access.
+- [x] 2.2.3. Add top-level version output and long-form CLI description.
+      See
+      [Gap 1d](ui-gap-analysis.md#gap-1d--no---version-flag)
+      and
+      [Gap 1e](ui-gap-analysis.md#gap-1e--no-long-description-or-after-help-text).
+  - [x] Enable clap-provided `--version` and `-V` support.
+  - [x] Add a `long_about` quick-start block aligned with the
+        [user's guide](users-guide.md).
+  - [x] Acceptance criteria: `weaver --version` and `weaver -V` both exit 0
+        and emit the same version string, and `weaver --help` includes at
+        least one runnable quick-start command example, and `make check-fmt`,
+        `make markdownlint`, `make fmt`, `make lint`, and `make test` pass.
+- [x] 2.2.4. Provide contextual guidance when a domain is supplied without an
+      operation. See
+      [Level 2](ui-gap-analysis.md#level-2--domain-without-operation-weaver-observe)
+      and
+      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
+      (10e).
+  - [x] Print available operations for the provided domain and a follow-up help
+        command.
+  - [x] Acceptance criteria: `weaver <domain>` without an operation exits
+        non-zero, lists all operations registered for that domain, and includes
+        one concrete `weaver <domain> <operation> --help` hint.
+
+### 2.3. Enrich validation and actionable error responses
+
+*Outcome: Ensure MVP error paths fail fast with deterministic, actionable*
+*operator guidance before daemon startup and during command routing.*
+
+- [x] 2.3.1. Validate domains client-side before daemon startup.
+      See
+      [Level 3](ui-gap-analysis.md#level-3--unknown-domain-weaver-bogus-something)
+      and
+      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
+      (10b).
+  - [x] Reject unknown domains with a valid-domain list.
+  - [x] Add edit-distance suggestions for close typos.
+  - [x] Acceptance criteria: invalid domains fail before daemon spawn, return
+        all three valid domains in the error body, and include a single
+        "did you mean" suggestion only when exactly one valid domain is within
+        edit distance 2.
+- [x] 2.3.2. Include valid operation alternatives for unknown operations.
+      See
+      [Level 4](ui-gap-analysis.md#level-4--unknown-operation-weaver-observe-nonexistent)
+      and
+      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
+      (10c).
+  - [x] Extend daemon and CLI error payloads to include known operations for
+        the domain.
+  - [x] Acceptance criteria: unknown-operation errors in both JSON and
+        human-readable output include the full known-operation set for the
+        domain, with a count equal to the router's `known_operations` length.
+- [x] 2.3.3. Standardize actionable guidance in startup and routing errors.
+      See
+      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
+      (10a-10e).
+  - [x] Apply a single error template: problem statement, valid alternatives,
+        and explicit next command.
+  - [x] Add startup failure guidance for `WEAVERD_BIN` and installation checks.
+  - [x] Acceptance criteria: each Level 10 path (10a through 10e) renders the
+        same three-part template (error, alternatives, next command), and
+        preserves stable non-zero exit-code semantics.
+- [x] 2.3.4. Return complete argument requirements for `act refactor`.
+      See
+      [Gap 5b](ui-gap-analysis.md#gap-5b--act-refactor-without-arguments).
+  - [x] List all required flags, valid provider names, and known refactoring
+        operations.
+  - [x] Acceptance criteria: `weaver act refactor` without arguments reports
+        all three required flags (`--provider`, `--refactoring`, `--file`) in
+        one response, plus at least one valid provider and refactoring value.
+
+## 3. Syntactic & relational intelligence
+
+*Goal: Add the Tree-sitter and call graph layers to provide deeper structural*
+*and relational understanding of code, and pair this with operation-level and*
+*localized help for dependable day-to-day operation.*
+
+### 3.1. Deliver syntax and graph foundations
+
+- [x] 3.1.1. Create the `weaver-syntax` crate and implement the structural
+      search
+    engine for `observe grep` and `act apply-rewrite`, drawing inspiration from
+    ast-grep's pattern language.
+  - Acceptance criteria: `observe grep` and `act apply-rewrite` both execute
+    through `weaver-syntax`; structural queries return deterministic spans and
+    rewrites for Rust, Python, and TypeScript fixtures; invalid query syntax
+    returns structured parse diagnostics; and snapshot tests cover success and
+    failure paths.
+
+- [x] 3.1.2. Integrate the "Syntactic Lock" from `weaver-syntax` into the
+    "Double-Lock" harness.
+  - Acceptance criteria: all `act` write paths invoke syntactic verification
+    before commit; lock failures prevent on-disk writes; diagnostics include
+    file path and source location; and behaviour tests cover pass/fail paths.
+
+- [x] 3.1.3. Extend the `LanguageServer` trait with document sync methods
+    (`did_open`, `did_change`, `did_close`) to enable semantic validation
+    of modified content at real file paths without writing to disk.
+  - Acceptance criteria: trait implementations expose `did_open`,
+    `did_change`, and `did_close`; semantic validation paths use in-memory
+    document sync instead of disk writes; and integration tests verify
+    diagnostics for open-change-close sequences.
+
+- [x] 3.1.4. Create the `weaver-graph` crate and implement the LSP Provider for
+      call
+    graph generation, using the `textDocument/callHierarchy` request as the
+    initial data source.
+  - Acceptance criteria: call hierarchy provider returns incoming and outgoing
+    edges via `textDocument/callHierarchy`; responses include stable node IDs,
+    spans, and relationship direction; provider errors are surfaced as
+    structured diagnostics; and end-to-end tests validate graph output.
+
+### 3.2. Expose configuration and operation-level help surfaces
+
+*Outcome: Make configuration and operation help directly discoverable from the*
+*CLI without requiring external documentation lookup.*
+
+- [x] 3.2.1. Surface configuration flags in clap help output.
+      Shipped: `locale` is now part of the shared configuration contract and is
+      visible as `--locale`, `WEAVER_LOCALE`, and the `locale` config-file key.
+      See
+      [Gap 1c](ui-gap-analysis.md#gap-1c--configuration-flags-invisible)
+      and
+      [Level 6](ui-gap-analysis.md#level-6--configuration-flags-invisible-in-help).
+      See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces)
+      and
+      [weaver design §2.3.1](weaver-design.md#231-configuration-contract).
+  - [x] Register `--config-path`, `--daemon-socket`, `--log-filter`,
+        `--log-format`, `--capability-overrides`, and `--locale` as visible
+        global flags.
+  - [x] Acceptance criteria: all six flags appear in both `weaver --help` and
+        `weaver daemon start --help`, and existing precedence tests
+        (file < env < CLI) continue to pass.
+- [ ] 3.2.2. Extend `daemon start` help with config and environment guidance.
+      See
+      [Level 8](ui-gap-analysis.md#level-8--daemon-subcommand-help).
+  - [ ] Document `WEAVERD_BIN` and `WEAVER_FOREGROUND` in `long_about` or
+        `after_help`.
+  - [ ] Acceptance criteria: `weaver daemon start --help` documents both
+        environment variables and includes at least one startup example using
+        an override.
+- [ ] 3.2.3. Re-enable and extend the `help` subcommand.
+      See
+      [Gap 1f](ui-gap-analysis.md#gap-1f--help-subcommand-disabled)
+      and
+      [Level 12](ui-gap-analysis.md#level-12--weaver-help-subcommand).
+  - [ ] Remove `disable_help_subcommand = true`.
+  - [ ] Support topic help for domains and operations (`weaver help <topic>`).
+  - [ ] Acceptance criteria: `weaver help`, `weaver help observe`, and
+        `weaver help act refactor` all exit 0 and return topic-specific help
+        with no fallback to generic top-level output.
+- [ ] 3.2.4. Deliver operation-level help for required arguments.
+      Requires 3.2.3. See
+      [Gap 5a](ui-gap-analysis.md#gap-5a--observe-get-definition-without-arguments).
+  - [ ] Implement nested clap subcommands, or an equivalent schema-backed help
+        pipeline, so `weaver <domain> <operation> --help` is operation-specific.
+  - [ ] Acceptance criteria: every exposed operation supports
+        `weaver <domain> <operation> --help` and each help screen includes
+        required flags, argument types, and at least one concrete invocation.
+- [x] 3.2.5. Document ortho-config v0.8.0 behaviour in 3.2 guidance. See
+      [ortho-config v0.8.0 migration guide](ortho-config-v0-8-0-migration-guide.md).
+  - [x] Document the new dependency-graph model used by configuration loading
+        and precedence resolution.
+  - [x] Document fail-fast discovery behaviour when configuration files exist
+        but are invalid.
+  - [x] Document YAML 1.2 parsing semantics via `SaphyrYaml`, including known
+        compatibility warnings.
+  - [x] Update internal runbooks and user-facing documentation to reflect
+        `ortho-config` v0.8.0 operational behaviour.
+  - [x] Validate documentation quality gates and docs tests after updates.
+  - [x] Acceptance criteria: migration guide, runbooks, and user docs are
+        updated with explicit sections for dependency graph, fail-fast
+        discovery, and YAML 1.2 semantics; and `make markdownlint`,
+        `make fmt`, `make nixie`, and documentation tests pass.
+- [ ] 3.2.6. Adopt `cargo orthohelp` for CI man page generation and retire the
+      existing `clap_mangen` infrastructure.
+      See
+      [ortho-config user's guide: Generating IR with cargo-orthohelp](ortho-config-users-guide.md#generating-ir-with-cargo-orthohelp)
+      and
+      [ortho-config user's guide: Generating man pages](ortho-config-users-guide.md#generating-man-pages).
+      See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Add `[package.metadata.ortho_config]` wiring for the Weaver CLI root
+        type and supported locales so `cargo orthohelp` can resolve schema and
+        Fluent metadata without a bespoke bridge.
+  - [ ] Replace the existing `clap_mangen`-based build/CI manpage generation
+        path with `cargo orthohelp --format man --locale en-US`, preserving the
+        current `en-US` packaging contract while leaving multi-locale emission
+        to roadmap item `5.7.3`.
+  - [ ] Validate that CI artefacts still land in the expected output paths and
+        that no manual post-processing is required after the switch.
+  - [ ] Acceptance criteria: CI generates the shipped `en-US` manpage via
+        `cargo orthohelp`, the `clap_mangen` infrastructure is removed, and the
+        resulting roff output still includes the full shared configuration
+        contract introduced in `3.2.1`.
+
+### 3.3. Deliver localized CLI and reference outputs
+
+*Outcome: Let operators choose a locale once and receive consistent Fluent-*
+*backed help, error text, and generated reference artefacts across Weaver.*
+
+- [ ] 3.3.1. Apply resolved locale during CLI bootstrap.
+      See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces)
+      and
+      [weaver design §2.3.1](weaver-design.md#231-configuration-contract).
+  - [ ] Add a pre-config bootstrap pass that honours `--locale` and
+        `WEAVER_LOCALE` before consulting `LC_ALL`, `LC_MESSAGES`, and `LANG`,
+        then rebuild the localizer if the resolved config locale differs.
+  - [ ] Acceptance criteria: `weaver --help` and other pre-config clap display
+        paths honour `--locale` and `WEAVER_LOCALE` immediately; malformed
+        `--locale` and `WEAVER_LOCALE` values fail fast; malformed ambient
+        `LC_*` or `LANG` values warn and fall back; file-backed locale settings
+        continue to apply after full config loading; and `en-US` remains the
+        guaranteed fallback.
+- [ ] 3.3.2. Localize clap help and parse errors through `ortho_config`.
+      Requires 3.3.1. See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Drive clap help with `Cli::command().localize(&localizer)` and route
+        parse failures through `localize_clap_error_with_command`.
+  - [ ] Move bare-invocation help, lifecycle guidance, and other manual
+        operator text to Fluent message IDs with argument-aware rendering.
+  - [ ] Acceptance criteria: bare invocation, `weaver --help`, and common clap
+        validation failures render translated copy for supported locales
+        without changing existing exit-code semantics.
+- [ ] 3.3.3. Centralize the localized command and operation catalogue.
+      Requires 2.2.4 and 3.3.2. See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Replace duplicated domain and operation tables with one structured
+        catalogue shared by the router, contextual-help renderer, and test
+        fixtures.
+  - [ ] Store message IDs, examples, and operation descriptions in that
+        catalogue instead of hard-coded padded English strings.
+  - [ ] Acceptance criteria: top-level help, domain-without-operation
+        guidance, and `weaver help <topic>` all read from the same catalogue,
+        and adding a new operation requires one metadata change rather than
+        parallel edits in help, tests, and routing.
+- [ ] 3.3.4. Generate localized reference artefacts from ortho-config
+      metadata. Requires 3.2.4 and 3.3.2. See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Add stable documentation IDs to config-backed fields and expose
+        `OrthoConfigDocs` metadata for the generated help schema.
+  - [ ] Add `[package.metadata.ortho_config]` wiring and `cargo orthohelp`
+        generation for at least `en-US` and one secondary locale.
+  - [ ] Acceptance criteria: localized intermediate representation (IR) files
+        are generated per locale, `en-US` manpage packaging remains intact,
+        and artefact validation proves the generated help text matches the
+        runtime Fluent catalogue.
+
+## 4. Query language infrastructure (Sempai)
+
+*Goal: Deliver the Semgrep-compatible query language stack as a standalone
+phase* *with explicit parser, backend, and Weaver-integration milestones.*
+
+### 4.1. Deliver Sempai core infrastructure
+
+*Outcome: Implement the Sempai front-end and normalization architecture from*
+*`docs/sempai-query-language-design.md`, including YAML parsing, one-liner*
+*domain-specific language (DSL) parsing, semantic validation, and stable*
+*diagnostic contracts.*
+
+- [x] 4.1.1. Scaffold `sempai_core` and `sempai` with stable public types and
+      facade entrypoints.
+  - Acceptance criteria: public API documentation builds for `sempai`, and
+    stable types cover language, span, match, capture, and diagnostics models.
+- [x] 4.1.2. Define structured diagnostics with stable `E_SEMPAI_*` error
+      codes and report schema.
+  - Acceptance criteria: diagnostics include code, message, primary span, and
+    notes, and JSON snapshots remain stable across parser and validator paths.
+- [x] 4.1.3. Implement YAML rule parsing via `saphyr` and `serde-saphyr` with
+      schema-aligned rule models.
+  - Acceptance criteria: rule metadata and query principals parse from
+    Semgrep-compatible YAML forms, and parse failures emit structured
+    diagnostics.
+- [x] 4.1.4. Implement mode-aware validation for `search`, `extract`, `taint`,
+      and `join`, with execution gating to supported modes.
+  - Acceptance criteria: unsupported execution modes return deterministic
+    `UnsupportedMode` diagnostics, and search mode validation enforces required
+    key combinations.
+- [x] 4.1.5. Implement legacy and v2 normalization into one canonical
+      `Formula` model with semantic constraint checks. Requires 4.1.3.
+  - Acceptance criteria: paired legacy and v2 fixtures normalize to equivalent
+    formulas, and semantic invalid states emit deterministic rule diagnostics.
+- [ ] 4.1.6. Implement `logos` tokenization and Chumsky Pratt parsing for the
+      one-liner DSL with Semgrep precedence mapping.
+  - Acceptance criteria: precedence tests match documented binding order, and
+    parser output round-trips for supported DSL forms.
+- [ ] 4.1.7. Implement DSL error recovery with delimiter anchors and partial
+      abstract syntax tree (AST) emission for best-effort diagnostics. Requires
+      4.1.6.
+  - Acceptance criteria: malformed DSL inputs produce partial parse output and
+    labelled diagnostics without parser panics.
+
+### 4.2. Deliver Sempai Tree-sitter backend
+
+*Outcome: Implement the Tree-sitter-backed Sempai execution engine with*
+*Semgrep-token rewriting, pattern intermediate representation (IR), formula*
+*evaluation, and bounded matching semantics across supported languages.*
+
+- [ ] 4.2.1. Implement language profiles and wrapper registry for Rust, Python,
+      TypeScript, and Go, with optional HashiCorp Configuration Language (HCL)
+      support.
+  - Acceptance criteria: Rust, Python, TypeScript, and Go profiles each define
+    wrapper templates, list-shape mappings, and rewrite boundaries; optional
+    HCL profile loads only when the feature flag is enabled; profile selection
+    failures return deterministic diagnostics; and fixtures validate all profile
+    registrations.
+- [ ] 4.2.2. Implement Semgrep-token rewrite logic with language-safe boundaries
+      for metavariables, ellipsis, and deep ellipsis.
+  - Acceptance criteria: rewrite logic avoids substitutions in unsafe lexical
+    regions and produces deterministic placeholder mappings.
+- [ ] 4.2.3. Compile rewritten snippets into `PatNode`-based pattern IR with
+      span traceability.
+  - Acceptance criteria: compiled IR snapshots are stable, and wrapper/root
+    extraction metadata is preserved for diagnostics.
+- [ ] 4.2.4. Implement node-kind matching and metavariable unification over
+      Tree-sitter syntax trees.
+  - Acceptance criteria: repeated metavariables unify across compatible nodes,
+    and mismatches fail deterministically.
+- [ ] 4.2.5. Implement list-context ellipsis and ellipsis-variable matching
+      using bounded dynamic programming.
+  - Acceptance criteria: list-context fixtures pass across supported languages,
+    and runtime avoids exponential backtracking.
+- [ ] 4.2.6. Implement deep-ellipsis matching with bounded traversal controls.
+  - Acceptance criteria: deep matching respects configured node limits and
+    returns bounded, deterministic results.
+- [ ] 4.2.7. Compile normalized formulas into plan nodes with explicit anchor
+      and constraint separation. Requires 4.1.5.
+  - Acceptance criteria: conjunction plans enforce positive-term requirements,
+    and compiled plan shapes remain snapshot-stable.
+- [ ] 4.2.8. Implement conjunction, disjunction, and negative-constraint
+      execution semantics.
+  - Acceptance criteria: `not`, `inside`, and `anywhere` semantics align with
+    documented behaviour and pass regression fixtures.
+- [ ] 4.2.9. Implement metavariable `where`-clause constraint evaluation with
+      supported and unsupported outcomes.
+  - Acceptance criteria: supported constraints execute deterministically, and
+    unsupported constraints return stable diagnostic codes.
+- [ ] 4.2.10. Implement focus selection plus `as` and `fix` projection
+      behaviour in emitted matches.
+  - Acceptance criteria: focus and capture projection follow documented
+    precedence, and `fix` is surfaced as metadata without direct application.
+- [ ] 4.2.11. Implement Tree-sitter query escape hatch with capture-name
+      mapping into Semgrep-style capture keys.
+  - Acceptance criteria: raw Tree-sitter queries emit normalized captures and
+    focus behaviour consistent with Sempai match output contracts.
+- [ ] 4.2.12. Add execution safety controls for match caps, capture text caps,
+      deep-search bounds, and bounded alternation.
+  - Acceptance criteria: safety limits are configurable, deterministic, and
+    enforced across execution paths.
+
+### 4.3. Deliver Sempai Weaver integration and readiness
+
+*Outcome: Integrate Sempai into Weaver observe flows with stable command and*
+*JSON Lines (JSONL) contracts, cache integration, diagnostics conformance, and*
+*release gates for default enablement.*
+
+- [ ] 4.3.1. Add Sempai execution routing in `weaverd` for `observe.query`.
+      Requires 4.2.12.
+  - Acceptance criteria: daemon execution paths compile and execute Sempai
+    plans for supported languages and return structured match streams.
+- [ ] 4.3.2. Add `weaver observe query` command surface with `--lang`, `--uri`,
+      and `--rule-file|--rule|--q` inputs. Requires 4.3.1.
+  - Acceptance criteria: CLI validates input combinations and supports YAML and
+    one-liner query workflows with stable error messaging.
+- [ ] 4.3.3. Define stable JSONL request and response schemas for Sempai query
+      operations, with snapshot coverage. Requires 4.3.2.
+  - Acceptance criteria: schema fixtures lock field names and payload shapes,
+    and streaming output remains deterministic.
+- [ ] 4.3.4. Integrate parse-cache adapter keyed by URI, language, and
+      revision, aligned with daemon document lifecycle.
+  - Acceptance criteria: cache keys use URI, language, and revision values;
+    repeated queries against unchanged revisions hit cache in integration tests;
+    revision changes invalidate cached parses deterministically; and cache
+    misses and invalidations preserve semantic correctness.
+- [ ] 4.3.5. Implement actuation handoff contract using focus-first selection
+      with span fallback and optional capture targeting. Requires 4.3.3.
+  - Acceptance criteria: downstream `act` commands can consume Sempai output
+    deterministically for target selection.
+- [ ] 4.3.6. Add diagnostics conformance suites for YAML, DSL, semantic,
+      compilation, and execution error categories.
+  - Acceptance criteria: each diagnostic category is covered by deterministic
+    snapshots and stable `E_SEMPAI_*` error codes.
+- [ ] 4.3.7. Add layered quality suites (unit, snapshot, corpus, property, and
+      fuzz) for parser and execution behaviour.
+  - Acceptance criteria: suites run under repository gates and include
+    representative language corpora and malformed-input coverage.
+- [ ] 4.3.8. Publish compatibility boundaries for supported operators, modes,
+      constraints, and escape-hatch behaviour in user-facing docs.
+  - Acceptance criteria: documentation clearly distinguishes supported,
+    unsupported, and parse-only behaviours with stable terminology.
+- [ ] 4.3.9. Define release gates for enabling Sempai by default, including
+      crash-free requirements, diagnostics parity, and documentation parity.
+  - Acceptance criteria: release checklist is codified in CI policy and blocks
+    default enablement when thresholds are not met.
+
+## 5. Plugin ecosystem & specialist tools
+
+*Goal: Build capability-driven plugin architecture in a dependency-first
+order:* *stabilize existing `rename-symbol` implementations, then extend to
+new* *capabilities and specialist providers.*
+
+### 5.1. Establish plugin platform foundation
+
+- [x] 5.1.1. Design and implement the `weaver-plugins` crate, including the
+      secure
+    IPC protocol between the `weaverd` broker and sandboxed plugin processes.
+    *(Phase 5.1.1 — see `docs/execplans/3-1-1-weaver-plugins-crate.md`)*
+  - Acceptance criteria: plugin broker and sandboxed plugin process establish
+    authenticated IPC sessions; request and response envelopes validate against
+    crate-level schemas; protocol errors return deterministic failure codes; and
+    behaviour tests cover handshake success, schema rejection, and timeout
+    cases.
+
+### 5.2. Migrate existing actuator plugins to `rename-symbol` capability
+
+*Outcome: Bring the existing Python and Rust actuator plugins into the new*
+*plugin architecture as first-class implementations of the `rename-symbol`*
+*capability, with deterministic routing and compatibility guarantees.*
+
+- [x] 5.2.1. Define the `rename-symbol` capability contract for actuator
+      plugins, including request schema, response schema, and refusal
+      diagnostics. Requires 5.1.1.
+  - Acceptance criteria: capability contract is versioned, broker validation
+    enforces schema shape, and refusal diagnostics use stable reason codes.
+- [x] 5.2.2. Update `weaver-plugin-rope` manifest and runtime handshake to
+      declare and serve `rename-symbol` through the capability interface.
+      Requires 5.2.1.
+  - Acceptance criteria: plugin advertises `rename-symbol` in capability probes,
+    request payloads conform to schema, and response payloads conform to schema.
+    Legacy provider routing is not required for Python rename flows.
+- [x] 5.2.3. Update `weaver-plugin-rust-analyzer` manifest and runtime
+      handshake to declare and serve `rename-symbol` through the capability
+      interface. Requires 5.2.1.
+  - Acceptance criteria: plugin advertises `rename-symbol` in capability probes,
+    request payloads conform to schema, and response payloads conform to schema.
+    Rust rename flows are capability-routed.
+- [x] 5.2.4. Implement daemon capability resolution for `rename-symbol` so
+      plugin selection is language-aware and policy-driven. Requires 5.2.2 and
+      5.2.3.
+  - Acceptance criteria: routing selects the correct plugin per language,
+    fallback and refusal paths are deterministic, and routing decisions include
+    machine-readable rationale.
+- [x] 5.2.5. Add unit, behavioural, and end-to-end coverage for Python and Rust
+      `rename-symbol` under the new capability architecture. Requires 5.2.4.
+  - Acceptance criteria: tests cover success paths, refusal paths, and rollback
+    guarantees, and both plugins pass shared contract fixtures.
+- [ ] 5.2.6. Publish migration notes for `rename-symbol` capability routing and
+      deprecate legacy provider-specific command paths. Requires 5.2.5.
+  - Acceptance criteria: docs and CLI guidance identify capability-based
+    behaviour as the default path, and deprecation messaging is stable.
+
+### 5.3. Deliver capability-first `act extricate`
+
+*Outcome: Implement the cross-language `extricate-symbol` capability model,*
+*command contract, and plugin-selection foundation defined in*
+*`docs/adr-001-plugin-capability-model-and-act-extricate.md`, including
+initial* *Python delivery and shared failure semantics.*
+
+- [ ] 5.3.1. Add capability ID scaffolding and resolver policy for actuator
+    capabilities (`rename-symbol`, `extricate-symbol`, `extract-method`,
+    `replace-body`, `extract-predicate`). Requires 5.2.4.
+  - Acceptance criteria: capability IDs are strongly typed in daemon routing,
+    and resolution output includes language, selected provider, and policy
+    rationale.
+- [ ] 5.3.2. Extend plugin manifest schema and broker loading to support
+      capability
+    declarations and capability-aware selection.
+  - Acceptance criteria: manifest validation enforces capability fields, and
+    provider selection respects language plus capability compatibility.
+- [ ] 5.3.3. Add the `weaver act extricate --uri --position --to` command
+      contract and
+    wire capability discovery output for `extricate-symbol`.
+  - Acceptance criteria: CLI request shape is stable across providers, and
+    capability probe output reports extrication support by language.
+- [ ] 5.3.4. Extend the Rope plugin with `extricate-symbol` support for Python.
+  - Acceptance criteria: plugin returns unified diffs through existing patch
+    application flow and preserves symbol semantics for supported Python shapes.
+- [ ] 5.3.5. Extend plugin and daemon failure schemas with deterministic refusal
+    diagnostics and hard rollback guarantees.
+  - Acceptance criteria: refusal paths emit structured `PluginDiagnostic`
+    payloads, include stable error codes, and leave the filesystem unchanged.
+- [ ] 5.3.6. Add unit, behavioural, and end-to-end coverage for capability
+    resolution and Python extrication baseline paths.
+  - Acceptance criteria: tests assert capability negotiation, refusal behaviour,
+    incomplete payload failures, and deterministic patch output.
+
+### 5.4. Deliver Rust `extricate-symbol` actuator
+
+*Outcome: Implement Rust `extricate-symbol` as a standalone actuator programme*
+*in line with `docs/rust-extricate-actuator-plugin-technical-design.md`, with*
+*safe orchestration, deterministic repair loops, and release-grade validation.*
+
+- [ ] 5.4.1. Define Rust extrication orchestration contracts and transaction
+      boundaries in `weaverd`, including capability ownership and stage
+      interfaces. Requires 5.3.3.
+  - Acceptance criteria: stage boundaries are explicit, rollback semantics are
+    codified per stage, and orchestration contracts are covered by unit tests.
+- [ ] 5.4.2. Implement Rust symbol planning pipeline using rust-analyzer
+      definition, references, and call-site discovery for move planning.
+      Requires 5.4.1.
+  - Acceptance criteria: planner identifies extraction scope deterministically,
+    and unsupported symbol shapes emit structured diagnostics.
+- [ ] 5.4.3. Implement staged Rust transformation execution via
+      `weaver-plugin-rust-analyzer`, including extraction edits, path updates,
+      and patch bundling. Requires 5.4.2.
+  - Acceptance criteria: staged execution emits unified diffs, preserves
+    deterministic operation order, and reports stage-level failures.
+- [ ] 5.4.4. Implement import and module-graph repair loops, including ambiguous
+      import handling and code-action follow-up passes. Requires 5.4.3.
+  - Acceptance criteria: common import breakages are auto-repaired, ambiguous
+    repairs return deterministic refusal diagnostics, and no partial writes are
+    committed.
+- [ ] 5.4.5. Integrate semantic verification and rollback enforcement for Rust
+      extrication transactions before commit. Requires 5.4.4 and 5.3.5.
+  - Acceptance criteria: semantic lock failures abort the transaction, rollback
+    is complete across all touched files, and diagnostics identify failed
+    verification stage.
+- [ ] 5.4.6. Add Rust-specific unit, behavioural, and end-to-end coverage for
+      extrication scenarios, including nested module moves, trait impl updates,
+      and macro-adjacent boundaries. Requires 5.4.5.
+  - Acceptance criteria: tests assert meaning-preservation probes, module graph
+    updates, rollback guarantees, and deterministic failure semantics.
+- [ ] 5.4.7. Publish Rust `extricate-symbol` compatibility boundaries and
+      operator guidance in docs and capability probe output. Requires 5.4.6.
+  - Acceptance criteria: docs and capability surfaces use stable terminology for
+    supported, partial, and unsupported Rust shapes.
+
+### 5.5. Deliver additional actuator plugins
+
+*Outcome: Extend actuator coverage beyond `rename-symbol` and*
+*`extricate-symbol` with precision syntactic editing support.*
+
+- [ ] 5.5.1. Deliver the `srgn` actuator plugin to provide high-performance,
+      precision syntactic editing via capability-routed patch generation.
+  - Acceptance criteria: plugin declares capability metadata in its manifest,
+    emits deterministic unified diffs for supported edit operations, rejects
+    unsupported inputs with structured diagnostics, and passes unit plus
+    integration coverage through the plugin broker.
+
+### 5.6. Deliver first specialist sensor plugin
+
+- [ ] 5.6.1. Deliver the `jedi` specialist sensor plugin to provide
+      supplementary Python static-analysis signals through the plugin broker.
+  - Acceptance criteria: plugin loads through `weaver-plugins`, returns
+    deterministic Python analysis payloads for supported files, rejects
+    unsupported languages with structured diagnostics, and integration tests
+    verify success and refusal paths.
+
+### 5.7. Deliver plugin and capability discoverability coverage
+
+*Outcome: Provide discoverability for plugin inventory and runtime capability*
+*negotiation directly from CLI help and introspection commands.*
+
+- [ ] 5.7.1. Add plugin introspection commands.
+      See
+      [Gap 1g](ui-gap-analysis.md#gap-1g--plugin-listing-absent)
+      and
+      [Level 7](ui-gap-analysis.md#level-7--plugin-discoverability).
+  - [ ] Implement `weaver list-plugins` with `--kind` and `--language`
+        filters.
+  - [ ] Show plugin name, kind, language support, version, and timeout data.
+  - [ ] Acceptance criteria: users can discover valid `act refactor`
+        providers from CLI output alone, and table output includes the five
+        fields `NAME`, `KIND`, `LANGUAGES`, `VERSION`, and `TIMEOUT`.
+- [ ] 5.7.2. Wire plugin introspection into refactor guidance paths.
+      Requires 5.7.1. See
+      [Gap 5b](ui-gap-analysis.md#gap-5b--act-refactor-without-arguments)
+      and
+      [Level 7](ui-gap-analysis.md#level-7--plugin-discoverability).
+  - [ ] Reference `weaver list-plugins` in refactor-related help and errors.
+  - [ ] Acceptance criteria: every provider-related error points users to a
+        discoverability command by including the exact string
+        `weaver list-plugins`.
+- [ ] 5.7.3. Regenerate and validate localized manpages from the schema-backed
+      help model. Requires 2.2.2, 3.2.1, 3.2.3, and 3.3.4. See
+      [Level 11](ui-gap-analysis.md#level-11--manpage).
+      See
+      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
+  - [ ] Verify that domain listings, operation listings, global config flags,
+        locale-aware help text, and help-topic content render in troff output.
+  - [ ] Acceptance criteria: generated manpages include all updated help
+        surfaces with no manual post-processing, ship `en-US` by default, and
+        can be emitted for additional supported locales including all six
+        global config flags.
+
+Capability probe discoverability tasks:
+
+- [ ] 5.7.4. Clarify current `--capabilities` output semantics.
+      See
+      [Level 9](ui-gap-analysis.md#level-9----capabilities-output).
+  - [ ] Annotate output and help text that current data represents overrides
+        unless runtime capability data is merged.
+  - [ ] Acceptance criteria: users can distinguish override configuration from
+        runtime-negotiated capability support via an explicit output marker and
+        matching help-text note.
+- [ ] 5.7.5. Merge runtime capability negotiation into the capabilities probe.
+      Requires daemon capability query support. See
+      [Level 9](ui-gap-analysis.md#level-9----capabilities-output).
+  - [ ] Query daemon-supported capabilities and combine them with configured
+        overrides into one matrix.
+  - [ ] Acceptance criteria: `weaver --capabilities` returns a complete matrix
+        for each configured language and operation, and includes source labels
+        for runtime capability versus override values.
+
+### 5.8. Refine graceful degradation guidance
+
+- [ ] 5.8.1. Refine the graceful degradation logic to suggest specific
+      plugin-based
+    solutions when core LSP features are missing.
+  - Acceptance criteria: missing core LSP features produce actionable fallback
+    suggestions naming compatible plugins; suggestions include command hints and
+    capability rationale; unavailable plugin paths return deterministic
+    diagnostics; and regression tests cover at least three degradation
+    scenarios.
+
+### 5.9. Deliver static analysis provider integration
+
+- [ ] 5.9.1. Implement the Static Analysis Provider for `weaver-graph` (for
+      example, wrapping PyCG) as the first major graph plugin.
+  - Acceptance criteria: provider ingests static-analysis call graphs into
+    `weaver-graph` with stable node and edge schemas; unsupported languages
+    return structured diagnostics; and integration tests validate successful
+    ingestion and refusal paths.
+
+## 6. Agent workflows & advanced support
+
+*Goal: Deliver advanced agent-facing workflows after core query and plugin*
+*infrastructure is in place, with explicit dependencies on earlier phases.*
+
+### 6.1. Deliver `act apply-patch` command
+
+*Outcome: Provide a safety-locked patch application path that mirrors the*
+*`apply_patch` semantics for agents and integrates with the Double-Lock
+harness.*
+
+- [x] 6.1.1. Add JSONL request/response types and a `weaver act apply-patch`
+      command
+    that reads the patch stream from standard input (STDIN) and forwards it to
+    the daemon.
+  - Acceptance criteria: CLI streams raw patch input, returns non-zero exit
+    codes on failure, and surfaces structured errors.
+- [x] 6.1.2. Implement the patch parser and matcher in `weaverd` to support
+      modify,
+    create, and delete operations, including fuzzy matching, line-ending
+    normalization, and path traversal checks.
+  - Acceptance criteria: patch application is atomic per command, missing
+    hunks are rejected, and parent directories are created for new files.
+- [x] 6.1.3. Integrate apply-patch with the safety harness using syntactic and
+    semantic locks, ensuring no on-disk writes on lock failure.
+  - Acceptance criteria: Tree-sitter validates modified/new files, LSP
+    diagnostics are compared against the pre-edit baseline, and failures
+    leave the filesystem untouched.
+- [x] 6.1.4. Add unit, BDD, and end-to-end tests covering create/modify/delete
+      and
+    failure paths (missing hunk, invalid header, traversal attempt).
+  - Acceptance criteria: tests pass under `make test` and error messaging is
+    asserted for each failure mode.
+
+### 6.2. Deliver advanced agent workflow foundations
+
+*Outcome: Add onboarding and interactive orchestration paths that build on*
+*completed command discoverability and plugin-capability infrastructure.*
+*Prerequisites: complete 2.2 and 2.3 for CLI help baselines, and complete 5.2*
+*and 5.7 for capability routing plus discoverability surfaces.*
+
+- [ ] 6.2.1. Deliver the `onboard-project` command that orchestrates existing
+      Weaver components to generate a deterministic `PROJECT.dna` summary
+      artefact.
+  - Acceptance criteria: command ingests repository metadata and analysis
+    outputs into one `PROJECT.dna` file; output schema is versioned and stable;
+    reruns on unchanged inputs produce byte-identical output; and failure paths
+    emit structured diagnostics with actionable remediation hints.
+
+- [ ] 6.2.2. Deliver a hybrid interactive mode (`--interactive`) that presents
+      lock-failure diffs and diagnostics for explicit human approval or
+      rejection before write operations continue.
+  - Acceptance criteria: interactive mode displays proposed diff plus syntactic
+    and semantic lock diagnostics; approval resumes execution and rejection
+    aborts without filesystem changes; timeout or non-interactive environments
+    fail closed; and behaviour tests cover approve, reject, and timeout flows.
+
+- [ ] 6.2.3. Deliver the Dynamic Analysis Ingestion provider for
+      `weaver-graph` to consume and merge profiling data from tools such as
+      `gprof` and `callgrind`.
+  - Acceptance criteria: provider ingests at least `gprof` and `callgrind`
+    traces into a normalized graph schema; merge logic preserves source
+    identity and call-edge attribution; malformed trace inputs return structured
+    ingestion diagnostics; and integration tests validate multi-source merges.
+
+## 7. Cards-first symbol context (Jacquard)
+
+*Goal: Deliver small, structured “symbol cards” and bounded symbol graph slices
+as first-class `observe` operations, then extend them to deterministic,
+budgeted history diffs over recent commits. This phase operationalizes the
+design in
+[`jacquard-card-first-symbol-graph-design.md`](jacquard-card-first-symbol-graph-design.md)
+ within Weaver’s existing Semantic Fusion architecture.*
+
+### 7.1. Deliver `observe get-card` (Tree-sitter first)
+
+*Outcome: Provide a deterministic, cacheable symbol card payload that defaults
+to Tree-sitter extraction and optionally enriches via LSP when available. See
+`docs/jacquard-card-first-symbol-graph-design.md` §9.1-§9.3 and §10.1-§10.3.*
+
+- [x] 7.1.1. Define stable JSONL request and response schemas for
+      `observe get-card`, including versioning, provenance fields, and
+      progressive detail levels. Requires 2.1.7 and 3.1.1.
+  - [x] Include attachment bundling and interstitial payloads in the schema
+        (doc comments, decorators, import blocks, and bundle rules).
+  - [x] Add schema fixtures and snapshot coverage for success and refusal
+        payloads.
+  - [x] Acceptance criteria: schema fixtures lock field names and payload
+        shapes, including attachments and interstitials; responses include
+        provenance for non-trivial fields; and the default output is stable
+        (byte-identical) for unchanged inputs.
+- [x] 7.1.2. Implement Tree-sitter symbol card extraction for the initial
+      supported languages (Rust, Python, and TypeScript). Requires 3.1.1.
+  - [x] Add an entity/interstitial region pass and attach interstitials to the
+        relevant cards (file/module or interstitial cards).
+  - [x] Bundle doc comments and decorator/annotation blocks onto symbol cards
+        using deterministic backwards-scanning rules.
+  - [x] Enforce nested entity filtering so locals/closures do not enter the
+        entity table by default.
+  - [x] Acceptance criteria: unit tests cover at least three symbol kinds per
+        language; extracted ranges are deterministic; comment/decorator
+        bundling is stable under whitespace edits; nested locals never appear
+        as entities; and whitespace-only edits do not change `SymbolId`
+        fingerprints.
+- [x] 7.1.3. Implement optional LSP enrichment for `observe get-card` when
+      `--detail semantic` (or higher) is requested. Requires 2.1.9 and 3.1.3.
+  - [x] Enrich cards with hover/type and deprecation metadata where supported.
+  - [x] Acceptance criteria: enrichment is gated by capability negotiation; LSP
+        unavailability degrades to the Tree-sitter-only card with explicit
+        provenance; and integration tests cover both enriched and degraded
+        behaviour.
+- [x] 7.1.4. Add cache integration for card extraction keyed by URI, language,
+      and document revision. Requires 7.1.2.
+  - [x] Reuse Tree-sitter parser registries and cache extracted entity tables
+        with an LRU (Least Recently Used) policy keyed by repo, ref, file path,
+        and blob hash.
+  - [x] Avoid unnecessary string cloning in card and region extraction; prefer
+        borrowing or interning for hot paths.
+  - [x] Acceptance criteria: repeated `get-card` requests for unchanged
+        revisions hit cache in integration tests; revision changes invalidate
+        deterministically; and cache misses preserve correctness.
+
+### 7.2. Deliver `observe graph-slice` (budgeted traversal)
+
+*Outcome: Return a bounded subgraph rooted at an entry symbol, with typed edges
+(`call`, `import`, and `config`) and explicit budget constraints. See
+`docs/jacquard-card-first-symbol-graph-design.md` §12.1-§12.3.*
+
+- [x] 7.2.1. Define stable JSONL request and response schemas for
+      `observe graph-slice`, including budgets, spillover metadata, and
+      provenance for edges. Requires 2.1.7.
+  - [x] Acceptance criteria: schema fixtures lock `budget` semantics and
+    default values; responses are deterministic for a fixed repo revision; and
+    spillover metadata is present when traversal is truncated; and edges carry
+    resolution scope (`full_symbol_table`, `partial_symbol_table`, or `lsp`).
+- [ ] 7.2.2. Implement a two-pass Tree-sitter extraction pipeline that builds a
+      symbol table before resolving edges.
+  - [ ] Acceptance criteria: edge extraction uses a full or partial symbol
+    table and marks resolution scope on each edge; unresolved references are
+    preserved as external nodes with explicit confidence.
+- [ ] 7.2.3. Implement call-edge slice expansion using the existing LSP call
+      hierarchy provider via `weaver-graph`. Requires 3.1.4 and 2.1.9.
+  - [ ] Acceptance criteria: `call` edges include explicit provenance; depth
+    limits are enforced; and end-to-end tests validate a depth-2 traversal on a
+    fixture repository.
+- [ ] 7.2.4. Implement baseline `import` and `config` edge extraction using
+      Tree-sitter interstitial passes and per-language queries. Requires 3.1.1.
+  - [ ] Acceptance criteria: extracted edges include confidence values and
+    provenance; edge extraction is bounded by the slice budget; and at least
+    one test per language asserts both `import` and `config` edge behaviour.
+- [ ] 7.2.5. Implement budgeted traversal using a priority-queue expansion
+      strategy with explicit `max_cards`, `max_edges`, and
+      `max_estimated_tokens` enforcement.
+  - [ ] Acceptance criteria: traversal never exceeds configured caps; rejection
+    reasons are emitted when `--debug` is enabled; and behaviour-driven
+    development (BDD) tests cover fan-out explosion and budget truncation
+    cases.
+
+### 7.3. Deliver `observe graph-history` in `snapshots_on_demand` mode
+
+*Outcome: Diff a slice over the last N commits without requiring a working tree
+checkout, producing deterministic output suitable for caching and regression
+tests. See `docs/jacquard-card-first-symbol-graph-design.md` §13.1-§13.2 and
+§22.*
+
+- [ ] 7.3.1. Implement git-backed blob loading for historical revisions without
+      checkout, scoped to only the files required by the slice budget.
+  - [ ] Add explicit operational limits for blob size, parse time per file,
+        total files per commit, and partial-parse thresholds, with fallback
+        reasons recorded in the output (`timeout`, `blob_too_large`,
+        `partial_parse`, `unsupported_grammar`).
+  - [ ] Acceptance criteria: history queries never invoke `git checkout`;
+    missing blobs return structured diagnostics; and the file loader is covered
+    by unit tests for typical path and revision scenarios.
+- [ ] 7.3.2. Implement slice reconstruction per commit with explicit data
+      quality metadata and partial symbol table resolution. Requires 7.2.5.
+  - [ ] Acceptance criteria: `--commits 5` returns a stable set of commits and
+    per-commit slice payloads with `quality.resolution_scope` and
+    `quality.fallbacks`; delta payloads include added/removed/changed nodes and
+    edges; and BDD tests validate output against a curated git fixture
+    repository.
+- [ ] 7.3.3. Implement delta computation normalization and change taxonomy
+      classification for nodes and edges.
+  - [ ] Treat import blocks and decorators as commutative sets for deltas, and
+        persist normalized representations alongside raw text.
+  - [ ] Acceptance criteria: import/decorator reordering is classified as
+        `text` change; taxonomy output includes confidence; and fixtures cover
+        comment-only and signature-only edits.
+- [ ] 7.3.4. Implement semantic risk warnings on history deltas for
+      dependency/dependent changes in the slice neighbourhood.
+  - [ ] Expose `--warning-depth` to widen the dependency neighbourhood scanned
+        for warnings.
+  - [ ] Acceptance criteria: warnings include edge paths and confidence;
+    `text`-only deltas emit lower-risk warnings; and curated fixtures validate
+    both warning types.
+- [ ] 7.3.5. Implement history-mode gating and safe defaults, with LSP
+      enrichment disabled by default for history queries.
+  - [ ] Acceptance criteria: default mode uses Tree-sitter-only extraction for
+    historical commits; enabling enrichment is explicit and documented; and
+    degraded behaviour is made visible via provenance fields.
+
+### 7.4. Deliver probabilistic matching and “reason codes”
+
+*Outcome: Map symbols across commits probabilistically when identifiers drift,
+exposing confidence and alternates rather than hiding ambiguity. See
+`docs/jacquard-card-first-symbol-graph-design.md` §14.1-§14.8.*
+
+- [ ] 7.4.1. Implement phase 1 stable-identity matching (type, name, container,
+      file hint), with explicit confidence output.
+  - [ ] Acceptance criteria: match outputs include the winning phase and
+    confidence; non-matching candidates are rejected rather than forced; and
+    fixtures include rename/move cases that must not match in phase 1.
+- [ ] 7.4.2. Implement phase 2 body-hash matching for rename detection.
+      Requires 7.4.1.
+  - [ ] Acceptance criteria: match outputs include the winning phase and
+    confidence; low-confidence matches are rejected rather than forced; and
+    fixtures cover rename scenarios with unchanged bodies.
+- [ ] 7.4.3. Implement phase 3 structural-hash matching on AST-normalized
+      shapes. Requires 7.4.2.
+  - [ ] Acceptance criteria: match outputs include the winning phase and
+    confidence; low-confidence matches are rejected rather than forced; and
+    fixtures cover move scenarios with formatting-only edits.
+- [ ] 7.4.4. Implement phase 4 fuzzy similarity matching (token overlap and
+      shingles). Requires 7.4.3.
+  - [ ] Acceptance criteria: match outputs include the winning phase and
+    confidence; low-confidence matches are rejected rather than forced; and
+    fixtures cover rename and move scenarios with minor body edits.
+- [ ] 7.4.5. Implement phase 5 graph refinement and global assignment
+      refinement. Requires 7.4.4.
+  - [ ] Acceptance criteria: match outputs include the winning phase and
+    confidence; low-confidence matches are rejected rather than forced; and
+    fixtures cover rename/move scenarios resolved by neighbourhood evidence.
+- [ ] 7.4.6. Implement feature extraction for cross-commit matching using
+      signature, AST-shape, docstring fingerprints, attachments, and
+      neighbourhood sketches.
+  - [ ] Acceptance criteria: feature extraction is deterministic for identical
+    inputs; unit tests cover feature stability under whitespace-only edits and
+    alpha-renaming of locals; and failures emit structured diagnostics.
+- [ ] 7.4.7. Implement candidate generation and scoring with calibrated
+      probabilities, emitting top-K alternates and “reason codes”. Requires
+      7.4.6.
+  - [ ] Acceptance criteria: response payloads always include `best_match` plus
+    alternates up to the requested cap; reason codes are stable enumerations;
+    and debug output surfaces the top contributing features.
+- [ ] 7.4.8. Implement duplicate-name guardrails (`max_duplicates`) that force
+      ambiguous mappings or fallback matching when homonyms explode.
+  - [ ] Acceptance criteria: `--max-duplicates` returns explicit “ambiguous
+    mapping” responses; observability counters capture guardrail triggers; and
+    fixtures with same-name functions avoid false renames.
+- [ ] 7.4.9. Implement assignment across the slice using a solver that avoids
+      mapping multiple sources to one target unless explicitly enabled.
+  - [ ] Acceptance criteria: property tests prevent illegal many-to-one
+    mappings by default; a feature flag enables split/merge experimentation;
+    and deterministic test fixtures cover rename and move scenarios.
+
+### 7.5. Optional ledger cache and richer edge types
+
+*Outcome: Add a persisted ledger keyed by commit hash for faster history
+queries and broader edge coverage once `snapshots_on_demand` is proven
+reliable. This step is intentionally staged behind the on-demand
+implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
+§18.1-§18.2.*
+
+- [ ] 7.5.1. Define a versioned on-disk ledger format for cards, edges, and
+      deltas keyed by commit hash. Requires 7.3.2.
+  - [ ] Acceptance criteria: format is forward-compatible via explicit version
+    fields; corruption is detected with checksums; and schema changes are gated
+    behind migrations.
+- [ ] 7.5.2. Implement incremental ledger population and invalidation rules.
+  - [ ] Acceptance criteria: ledger writes are atomic; invalidation occurs when
+    inputs change; and performance benchmarks show a measurable improvement for
+    repeated history queries.
+
+## 8. Formal verification and proof tooling
+
+*Goal: Add bounded formal verification checks for Weaver-owned transactional,*
+*patching, routing, and guardrail invariants without replacing the existing*
+*test stack. See `docs/formal-verification-methods-in-weaver.md`.*
+
+### 8.1. Establish formal verification tooling
+
+*Outcome: Add pinned verifier installation, explicit make targets, and staged*
+*Continuous Integration (CI) entry points for Kani and Verus.*
+
+- [ ] 8.1.1. Add pinned verifier version files and install scripts for Kani and
+      Verus. See `docs/formal-verification-methods-in-weaver.md`
+      "Repository layout and tooling".
+  - [ ] Add `tools/kani/VERSION`.
+  - [ ] Add `tools/verus/VERSION` and `tools/verus/SHA256SUMS`.
+  - [ ] Add `scripts/install-kani.sh`, `scripts/install-verus.sh`, and
+        `scripts/run-verus.sh`.
+  - [ ] Acceptance criteria: local installs are reproducible from pinned
+        versions, scripts fail fast on version or checksum mismatch, and the
+        normal Rust toolchain workflow remains unchanged unless a formal target
+        is invoked.
+- [ ] 8.1.2. Add explicit `make kani`, `make kani-full`, `make verus`,
+      `make formal-pr`, and `make formal-nightly` targets. Requires 8.1.1.
+  - [ ] Keep the Kani smoke harness list explicit rather than scan-based.
+  - [ ] Keep Verus execution outside Cargo through `scripts/run-verus.sh`.
+  - [ ] Acceptance criteria: `make kani` runs only smoke harnesses,
+        `make kani-full` runs all checked-in Kani harnesses, `make verus`
+        executes the proof entrypoint, and the new targets are documented in
+        the `Makefile`.
+- [ ] 8.1.3. Add staged CI jobs for formal verification. Requires 8.1.2.
+  - [ ] Add `kani-smoke` to pull-request validation after the first smoke
+        harnesses land.
+  - [ ] Add `verus-proofs` as manual or nightly validation first, then promote
+        only if the proof set remains stable.
+  - [ ] Acceptance criteria: the existing `build-test` job remains intact,
+        formal jobs install their own tools, and slow proof suites are isolated
+        from the default pull-request path.
+
+### 8.2. Clarify proof contracts before gating
+
+*Outcome: Define the exact assurances that Kani and Verus are expected to*
+*prove, including filesystem assumptions and trust boundaries.*
+
+- [ ] 8.2.1. Publish the transaction atomicity contract for the Double-Lock
+      path. See `docs/formal-verification-methods-in-weaver.md`
+      "Atomicity contract".
+  - [ ] State the filesystem assumptions that define "all changes applied or
+        original state restored".
+  - [ ] State catastrophic failure conditions that are outside the verified
+        model.
+  - [ ] Acceptance criteria: the design document and user's guide describe the
+        same atomicity promise using one shared contract.
+- [ ] 8.2.2. Define the semantic-lock contract precisely. Requires 8.2.1. See
+      `docs/formal-verification-methods-in-weaver.md`
+      "Semantic-lock contract".
+  - [ ] Specify severity handling, provider normalization, baseline scope, and
+        backend-unavailable semantics.
+  - [ ] Acceptance criteria: implementation docs, CLI behaviour, and future
+        proof harnesses can refer to one explicit semantic-lock definition
+        without relying on inferred behaviour.
+- [ ] 8.2.3. Document the formal-verification trust boundary. Requires 8.2.2.
+      See `docs/formal-verification-methods-in-weaver.md` "Trust boundary".
+  - [ ] Separate verified orchestration invariants from trusted external-tool
+        assumptions.
+  - [ ] Acceptance criteria: docs name the verified kernel, list unverified
+        dependencies explicitly, and avoid claiming semantic correctness for
+        third-party tools.
+
+### 8.3. Add Kani checks for the transaction and patch kernels
+
+*Outcome: Add bounded model-checking coverage for the highest-risk write path*
+*that Weaver owns directly.*
+
+- [ ] 8.3.1. Add Kani smoke harnesses for Double-Lock transaction ordering in
+      `crates/weaverd/src/safety_harness/`. Requires 8.1.2 and 8.2.1.
+  - [ ] Prove commit is reachable only when both locks pass.
+  - [ ] Prove lock-failure and backend-unavailable states are non-committing.
+  - [ ] Acceptance criteria: `make kani` executes transaction smoke harnesses,
+        and counterexamples are reproducible through the documented target.
+- [ ] 8.3.2. Add Kani smoke harnesses for rollback bookkeeping and bounded file
+      traces in `crates/weaverd/src/safety_harness/`. Requires 8.3.1.
+  - [ ] Cover bounded create, modify, and delete combinations.
+  - [ ] Cover commit-phase failure that restores the pre-state under the
+        documented assumptions.
+  - [ ] Acceptance criteria: harnesses assert file-set preservation and
+        rollback restoration over bounded traces.
+- [ ] 8.3.3. Add Kani smoke harnesses for `act apply-patch` matching and path
+      guardrails in `crates/weaverd/src/dispatch/act/apply_patch/`.
+      Requires 8.3.1 and 6.1.4.
+  - [ ] Cover cursor monotonicity for ordered `SEARCH`/`REPLACE` blocks.
+  - [ ] Cover whole-command abort on unmatched blocks.
+  - [ ] Cover path normalization rejecting absolute and parent-escape paths.
+  - [ ] Acceptance criteria: `make kani` includes apply-patch smoke harnesses,
+        and the checked properties map directly to the documented patch
+        contract.
+- [ ] 8.3.4. Promote larger transaction and patch harnesses to `make kani-full`
+      once the smoke harnesses are stable. Requires 8.3.2 and 8.3.3.
+  - [ ] Expand touched-file counts and mixed-operation sequences.
+  - [ ] Keep smoke and full harnesses separate.
+  - [ ] Acceptance criteria: `make kani-full` exercises larger bounded traces
+        than the pull-request smoke set, and scheduled runs record stable pass
+        or fail outcomes.
+
+### 8.4. Add Kani checks for capability routing and refusal semantics
+
+*Outcome: Verify bounded capability-selection invariants in the plugin control*
+*plane before expanding proof coverage elsewhere.*
+
+- [ ] 8.4.1. Add Kani smoke harnesses for capability-resolution soundness in
+      `crates/weaver-plugins/src/`. Requires 8.1.2, 5.3.2, and 8.2.3.
+  - [ ] Prove the selected provider satisfies the requested language and
+        capability.
+  - [ ] Prove refusal is deterministic when no compatible provider exists.
+  - [ ] Acceptance criteria: `make kani` runs capability-routing smoke
+        harnesses, and refusal semantics are asserted over bounded routing
+        tables.
+- [ ] 8.4.2. Add property-based tests for refusal-code stability, path-policy
+      helpers, and bounded routing tables. Requires 8.4.1.
+  - [ ] Acceptance criteria: generated tests complement the Kani harnesses by
+        exploring larger input spaces without widening the verified kernel
+        claims.
+
+### 8.5. Add a proof-only Verus kernel
+
+*Outcome: Prove the smallest stable invariants in proof-only modules outside*
+*the main Cargo build.*
+
+- [ ] 8.5.1. Add a proof-only Verus workspace under `verus/` with
+      `weaver_proofs.rs` as the entrypoint. Requires 8.1.2 and 8.2.3.
+  - [ ] Add `transaction_kernel.rs`, `capability_routing.rs`, and
+        `apply_patch_paths.rs`.
+  - [ ] Acceptance criteria: `make verus` executes the proof entrypoint, and
+        the proof modules use proof-specific types rather than widening the
+        production API.
+- [ ] 8.5.2. Prove transaction-gating and rollback-restoration lemmas over a
+      modelled workspace state. Requires 8.5.1 and 8.2.1.
+  - [ ] Acceptance criteria: proofs establish that commit requires both locks
+        and that documented rollback restoration holds under the chosen model
+        assumptions.
+- [ ] 8.5.3. Prove capability-resolution soundness over an abstract resolver.
+      Requires 8.5.1 and 8.2.3.
+  - [ ] Acceptance criteria: proofs establish that successful resolution
+        satisfies language, capability, and policy predicates, and that refusal
+        occurs instead of silent fallback when no provider qualifies.
+
+### 8.6. Extend formal verification coverage after later roadmap features land
+
+*Outcome: Expand proof coverage only when the underlying contracts and kernels*
+*are implemented and stable.*
+
+- [ ] 8.6.1. Add Kani harnesses for graph-slice budget enforcement after 7.2.5
+      lands. Requires 7.2.5 and 8.3.4.
+  - [ ] Acceptance criteria: bounded graph harnesses prove counters do not
+        exceed accepted-card, edge, and token-budget caps on small graphs.
+- [ ] 8.6.2. Add Kani harnesses for duplicate-name guardrails and assignment
+      injectivity after 7.4.8 and 7.4.9 land. Requires 7.4.8, 7.4.9, and
+      8.3.4.
+  - [ ] Acceptance criteria: bounded matching harnesses prove injective
+        assignments by default and prove many-to-one assignments remain gated
+        behind explicit split or merge modes.
+- [ ] 8.6.3. Add Kani harnesses for Sempai semantic constraints only after the
+      planned parser and backend crates exist. Requires 4.2 and 4.3.
+  - [ ] Acceptance criteria: formal checks cover deterministic matcher and
+        normalization kernels without trying to verify external parser or
+        runtime dependencies wholesale.
+
+*Prerequisites note: Phases 9–11 depend on tasks from earlier phases (e.g.
+"Requires 4.1.5" or "Requires 7.2.3"). Each prerequisite uses the dotted-number
+identifier from its parent phase above — search this document for the number to
+locate the full task description and its own dependency chain.*
+
+## 9. Vertical slice (Sempai → Jacquard → one-hop traversal)
+
+*Goal: Cut one thin, end-to-end path from a Sempai query through canonical
+symbol resolution to a JacquardCard with one navigable relation, proving the
+core Weaver loop in an agent-consumable CLI surface. The definition of done is:
+an agent sends a symbol-ish query to Sempai, receives a canonical JacquardCard
+over the CLI, then follows one returned relation to a second card, with no
+interactive prompts.[^1][^2][^3]*
+
+### 9.1. Deliver minimal Sempai `search` execution (YAML only)
+
+*Outcome: Execute a minimal positive-anchor Semgrep-compatible `search` query
+from a YAML rule file, returning deterministic match spans for one language.
+This deliberately limits scope to YAML input (not the one-liner DSL), a single
+`pattern` or `match.pattern` principal, and no conjunctions, negation, ellipsis
+families, or `where` clauses.[^1]*
+
+- [ ] 9.1.1. Implement minimal positive-anchor normalization into
+      a canonical `Formula::Atom(Pattern)` form for `pattern` and
+      `match.pattern` principals. Requires 4.1.5.
+  - [ ] Acceptance criteria: paired legacy `pattern` and v2
+        `match.pattern` fixtures normalize to equivalent
+        `Formula::Atom` values; unsupported operators (`patterns`,
+        `pattern-either`, `pattern-not`, `inside`, `where`) return
+        deterministic `E_SEMPAI_*` diagnostics; and no ellipsis,
+        deep-ellipsis, or conjunction forms are accepted.
+- [ ] 9.1.2. Implement token rewriting and pattern intermediate
+      representation (IR) compilation for a single language (Rust
+      or Python). Requires 9.1.1 and 4.2.1.
+  - [ ] Acceptance criteria: rewritten snippets compile into
+        `PatNode`-based IR with span traceability; metavariables
+        `$X` and `$_` are supported; ellipsis and deep-ellipsis
+        forms are rejected with structured diagnostics; and
+        snapshot tests lock IR shapes for positive-anchor patterns.
+- [ ] 9.1.3. Implement node-kind matching and metavariable
+      unification over Tree-sitter syntax trees for the chosen
+      first language. Requires 9.1.2 and 4.2.4.
+  - [ ] Acceptance criteria: repeated metavariables unify across
+        compatible nodes; mismatches fail deterministically; and
+        end-to-end match output includes `uri`, `span`, and
+        default `focus` fields.
+- [ ] 9.1.4. Add Sempai execution routing in `weaverd` for
+      `observe query` limited to the minimal `search` subset.
+      Requires 9.1.3.
+  - [ ] Acceptance criteria: daemon routes `observe.query`
+        requests through the minimal Sempai pipeline; responses
+        are deterministic JSONL match streams with `uri`, `span`,
+        and `focus`; unsupported query forms return structured
+        diagnostics without daemon failure.
+- [ ] 9.1.5. Add `weaver observe query --lang --uri --rule-file`
+      command surface for the minimal `search` subset.
+      Requires 9.1.4.
+  - [ ] Acceptance criteria: CLI validates input combinations;
+        `--rule-file` accepts YAML rule files; `--rule` accepts
+        inline YAML; `--q` is explicitly absent from this step;
+        and stable error messaging covers missing file,
+        unsupported mode, and parse failure paths.
+
+### 9.2. Deliver symbol-first card retrieval
+
+*Outcome: Allow agents to retrieve a JacquardCard by symbol name or
+qualified-name selector, without requiring a line-and-column position. This
+bridges the gap between Sempai match output and the existing position-based
+`observe get-card` path.[^2]*
+
+- [ ] 9.2.1. Add a `--symbol` selector to `observe get-card` that
+      accepts symbol names, qualified names, and path-qualified
+      names. Requires 7.1.2.
+  - [ ] Acceptance criteria: `weaver observe get-card --uri <URI>
+        --symbol <NAME>` resolves a symbol by name within the
+        file's entity table and returns the same
+        `GetCardResponse` envelope as the position-based path;
+        ambiguous matches return a structured refusal listing
+        candidates with positions; and the position-based
+        `--position` path remains unchanged.
+- [ ] 9.2.2. Add path-qualified disambiguation for `--symbol`
+      selectors. Requires 9.2.1.
+  - [ ] Acceptance criteria: selectors of the form `path:Symbol`
+        and `path:Parent.Symbol` filter the entity table by file
+        path pattern before name matching; and disambiguation
+        tests cover multi-file workspaces with identically named
+        symbols.
+- [ ] 9.2.3. Wire Sempai match output into symbol-first card
+      retrieval so `observe query` results can feed
+      `observe get-card` without manual position extraction.
+      Requires 9.1.5 and 9.2.1.
+  - [ ] Acceptance criteria: a Sempai match span resolves to a
+        card via both the `--position` and `--symbol` paths; an
+        end-to-end test demonstrates the query-to-card loop for
+        a single fixture using `--symbol`; and the test asserts
+        that the `GetCardResponse` envelope is identical
+        regardless of which selector path is used.
+
+### 9.3. Deliver one-hop relation traversal
+
+*Outcome: Include exactly one navigable relation type in card output so that an
+agent can follow a returned `symbol_id` back into the same command path. This
+is the thinnest useful slice of JacquardWeave.[^2]*
+
+- [ ] 9.3.1. Add a `relations` field to `SymbolCard` containing a
+      small ranked list of related `SymbolRef` values for one
+      relation type (references, containment, or
+      callers/callees). Requires 7.1.2 and 3.1.4.
+  - [ ] Acceptance criteria: the chosen relation type is populated
+        from the existing LSP or Tree-sitter substrate; related
+        items are stable `SymbolRef` values that can be fed back
+        into `observe get-card --position`; the `relations` field
+        is absent (not empty) when no relations are found; and
+        schema fixtures lock the new field shape.
+- [ ] 9.3.2. Implement the query-to-card-to-relation loop as a
+      documented agent workflow. Requires 9.2.3 and 9.3.1.
+  - [ ] Acceptance criteria: an end-to-end test demonstrates the
+        full loop (query → resolve → card → related symbol →
+        second card) using CLI commands; the workflow is documented
+        in the user's guide[^5]; and no interactive prompts are
+        required at any step.
+
+## 10. Leta parity for supported languages
+
+*Goal: Ship the high-frequency semantic navigation verbs that an agent needs
+every few minutes, bringing Weaver's public CLI surface to parity with
+[Leta](https://github.com/andreasjansson/leta) for Rust, Python, and
+TypeScript. This phase prioritizes the everyday agent navigation loop — find,
+show, trace, search, rename — over exotic analysis. Each operation must honour
+Weaver's existing JSONL envelope, exit-code contract, and human-readable
+rendering conventions.[^3][^4][^5]*
+
+### 10.1. Deliver `observe find-references` end-to-end
+
+*Outcome: Expose LSP `textDocument/references` as a stable, end-to-end CLI
+operation with human-readable and JSONL output. The underlying LSP substrate
+already supports references in `weaver-lsp-host`.[^5]*
+
+- [ ] 10.1.1. Wire `observe find-references` daemon dispatch to
+      the existing `LspHost::references()` method, returning
+      structured location arrays. Requires 2.1.8 and 2.1.9.
+  - [ ] Acceptance criteria: `weaver observe find-references
+        --uri <URI> --position <LINE:COL>` returns a JSONL
+        response containing an array of reference locations; empty
+        results return an empty array (not an error); unsupported
+        languages return a structured diagnostic; and
+        human-readable output renders context blocks with line
+        numbers.
+- [ ] 10.1.2. Add unit, behavioural, and end-to-end coverage for
+      `observe find-references`. Requires 10.1.1.
+  - [ ] Acceptance criteria: tests cover success paths (single
+        and multiple references), empty-result paths,
+        unsupported-language refusal, and pre-initialization error
+        paths for Rust, Python, and TypeScript fixtures.
+
+### 10.2. Deliver symbol-first `observe show`
+
+*Outcome: Provide a `show` equivalent that accepts a symbol-ish selector and
+returns the full definition body, mirroring Leta's `show` command. This builds
+on the symbol-first card retrieval from 9.2 and the existing `observe get-card`
+infrastructure.[^2]*
+
+- [ ] 10.2.1. Add an `observe show` command that accepts
+      `--symbol` (or positional symbol name), resolves it via the
+      entity table, and returns the full symbol body with
+      surrounding context. Requires 9.2.1.
+  - [ ] Acceptance criteria: `weaver observe show <SYMBOL>
+        --uri <URI>` returns the complete symbol definition
+        including doc comments and decorators; `--context <N>`
+        adds surrounding lines; human-readable output includes
+        file path, line numbers, and syntax-highlighted source;
+        JSONL output includes `uri`, `range`, `source_text`, and
+        `symbol` identity fields; and ambiguous symbols return a
+        structured disambiguation response.
+- [ ] 10.2.2. Add qualified-name and path-filter support for
+      `observe show`. Requires 10.2.1 and 9.2.2.
+  - [ ] Acceptance criteria: selectors of the form
+        `Parent.Symbol`, `path:Symbol`, and `path:Parent.Symbol`
+        resolve correctly; and tests cover disambiguation across
+        multiple files with identically named symbols.
+
+### 10.3. Deliver `observe call-hierarchy` end-to-end
+
+*Outcome: Expose the existing `weaver-graph` call hierarchy provider as a
+stable CLI operation with configurable direction and depth. The internal
+`CallGraph` provider is complete.[^5][^2]*
+
+- [ ] 10.3.1. Wire `observe call-hierarchy` daemon dispatch to
+      the existing `weaver-graph` call hierarchy provider with
+      `--direction` and `--max-depth` flags. Requires 2.1.8,
+      2.1.9, and 3.1.4.
+  - [ ] Acceptance criteria: `weaver observe call-hierarchy
+        --uri <URI> --position <LINE:COL>` returns a JSONL
+        response containing `nodes` and `edges` arrays;
+        `--direction` supports `incoming`, `outgoing`, and `both`;
+        `--max-depth` limits traversal; provenance and call-site
+        positions are included on edges; and human-readable output
+        renders a tree view.
+- [ ] 10.3.2. Add unit, behavioural, and end-to-end coverage for
+      `observe call-hierarchy`. Requires 10.3.1.
+  - [ ] Acceptance criteria: tests cover outgoing calls, incoming
+        calls, bidirectional traversal, depth limiting, empty
+        results, and unsupported-language refusal for Rust,
+        Python, and TypeScript fixtures.
+
+### 10.4. Deliver `observe grep` end-to-end
+
+*Outcome: Expose the existing `weaver-syntax` structural search engine as a
+stable CLI operation for semantic symbol search with kind filtering. The
+underlying engine is complete.[^3]*
+
+- [ ] 10.4.1. Wire `observe grep` daemon dispatch to
+      `weaver-syntax` with `--pattern`, `--kind`, `--uri`, and
+      `--lang` flags. Requires 2.1.8 and 3.1.1.
+  - [ ] Acceptance criteria: `weaver observe grep --pattern
+        <PATTERN> --lang <LANG>` returns a JSONL response
+        containing match locations with symbol kind, name, and
+        span; `--kind` filters by symbol kind; `--uri` scopes to
+        a specific file; human-readable output renders matches
+        with file path, line number, kind, and name; and invalid
+        patterns return structured parse diagnostics.
+- [ ] 10.4.2. Add unit, behavioural, and end-to-end coverage for
+      `observe grep`. Requires 10.4.1.
+  - [ ] Acceptance criteria: tests cover pattern matching, kind
+        filtering, file scoping, invalid pattern diagnostics, and
+        empty-result paths for Rust, Python, and TypeScript
+        fixtures.
+
+### 10.5. Deliver `act rename-symbol` end-to-end
+
+*Outcome: Expose the existing capability-routed `rename-symbol` plugins as a
+stable, end-to-end CLI operation with safety-harness integration. The
+capability contract and plugin implementations are in place (5.2.1–5.2.4).[^6]*
+
+- [ ] 10.5.1. Wire `act rename-symbol` as a first-class CLI
+      command with `--uri`, `--position`, and `--new-name` flags,
+      routing through capability-based plugin selection.
+      Requires 5.2.4.
+  - [ ] Acceptance criteria: `weaver act rename-symbol --uri <URI>
+        --position <LINE:COL> --new-name <NAME>` applies a
+        workspace-wide rename through the Double-Lock safety
+        harness; JSONL output includes the list of modified files
+        and applied edits; human-readable output shows a unified
+        diff; refusal paths (unsupported language, symbol not
+        found) return structured diagnostics; and the filesystem
+        is unchanged on lock failure.
+- [ ] 10.5.2. Add unit, behavioural, and end-to-end coverage for
+      `act rename-symbol`. Requires 10.5.1 and 5.2.5.
+  - [ ] Acceptance criteria: tests cover successful rename for
+        Python and Rust, refusal paths, rollback guarantees, and
+        safety-harness integration.
+
+## 11. Weaver unique selling proposition (USP): composable agent-grade CLI primitives
+
+*Goal: Deliver the capabilities that make Weaver more than a Leta clone. Where
+Phase 10 reaches parity, this phase delivers Weaver's USP: budgeted graph-slice
+traversal, card-driven exploration, deterministic CLI contracts for agent tool
+loops, and the safety harness that makes write operations trustworthy. These
+are the features that justify choosing Weaver over a thinner LSP
+wrapper.[^3][^2][^7]*
+
+### 11.1. Deliver `observe graph-slice` traversal
+
+*Outcome: Wire the budgeted graph traversal from 7.2.5 into a stable CLI
+command with the full flag set from the design document. This is the first
+Weaver-specific differentiator beyond Leta's `graph` command. Requires the
+schema work from 7.2.1.[^2]*
+
+- [ ] 11.1.1. Wire `observe graph-slice` as a stable CLI command
+      consuming the traversal engine from 7.2.5, the schema from
+      7.2.1, and the call-edge provider from 7.2.3.
+      Requires 7.2.1, 7.2.3, and 7.2.5.
+  - [ ] Acceptance criteria: `weaver observe graph-slice
+        --uri <URI> --position <LINE:COL>` returns a JSONL
+        response containing `cards`, `edges`, and `spillover`
+        fields; all budget flags (`--max-cards`, `--max-edges`,
+        `--max-estimated-tokens`, `--depth`, `--direction`,
+        `--edge-types`, `--min-confidence`, `--entry-detail`,
+        `--node-detail`) are exposed; human-readable output
+        renders a tree with depth markers; and exit-code semantics
+        distinguish success from truncation.
+
+### 11.2. Deliver card-driven traversal workflow
+
+*Outcome: Enable agents to navigate from one symbol card to related symbols
+through structured relation data, completing the "postcard to loom" loop.[^2]*
+
+- [ ] 11.2.1. Extend the `relations` field from 9.3.1 to support
+      multiple relation types (references, containment, and
+      callers/callees). Requires 9.3.1.
+  - [ ] Acceptance criteria: cards include relations from all
+        available providers; each relation carries a `type` field
+        and a ranked list of `SymbolRef` values; relation types
+        are explicitly enumerated in the schema; and empty
+        relation types are omitted rather than included as empty
+        arrays.
+- [ ] 11.2.2. Add dependency and dependent fan metrics to
+      `full`-detail cards. Requires 11.2.1 and 7.1.3.
+  - [ ] Acceptance criteria: `--detail full` cards include
+        `fan_in` and `fan_out` counts sourced from
+        `weaver-graph`; provenance marks the data source (`lsp`,
+        `tree_sitter`, or `static_analysis`); and metrics are
+        absent (not zero) when the underlying provider is
+        unavailable.
+
+### 11.3. Deliver agent-grade CLI contract hardening
+
+*Outcome: Harden the CLI surface so that Weaver behaves as a reliable primitive
+for agent tool loops (Codex CLI, Claude Code, and similar). The contract must
+be deterministic, non-interactive, and machine-readable.[^3]*
+
+- [ ] 11.3.1. Enforce deterministic stdout/stderr separation
+      across all `observe` and `act` commands.
+  - [ ] Acceptance criteria: `stdout` contains only the result
+        payload (JSONL or human-readable); `stderr` carries logs,
+        progress, and diagnostics; no command writes diagnostic
+        text to `stdout`; and regression tests assert separation
+        for every implemented command.
+- [ ] 11.3.2. Add explicit `schema_version` to all JSONL response
+      envelopes.
+  - [ ] Acceptance criteria: every JSONL response includes a
+        top-level `schema_version` field; version values are
+        stable across patch releases; and snapshot tests lock the
+        version for each response type.
+- [ ] 11.3.3. Standardize exit codes across all commands to
+      distinguish `resolved`, `ambiguous`, `not_found`, and
+      `backend_unavailable`.
+  - [ ] Acceptance criteria: exit-code semantics are documented
+        in the user's guide[^5]; every command uses the shared
+        exit-code enumeration; and BDD tests assert each exit
+        code for at least one command.
+- [ ] 11.3.4. Ensure compact output by default with opt-in
+      expansion for all `observe` commands.
+  - [ ] Acceptance criteria: default output stays within a
+        configurable token budget; `--detail` or `--expand` flags
+        opt into richer output; and agents can rely on bounded
+        response sizes without explicit truncation.
+
+### 11.4. Deliver safety-harness integration as a visible differentiator
+
+*Outcome: Surface the Double-Lock safety harness as a visible, documented
+feature that agents and operators can rely on for trustworthy write operations.
+This is a key Weaver differentiator.[^7][^8]*
+
+- [ ] 11.4.1. Add structured safety-harness result metadata to
+      all `act` command JSONL responses. Requires 2.1.13.
+  - [ ] Acceptance criteria: every `act` response includes a
+        `safety_harness` field reporting syntactic-lock and
+        semantic-lock outcomes; lock failures include diagnostic
+        spans and reasons; and the field is present even on
+        success (reporting `passed`).
+- [ ] 11.4.2. Document the safety-harness contract for agent
+      consumption in the user's guide[^5]. Requires 11.4.1.
+  - [ ] Acceptance criteria: the user's guide includes a
+        dedicated section explaining the Double-Lock model, what
+        agents can rely on, and how to interpret lock-failure
+        diagnostics; and the section references the formal
+        verification design document for deeper guarantees.
+
+[^1]: [`sempai-query-language-design.md`](sempai-query-language-design.md)
+[^2]: [`jacquard-card-first-symbol-graph-design.md`](jacquard-card-first-symbol-graph-design.md)
+[^3]: [`weaver-design.md`](weaver-design.md)
+[^4]: [`ui-gap-analysis.md`](ui-gap-analysis.md)
+[^5]: [`users-guide.md`](users-guide.md)
+[^6]: [`adr-001-plugin-capability-model-and-act-extricate.md`](adr-001-plugin-capability-model-and-act-extricate.md)
+[^7]: [`weaver-design.md`](weaver-design.md) §5.1 and §6.1
+[^8]: [`formal-verification-methods-in-weaver.md`](formal-verification-methods-in-weaver.md)

--- a/docs/archive/prototype-roadmap.md
+++ b/docs/archive/prototype-roadmap.md
@@ -29,7 +29,7 @@ The live roadmap carries these relevant archive themes forward:
 - Sempai one-liner parsing, Tree-sitter execution, selector records, and
   selector-to-card composition in phase `15`;
 - patch application, idempotent transactions, selector-fed mutation,
-  capability-routed rename, and move/extract validation in phase `16`;
+  capability-routed rename, and `extricate-symbol` validation in phase `16`;
 - graph slices, historical graph reconstruction, probabilistic matching, graph
   budgets, and optional ledger-cache decisions in phase `17`;
 - specialist perceptor and actuator providers, capability manifests, provider
@@ -55,52 +55,52 @@ unfinished product intent is active in `docs/roadmap.md`. "Superseded" means
 the historical spelling or implementation path is not part of the current
 product plan, but any still-useful behaviour has been re-expressed elsewhere.
 
-| Archive step | Disposition                         | Live destination or reason                                                                                                   |
-| ------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 1.1          | Foundation                          | Repository and documentation baseline retained as product history.                                                           |
-| 2.1          | Foundation                          | Daemon, JSONL transport, LSP host, sandbox, Double-Lock, and atomic-edit work underpins phases 13, 14, 16, and 19.           |
-| 2.2          | Foundation, then superseded grammar | Discoverability lessons carry into phase 13; public `observe` / `act` / `verify` examples are provenance only.               |
-| 2.3          | Foundation, then superseded grammar | Enumerating errors carry into 13.2 and 13.3; `act refactor` wording is replaced by capability-routed resource commands.      |
-| 3.1          | Foundation                          | Syntax, syntactic-lock, document-sync, and graph crates feed phases 14, 15, 16, and 17.                                      |
-| 3.2          | Migrated                            | Help, command metadata, and manpage work moves to 13.2 and 13.3, with OrthoConfig dependencies instead of local duplication. |
-| 3.3          | Migrated                            | Locale bootstrap, localized help, catalogues, and generated references move to 13.2 and 13.3.                                |
-| 4.1          | Foundation and migrated             | Completed Sempai facade and YAML normalization remain foundation; one-liner parser and recovery move to 15.1.                |
-| 4.2          | Migrated                            | Tree-sitter profiles, rewriting, matching, formula execution, and safety controls move to 15.2.                              |
-| 4.3          | Migrated, renamed                   | `observe query` becomes `symbols list --query` and selector-stream integration in 15.3.                                      |
-| 5.1          | Foundation                          | Plugin platform foundation remains provider infrastructure for phases 16 and 18.                                             |
-| 5.2          | Foundation and migrated             | Completed rename capability work supports 16.2; migration notes and capability discoverability move to 18.2.                 |
-| 5.3          | Migrated, renamed                   | `act extricate` becomes the `symbol.move` or `symbol.extract` validation slice in 16.3.                                      |
-| 5.4          | Migrated, renamed                   | Rust extrication work moves to the move/extract viability decision in 16.3.                                                  |
-| 5.5          | Migrated                            | `srgn` becomes an optional provider experiment in 18.1.                                                                      |
-| 5.6          | Migrated                            | `jedi` becomes the first specialist perceptor experiment in 18.1.                                                            |
-| 5.7          | Migrated                            | Plugin introspection and capability probe work becomes `capabilities list` and `context --json` in 13.3 and 18.2.            |
-| 5.8          | Migrated                            | Graceful degradation guidance moves to provider failure handling in 18.1 and 18.2.                                           |
-| 5.9          | Migrated                            | Static-analysis graph edges move to 17.1.                                                                                    |
-| 6.1          | Foundation and migrated             | Completed patch application is re-surfaced as `patches apply` in 16.1.                                                       |
-| 6.2          | Migrated and partly deferred        | Onboarding and explicit interaction move to 19.2; dynamic-analysis ingestion is validated or deferred by 19.2.3.             |
-| 7.1          | Foundation and migrated             | Completed card schemas, extraction, enrichment, and cache work moves to `cards get` in 14.2.                                 |
-| 7.2          | Foundation and migrated             | Completed graph-slice schema is retained; traversal and edge work moves to 17.1.                                             |
-| 7.3          | Migrated                            | Graph history moves to 17.2 after bounded graph slices prove value.                                                          |
-| 7.4          | Migrated                            | Probabilistic matching moves to 17.3 and remains conditional on history needs.                                               |
-| 7.5          | Deferred decision                   | Ledger caching is reconsidered only after 17.2.3 supplies performance evidence.                                              |
-| 8.1          | Migrated                            | Formal tooling setup moves to 19.3 after safety-critical command paths exist.                                                |
-| 8.2          | Migrated                            | Proof contracts and trust boundary move to 19.3.                                                                             |
-| 8.3          | Migrated                            | Transaction and patch Kani checks move to 19.3.                                                                              |
-| 8.4          | Migrated                            | Capability-routing checks move to 19.3.                                                                                      |
-| 8.5          | Migrated                            | Proof-only Verus kernels move to 19.3 after stable abstractions exist.                                                       |
-| 8.6          | Migrated, conditional               | Later graph, matching, and Sempai checks are folded into 19.3 only after their product slices survive.                       |
-| 9.1          | Migrated, narrowed                  | Minimal Sempai execution is recast as one-liner selector validation in 15.1 and 15.2.                                        |
-| 9.2          | Migrated, renamed                   | Symbol-first card retrieval becomes selector-aware `cards get` in 14.2 and 15.3.                                             |
-| 9.3          | Migrated                            | One-hop relation traversal moves to card summaries and selector-to-context workflows in 14.2 and 15.3.                       |
-| 10.1         | Migrated, renamed                   | `observe find-references` becomes `references list` in 14.1.                                                                 |
-| 10.2         | Migrated, renamed                   | `observe show` becomes selector-aware `cards get` and relation summaries in 14.2 and 15.3.                                   |
-| 10.3         | Migrated, renamed                   | `observe call-hierarchy` becomes bounded graph slices and card relation summaries in 14.2 and 17.1.                          |
-| 10.4         | Migrated, conditional               | `observe grep` becomes a `symbols list --pattern` decision in 14.3, or folds into Sempai selectors.                          |
-| 10.5         | Migrated, renamed                   | `act rename-symbol` becomes `symbols rename` in 16.2.                                                                        |
-| 11.1         | Migrated, renamed                   | `observe graph-slice` becomes `graph-slices get` in 17.1.                                                                    |
-| 11.2         | Migrated                            | Card-driven traversal becomes one-hop cards plus graph-slice expansion in 14.2 and 17.1.                                     |
-| 11.3         | Migrated                            | Agent-grade stdout/stderr, schema, exit-code, and compact-output contracts move to 13.2 and 13.3.                            |
-| 11.4         | Migrated                            | Visible safety-harness metadata moves to `patches apply`, mutation metadata, and user documentation in 16.1.                 |
+| Archive step | Disposition                         | Live destination or reason                                                                                                          |
+| ------------ | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 1.1          | Foundation                          | Repository and documentation baseline retained as product history.                                                                  |
+| 2.1          | Foundation                          | Daemon, JSONL transport, LSP host, sandbox, Double-Lock, and atomic-edit work underpins phases 13, 14, 16, and 19.                  |
+| 2.2          | Foundation, then superseded grammar | Discoverability lessons carry into phase 13; public `observe` / `act` / `verify` examples are provenance only.                      |
+| 2.3          | Foundation, then superseded grammar | Enumerating errors carry into 13.2 and 13.3; `act refactor` wording is replaced by capability-routed resource commands.             |
+| 3.1          | Foundation                          | Syntax, syntactic-lock, document-sync, and graph crates feed phases 14, 15, 16, and 17.                                             |
+| 3.2          | Migrated                            | Help, command metadata, and manpage work moves to 13.2 and 13.3, with OrthoConfig dependencies instead of local duplication.        |
+| 3.3          | Migrated                            | Locale bootstrap, localized help, catalogues, and generated references move to 13.2 and 13.3.                                       |
+| 4.1          | Foundation and migrated             | Completed Sempai facade and YAML normalization remain foundation; one-liner parser and recovery move to 15.1.                       |
+| 4.2          | Migrated                            | Tree-sitter profiles, rewriting, matching, formula execution, and safety controls move to 15.2.                                     |
+| 4.3          | Migrated, renamed                   | `observe query` becomes `symbols list --query` and selector-stream integration in 15.3.                                             |
+| 5.1          | Foundation                          | Plugin platform foundation remains provider infrastructure for phases 16 and 18.                                                    |
+| 5.2          | Foundation and migrated             | Completed rename capability work supports 16.2; migration notes and capability discoverability move to 18.2.                        |
+| 5.3          | Migrated, renamed                   | `act extricate` becomes `weaver symbols move` backed by `extricate-symbol` in 16.3; `extract-method` remains a separate capability. |
+| 5.4          | Migrated, renamed                   | Rust `extricate-symbol` orchestration, repair, verification, and compatibility work moves to 16.4.                                  |
+| 5.5          | Migrated                            | `srgn` becomes an optional provider experiment in 18.1.                                                                             |
+| 5.6          | Migrated                            | `jedi` becomes the first specialist perceptor experiment in 18.1.                                                                   |
+| 5.7          | Migrated                            | Plugin introspection and capability probe work becomes `capabilities list` and `context --json` in 13.3 and 18.2.                   |
+| 5.8          | Migrated                            | Graceful degradation guidance moves to provider failure handling in 18.1 and 18.2.                                                  |
+| 5.9          | Migrated                            | Static-analysis graph edges move to 17.1.                                                                                           |
+| 6.1          | Foundation and migrated             | Completed patch application is re-surfaced as `patches apply` in 16.1.                                                              |
+| 6.2          | Migrated and partly deferred        | Onboarding and explicit interaction move to 19.2; dynamic-analysis ingestion is validated or deferred by 19.2.3.                    |
+| 7.1          | Foundation and migrated             | Completed card schemas, extraction, enrichment, and cache work moves to `cards get` in 14.2.                                        |
+| 7.2          | Foundation and migrated             | Completed graph-slice schema is retained; traversal and edge work moves to 17.1.                                                    |
+| 7.3          | Migrated                            | Graph history moves to 17.2 after bounded graph slices prove value.                                                                 |
+| 7.4          | Migrated                            | Probabilistic matching moves to 17.3 and remains conditional on history needs.                                                      |
+| 7.5          | Deferred decision                   | Ledger caching is reconsidered only after 17.2.3 supplies performance evidence.                                                     |
+| 8.1          | Migrated                            | Formal tooling setup moves to 19.3 after safety-critical command paths exist.                                                       |
+| 8.2          | Migrated                            | Proof contracts and trust boundary move to 19.3.                                                                                    |
+| 8.3          | Migrated                            | Transaction and patch Kani checks move to 19.3.                                                                                     |
+| 8.4          | Migrated                            | Capability-routing checks move to 19.3.                                                                                             |
+| 8.5          | Migrated                            | Proof-only Verus kernels move to 19.3 after stable abstractions exist.                                                              |
+| 8.6          | Migrated, conditional               | Later graph, matching, and Sempai checks are folded into 19.3 only after their product slices survive.                              |
+| 9.1          | Migrated, narrowed                  | Minimal Sempai execution is recast as one-liner selector validation in 15.1 and 15.2.                                               |
+| 9.2          | Migrated, renamed                   | Symbol-first card retrieval becomes selector-aware `cards get` in 14.2 and 15.3.                                                    |
+| 9.3          | Migrated                            | One-hop relation traversal moves to card summaries and selector-to-context workflows in 14.2 and 15.3.                              |
+| 10.1         | Migrated, renamed                   | `observe find-references` becomes `references list` in 14.1.                                                                        |
+| 10.2         | Migrated, renamed                   | `observe show` becomes selector-aware `cards get` and relation summaries in 14.2 and 15.3.                                          |
+| 10.3         | Migrated, renamed                   | `observe call-hierarchy` becomes bounded graph slices and card relation summaries in 14.2 and 17.1.                                 |
+| 10.4         | Migrated, conditional               | `observe grep` becomes a `symbols list --pattern` decision in 14.3, or folds into Sempai selectors.                                 |
+| 10.5         | Migrated, renamed                   | `act rename-symbol` becomes `symbols rename` in 16.2.                                                                               |
+| 11.1         | Migrated, renamed                   | `observe graph-slice` becomes `graph-slices get` in 17.1.                                                                           |
+| 11.2         | Migrated                            | Card-driven traversal becomes one-hop cards plus graph-slice expansion in 14.2 and 17.1.                                            |
+| 11.3         | Migrated                            | Agent-grade stdout/stderr, schema, exit-code, and compact-output contracts move to 13.2 and 13.3.                                   |
+| 11.4         | Migrated                            | Visible safety-harness metadata moves to `patches apply`, mutation metadata, and user documentation in 16.1.                        |
 
 ## 1. Foundation & tooling (complete)
 

--- a/docs/archive/prototype-roadmap.md
+++ b/docs/archive/prototype-roadmap.md
@@ -79,10 +79,10 @@ product plan, but any still-useful behaviour has been re-expressed elsewhere.
 | 6.1          | Foundation and migrated             | Completed patch application is re-surfaced as `patches apply` in 16.1.                                                              |
 | 6.2          | Migrated and partly deferred        | Onboarding and explicit interaction move to 19.2; dynamic-analysis ingestion is validated or deferred by 19.2.3.                    |
 | 7.1          | Foundation and migrated             | Completed card schemas, extraction, enrichment, and cache work moves to `cards get` in 14.2.                                        |
-| 7.2          | Foundation and migrated             | Completed graph-slice schema is retained; traversal and edge work moves to 17.1.                                                    |
-| 7.3          | Migrated                            | Graph history moves to 17.2 after bounded graph slices prove value.                                                                 |
-| 7.4          | Migrated                            | Probabilistic matching moves to 17.3 and remains conditional on history needs.                                                      |
-| 7.5          | Deferred decision                   | Ledger caching is reconsidered only after 17.2.3 supplies performance evidence.                                                     |
+| 7.2          | Foundation and migrated             | Completed graph-slice schema is retained; traversal, edge extraction, and budget work move to 17.1.                                 |
+| 7.3          | Migrated                            | Graph history, checkout-free blob loading, deltas, warnings, and safe defaults move to 17.2.                                        |
+| 7.4          | Migrated                            | Probabilistic matching phases, reason codes, duplicate guardrails, and injective assignment move to 17.3.                           |
+| 7.5          | Migrated conditionally              | Ledger cache validation, format, population, and invalidation move to 17.4 behind the on-demand history evidence gate.              |
 | 8.1          | Migrated                            | Formal tooling setup moves to 19.3 after safety-critical command paths exist.                                                       |
 | 8.2          | Migrated                            | Proof contracts and trust boundary move to 19.3.                                                                                    |
 | 8.3          | Migrated                            | Transaction and patch Kani checks move to 19.3.                                                                                     |

--- a/docs/archive/prototype-roadmap.md
+++ b/docs/archive/prototype-roadmap.md
@@ -12,6 +12,41 @@ roadmap under resource-first command names. Prototype `observe`, `act`, and
 `verify` spellings are not future public grammar unless a live roadmap task
 explicitly reintroduces them.
 
+## 2026-05-13 assessment
+
+The archive has been assessed against the current product plan in
+[`../roadmap.md`](../roadmap.md). Completed tasks remain historical foundation
+and implementation evidence. Unchecked tasks that still serve the product have
+been migrated into live phases `12` through `20`, where they are sequenced as
+vertical slices that validate or invalidate product hypotheses.
+
+The live roadmap carries these relevant archive themes forward:
+
+- command discoverability, localization, manpages, context output, skills, and
+  drift prevention in phase `13`;
+- Language Server Protocol (LSP) reads, diagnostics, cards, and compact
+  same-symbol context in phase `14`;
+- Sempai one-liner parsing, Tree-sitter execution, selector records, and
+  selector-to-card composition in phase `15`;
+- patch application, idempotent transactions, selector-fed mutation,
+  capability-routed rename, and move/extract validation in phase `16`;
+- graph slices, historical graph reconstruction, probabilistic matching, graph
+  budgets, and optional ledger-cache decisions in phase `17`;
+- specialist perceptor and actuator providers, capability manifests, provider
+  state, and graceful degradation in phase `18`;
+- profiles, jobs, delivery, feedback, onboarding, explicit interaction,
+  dynamic-analysis decisions, and formal assurance in phase `19`; and
+- MCP, explorer, deferred provider, dynamic-analysis, and cache experiments in
+  phase `20`.
+
+Superseded prototype guidance is not active backlog. This includes the public
+`observe` / `act` / `verify` command grammar, root `--output`, operation-local
+`--format`, provider-first public commands, and root `--capabilities` as the
+main introspection contract. Their product intent has moved to resource-first
+commands, canonical `--json`, `weaver context --json`,
+`weaver capabilities list --json`, capability-routed providers, and selector
+pipelines in the live roadmap.
+
 ## 1. Foundation & tooling (complete)
 
 ### 1.1. Establish foundation and documentation baseline

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -418,7 +418,7 @@ CQRS is an architectural pattern that segregates operations that modify state
 and should represent specific business intentions (e.g.,
 
 `BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries
-never alter data and return Data Transfer Objects (DTOs) optimised for display
+never alter data and return Data Transfer Objects (DTOs) optimized for display
 needs.18
 
 While CQRS operates at a higher architectural level than a single Bumpy Road

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -95,7 +95,7 @@ Cognitive Complexity is incremented based on three main rules 8:
 3. **Shorthand Discount:** Structures that allow multiple statements to be read
    as a single unit (e.g., a well-named method call) do not incur the same
    penalties as the raw statements they encapsulate. Method calls are generally
-   "free" in terms of cognitive complexity, as a well-chosen name summarises
+   "free" in terms of cognitive complexity, as a well-chosen name summarizes
    the underlying logic, allowing readers to grasp the high-level view before
    diving into details. However, recursive calls do increment the score.8
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -28,6 +28,9 @@
   surface](adr-007-agent-native-command-surface.md)
   - Decision record for the human-friendly, agent-native 0.1.0 command
     contract and OrthoConfig dependency boundary.
+- [Archived prototype roadmap](archive/prototype-roadmap.md)
+  - Historical completed and superseded roadmap tasks from the pre-ADR-007
+    command grammar, preserving task numbers `1` through `11`.
 - [Building an error-recovering parser with Chumsky](building-an-error-recovering-parser-with-chumsky.md)
   - Practical parser-construction guidance for resilient parsing workflows.
 - [Code complexity guide](complexity-antipatterns-and-refactoring-strategies.md)

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -24,6 +24,10 @@
   orchestration
   strategy](adr-006-plugin-execution-and-orchestration-strategy.md)
   - Decision record for one-shot JSONL execution and broker-owned orchestration.
+- [Architectural decision record (ADR) 007: Agent-native command
+  surface](adr-007-agent-native-command-surface.md)
+  - Decision record for the human-friendly, agent-native 0.1.0 command
+    contract and OrthoConfig dependency boundary.
 - [Building an error-recovering parser with Chumsky](building-an-error-recovering-parser-with-chumsky.md)
   - Practical parser-construction guidance for resilient parsing workflows.
 - [Code complexity guide](complexity-antipatterns-and-refactoring-strategies.md)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -11,9 +11,9 @@ The workspace targets `ortho_config` v0.8.0 and Rust 1.88.
 
 ## Sempai overview
 
-Sempai is Weaver's Semgrep-compatible query engine facade. It parses rule
-YAML, normalizes supported search syntax into a canonical formula model, and
-prepares per-language query plans for later execution.
+Sempai is Weaver's Semgrep-compatible query engine facade. It parses rule YAML,
+normalizes supported search syntax into a canonical formula model, and prepares
+per-language query plans for later execution.
 
 ## Sempai query pipeline (milestone 4.1.5)
 
@@ -826,7 +826,9 @@ of `act refactor`. It is a non-test module consumed by both the
 argument-parsing layer and the test suite to keep validation, guidance text,
 and supported-value lists in one place.
 
-The module exposes seven `pub(crate)` functions:
+The module exposes seven `pub(crate)` functions. The exact signatures live in
+Rustdoc; this section records each helper's contract so the Markdown remains
+readable after automated wrapping:
 
 - `supported_provider_names() -> &'static [&'static str]` — returns the
   canonical slice of accepted provider names (e.g. `rope`, `rust-analyzer`),
@@ -844,19 +846,16 @@ The module exposes seven `pub(crate)` functions:
   and returns `DispatchError::InvalidArguments` with
   `act refactor does not support refactoring '<value>'` plus the shared
   guidance block when `refactoring` is not in `supported_refactoring_names()`.
-- `effective_operation(refactoring: &str) -> Result<&'static str,
-  DispatchError>` — maps a user-facing refactoring name to the underlying
-  plugin capability operation string (`"rename"` → `"rename-symbol"`),
-  returning the same unsupported-refactoring
+- `effective_operation(...)` — maps a user-facing refactoring name to the
+  underlying plugin capability operation string (`"rename"` →
+  `"rename-symbol"`), returning the same unsupported-refactoring
   `DispatchError::InvalidArguments` as `validate_refactoring(…)` for unknown
   user-facing names.
-- `capability_for_operation(operation: &str) -> Result<CapabilityId,
-  DispatchError>` — maps a capability operation string to its
-  `CapabilityId` variant (`"rename-symbol"` →
-  `CapabilityId::RenameSymbol`), returning
-  `DispatchError::InvalidArguments` with `act refactor does not support
-  capability resolution for '<operation>'` and the supported
-  capability-operation tokens for unknown operations.
+- `capability_for_operation(...)` — maps a capability operation string to its
+  `CapabilityId` variant (`"rename-symbol"` → `CapabilityId::RenameSymbol`),
+  returning `DispatchError::InvalidArguments` with
+  `act refactor does not support capability resolution for '<operation>'` and
+  the supported capability-operation tokens for unknown operations.
 - `missing_requirements_error() -> DispatchError` — builds the deterministic
   `DispatchError::InvalidArguments` with `act refactor requires ...`, every
   required flag (`--provider <plugin>`, `--refactoring <operation>`,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -9,6 +9,45 @@ need but operators do not. For user-facing behaviour see the
 
 The workspace targets `ortho_config` v0.8.0 and Rust 1.88.
 
+## Adding or renaming public commands
+
+ADR 007 makes the 0.1.0 public command surface resource-first and generated
+from OrthoConfig-backed command metadata plus Weaver-owned semantic adapters.
+Do not add new public command grammar by hand in `clap`, daemon routing, manual
+pages, help text, and docs independently.
+
+When adding or renaming a public command:
+
+1. Update the OrthoConfig-backed command metadata or the Weaver semantic
+   command-surface adapter, depending on whether the change is reusable
+   command-contract machinery or Weaver-specific semantic behaviour.
+2. Declare the capability ID the command exposes, or reuse an existing
+   capability such as `definition.get`, `references.list`, `diagnostics.list`,
+   `symbol.rename`, `symbol.move`, or `patch.apply`.
+3. Provide localized human message IDs, copy-pasteable examples, and the human
+   renderer layout hints needed for default output, `--plain`, colour control,
+   and terminal-width fallbacks.
+4. Provide JSON success and error schemas. Protocol identifiers, field names,
+   schema versions, enum values, capability IDs, and exit classes are stable
+   and non-localized.
+5. Declare selector support, mutability, async behaviour, pagination bounds,
+   profile interaction, delivery support, and feedback exposure.
+6. Update or regenerate documentation snippets, `context --json`
+   introspection, skill-manifest references, manpage inputs, shell completions,
+   and tests from the same metadata.
+7. Run the drift, vocabulary, renderer, JSON, bounded-output, capability, and
+   example gates before merging the command change.
+
+Provider names are not the ordinary public workflow. Commands should expose
+semantic resources and capabilities, while Rope, rust-analyzer, Sempai,
+Tree-sitter, Language Server Protocol (LSP) servers, and built-in helpers stay
+behind deterministic provider routing. Provider names may appear in provenance,
+diagnostics, `--verbose` output, policy, and expert overrides.
+
+Sections below that document `observe`, `act`, `verify`, or `act refactor`
+describe the current prototype implementation. They are useful for maintaining
+shipped code, but they do not define the 0.1.0 public command contract.
+
 ## Sempai overview
 
 Sempai is Weaver's Semgrep-compatible query engine facade. It parses rule YAML,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -669,7 +669,7 @@ CLI configuration flags like any other config field.
 
 Full CLI localization bootstrap was historically deferred to prototype archive
 roadmap item `3.3.1`; the forward command-surface reset carries localized
-renderer work in roadmap item `13.3.1`. Weaver does not yet resolve the final
+renderer work in roadmap item `13.2.1`. Weaver does not yet resolve the final
 locale and use it to construct the `Localizer` before clap parse errors are
 formatted. The current `Locale` type exists so the configuration contract is
 real now and the later localization bootstrap can reuse the validated domain

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -827,7 +827,7 @@ argument-parsing layer and the test suite to keep validation, guidance text,
 and supported-value lists in one place.
 
 The module exposes seven `pub(crate)` functions. The exact signatures live in
-Rustdoc; this section records each helper's contract so the Markdown remains
+Rustdoc; this section records each helper's contract, so the Markdown remains
 readable after automated wrapping:
 
 - `supported_provider_names() -> &'static [&'static str]` — returns the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -671,8 +671,8 @@ Full CLI localization bootstrap was historically deferred to prototype archive
 roadmap item `3.3.1`; the forward command-surface reset carries localized
 renderer work in roadmap item `13.2.1`. Weaver does not yet resolve the final
 locale and use it to construct the `Localizer` before clap parse errors are
-formatted. The current `Locale` type exists so the configuration contract is
-real now and the later localization bootstrap can reuse the validated domain
+formatted. The current `Locale` type exists, so the configuration contract is
+real now, and the later localization bootstrap can reuse the validated domain
 value.
 
 ### 2.5 Daemon command execution glue (`crates/weaver-cli/src/runner_glue.rs`)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -54,7 +54,7 @@ Sempai is Weaver's Semgrep-compatible query engine facade. It parses rule YAML,
 normalizes supported search syntax into a canonical formula model, and prepares
 per-language query plans for later execution.
 
-## Sempai query pipeline (milestone 4.1.5)
+## Sempai query pipeline (prototype archive milestone 4.1.5)
 
 - Canonical model (`sempai_core::formula`):
   - `Formula` enum: `Atom`, `Not`, `Inside`, `Anywhere`, `And`, `Or`
@@ -524,7 +524,7 @@ catalogue. `GraphSliceFixtureCase` is a type alias for `CardFixtureCase`.
   an out-of-range position and asserts
   `refusal.reason == "position_out_of_range"`.
 
-## Public API additions in milestone 7.2.1
+## Public API additions in prototype archive milestone 7.2.1
 
 ### `handle` signature — `FusionBackends` parameter
 
@@ -667,11 +667,13 @@ The built-in default is `en-US`. That value is part of the current shared
 configuration contract and is available from files, environment variables, and
 CLI configuration flags like any other config field.
 
-Full CLI localization bootstrap is intentionally deferred to roadmap item
-`3.3.1`. In particular, Weaver does not yet resolve the final locale and use it
-to construct the `Localizer` before clap parse errors are formatted. The
-current `Locale` type exists so the configuration contract is real now and the
-later localization bootstrap can reuse the validated domain value.
+Full CLI localization bootstrap was historically deferred to prototype archive
+roadmap item `3.3.1`; the forward command-surface reset carries localized
+renderer work in roadmap item `13.3.1`. Weaver does not yet resolve the final
+locale and use it to construct the `Localizer` before clap parse errors are
+formatted. The current `Locale` type exists so the configuration contract is
+real now and the later localization bootstrap can reuse the validated domain
+value.
 
 ### 2.5 Daemon command execution glue (`crates/weaver-cli/src/runner_glue.rs`)
 

--- a/docs/execplans/2-2-1-act-apply-patch-sub-command.md
+++ b/docs/execplans/2-2-1-act-apply-patch-sub-command.md
@@ -1,5 +1,9 @@
 # Deliver act apply-patch sub-command
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
@@ -35,7 +39,8 @@ writes.
   400 lines; extract helpers where needed per
   `docs/complexity-antipatterns-and-refactoring-strategies.md`.
 - Documentation updates are required in `docs/weaver-design.md`,
-  `docs/users-guide.md`, and the Phase 2 roadmap entry in `docs/roadmap.md`.
+  `docs/users-guide.md`, and the Phase 2 roadmap entry in
+  `docs/archive/prototype-roadmap.md`.
 - Run `make check-fmt`, `make lint`, and `make test` and ensure they pass.
 - Use en-GB-oxendict spelling in prose and comments.
 
@@ -184,7 +189,7 @@ traversal attempt, syntactic lock failure, semantic lock failure).
 Stage G (docs and roadmap): update `docs/weaver-design.md` with decisions made
 (request schema, error envelope, request size limit), update
 `docs/users-guide.md` with CLI usage and behaviour changes, and mark the
-apply-patch entry as done in `docs/roadmap.md`.
+apply-patch entry as done in `docs/archive/prototype-roadmap.md`.
 
 Stage H (quality gates): run `make check-fmt`, `make lint`, `make test`,
 `make markdownlint`, `make fmt`, and `make nixie` as required, using `tee` and
@@ -225,7 +230,7 @@ The feature is complete when:
   filesystem untouched.
 - Unit tests and rstest-bdd scenarios cover happy and unhappy paths.
 - `docs/weaver-design.md` and `docs/users-guide.md` reflect the new command
-  behaviour, and `docs/roadmap.md` marks the entry as done.
+  behaviour, and `docs/archive/prototype-roadmap.md` marks the entry as done.
 - `make check-fmt`, `make lint`, `make test`, `make markdownlint`, `make fmt`,
   and `make nixie` succeed.
 
@@ -246,7 +251,7 @@ Expected artifacts include:
   `crates/weaver-cli/tests/golden/`.
 - A new apply-patch handler module under `crates/weaverd/src/dispatch/act/`.
 - Updated docs in `docs/weaver-design.md`, `docs/users-guide.md`, and
-  `docs/roadmap.md`.
+  `docs/archive/prototype-roadmap.md`.
 
 ## Interfaces and dependencies
 

--- a/docs/execplans/2-2-2-list-all-domains-in-top-level-help.md
+++ b/docs/execplans/2-2-2-list-all-domains-in-top-level-help.md
@@ -1,5 +1,9 @@
 # 2.2.2 List all domains and operations in top-level help output
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -42,7 +46,7 @@ Domains and operations:
 ```
 
 This satisfies roadmap task 2.2.2 and closes the relevant checkboxes in
-`docs/roadmap.md`.
+`docs/archive/prototype-roadmap.md`.
 
 ## Constraints
 
@@ -235,7 +239,7 @@ _Table: Key files referenced in this plan._
 | `crates/weaver-cli/build.rs`                          | 70    | Manpage generation (includes cli.rs)     |
 | `crates/weaverd/src/dispatch/router.rs`               | 264   | Authoritative domain/operation lists     |
 | `docs/users-guide.md`                                 | 889   | Operator documentation                   |
-| `docs/roadmap.md`                                     | 771   | Roadmap checkboxes                       |
+| `docs/archive/prototype-roadmap.md`                   | 771   | Roadmap checkboxes                       |
 
 ### Localization pattern
 
@@ -338,7 +342,7 @@ Run `make test` and confirm all new tests pass.
 After the "Bare invocation" subsection, add a "Top-level help" subsection
 describing the new `--help` output with the domains-and-operations catalogue.
 
-**D2. Mark roadmap task 2.2.2 as done in `docs/roadmap.md`.**
+**D2. Mark roadmap task 2.2.2 as done in `docs/archive/prototype-roadmap.md`.**
 
 Change the three `[ ]` checkboxes for task 2.2.2 to `[x]`.
 
@@ -388,7 +392,7 @@ All commands run from the workspace root `/home/user/project`.
 ### Stage D
 
 1. Edit `docs/users-guide.md` — add "Top-level help" subsection.
-2. Edit `docs/roadmap.md` — mark 2.2.2 as done.
+2. Edit `docs/archive/prototype-roadmap.md` — mark 2.2.2 as done.
 3. Run `make fmt`.
 
 ### Stage E
@@ -467,7 +471,7 @@ _Table: Summary of modified files._
 | `crates/weaver-cli/src/tests/unit/after_help.rs`             | New: unit tests for after-help                  |
 | `crates/weaver-cli/tests/main_entry.rs`                      | Add integration test for `--help`               |
 | `docs/users-guide.md`                                        | Add "Top-level help" subsection                 |
-| `docs/roadmap.md`                                            | Mark 2.2.2 checkboxes as done                   |
+| `docs/archive/prototype-roadmap.md`                          | Mark 2.2.2 checkboxes as done                   |
 | `docs/execplans/2-2-2-list-all-domains-in-top-level-help.md` | This ExecPlan                                   |
 
 Total: 9 files (within 15-file tolerance).

--- a/docs/execplans/2-2-3-top-level-version-output.md
+++ b/docs/execplans/2-2-3-top-level-version-output.md
@@ -1,5 +1,9 @@
 # Add top-level version output and long-form command-line interface (CLI) description
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -414,8 +418,8 @@ run.
 
 ### Stage H: Mark roadmap done
 
-**`docs/roadmap.md`** — Change lines 168-178: replace `[ ]` with `[x]` on all
-four items (the parent 2.2.3 and its three sub-items).
+**`docs/archive/prototype-roadmap.md`** — Change lines 168-178: replace `[ ]`
+with `[x]` on all four items (the parent 2.2.3 and its three sub-items).
 
 ## Concrete steps
 
@@ -514,7 +518,7 @@ Existing reusable code:
 | `tests/features/weaver_cli_version.feature` | New file                                   | 0            | ~20         |
 | `tests/main_entry.rs`                       | Add version/help integration tests         | 54           | ~79         |
 | `docs/users-guide.md`                       | Add version section, update help section   | ~999         | ~1015       |
-| `docs/roadmap.md`                           | Mark 2.2.3 done                            | ---          | ---         |
+| `docs/archive/prototype-roadmap.md`         | Mark 2.2.3 done                            | ---          | ---         |
 
 All paths are relative to `crates/weaver-cli/` except `docs/` which is relative
 to workspace root.

--- a/docs/execplans/2-2-4-provide-contextual-domain-guidance.md
+++ b/docs/execplans/2-2-4-provide-contextual-domain-guidance.md
@@ -1,5 +1,9 @@
 # 2.2.4 Provide contextual guidance when a domain is supplied without an operation
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -353,7 +357,7 @@ Include one sample output block and make clear that the command is a
 discoverability aid, not a daemon request.
 
 When the implementation and validation are complete, mark roadmap item 2.2.4
-done in `docs/roadmap.md`.
+done in `docs/archive/prototype-roadmap.md`.
 
 ### Stage E: validate end to end
 
@@ -388,8 +392,8 @@ The implementation is complete only when all of the following are true:
    auto-start.
 5. `weaver bogus` is unchanged by this task and remains reserved for roadmap
    2.3.1.
-6. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md` are
-   updated.
+6. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` are updated.
 7. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
    `make lint`, and `make test` all succeed.
 

--- a/docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md
+++ b/docs/execplans/2-3-1-validate-domains-client-side-before-daemon-startup.md
@@ -1,5 +1,9 @@
 # 2.3.1 Validate domains client-side before daemon startup
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -132,7 +136,8 @@ Both commands exit non-zero and do not print `Waiting for daemon start...`.
 
 ## Progress
 
-- [x] (2026-03-22 00:00Z) Read `docs/roadmap.md`, `docs/ui-gap-analysis.md`,
+- [x] (2026-03-22 00:00Z) Read `docs/archive/prototype-roadmap.md`,
+      `docs/ui-gap-analysis.md`,
       `docs/weaver-design.md`, the relevant testing guides, and the prior
       `2.2.4` ExecPlan.
 - [x] (2026-03-22 00:00Z) Confirmed the current runtime path in
@@ -157,8 +162,8 @@ Both commands exit non-zero and do not print `Waiting for daemon start...`.
       edit-distance suggestions, and renamed the sentinel to
       `PreflightGuidance`.
 - [x] (2026-03-22 14:10Z) Stage C: updated `docs/weaver-design.md`,
-      `docs/users-guide.md`, and `docs/roadmap.md` to reflect the shipped
-      behaviour.
+      `docs/users-guide.md`, and `docs/archive/prototype-roadmap.md` to
+      reflect the shipped behaviour.
 - [x] (2026-03-22 14:20Z) Stage D: ran `make fmt`, `make markdownlint`,
       `make nixie`, `make check-fmt`, `make lint`, and `make test` with logged
       output.
@@ -232,8 +237,8 @@ Target outcome at completion:
    roadmap `2.2.4`.
 6. Unit tests, integration tests, and `rstest-bdd` scenarios cover happy,
    unhappy, and edge cases.
-7. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-   reflect the final behaviour.
+7. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` reflect the final behaviour.
 8. `make check-fmt`, `make lint`, and `make test` pass, along with the
    Markdown gates required by `AGENTS.md`.
 
@@ -403,7 +408,7 @@ Update the design and operator docs once the code and tests are stable.
   Replace the current statement that unknown domains print the built-in
   domain-operation catalogue. Include one concrete example showing the new
   `Valid domains:` line and, if retained, the `Did you mean` hint.
-- `docs/roadmap.md`
+- `docs/archive/prototype-roadmap.md`
   Mark item `2.3.1` complete only after the implementation and all gates pass.
 
 Go/no-go:
@@ -434,6 +439,6 @@ Expected evidence:
 
 ## References
 
-[^roadmap]: [docs/roadmap.md](../roadmap.md)
+[^roadmap]: [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md)
 [^level3]: [docs/ui-gap-analysis.md Level 3](../ui-gap-analysis.md#level-3--unknown-domain-weaver-bogus-something)
 [^level10]: [docs/ui-gap-analysis.md Level 10](../ui-gap-analysis.md#level-10--error-messages-and-exit-codes)

--- a/docs/execplans/2-3-2-valid-operation-alternatives-for-unknown-operations.md
+++ b/docs/execplans/2-3-2-valid-operation-alternatives-for-unknown-operations.md
@@ -1,5 +1,9 @@
 # 2.3.2 Include valid operation alternatives for unknown operations
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -149,7 +153,7 @@ the UI gap analysis.[^3][^4]
 
 ## Progress
 
-- [x] (2026-03-28 00:00Z) Read `docs/roadmap.md`,
+- [x] (2026-03-28 00:00Z) Read `docs/archive/prototype-roadmap.md`,
       `docs/ui-gap-analysis.md`, `docs/weaver-design.md`,
       `docs/users-guide.md`, and the referenced testing guides.
 - [x] (2026-03-28 00:10Z) Confirmed the live daemon path:
@@ -174,9 +178,9 @@ the UI gap analysis.[^3][^4]
       `UnknownOperation` payloads and confirmed the new `rstest-bdd` scenarios
       pass for both daemon and CLI.
 - [x] (2026-03-29 12:45Z) Stage D: updated `docs/weaver-design.md`,
-      `docs/users-guide.md`, and `docs/roadmap.md` to describe the shipped
-      daemon-routed `UnknownOperation` contract and marked roadmap item
-      `2.3.2` done.
+      `docs/users-guide.md`, and `docs/archive/prototype-roadmap.md` to
+      describe the shipped daemon-routed `UnknownOperation` contract and marked
+      roadmap item `2.3.2` done.
 - [x] (2026-03-29 12:59Z) Stage E: ran `make fmt`,
       `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
       `make test` successfully after fixing one daemon unit assertion to parse
@@ -247,8 +251,8 @@ Target outcome at completion:
    `Available operations:` block from the structured daemon payload.
 4. The daemon and CLI behavioural suites exercise the new path with
    `rstest-bdd` using the existing harnesses.
-5. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-   reflect the shipped behaviour.
+5. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` reflect the shipped behaviour.
 6. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
    `make lint`, and `make test` all pass.
 
@@ -301,7 +305,7 @@ The change spans two crates and three documentation files.
   payload, not the CLI catalogue, is the source of truth for alternatives.
 - `docs/users-guide.md`
   Must show the new operator-visible human and JSON behaviour.
-- `docs/roadmap.md`
+- `docs/archive/prototype-roadmap.md`
   Must mark `2.3.2` done once the implementation and all gates are complete.
 
 ## Implementation plan
@@ -423,7 +427,7 @@ that the returned operations list comes from the daemon router and may include
 implemented and not-yet-implemented operations alike.
 
 After code, tests, and docs are complete, mark roadmap item `2.3.2` done in
-`docs/roadmap.md`.
+`docs/archive/prototype-roadmap.md`.
 
 ### Stage E - run the full gates and capture evidence
 
@@ -471,12 +475,12 @@ This work is complete only when all of the following are true:
 4. `--output json` forwards the structured payload unchanged.
 5. Unit tests and `rstest-bdd` behavioural tests pass for both daemon and CLI
    paths.
-6. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md` are
-   updated.
+6. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` are updated.
 7. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
    `make lint`, and `make test` all pass.
 
-[^1]: `docs/roadmap.md` item `2.3.2`.
+[^1]: `docs/archive/prototype-roadmap.md` item `2.3.2`.
 [^2]: `docs/ui-gap-analysis.md` Level 4.
 [^3]: `docs/ui-gap-analysis.md#level-4--unknown-operation-weaver-observe-nonexistent`.
 [^4]: `docs/ui-gap-analysis.md#level-10--error-messages-and-exit-codes`.

--- a/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
+++ b/docs/execplans/2-3-3-standardize-actionable-guidance-in-startup-errors.md
@@ -1,5 +1,9 @@
 # 2.3.3 Standardize actionable guidance in startup and routing errors
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -49,8 +53,8 @@ This work is successful when the following are all true:
 3. stable non-zero exit behaviour does not change;
 4. unit tests and `rstest-bdd` scenarios cover the happy path, unhappy paths,
    and edge cases;
-5. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-   reflect the shipped behaviour.
+5. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` reflect the shipped behaviour.
 
 ## Constraints
 
@@ -147,7 +151,8 @@ This work is successful when the following are all true:
 
 ## Progress
 
-- [x] (2026-04-07) Read `docs/roadmap.md`, `docs/ui-gap-analysis.md`,
+- [x] (2026-04-07) Read `docs/archive/prototype-roadmap.md`,
+      `docs/ui-gap-analysis.md`,
   `docs/weaver-design.md`, `docs/users-guide.md`, and the referenced testing
   guidance.
 - [x] (2026-04-07) Confirmed the current Level 10 implementation split across
@@ -168,7 +173,7 @@ This work is successful when the following are all true:
   failures through the same formatter while preserving existing exit codes and
   daemon payload semantics.
 - [x] Stage D: update `docs/weaver-design.md`, `docs/users-guide.md`, and
-  `docs/roadmap.md`.
+  `docs/archive/prototype-roadmap.md`.
 - [x] Stage E: run the full Markdown and Rust validation gates sequentially.
 
 ## Surprises & Discoveries
@@ -231,8 +236,9 @@ Target outcome at completion:
 6. The feature is covered by unit tests and `rstest-bdd` scenarios, and the
    final repository state passes `make fmt`, `make markdownlint`, `make nixie`,
    `make check-fmt`, `make lint`, and `make test`.
-7. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-   accurately describe the shipped behaviour.
+7. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` accurately describe the shipped
+   behaviour.
 
 Retrospective notes will be added after implementation.
 
@@ -288,7 +294,7 @@ The documentation surfaces that must be updated after implementation are:
 
 - `docs/weaver-design.md` (CLI preflight and startup guidance policy)
 - `docs/users-guide.md` (operator-visible examples)
-- `docs/roadmap.md` (mark `2.3.3` done)
+- `docs/archive/prototype-roadmap.md` (mark `2.3.3` done)
 
 ## Plan of work
 
@@ -436,8 +442,8 @@ outputs for:
 - daemon auto-start or explicit start failure caused by a missing `weaverd`
   binary.
 
-Update `docs/roadmap.md` only after the code and all documentation are final,
-and only when the validation gates are green.
+Update `docs/archive/prototype-roadmap.md` only after the code and all
+documentation are final, and only when the validation gates are green.
 
 ### Stage E: run the full validation suite and capture evidence
 
@@ -608,7 +614,7 @@ The likely touched source files are:
 - `crates/weaver-cli/tests/features/weaver_cli.feature`
 - `docs/weaver-design.md`
 - `docs/users-guide.md`
-- `docs/roadmap.md`
+- `docs/archive/prototype-roadmap.md`
 
 ## Revision note
 

--- a/docs/execplans/2-3-4-return-argument-requirements-for-act-refactor.md
+++ b/docs/execplans/2-3-4-return-argument-requirements-for-act-refactor.md
@@ -1,5 +1,9 @@
 # 2.3.4 Return complete argument requirements for `act refactor`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -43,8 +47,8 @@ This work is successful when the following are all true:
 4. Unit tests and `rstest-bdd` behavioural tests cover the happy path, the
    missing-arguments failure path, and edge cases such as partially supplied
    flags and unsupported values.
-5. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-   reflect the final operator contract.
+5. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` reflect the final operator contract.
 
 ## Constraints
 
@@ -140,7 +144,8 @@ This work is successful when the following are all true:
 
 ## Progress
 
-- [x] (2026-04-10) Read `docs/roadmap.md`, `docs/ui-gap-analysis.md`,
+- [x] (2026-04-10) Read `docs/archive/prototype-roadmap.md`,
+      `docs/ui-gap-analysis.md`,
   `docs/weaver-design.md`, `docs/users-guide.md`, and the referenced testing
   guidance.
 - [x] (2026-04-10) Confirmed that
@@ -159,7 +164,7 @@ This work is successful when the following are all true:
 - [x] Stage C: update `act refactor` parsing and routing so the new
   requirements are enforced consistently.
 - [x] Stage D: update `docs/weaver-design.md`, `docs/users-guide.md`, and
-  `docs/roadmap.md`.
+  `docs/archive/prototype-roadmap.md`.
 - [x] Stage E: run the full Markdown and Rust validation gates sequentially.
 
 ## Surprises & Discoveries
@@ -223,8 +228,9 @@ Target outcome at completion:
 5. `rstest-bdd` scenarios cover the happy path and the new unhappy-path
    validation behaviour.
 6. Any end-to-end CLI assertion added for the operator-visible output passes.
-7. `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-   accurately describe the shipped behaviour.
+7. `docs/weaver-design.md`, `docs/users-guide.md`, and
+   `docs/archive/prototype-roadmap.md` accurately describe the shipped
+   behaviour.
 8. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
    `make lint`, and `make test` all pass.
 
@@ -343,7 +349,7 @@ exactly which flags are required, which provider names are valid today, and
 which refactorings the MVP supports today.
 
 After the feature ships and all gates pass, mark roadmap item `2.3.4` as done
-in `docs/roadmap.md`.
+in `docs/archive/prototype-roadmap.md`.
 
 ### Stage E: validate end to end
 

--- a/docs/execplans/3-1-1-weaver-plugins-crate.md
+++ b/docs/execplans/3-1-1-weaver-plugins-crate.md
@@ -1,5 +1,9 @@
 # Implement the `weaver-plugins` crate with secure broker-plugin inter-process communication (IPC)
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan is a living document. The sections Constraints, Tolerances,
 Risks, Progress, Surprises & Discoveries, Decision Log, and Outcomes &
 Retrospective must be kept up to date as work proceeds.
@@ -334,7 +338,8 @@ Wire the plugin system into the `weaverd` dispatch layer:
    - The `act refactor` command syntax.
    - How plugin output is validated through the Double-Lock harness.
 
-3. Mark the first Phase 3 roadmap entry as done in `docs/roadmap.md`.
+3. Mark the first Phase 3 roadmap entry as done in
+   `docs/archive/prototype-roadmap.md`.
 
 ### Stage F: Final verification
 
@@ -449,8 +454,8 @@ Add `weaver-plugins` dependency to `crates/weaverd/Cargo.toml`. Create the
 
 ### Step 7: Update documentation
 
-Edit `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`.
-Verify:
+Edit `docs/weaver-design.md`, `docs/users-guide.md`, and
+`docs/archive/prototype-roadmap.md`. Verify:
 
     make check-fmt
 
@@ -474,8 +479,8 @@ Quality criteria (what "done" means):
 - Lint: `make lint` passes with zero warnings.
 - Format: `make check-fmt` reports no formatting violations.
 - Documentation: `docs/weaver-design.md` contains implementation decisions.
-  `docs/users-guide.md` documents the plugin system. `docs/roadmap.md` marks
-  the entry as done.
+  `docs/users-guide.md` documents the plugin system.
+  `docs/archive/prototype-roadmap.md` marks the entry as done.
 
 Quality method (how we check):
 

--- a/docs/execplans/3-1-1a-plugin-for-rope.md
+++ b/docs/execplans/3-1-1a-plugin-for-rope.md
@@ -1,5 +1,9 @@
 # Implement the first actuator plugin for `rope`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This Execution Plan (ExecPlan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -29,8 +33,8 @@ Observable success:
   and lock failures return structured failures and leave files unchanged.
 - Unit, behavioural, and end-to-end tests cover happy paths, unhappy paths,
   and edge cases.
-- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-  reflect the shipped behaviour.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/archive/prototype-roadmap.md` reflect the shipped behaviour.
 - `make check-fmt`, `make lint`, and `make test` succeed.
 
 ## Constraints
@@ -151,8 +155,9 @@ Observable success:
   `assert_cmd` and `insta` for:
   - isolated `act refactor` invocation;
   - pipeline invocation chaining `observe` output through `jq`.
-- Updated `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-  to reflect shipped behaviour and configuration.
+- Updated `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/archive/prototype-roadmap.md` to reflect shipped behaviour and
+  configuration.
 - Full repository quality gates passed after implementation and documentation
   updates.
 
@@ -168,7 +173,8 @@ Relevant existing components:
 - `crates/weaverd/src/dispatch/act/apply_patch/mod.rs` contains the existing
   patch parser + transaction flow that already enforces Double-Lock semantics.
 - `crates/weaverd/src/process/launch.rs` constructs the dispatch runtime.
-- `docs/roadmap.md` Phase 3 still marks rope plugin as incomplete.
+- `docs/archive/prototype-roadmap.md` Phase 3 still marks rope plugin as
+  incomplete.
 - `docs/users-guide.md` currently documents `act refactor` as not yet wired
   end-to-end.
 
@@ -308,7 +314,8 @@ Update docs to match shipped behaviour:
   runtime bootstrap, and diff-to-Double-Lock path.
 - `docs/users-guide.md`: remove "not yet available" note for `act refactor`
   and document rope-supported operations, arguments, and failure modes.
-- `docs/roadmap.md`: mark the rope plugin checklist item as done.
+- `docs/archive/prototype-roadmap.md`: mark the rope plugin checklist item as
+  done.
 
 ### Stage G: full quality gates
 
@@ -360,7 +367,7 @@ The feature is accepted when all items below are true:
     invocation.
 - `docs/weaver-design.md` records the decisions made by this implementation.
 - `docs/users-guide.md` documents user-visible behaviour and configuration.
-- `docs/roadmap.md` marks rope plugin entry as done.
+- `docs/archive/prototype-roadmap.md` marks rope plugin entry as done.
 - `make check-fmt`, `make lint`, and `make test` pass.
 
 ## Idempotence and recovery
@@ -382,7 +389,8 @@ Expected artifacts:
 - New behavioural feature files and step definitions for rope plugin and
   `act refactor`
 - Updated docs:
-  `docs/weaver-design.md`, `docs/users-guide.md`, `docs/roadmap.md`
+  `docs/weaver-design.md`, `docs/users-guide.md`,
+  `docs/archive/prototype-roadmap.md`
 
 ## Interfaces and dependencies
 

--- a/docs/execplans/3-1-1b-plugin-for-rust-analyzer.md
+++ b/docs/execplans/3-1-1b-plugin-for-rust-analyzer.md
@@ -1,5 +1,9 @@
 # Implement the rust-analyzer actuator plugin
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This Execution Plan (ExecPlan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -34,8 +38,8 @@ Observable success:
   failures return structured failures and leave files unchanged.
 - Unit, behavioural (`rstest-bdd` v0.5.0), and end-to-end tests cover happy,
   unhappy, and edge cases.
-- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-  reflect shipped behaviour.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/archive/prototype-roadmap.md` reflect shipped behaviour.
 - `make check-fmt`, `make lint`, and `make test` succeed.
 
 ## Constraints
@@ -119,6 +123,6 @@ Observable success:
   `WEAVER_RUST_ANALYZER_PLUGIN_PATH`, and timeout `60s`.
 - Added plugin unit tests, `rstest-bdd` behavioural tests, and e2e CLI
   snapshot coverage for actuator isolation and observe→jq→act pipelines.
-- Updated `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-  to capture behaviour and design decisions.
+- Updated `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/archive/prototype-roadmap.md` to capture behaviour and design decisions.
 - Full quality gates passed before completion.

--- a/docs/execplans/3-2-1-surface-configuration-flags-in-clap-help-output.md
+++ b/docs/execplans/3-2-1-surface-configuration-flags-in-clap-help-output.md
@@ -1,5 +1,9 @@
 # Surface configuration flags in clap help output
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -169,7 +173,7 @@ intended order without adding another configuration parser.
 
 ## Progress
 
-- [x] (2026-04-10 00:00Z) Read `docs/roadmap.md`[^1],
+- [x] (2026-04-10 00:00Z) Read `docs/archive/prototype-roadmap.md`[^1],
       `docs/ui-gap-analysis.md`[^2], `docs/weaver-design.md`[^3],
       `docs/users-guide.md`[^4], and the referenced testing guides.
 - [x] (2026-04-10 00:10Z) Confirmed the live implementation seam:
@@ -204,7 +208,7 @@ intended order without adding another configuration parser.
       `crates/weaver-cli/src/lib.rs` under 400 lines while rendering help from
       an augmented clap command only when clap itself requests help.
 - [x] (2026-04-11 01:20Z) Stage D: updated `crates/weaver-cli/build.rs`,
-      `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`,
+      `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/archive/prototype-roadmap.md`,
       then passed `make fmt`, `make markdownlint`, `make nixie`,
       `make check-fmt`, `make lint`, and `make test`.
 
@@ -272,7 +276,7 @@ Target outcome at completion:
 5. Unit tests, integration tests, and `rstest-bdd` scenarios cover happy
    paths, unhappy paths, and the relevant ordering and precedence edge cases.
 6. `docs/weaver-design.md`[^3], `docs/users-guide.md`[^4], and
-   `docs/roadmap.md`[^1] reflect the shipped behaviour.
+   `docs/archive/prototype-roadmap.md`[^1] reflect the shipped behaviour.
 7. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
    `make lint`, and `make test` all pass.
 
@@ -451,7 +455,7 @@ should restate that the flags must appear before the command domain or
 structured subcommand to take effect.
 
 Only after the implementation, tests, and docs are complete should
-`docs/roadmap.md`[^1] mark `3.2.1` as done.
+`docs/archive/prototype-roadmap.md`[^1] mark `3.2.1` as done.
 
 ## Validation
 
@@ -491,7 +495,8 @@ set -o pipefail; make lint 2>&1 | tee /tmp/3-2-1-make-lint.log
 set -o pipefail; make test 2>&1 | tee /tmp/3-2-1-make-test.log
 ```
 
-[^1]: `docs/roadmap.md` records roadmap item `3.2.1`, its shipped status, and
+[^1]: `docs/archive/prototype-roadmap.md` records roadmap item `3.2.1`, its
+      shipped status, and
     the later locale-bootstrap scope.
 [^2]: `docs/ui-gap-analysis.md` records the discovery gap that made
     configuration flags hard to find from the CLI help surface.

--- a/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
+++ b/docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md
@@ -1,5 +1,9 @@
 # 4.1.1 Scaffold `sempai_core` and `sempai` with stable public types and facade entrypoints
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -30,7 +34,8 @@ make test         # exits 0, including all new sempai_core and sempai tests
 cargo doc -p sempai --no-deps   # exits 0 with zero warnings
 ```
 
-This satisfies roadmap task 4.1.1 from `docs/roadmap.md` (lines 347-350).
+This satisfies roadmap task 4.1.1 from `docs/archive/prototype-roadmap.md`
+(lines 347-350).
 
 ## Constraints
 
@@ -176,7 +181,7 @@ All acceptance criteria met:
    `rstest-bdd` v0.5.0 with happy and unhappy path scenarios.
 4. `make check-fmt`, `make lint`, and `make test` all exit 0.
 5. `docs/users-guide.md` updated with Sempai query engine section.
-6. Roadmap task 4.1.1 marked as done in `docs/roadmap.md`.
+6. Roadmap task 4.1.1 marked as done in `docs/archive/prototype-roadmap.md`.
 
 Net new files: 28 (two crates with source, tests, and features). No existing
 crate APIs were modified.
@@ -523,8 +528,8 @@ documenting the existence of the `sempai` and `sempai_core` crates, the
 available public types, and a note that engine methods are stubbed pending
 backend implementation.
 
-**F2.** Mark roadmap task 4.1.1 as done in `docs/roadmap.md` (line 347): change
-`- [ ] 4.1.1.` to `- [x] 4.1.1.`.
+**F2.** Mark roadmap task 4.1.1 as done in `docs/archive/prototype-roadmap.md`
+(line 347): change `- [ ] 4.1.1.` to `- [x] 4.1.1.`.
 
 **F3.** Record design decisions taken in the design document
 `docs/sempai-query-language-design.md` if any type definitions diverge from the
@@ -613,7 +618,7 @@ All commands run from the workspace root.
 
 ### Stage F
 
-1. Update `docs/users-guide.md`, `docs/roadmap.md`.
+1. Update `docs/users-guide.md`, `docs/archive/prototype-roadmap.md`.
 
 2. Run `make fmt`.
 
@@ -864,5 +869,5 @@ Summary of files added or modified in this change.
 | `crates/sempai/src/tests/behaviour.rs`                    | New    |
 | `crates/sempai/tests/features/sempai_engine.feature`      | New    |
 | `docs/users-guide.md`                                     | Edit   |
-| `docs/roadmap.md`                                         | Edit   |
+| `docs/archive/prototype-roadmap.md`                       | Edit   |
 | `docs/execplans/4-1-1-scaffold-sempai-core-and-sempai.md` | New    |

--- a/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
+++ b/docs/execplans/4-1-2-structured-diagnostics-with-stable-error-codes.md
@@ -1,5 +1,9 @@
 # 4.1.2 Define structured diagnostics with stable `E_SEMPAI_*` error codes and report schema
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -15,7 +19,8 @@ semantic validation logic. Every emitted diagnostic payload will include:
 `code`, `message`, `primary_span`, and `notes`, with stable `E_SEMPAI_*` codes
 and snapshot-locked JSON output.
 
-This directly fulfills roadmap item 4.1.2 in [docs/roadmap.md](../roadmap.md):
+This directly fulfills roadmap item 4.1.2 in
+[docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md):
 
 - Define structured diagnostics with stable `E_SEMPAI_*` error codes and
   report schema.
@@ -55,7 +60,8 @@ make nixie        # exits 0
 - Update documentation:
   - `docs/sempai-query-language-design.md` for design decisions.
   - `docs/users-guide.md` for user-visible diagnostic contract changes.
-  - `docs/roadmap.md` mark 4.1.2 done when implementation is complete.
+  - `docs/archive/prototype-roadmap.md` mark 4.1.2 done when implementation is
+    complete.
 - Run all required quality gates before completion.
 
 ## Tolerances (exception triggers)
@@ -183,7 +189,7 @@ Primary files for this work:
 - [crates/sempai-core/tests/features/sempai_core.feature](../../crates/sempai-core/tests/features/sempai_core.feature)
 - [docs/sempai-query-language-design.md](../sempai-query-language-design.md)
 - [docs/users-guide.md](../users-guide.md)
-- [docs/roadmap.md](../roadmap.md)
+- [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md)
 
 ## Plan of work
 
@@ -255,7 +261,7 @@ Update docs once implementation is stable:
 - `docs/users-guide.md`:
   - Document the diagnostic schema users can rely on.
   - Clarify code semantics and parser/validator applicability.
-- `docs/roadmap.md`:
+- `docs/archive/prototype-roadmap.md`:
   - Mark 4.1.2 as done only after all tests and gates pass.
 
 Go/no-go:

--- a/docs/execplans/4-1-3-yaml-rule-parsing-via-saphyr-and-serde-saphyr.md
+++ b/docs/execplans/4-1-3-yaml-rule-parsing-via-saphyr-and-serde-saphyr.md
@@ -1,5 +1,9 @@
 # 4.1.3 Implement YAML rule parsing via `saphyr` and `serde-saphyr`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -77,8 +81,9 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-3-make-nixie.log
   [docs/sempai-query-language-design.md](../sempai-query-language-design.md).
 - Update [docs/users-guide.md](../users-guide.md) for any user-visible
   behaviour changes, including any change to `compile_yaml` failure semantics.
-- Mark roadmap item 4.1.3 done in [docs/roadmap.md](../roadmap.md) only after
-  the code, tests, and documentation all pass their gates.
+- Mark roadmap item 4.1.3 done in
+  [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md) only
+  after the code, tests, and documentation all pass their gates.
 
 ## Tolerances (exception triggers)
 
@@ -227,7 +232,7 @@ Target outcome at completion:
    during implementation.
 6. `docs/users-guide.md` explains any changed user-visible behaviour,
    especially `compile_yaml` failure semantics.
-7. `docs/roadmap.md` marks 4.1.3 done.
+7. `docs/archive/prototype-roadmap.md` marks 4.1.3 done.
 8. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
    `make lint`, and `make test` all pass.
 
@@ -260,7 +265,7 @@ Relevant current files:
 - [docs/sempai-query-language-design.md](../sempai-query-language-design.md)
 - [docs/semgrep-language-reference/semgrep-rule-schema.yaml](../semgrep-language-reference/semgrep-rule-schema.yaml)
 - [docs/users-guide.md](../users-guide.md)
-- [docs/roadmap.md](../roadmap.md)
+- [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md)
 
 The design document's planned crate map adds `crates/sempai-yaml` as the YAML
 front-end. This milestone should create that crate and keep the public surface
@@ -395,7 +400,7 @@ Update documentation after the parser behaviour is stable:
 - `docs/users-guide.md`
   - explain the current `compile_yaml` behaviour and what errors users should
     expect from malformed or structurally invalid YAML.
-- `docs/roadmap.md`
+- `docs/archive/prototype-roadmap.md`
   - mark 4.1.3 done only after all tests and gates pass.
 
 Then run the full gate sequence with `tee` logs.
@@ -488,7 +493,7 @@ Acceptance is satisfied when all of the following are true:
   paths for the new parser crate and the `sempai` facade behaviour.
 - `docs/sempai-query-language-design.md` records the parser decisions taken.
 - `docs/users-guide.md` reflects any changed user-visible behaviour.
-- `docs/roadmap.md` marks 4.1.3 done.
+- `docs/archive/prototype-roadmap.md` marks 4.1.3 done.
 - `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
   `make lint`, and `make test` all succeed.
 

--- a/docs/execplans/4-1-4-mode-aware-sempai-validation.md
+++ b/docs/execplans/4-1-4-mode-aware-sempai-validation.md
@@ -1,5 +1,9 @@
 # 4.1.4 Implement mode-aware Sempai validation and execution gating
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -87,8 +91,9 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-4-make-nixie.log
   [docs/sempai-query-language-design.md](../sempai-query-language-design.md).
 - Update [docs/users-guide.md](../users-guide.md) with the user-visible change
   in `compile_yaml(...)` behaviour by mode.
-- Mark roadmap item 4.1.4 done in [docs/roadmap.md](../roadmap.md) only after
-  all tests and quality gates pass.
+- Mark roadmap item 4.1.4 done in
+  [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md) only
+  after all tests and quality gates pass.
 
 ## Tolerances
 
@@ -252,7 +257,7 @@ Target outcome at completion:
    parser validation and engine validation.
 7. `docs/users-guide.md` explains the mode-specific `compile_yaml(...)`
    behaviour users now see.
-8. `docs/roadmap.md` marks 4.1.4 done.
+8. `docs/archive/prototype-roadmap.md` marks 4.1.4 done.
 9. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
    `make lint`, and `make test` all pass.
 
@@ -295,7 +300,7 @@ Current files that matter for this milestone:
 - [crates/sempai-core/src/diagnostic.rs](../../crates/sempai-core/src/diagnostic.rs)
 - [docs/sempai-query-language-design.md](../sempai-query-language-design.md)
 - [docs/users-guide.md](../users-guide.md)
-- [docs/roadmap.md](../roadmap.md)
+- [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md)
 
 Current behaviour to preserve or intentionally change:
 
@@ -410,7 +415,7 @@ Once the implementation is stable, synchronize the living documentation.
   - explain that `compile_yaml(...)` now distinguishes supported search rules
     from parse-only unsupported modes
   - show which diagnostic codes users should expect
-- Update [docs/roadmap.md](../roadmap.md):
+- Update [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md):
   - mark 4.1.4 done only after every required gate passes
 
 Go/no-go:

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -96,8 +96,9 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
 ## Tolerances (exception triggers)
 
 - Scope: if implementation requires more than 18 net file touches outside the
-  `crates/sempai*` directories and the three required docs (`roadmap.md`,
-  `users-guide.md`, `sempai-query-language-design.md`), stop and escalate.
+  `crates/sempai*` directories and the three required docs
+  (`docs/archive/prototype-roadmap.md`, `users-guide.md`,
+  `sempai-query-language-design.md`), stop and escalate.
 - Interface: if normalization requires a breaking change to the public
   signature of `sempai::Engine::compile_yaml` (beyond replacing the
   `NOT_IMPLEMENTED` stub with a real return), stop and escalate.

--- a/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
+++ b/docs/execplans/4-1-5-normalization-into-canonical-formula-model.md
@@ -1,5 +1,9 @@
 # 4.1.5 Implement normalization into canonical Formula model
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -86,7 +90,8 @@ set -o pipefail; make nixie 2>&1 | tee /tmp/4-1-5-make-nixie.log
 - Record design decisions in
   `docs/sempai-query-language-design.md`.
 - Update `docs/users-guide.md` with any user-visible behaviour change.
-- Mark roadmap item 4.1.5 done in `docs/roadmap.md` only after all gates pass.
+- Mark roadmap item 4.1.5 done in `docs/archive/prototype-roadmap.md` only
+  after all gates pass.
 
 ## Tolerances (exception triggers)
 
@@ -425,7 +430,7 @@ Go/no-go: `cargo test -p sempai_core`, `cargo test -p sempai` both pass.
 2. `docs/users-guide.md` — update the Sempai section to reflect that
    `compile_yaml` now returns compiled plans for valid search rules instead of
    `NOT_IMPLEMENTED`.
-3. `docs/roadmap.md` — mark item 4.1.5 as `[x]` done.
+3. `docs/archive/prototype-roadmap.md` — mark item 4.1.5 as `[x]` done.
 
 Go/no-go: `make markdownlint`, `make fmt`, and `make nixie` pass.
 

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -759,7 +759,7 @@ All three must pass with zero exit code.
 All commands run from the workspace root `/home/user/project`.
 
 The concrete steps mirror the Plan of Work stages A through F. See the Plan of
-Work for full code listings; this section summarises the edits and commands.
+Work for full code listings; this section summarizes the edits and commands.
 
 ### Stage A: Upgrade ortho-config
 

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -1,6 +1,6 @@
 # 5.1.1 Show short help on bare invocation (Fluent-localized)
 
-> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> Historical note: This ExecPlan targets a prototype roadmap item now preserved
 > in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
 > dotted task references are archive numbers unless explicitly stated otherwise.
 

--- a/docs/execplans/5-1-1-entry-help.md
+++ b/docs/execplans/5-1-1-entry-help.md
@@ -1,5 +1,9 @@
 # 5.1.1 Show short help on bare invocation (Fluent-localized)
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -40,7 +44,7 @@ This addresses the P0 gap identified in the
 [UI gap analysis Level 0](../ui-gap-analysis.md#level-0--bare-invocation-weaver)
  and
 [Level 10d](../ui-gap-analysis.md#level-10--error-messages-and-exit-codes), and
-satisfies roadmap task 5.1.1 in `../roadmap.md`.
+satisfies roadmap task 5.1.1 in `../archive/prototype-roadmap.md`.
 
 ## Constraints
 
@@ -299,7 +303,7 @@ _Table 1: Key files involved in this change and their purpose._
 | `crates/weaver-cli/src/tests/behaviour.rs`            | 340   | BDD step definitions               |
 | `crates/weaver-cli/src/tests/support/mod.rs`          | 323   | Test world/helpers                 |
 | `crates/weaver-cli/tests/features/weaver_cli.feature` | 77    | BDD scenarios                      |
-| `docs/roadmap.md`                                     | 424   | Roadmap checkboxes                 |
+| `docs/archive/prototype-roadmap.md`                   | 424   | Roadmap checkboxes                 |
 | `docs/users-guide.md`                                 | 837   | User documentation                 |
 
 ### Test infrastructure
@@ -735,7 +739,7 @@ Add a heading `### Bare invocation` describing the new behaviour.  Include a
 configuration file or a running daemon.  See the actual `docs/users-guide.md`
 change for the rendered version.
 
-**E2. Mark roadmap task 5.1.1 as done in `docs/roadmap.md`.**
+**E2. Mark roadmap task 5.1.1 as done in `docs/archive/prototype-roadmap.md`.**
 
 Change the three `[ ]` checkboxes for task 5.1.1 to `[x]`.
 
@@ -797,7 +801,7 @@ Work for full code listings; this section summarizes the edits and commands.
 ### Stage E: Documentation
 
 1. Add "Bare invocation" subsection to `docs/users-guide.md`.
-2. Mark 5.1.1 as done in `docs/roadmap.md`.
+2. Mark 5.1.1 as done in `docs/archive/prototype-roadmap.md`.
 3. Run `make fmt && make markdownlint`.
 
 ### Stage F: Final validation
@@ -901,4 +905,4 @@ _Table 2: Files modified and their changes._
 | `crates/weaver-cli/src/tests/support/mod.rs`          | Pass `NoOpLocalizer`                                      |
 | `crates/weaver-cli/tests/features/weaver_cli.feature` | Add BDD scenario                                          |
 | `docs/users-guide.md`                                 | Add "Bare invocation" subsection                          |
-| `docs/roadmap.md`                                     | Mark 5.1.1 checkboxes as done                             |
+| `docs/archive/prototype-roadmap.md`                   | Mark 5.1.1 checkboxes as done                             |

--- a/docs/execplans/5-2-1-define-the-rename-symbol-capability-contract.md
+++ b/docs/execplans/5-2-1-define-the-rename-symbol-capability-contract.md
@@ -1,5 +1,9 @@
 # Define the `rename-symbol` capability contract for actuator plugins
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work

--- a/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
+++ b/docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md
@@ -1,5 +1,9 @@
 # Update weaver-plugin-rope manifest and runtime handshake for rename-symbol
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -135,7 +139,7 @@ Observable behaviour after this change:
 - [x] (2026-03-05) Add weaverd contract conformance test in
   `src/dispatch/act/refactor/tests.rs`.
 - [x] (2026-03-05) Update `docs/users-guide.md`.
-- [x] (2026-03-05) Mark `docs/roadmap.md` entry 5.2.2 as done.
+- [x] (2026-03-05) Mark `docs/archive/prototype-roadmap.md` entry 5.2.2 as done.
 - [x] (2026-03-05) Run `make check-fmt`, `make lint`, `make test` — all pass
   (152 tests, 0 failures).
 
@@ -202,7 +206,7 @@ lines), `crates/weaver-plugin-rope/src/tests/mod.rs`,
 `crates/weaver-plugin-rope/src/tests/behaviour.rs`,
 `crates/weaver-plugin-rope/tests/features/rope_plugin.feature`,
 `crates/weaverd/src/dispatch/act/refactor/tests.rs`, `docs/users-guide.md`,
-`docs/roadmap.md`, and this ExecPlan
+`docs/archive/prototype-roadmap.md`, and this ExecPlan
 (`docs/execplans/5-2-2-update-weaver-plugin-rope-manifest.md`).
 
 Lessons: Always derive `Debug` on error types that might be used with
@@ -374,7 +378,7 @@ Validation: `cargo test -p weaverd` passes.
    `"rename-symbol"` internally. Update the parameter table to note that
    `offset` is mapped to `position` in the plugin protocol. Add a note that the
    rope plugin now declares the `rename-symbol` capability.
-2. Mark `docs/roadmap.md` entry 5.2.2 as done (`[x]`).
+2. Mark `docs/archive/prototype-roadmap.md` entry 5.2.2 as done (`[x]`).
 3. Run `make fmt` to format all changed files.
 4. Run `make markdownlint` to validate Markdown.
 

--- a/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
+++ b/docs/execplans/5-2-3-update-rust-plugin-to-declare-rename-symbol.md
@@ -1,5 +1,9 @@
 # Update weaver-plugin-rust-analyzer manifest and handshake for `rename-symbol`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -51,8 +55,8 @@ Observable success for this roadmap item:
   class is known.
 - Unit tests and `rstest-bdd` v0.5.0 behaviour-driven development (BDD) tests
   cover happy paths, unhappy paths, and edge cases for the contract migration.
-- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-  reflect the shipped behaviour.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/archive/prototype-roadmap.md` reflect the shipped behaviour.
 - `make fmt`, `make markdownlint`, `make check-fmt`, `make lint`, and
   `make test` all pass.
 
@@ -145,7 +149,7 @@ Observable success for this roadmap item:
 - [x] (2026-03-07) Updated daemon manifest registration and request-capture
   tests proving Rust rename requests are capability-routed.
 - [x] (2026-03-07) Updated `docs/weaver-design.md`, `docs/users-guide.md`,
-  and `docs/roadmap.md`.
+  and `docs/archive/prototype-roadmap.md`.
 - [x] (2026-03-07) Ran `make fmt`, `make markdownlint`, `make check-fmt`,
   `make lint`, and `make test`, each via `tee` with `set -o pipefail`.
 
@@ -235,7 +239,7 @@ Files materially changed:
 - `crates/weaver-cli/src/tests/unit/auto_start.rs`
 - `docs/weaver-design.md`
 - `docs/users-guide.md`
-- `docs/roadmap.md`
+- `docs/archive/prototype-roadmap.md`
 
 Validation results:
 
@@ -380,7 +384,7 @@ clear that both built-in rename providers now implement the same internal
 contract while the CLI remains `--refactoring rename`.
 
 After implementation passes the gates, mark roadmap item 5.2.3 as done in
-`docs/roadmap.md`.
+`docs/archive/prototype-roadmap.md`.
 
 ### Stage 5: run the quality gates and capture evidence
 

--- a/docs/execplans/5-2-4-daemon-capability-resolution-for-rename-symbol.md
+++ b/docs/execplans/5-2-4-daemon-capability-resolution-for-rename-symbol.md
@@ -1,5 +1,9 @@
 # Implement daemon capability resolution for `rename-symbol`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -46,8 +50,9 @@ Observable success for the eventual implementation:
 - Human-readable mode does not degrade into raw JSON noise; any new structured
   routing payload is either rendered cleanly by the command-line interface
   (CLI) or otherwise surfaced in a deliberate, documented form.
-- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`
-  reflect the shipped behaviour once implementation is complete.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/archive/prototype-roadmap.md` reflect the shipped behaviour once
+  implementation is complete.
 
 ## Constraints
 
@@ -248,7 +253,7 @@ The likely files touched by implementation are:
 - `crates/weaver-cli/src/output/models.rs`
 - `docs/weaver-design.md`
 - `docs/users-guide.md`
-- `docs/roadmap.md`
+- `docs/archive/prototype-roadmap.md`
 
 ## Implementation plan
 
@@ -400,7 +405,7 @@ Once the implementation and tests are green, update the docs in the same change:
   Explain that `rename` routing is now language-aware, describe whether
   `--provider` is optional or override-only, show at least one provider-less
   example, and document the structured rationale visible in JSON mode.
-- `docs/roadmap.md`
+- `docs/archive/prototype-roadmap.md`
   Mark 5.2.4 as done only after all tests and gates pass.
 
 ## Validation

--- a/docs/execplans/5-2-5-unit-behavioural-and-end-to-end-coverage-for-rename-symbol.md
+++ b/docs/execplans/5-2-5-unit-behavioural-and-end-to-end-coverage-for-rename-symbol.md
@@ -1,5 +1,9 @@
 # Add unit, behavioural, and end-to-end coverage for `rename-symbol`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -39,7 +43,7 @@ After this change:
   explicitly in the behavioural and end-to-end tests.
 - `docs/users-guide.md` is reviewed and updated if any observable behaviour
   changes surface during testing.
-- `docs/roadmap.md` marks 5.2.5 as done.
+- `docs/archive/prototype-roadmap.md` marks 5.2.5 as done.
 
 Observable success: running `make test` passes with the new tests included, and
 the shared contract fixtures produce identical pass/fail verdicts for both
@@ -211,8 +215,8 @@ plugins.
   failure paths.
 - Extended end-to-end snapshot coverage so the CLI now records automatic
   routing and structured mismatch refusals for both built-in rename flows.
-- Updated `docs/users-guide.md` and `docs/roadmap.md` so the documented state
-  matches the implemented coverage milestone.
+- Updated `docs/users-guide.md` and `docs/archive/prototype-roadmap.md` so the
+  documented state matches the implemented coverage milestone.
 
 ## Context and orientation
 
@@ -302,7 +306,7 @@ The `weaver-e2e` crate contains CLI ergonomics snapshot tests:
 
 - `docs/users-guide.md`: documents `act refactor` syntax, parameter
   semantics, routing rationale, and plugin inventory.
-- `docs/roadmap.md`: section 5.2.5 is marked done.
+- `docs/archive/prototype-roadmap.md`: section 5.2.5 is marked done.
 
 ## Plan of work
 
@@ -517,8 +521,8 @@ the Decision Log that the user's guide was reviewed and found current.
 
 #### 5b: Mark roadmap 5.2.5 as done
 
-In `docs/roadmap.md`, find roadmap item `5.2.5` and change its checkbox from
-`- [ ]` to `- [x]`.
+In `docs/archive/prototype-roadmap.md`, find roadmap item `5.2.5` and change
+its checkbox from `- [ ]` to `- [x]`.
 
 #### 5c: Final validation
 
@@ -544,8 +548,8 @@ Quality criteria (what "done" means):
   end-to-end (e2e) snapshot tests pass.
 - Lint/typecheck: `make check-fmt` and `make lint` both pass.
 - Documentation: `make markdownlint` and `make nixie` pass.
-  `docs/users-guide.md` is reviewed and current. `docs/roadmap.md` marks 5.2.5
-  as done.
+  `docs/users-guide.md` is reviewed and current.
+  `docs/archive/prototype-roadmap.md` marks 5.2.5 as done.
 - Rollback guarantees: every refusal and failure path is asserted to produce
   no filesystem-modifying output (no `PluginOutput::Diff` on failure, no
   apply-patch invocation on refusal).
@@ -613,7 +617,7 @@ Modified files:
 - `crates/weaver-e2e/tests/refactor_rope_cli_snapshots.rs`
 - `crates/weaver-e2e/tests/refactor_rust_analyzer_cli_snapshots.rs`
 - `docs/users-guide.md` (review; update only if needed)
-- `docs/roadmap.md` (mark 5.2.5 as done)
+- `docs/archive/prototype-roadmap.md` (mark 5.2.5 as done)
 
 ## Interfaces and dependencies
 

--- a/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
+++ b/docs/execplans/7-1-1-stable-jsonl-schemas-for-observe-get-card.md
@@ -1,5 +1,9 @@
 # 7.1.1 Define stable JSON Lines (JSONL) request and response schemas for `observe get-card`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -50,9 +54,10 @@ Specifically:
    JSON payload that tells the caller exactly why no card was produced.
 6. `docs/users-guide.md` is updated with `observe get-card` command
    documentation including syntax, arguments, and response format.
-7. Roadmap item 7.1.1 in `docs/roadmap.md` is marked complete.
+7. Roadmap item 7.1.1 in `docs/archive/prototype-roadmap.md` is marked complete.
 
-This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
+This satisfies roadmap task 7.1.1 from `docs/archive/prototype-roadmap.md`[^1]
+and closes #75.
 
 ## Constraints
 
@@ -142,7 +147,7 @@ This satisfies roadmap task 7.1.1 from `docs/roadmap.md`[^1] and closes #75.
 - [x] Stage G: Wire `weaverd` dispatch — add `"get-card"` to known
   operations, add `get_card` handler module returning structured refusal.
 - [x] Stage H: Update documentation (`docs/users-guide.md`,
-  `docs/repository-layout.md`, `docs/roadmap.md`).
+  `docs/repository-layout.md`, `docs/archive/prototype-roadmap.md`).
 - [x] Stage I: Final validation and commit gating.
 
 ## Surprises & discoveries
@@ -623,7 +628,7 @@ Add an `#### observe get-card` section after the existing
 
 Add `weaver-cards/` to the crate listing in the `crates/` tree (line 31-45).
 
-**Modify: `docs/roadmap.md`**
+**Modify: `docs/archive/prototype-roadmap.md`**
 
 Mark 7.1.1 as complete: change `- [ ]` to `- [x]` on lines 788-795 (the main
 task and both sub-tasks).
@@ -733,7 +738,7 @@ Quality criteria (what "done" means):
 - Provenance: every non-trivial field section includes a `source` field.
 - User guide: `docs/users-guide.md` documents the `observe get-card`
   command.
-- Roadmap: 7.1.1 is marked complete in `docs/roadmap.md`.
+- Roadmap: 7.1.1 is marked complete in `docs/archive/prototype-roadmap.md`.
 
 Quality method (how checks are performed):
 
@@ -926,7 +931,7 @@ Modified files (8):
 3. `crates/weaverd/src/dispatch/router.rs` — add known op and match arm
 4. `crates/weaverd/src/dispatch/observe/mod.rs` — add module declaration
 5. `crates/weaverd/src/dispatch/router/tests.rs` — extend helper
-6. `docs/roadmap.md` — mark 7.1.1 complete
+6. `docs/archive/prototype-roadmap.md` — mark 7.1.1 complete
 7. `docs/repository-layout.md` — add crate listing
 8. `docs/users-guide.md` — add `observe get-card` documentation
 
@@ -950,4 +955,4 @@ snapshot outputs from the 25-file tolerance count.
 - `crates/weaverd/src/dispatch/router/tests.rs` — existing router test
   structure to extend
 
-[^1]: `docs/roadmap.md`, lines 788–795
+[^1]: `docs/archive/prototype-roadmap.md`, lines 788–795

--- a/docs/execplans/7-1-2-tree-sitter-symbol-card-extraction.md
+++ b/docs/execplans/7-1-2-tree-sitter-symbol-card-extraction.md
@@ -1,5 +1,9 @@
 # 7.1.2 Implement Tree-sitter symbol card extraction for `observe get-card`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -66,7 +70,8 @@ Observable behaviour after implementation:
    must remain named `world`.
 8. Documentation changes are part of scope:
    `docs/jacquard-card-first-symbol-graph-design.md`, `docs/users-guide.md`,
-   and `docs/roadmap.md` must be updated before the work is considered complete.
+   and `docs/archive/prototype-roadmap.md` must be updated before the work is
+   considered complete.
 9. `docs/users-guide.md` must explain any new user-visible behaviour,
    especially successful `get-card` responses, refusal cases, and the fact that
    `semantic` / `full` requests still degrade to Tree-sitter-only sections in
@@ -423,8 +428,8 @@ language in the `observe get-card` section with:
 - refusal cases,
 - the meaning of detail levels in the Tree-sitter-first phase.
 
-Only after the feature, tests, and docs are complete should `docs/roadmap.md`
-mark item 7.1.2 as done.
+Only after the feature, tests, and docs are complete should
+`docs/archive/prototype-roadmap.md` mark item 7.1.2 as done.
 
 ## Validation
 

--- a/docs/execplans/7-1-3-implement-optional-lsp-enrichment-for-observe-get-card.md
+++ b/docs/execplans/7-1-3-implement-optional-lsp-enrichment-for-observe-get-card.md
@@ -1,5 +1,9 @@
 # 7.1.3 Implement optional LSP enrichment for `observe get-card`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -114,7 +118,8 @@ Observable behaviour after implementation:
   path is naturally exercised since no real language servers are registered.
   The `behaviour.rs` BDD test in `weaver-lsp-host` needed `hover: None` added
   to `sample_responses()` and `.with_hover(true)` added to `all_caps`.
-- [x] (2026-03-15) Stage F: Updated `docs/roadmap.md` (ticked 7.1.3
+- [x] (2026-03-15) Stage F: Updated `docs/archive/prototype-roadmap.md` (ticked
+      7.1.3
   checkboxes) and `docs/users-guide.md` (documented enrichment and degradation
   behaviour).
 - [x] (2026-03-15) Stage G: `make check-fmt`, `make lint`, and
@@ -440,7 +445,7 @@ E2E concern for a future milestone.
 
 ### Stage F: Documentation
 
-**F1. Update `docs/roadmap.md`** — tick the 7.1.3 checkboxes.
+**F1. Update `docs/archive/prototype-roadmap.md`** — tick the 7.1.3 checkboxes.
 
 **F2. Update `docs/users-guide.md`** — document that `--detail semantic` now
 attempts LSP enrichment and explain the degradation behaviour.

--- a/docs/execplans/7-1-4-cache-integration-for-card-extraction-keyed-by-uri.md
+++ b/docs/execplans/7-1-4-cache-integration-for-card-extraction-keyed-by-uri.md
@@ -1,5 +1,9 @@
 # 7.1.4 Cache integration for card extraction keyed by URI
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -572,8 +576,8 @@ considerations" section (lines 953–965), add a note recording:
 
 ### Stage L: Mark roadmap and run full validation
 
-1. In `docs/roadmap.md`, change the `[ ]` checkboxes for 7.1.4 and its sub-items
-   to `[x]`.
+1. In `docs/archive/prototype-roadmap.md`, change the `[ ]` checkboxes for
+   7.1.4 and its sub-items to `[x]`.
 2. Run the full validation suite:
 
 ```sh

--- a/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
+++ b/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
@@ -1,5 +1,9 @@
 # 7.2.1 Define stable JSON Lines (JSONL) request and response schemas for `observe graph-slice`
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -40,7 +44,8 @@ Observable behaviour after implementation:
    documentation gates `make markdownlint` and `make nixie` also exit `0`
    because this task changes Markdown.
 
-This plan covers roadmap item 7.2.1 in [docs/roadmap.md](../roadmap.md).
+This plan covers roadmap item 7.2.1 in
+[docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md).
 
 ## Constraints
 
@@ -74,8 +79,8 @@ This plan covers roadmap item 7.2.1 in [docs/roadmap.md](../roadmap.md).
 8. Documentation updates are part of the feature:
    [docs/jacquard-card-first-symbol-graph-design.md](../jacquard-card-first-symbol-graph-design.md),
    [docs/users-guide.md](../users-guide.md), and
-   [docs/roadmap.md](../roadmap.md) must all be updated before the work is
-   complete.
+   [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md) must
+   all be updated before the work is complete.
 9. The roadmap checkbox for 7.2.1 must not be marked done until all code,
    tests, e2e snapshots, documentation, and validation gates pass.
 
@@ -538,7 +543,7 @@ Update the user guide with:
 5. how semantic detail interacts with cards embedded in the slice.
 
 Only after code, tests, and docs all match should the roadmap entry be checked
-off in [docs/roadmap.md](../roadmap.md).
+off in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md).
 
 ### Stage G: Run the full validation and commit gates
 

--- a/docs/execplans/adopt-ortho-config-v0-8-0.md
+++ b/docs/execplans/adopt-ortho-config-v0-8-0.md
@@ -1,5 +1,9 @@
 # Adopt `ortho-config` v0.8.0 across Weaver
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -110,7 +114,8 @@ Observable success after implementation:
   medium. Likelihood: certain. Mitigation: update active operator/developer
   docs (`README.md`, `docs/users-guide.md`, `docs/weaver-design.md`,
   `docs/ortho-config-users-guide.md`, `docs/contents.md`, and
-  `docs/roadmap.md`) while leaving historical execplans untouched.
+  `docs/archive/prototype-roadmap.md`) while leaving historical execplans
+  untouched.
 
 - Risk: `weaver-config/src/lib.rs` wraps derive-generated loaders and
   currently carries `#[allow(unfulfilled_lint_expectations)]` around
@@ -263,9 +268,10 @@ The upgrade is concentrated in a small set of files.
   point because it forwards CLI flags into `Config::load_from_iter`.
 - `./README.md`,
   `docs/users-guide.md`, `docs/weaver-design.md`,
-  `docs/ortho-config-users-guide.md`, `docs/contents.md`, and `docs/roadmap.md`
-  all describe the current configuration story and will become stale if the
-  migration lands without documentation updates.
+  `docs/ortho-config-users-guide.md`, `docs/contents.md`, and
+  `docs/archive/prototype-roadmap.md` all describe the current configuration
+  story and will become stale if the migration lands without documentation
+  updates.
 
 The current implementation does not appear to use the migration-note edge
 cases. There is no alias for the `ortho_config` crate, no direct
@@ -397,7 +403,7 @@ The code change is small; the documentation clean-up is not optional.
    story accurately. These files should say that Weaver now uses `ortho-config`
    v0.8.0 and Rust 1.88+, and they should not imply that YAML is part of
    Weaver's runtime config path unless it truly is.
-5. Update `docs/roadmap.md` item 3.2.5 so it points at
+5. Update `docs/archive/prototype-roadmap.md` item 3.2.5 so it points at
    the v0.8.0 guide and no longer asks for already-completed v0.6.0
    documentation work.
 6. Update `./README.md` so the build requirements say

--- a/docs/execplans/adopt-ortho-config-v0-8-0.md
+++ b/docs/execplans/adopt-ortho-config-v0-8-0.md
@@ -55,7 +55,7 @@ Observable success after implementation:
    Derive-adjacent imports and examples should prefer the `ortho_config::...`
    re-exports.
 5. Preserve the existing localization behaviour in
-   `crates/weaver-cli/src/localizer.rs`. The Fluent-backed localiser and
+   `crates/weaver-cli/src/localizer.rs`. The Fluent-backed localizer and
    English fallbacks must keep working after the dependency bump.
 6. Treat the `orthohelp` metadata flow as conditional. The current
    repository generates CLI man pages via build scripts, but the audit found no
@@ -161,7 +161,7 @@ Observable success after implementation:
 - `crates/weaver-config/src/lib.rs` is the primary derive site. It uses
   `#[derive(OrthoConfig)]` with a `#[ortho_config(discovery(...))]` attribute
   and does not alias the runtime crate.
-- The CLI localiser in `crates/weaver-cli/src/localizer.rs` uses
+- The CLI localizer in `crates/weaver-cli/src/localizer.rs` uses
   `FluentLocalizer`, `Localizer`, and `NoOpLocalizer` from `ortho_config`
   directly. This is the main non-config API surface exercised by the dependency
   today.
@@ -231,7 +231,7 @@ The code impact was deliberately small. No aliasing, `SelectedSubcommandMerge`,
 `cli_default_as_absent`, or `orthohelp` wiring was needed in Weaver. The only
 code changes beyond manifests were the four toolchain-driven lint fixes noted
 above. Behaviourally, the configuration contract for `weaver-config::Config`
-and the CLI localiser remained unchanged.
+and the CLI localizer remained unchanged.
 
 Documentation now matches the upgraded state. The repository gained
 `docs/ortho-config-v0-8-0-migration-guide.md`, the local

--- a/docs/execplans/phase-1-end-to-end-domain-command-execution.md
+++ b/docs/execplans/phase-1-end-to-end-domain-command-execution.md
@@ -284,7 +284,7 @@ impl SemanticBackendProvider {
         }
     }
 
-    /// Returns access to the LSP host, if initialised.
+    /// Returns access to the LSP host, if initialized.
     pub fn lsp_host(&self) -> Arc<Mutex<Option<LspHost>>> {
         Arc::clone(&self.lsp_host)
     }
@@ -359,10 +359,10 @@ pub fn handle<W: Write>(
     let mut lsp_guard = lsp_host_arc.lock()
         .map_err(|_| DispatchError::lsp_host(language, "lock poisoned"))?;
     let lsp_host = lsp_guard.as_mut()
-        .ok_or_else(|| DispatchError::lsp_host(language, "host not initialised"))?;
+        .ok_or_else(|| DispatchError::lsp_host(language, "host not initialized"))?;
 
-    // 4. Ensure language is initialised
-    lsp_host.initialise(language)
+    // 4. Ensure language is initialized
+    lsp_host.initialize(language)
         .map_err(|e| DispatchError::lsp_host_from(language, e))?;
 
     // 5. Call goto_definition

--- a/docs/execplans/phase-1-end-to-end-domain-command-execution.md
+++ b/docs/execplans/phase-1-end-to-end-domain-command-execution.md
@@ -1,5 +1,9 @@
 # ExecPlan: End-to-End Domain Command Execution
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 ## Summary
 
 Wire End-to-End (E2E) domain command execution from command-line interface
@@ -65,7 +69,7 @@ ______________________________________________________________________
 | `crates/weaverd/tests/features/daemon_dispatch.feature` | BDD scenarios                |
 | `crates/weaverd/src/tests/dispatch_behaviour.rs`        | Step definitions             |
 | [users guide](../users-guide.md)                        | Documentation updates        |
-| `docs/roadmap.md`                                       | Mark task complete           |
+| `docs/archive/prototype-roadmap.md`                     | Mark task complete           |
 
 ______________________________________________________________________
 
@@ -576,7 +580,7 @@ fully implemented. Update the `observe get-definition` command reference with:
 - Response format (JSON array of locations written to stdout stream)
 - Error handling for missing arguments and unsupported languages
 
-**File:** `docs/roadmap.md`
+**File:** `docs/archive/prototype-roadmap.md`
 
 Mark the task as complete:
 

--- a/docs/execplans/phase-1-human-readable-output.md
+++ b/docs/execplans/phase-1-human-readable-output.md
@@ -1,5 +1,9 @@
 # Phase 1: Human-Readable Output Rendering
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 ## Goal
 
 Implement human-readable rendering for command outputs that contain code
@@ -115,7 +119,8 @@ crates/weaver-cli/src/
 
 ### Step 10: Mark roadmap entry done
 
-- Update `docs/roadmap.md` to mark the human-readable output item complete.
+- Update `docs/archive/prototype-roadmap.md` to mark the human-readable output
+  item complete.
 
 ### Step 11: Run quality gates
 
@@ -146,7 +151,7 @@ updates, per `AGENTS.md`.
 | `crates/weaver-e2e/tests/`                                   | Extend for human-readable output validation |
 | `docs/weaver-design.md`                                      | Record design decisions                     |
 | `docs/users-guide.md`                                        | Document output format changes              |
-| `docs/roadmap.md`                                            | Mark entry done                             |
+| `docs/archive/prototype-roadmap.md`                          | Mark entry done                             |
 | `docs/execplans/phase-1-human-readable-output.md`            | Create                                      |
 
 ## Dependencies

--- a/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
+++ b/docs/execplans/phase-1-implement-the-socket-listener-in-weaverd.md
@@ -1,5 +1,9 @@
 # Implement the weaverd socket listener (Phase 1)
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This execution plan (ExecPlan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
@@ -138,7 +142,7 @@ Key files likely to change or be referenced:
 - `crates/weaver-cli/src/transport.rs` (client transport expectations).
 - `docs/weaver-design.md` and `docs/users-guide.md` (design and user-facing
   behaviour).
-- `docs/roadmap.md` (Phase 1 socket listener entry).
+- `docs/archive/prototype-roadmap.md` (Phase 1 socket listener entry).
 
 ## Plan of Work
 
@@ -208,7 +212,8 @@ are safe to re-run.
    - `docs/weaver-design.md` to record the listener strategy and error
      handling decisions.
    - `docs/users-guide.md` to describe any user-visible behaviour changes.
-   - `docs/roadmap.md` to mark the socket listener item as done.
+   - `docs/archive/prototype-roadmap.md` to mark the socket listener item as
+     done.
 
 8. Format and validate documentation if any docs changed:
 

--- a/docs/execplans/phase-1-jsonl-request-dispatch-loop.md
+++ b/docs/execplans/phase-1-jsonl-request-dispatch-loop.md
@@ -1,5 +1,9 @@
 # Phase 1: JSON Lines (JSONL) Request Dispatch Loop
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 ## Goal
 
 Implement the JSONL request dispatch loop in `weaverd` that reads
@@ -211,7 +215,7 @@ handling:
 
 ### Step 11: Mark roadmap entry as done
 
-Update `docs/roadmap.md`, changing:
+Update `docs/archive/prototype-roadmap.md`, changing:
 
 ```markdown
 - [ ] Implement the JSONL request dispatch loop...
@@ -248,7 +252,7 @@ make test 2>&1 | tee /tmp/test.log
 | `crates/weaverd/src/tests/dispatch_behaviour.rs`        | Created                                  |
 | `crates/weaverd/src/tests/mod.rs`                       | Modified (add `mod dispatch_behaviour;`) |
 | `docs/users-guide.md`                                   | Modified (update daemon description)     |
-| `docs/roadmap.md`                                       | Modified (mark entry done)               |
+| `docs/archive/prototype-roadmap.md`                     | Modified (mark entry done)               |
 | `docs/execplans/phase-1-jsonl-request-dispatch-loop.md` | Created                                  |
 
 ## Dependencies

--- a/docs/execplans/phase-1-process-based-language-server-adapters.md
+++ b/docs/execplans/phase-1-process-based-language-server-adapters.md
@@ -1,13 +1,17 @@
 # ExecPlan: Process-Based Language Server Adapters
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 ## Metadata
 
-| Field             | Value                                |
-| ----------------- | ------------------------------------ |
-| **Status**        | Complete                             |
-| **Created**       | 2026-01-21                           |
-| **Target**        | Phase 1 Minimum Viable Product (MVP) |
-| **Roadmap Entry** | `docs/roadmap.md` line 79-87         |
+| Field             | Value                                          |
+| ----------------- | ---------------------------------------------- |
+| **Status**        | Complete                                       |
+| **Created**       | 2026-01-21                                     |
+| **Target**        | Phase 1 Minimum Viable Product (MVP)           |
+| **Roadmap Entry** | `docs/archive/prototype-roadmap.md` line 79-87 |
 
 ## Big Picture
 
@@ -149,7 +153,7 @@ ______________________________________________________________________
 
 ### Task 13: Mark roadmap entry complete
 
-**File:** `docs/roadmap.md`
+**File:** `docs/archive/prototype-roadmap.md`
 
 **Verification:** Roadmap reflects completion
 

--- a/docs/execplans/phase-2-double-lock-on-syntactic-lock.md
+++ b/docs/execplans/phase-2-double-lock-on-syntactic-lock.md
@@ -1,5 +1,9 @@
 # Execution Plan: Integrate Syntactic Lock into Double-Lock Harness
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 **Status**: Complete **Phase**: 2 - Syntactic & Relational Intelligence **Last
 Updated**: 2025-12-16
 
@@ -147,7 +151,7 @@ BDD tests.
 | `crates/weaverd/src/safety_harness/mod.rs`                    | Complete | Public export      |
 | `crates/weaverd/src/tests/safety_harness_behaviour.rs`        | Complete | BDD world & steps  |
 | `crates/weaverd/tests/features/safety_harness.feature`        | Complete | BDD scenarios      |
-| `docs/roadmap.md`                                             | Complete | Mark complete      |
+| `docs/archive/prototype-roadmap.md`                           | Complete | Mark complete      |
 | `docs/users-guide.md`                                         | Complete | Verify accuracy    |
 
 ## Test Coverage

--- a/docs/execplans/phase-4-weaver-graph.md
+++ b/docs/execplans/phase-4-weaver-graph.md
@@ -1,5 +1,9 @@
 # Deliver the weaver-graph call hierarchy provider
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan is a living document. The sections `Progress`,
 `Surprises & discoveries`, `Decision log`, and `Outcomes & retrospective` must
 be kept up to date as work proceeds.
@@ -45,12 +49,12 @@ Not started yet.
 
 ## Context and orientation
 
-The Phase 2 roadmap item lives in `docs/roadmap.md` and calls for creating the
-`weaver-graph` crate with an LSP-backed provider. The design context for call
-graphs is documented in `docs/weaver-design.md` (see the call graph and
-provider strategy section). The call hierarchy capability is part of the LSP
-surface in `crates/weaver-lsp-host`, while user-facing behaviour is documented
-in `docs/users-guide.md` under `observe call-hierarchy`.
+The Phase 2 roadmap item lives in `docs/archive/prototype-roadmap.md` and calls
+for creating the `weaver-graph` crate with an LSP-backed provider. The design
+context for call graphs is documented in `docs/weaver-design.md` (see the call
+graph and provider strategy section). The call hierarchy capability is part of
+the LSP surface in `crates/weaver-lsp-host`, while user-facing behaviour is
+documented in `docs/users-guide.md` under `observe call-hierarchy`.
 
 Key files and modules to understand or edit:
 
@@ -61,8 +65,8 @@ Key files and modules to understand or edit:
   call hierarchy support and capability negotiation.
 - `crates/weaver-graph/tests` for behavioural tests and
   `crates/weaver-graph/src/tests.rs` (or `src/tests/`) for unit tests.
-- `docs/weaver-design.md`, `docs/users-guide.md`, and `docs/roadmap.md` for
-  documentation updates.
+- `docs/weaver-design.md`, `docs/users-guide.md`, and
+  `docs/archive/prototype-roadmap.md` for documentation updates.
 
 Definitions used in this plan:
 
@@ -106,7 +110,7 @@ Update documentation to reflect the implemented behaviour. In
 provider strategy, including provenance on edges. In `docs/users-guide.md`,
 confirm the `observe call-hierarchy` output schema matches the implemented
 graph (nodes and edges, and any fields such as source or confidence). Finally,
-mark the Phase 2 roadmap item as done in `docs/roadmap.md`.
+mark the Phase 2 roadmap item as done in `docs/archive/prototype-roadmap.md`.
 
 ## Concrete steps
 
@@ -154,7 +158,7 @@ are safe to re-run.
 
    - `docs/weaver-design.md`
    - `docs/users-guide.md`
-   - `docs/roadmap.md`
+   - `docs/archive/prototype-roadmap.md`
 
 7. Format and validate documentation (required after doc changes):
 

--- a/docs/execplans/sempai-design.md
+++ b/docs/execplans/sempai-design.md
@@ -1,5 +1,9 @@
 # Normalize documentation style and navigation for parser and Semgrep docs
 
+> Historical note: this ExecPlan targets a prototype roadmap item now preserved
+> in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
+> dotted task references are archive numbers unless explicitly stated otherwise.
+
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: IN PROGRESS
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root. It plans a documentation and roadmap overhaul only. It does
@@ -202,8 +202,13 @@ teams a sequenced build plan.
       observe/filter/act pipeline requirements, then reran `make fmt`,
       `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
       `make test`.
-- [ ] Obtain explicit approval before executing the planned documentation
-      overhaul.
+- [x] (2026-05-11) Treated the active implementation instruction as approval
+      to begin executing the documentation overhaul.
+- [x] (2026-05-11) Completed Milestone 1 by adding ADR 007 and indexing it in
+      `docs/contents.md`.
+- [x] (2026-05-11) Ran Milestone 1 gates: `make fmt`,
+      `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+      `make test`.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.
@@ -315,6 +320,11 @@ teams a sequenced build plan.
   functionality after the UI redesign. Completed safety, atomic-edit,
   capability-routing, card, graph, and help work should be retained as
   foundation or migrated into the new command grammar. Date: 2026-05-11.
+
+- Decision: start execution on this branch from the existing ExecPlan.
+  Rationale: the active implementation instruction explicitly asks to proceed
+  with the planned functionality and keep the ExecPlan current, which satisfies
+  the plan's approval gate for this workstream. Date: 2026-05-11.
 
 ## Context and orientation
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -597,7 +597,7 @@ weaver feedback create "the enum error did not list valid values"
 ```
 
 Canonical verbs are `get`, `list`, `create`, `update`, `delete`, `apply`,
-`run`, `prune`, `save`, `show`, `rename`, `move`, and `send`. The final
+`move`, `rename`, `run`, `prune`, `save`, `send`, and `show`. The final
 vocabulary policy must include every verb used by target examples and planned
 resource commands, or must change those examples before the policy lands.
 Banned or non-canonical public forms include `info`, `ls`,

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -245,6 +245,10 @@ teams a sequenced build plan.
       matrix that maps current prototype evidence to ADR 007, the new design,
       the reordered roadmap, OrthoConfig dependencies, selector composition,
       and capability-routed provider gaps.
+- [x] (2026-05-12) Started Milestone 5 by adding a 0.1.0 target
+      command-surface section to `docs/users-guide.md` and labelling the
+      remaining `observe` / `act` / `verify` command reference as the current
+      prototype implementation rather than the future public grammar.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -240,6 +240,11 @@ teams a sequenced build plan.
 - [x] (2026-05-12) Ran the Milestone 3 roadmap gates: `make fmt`,
       `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
       `make test`.
+- [x] (2026-05-12) Completed Milestone 4 by replacing
+      `docs/ui-gap-analysis.md` with an agent-native, human-friendly gap
+      matrix that maps current prototype evidence to ADR 007, the new design,
+      the reordered roadmap, OrthoConfig dependencies, selector composition,
+      and capability-routed provider gaps.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.
@@ -295,6 +300,13 @@ teams a sequenced build plan.
   used by the Weaver roadmap rewrite: 5.2.3, 6.1.1, 6.1.2, 6.2.1 through 6.2.3,
   6.3.1, 6.3.2, 7.1.1 through 7.1.3, 7.2.1 through 7.2.7, 8.1.1, 8.1.2, and
   9.1.1 through 9.3.3.
+
+- Discovery: the previous `docs/ui-gap-analysis.md` remained accurate as
+  current-state evidence, but its recommended remedies would have preserved too
+  much of the superseded `observe` / `act` / `verify` grammar if followed
+  literally. The revised gap analysis must therefore retain those observations
+  as historical evidence while pointing implementation at ADR 007 and the new
+  roadmap phases.
 
 ## Decision Log
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -9,7 +9,7 @@ Status: DRAFT
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root. It plans a documentation and roadmap overhaul only. It does
-not authorise the product implementation until the plan is approved.
+not authorize the product implementation until the plan is approved.
 
 ## Purpose / big picture
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -209,6 +209,16 @@ teams a sequenced build plan.
 - [x] (2026-05-11) Ran Milestone 1 gates: `make fmt`,
       `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
       `make test`.
+- [x] (2026-05-11) Ran `coderabbit review --agent --base-commit HEAD~1
+      --type committed` for the ADR 007 milestone; CodeRabbit completed with
+      zero findings.
+- [x] (2026-05-11) Started Milestone 2 by rewriting the design document's
+      executive summary, Weaver philosophy, client-daemon command surface,
+      selector pipeline, renderer, introspection, state, two-way I/O, and
+      capability-provider sections around ADR 007.
+- [x] (2026-05-11) Ran the Milestone 2 design-surface gates: `make fmt`,
+      `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+      `make test`.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.
@@ -253,6 +263,12 @@ teams a sequenced build plan.
   delivery and feedback contracts, and execution-ledger contracts. Weaver's
   plan must consume or depend on those tasks instead of reimplementing them as
   local generic framework work.
+
+- Discovery: `coderabbit review --agent` against the entire branch cannot run
+  because the existing PR diff contains 402 files, above CodeRabbit's 300-file
+  limit. Milestone validation should use
+  `coderabbit review --agent --base-commit HEAD~1 --type committed` or another
+  narrow comparison until the branch diff is small enough for whole-PR review.
 
 ## Decision Log
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -298,6 +298,9 @@ teams a sequenced build plan.
       `extricate-symbol` with `extract-method` and expanded the compressed
       symbol-relocation slice back into separate Python and Rust extrication
       workstreams.
+- [x] (2026-05-13) Corrected the Sempai roadmap migration to preserve archive
+      work 4.2.1 through 4.2.12 and 4.3.1 through 4.3.9 at task fidelity under
+      live steps 15.2, 15.3, and 15.4.
 - [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [x] Run documentation and repository gates.
@@ -478,6 +481,14 @@ teams a sequenced build plan.
   tasks for capability scaffolding, Python extrication, and Rust orchestration;
   compressing that into a single viability task hid real risk and made the
   public grammar ambiguous. Date: 2026-05-13.
+
+- Decision: preserve Sempai backend and Weaver integration work at the original
+  archive task fidelity instead of compressing 4.2 and 4.3 into broad selector
+  tasks. Rationale: language profiles, Semgrep rewriting, `PatNode` IR, formula
+  execution, ellipsis families, `where` constraints, focus projection, raw
+  Tree-sitter query escape hatches, parse caching, diagnostics conformance,
+  quality suites, and release gates are distinct risks and deserve distinct
+  review-sized roadmap tasks. Date: 2026-05-13.
 
 ## Context and orientation
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: IMPLEMENTATION FOLLOW-UP IN PROGRESS
+Status: COMPLETE
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root. It plans a documentation and roadmap overhaul only. It does

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -219,6 +219,17 @@ teams a sequenced build plan.
 - [x] (2026-05-11) Ran the Milestone 2 design-surface gates: `make fmt`,
       `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
       `make test`.
+- [x] (2026-05-12) Verified the review comments about `authorize`, helper
+      punctuation, and remaining clear Oxford spelling issues against current
+      docs. The named findings were already fixed; clear prose spelling issues
+      were corrected, while a URL, a string literal, and code identifiers were
+      left unchanged.
+- [x] (2026-05-12) Ran review-fix gates: `make fmt`, `make markdownlint`,
+      `make nixie`, `make check-fmt`, `make lint`, and `make test`.
+- [x] (2026-05-12) Committed the review-fix/design-surface batch as
+      `6de701f`, ran `coderabbit review --agent --base-commit HEAD~1 --type
+      committed` with zero findings, and pushed `feat/weaver-agent-roadmap` to
+      `https://github.com/leynos/weaver.git`.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -301,6 +301,9 @@ teams a sequenced build plan.
 - [x] (2026-05-13) Corrected the Sempai roadmap migration to preserve archive
       work 4.2.1 through 4.2.12 and 4.3.1 through 4.3.9 at task fidelity under
       live steps 15.2, 15.3, and 15.4.
+- [x] (2026-05-14) Corrected the Jacquard roadmap migration to preserve archive
+      work 7.2.2 through 7.2.5, 7.3.1 through 7.3.5, 7.4.1 through 7.4.9, and
+      7.5.1 through 7.5.2 at task fidelity under live steps 17.1 through 17.4.
 - [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [x] Run documentation and repository gates.
@@ -489,6 +492,16 @@ teams a sequenced build plan.
   Tree-sitter query escape hatches, parse caching, diagnostics conformance,
   quality suites, and release gates are distinct risks and deserve distinct
   review-sized roadmap tasks. Date: 2026-05-13.
+
+- Decision: preserve Jacquard graph, history, probabilistic matching, and
+  ledger-cache work at the original archive task fidelity instead of
+  compressing 7.2 through 7.5 into broad impact-slice tasks. Rationale:
+  two-pass symbol-table extraction, call-edge expansion, import and config
+  edges, budgeted traversal, checkout-free history loading, delta
+  normalization, risk warnings, safe history defaults, matching phases, feature
+  extraction, calibrated reason codes, duplicate-name guardrails, injective
+  assignment, and ledger invalidation are distinct risks and deserve distinct
+  review-sized roadmap tasks. Date: 2026-05-14.
 
 ## Context and orientation
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -1,0 +1,813 @@
+# Plan the agent-native Weaver documentation reset
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md` at the
+repository root. It plans a documentation and roadmap overhaul only. It does
+not authorise the product implementation until the plan is approved.
+
+## Purpose / big picture
+
+Weaver is pre-0.1.0, so the project can burn down prototype command grammar
+without preserving backwards compatibility. The goal of the planned overhaul is
+to update the design documents and roadmap so they give uncompromised,
+buildable instructions for a human-friendly, agent-native Weaver.
+
+After the overhaul, a reader should be able to open `docs/weaver-design.md`,
+the new agent-native architectural decision record (ADR), and `docs/roadmap.md`
+and see one coherent product direction:
+
+- Weaver has one generated command contract with two first-class renderers.
+- The default renderer remains friendly, localized, accessible, and pleasant
+  for humans at a terminal.
+- `--json` gives agents and scripts a stable, non-localized, parseable
+  protocol surface.
+- Public commands are resource-first and community-consistent, not prototype
+  `observe` / `act` / `verify` domains.
+- Capability is the public abstraction. Rope, rust-analyzer, Language Server
+  Protocol (LSP) servers, Tree-sitter, Sempai, and future helpers are provider
+  implementations behind stable perceptor and actuator capabilities.
+- The roadmap puts the command-surface reset before later command growth, so
+  Sempai, plugins, graph work, and advanced workflows do not multiply the old
+  patterns.
+
+The observable outcome of this plan, when executed later, is a documentation
+set in which every public-facing page, ADR, roadmap section, and gap analysis
+uses the same language for the 0.1.0 command contract and gives implementation
+teams a sequenced build plan.
+
+## Constraints
+
+- Do not remove the human interface. The design must keep localized help,
+  manpages, shell completions, readable default output, accessible plain
+  output, terminal-width-aware layouts, colour control, and explicit
+  interactive review workflows.
+- Do not preserve backwards compatibility for prototype public grammar.
+  Pre-0.1.0 freedom means the docs should replace `observe` / `act` / `verify`,
+  root `--output`, operation-local `--format`, root `--capabilities`, and
+  provider-first `act refactor` with the final 0.1.0 contract.
+- Do not expose provider names as the normal user workflow. Users ask Weaver
+  for semantic work through resources and capabilities; providers appear in
+  provenance, diagnostics, `--verbose` output, policy, and expert overrides.
+- Keep protocol identifiers stable and non-localized. Localize prose, help,
+  human headings, examples, and recovery guidance, but not JSON field names,
+  schema versions, error codes, enum values, capability IDs, or exit classes.
+- Preserve the existing safety principles. All actuator output still flows
+  through Weaver-owned transaction, sandbox, Double-Lock, atomic-write,
+  idempotency, and rollback semantics.
+- Keep the docs self-consistent. Any new ADR, roadmap phase, crate/module
+  name, command name, or storage path must be reflected in `docs/contents.md`,
+  `docs/repository-layout.md`, `docs/users-guide.md`, `README.md`, and related
+  ADRs where appropriate.
+- Use en-GB Oxford spelling in documentation, except for external API names
+  and literal identifiers.
+- Validate Markdown with `make fmt`, `make markdownlint`, and `make nixie`.
+  Run `make check-fmt`, `make lint`, and `make test` before committing the
+  final documentation overhaul, because repository instructions require the
+  full gates before commits.
+- Do not run formatting, linting, or tests in parallel. Use `tee` and write
+  logs under `/tmp` with branch-specific names.
+
+## Tolerances (exception triggers)
+
+- Scope: if the documentation overhaul needs changes to more than 14
+  documentation files, or more than 2,500 net documentation lines, stop and
+  confirm the expanded scope.
+- Interface: if a proposed command shape conflicts with an already completed
+  implementation in a way that would require immediate code changes to keep the
+  docs truthful, stop and present options.
+- Architecture: if capability-first plugins cannot be described without
+  exposing provider-specific public commands, stop and escalate with the failed
+  abstraction boundary.
+- Roadmap: if the new roadmap cannot be sequenced so the command-surface reset
+  lands before further Sempai, plugin, or graph command growth, stop and
+  present the dependency conflict.
+- Dependencies: if executing this documentation plan appears to require a new
+  crate or external dependency immediately, stop and separate documentation
+  planning from product implementation.
+- Validation: if Markdown or full repository gates still fail after three
+  repair loops, stop and record the failing log paths in `Decision Log`.
+- Ambiguity: if later review changes the product direction between
+  "agent-native human-friendly CLI" and "agent-only API appliance", stop and
+  ask for an explicit product decision.
+
+## Risks
+
+- Risk: the current docs already describe shipped `observe`, `act`, and
+  `verify` commands, so replacing them in design language may temporarily make
+  the docs aspirational rather than descriptive. Severity: high. Likelihood:
+  high. Mitigation: label the reset as the 0.1.0 target, update the roadmap
+  before user-facing examples, and keep the current-state notes explicit until
+  implementation catches up.
+
+- Risk: "agent-native" may be misread as "human-hostile." Severity: high.
+  Likelihood: medium. Mitigation: put the dual-renderer contract and
+  accessibility rules in the ADR and design document before any machine-only
+  details.
+
+- Risk: capability, provider, perceptor, and actuator terminology can become
+  confusing if the docs use them inconsistently. Severity: medium. Likelihood:
+  high. Mitigation: define the terms once in the new ADR, then use the same
+  vocabulary in design, roadmap, user guide, and developer guide.
+
+- Risk: the roadmap may become a horizontal layer cake around schema,
+  renderer, router, and plugin internals. Severity: medium. Likelihood: medium.
+  Mitigation: keep the first reset phase foundational, then frame later phases
+  as vertical slices that deliver usable resource commands end to end.
+
+- Risk: `agent-context`, skills, jobs, profiles, delivery, and feedback could
+  be documented as isolated conveniences instead of parts of the agent-native
+  product shape. Severity: medium. Likelihood: medium. Mitigation: describe
+  each as an agent state, introspection, or two-way I/O surface in the product
+  rationale and roadmap acceptance criteria.
+
+- Risk: provider hiding may go too far and make failures opaque. Severity:
+  medium. Likelihood: medium. Mitigation: keep provider names out of ordinary
+  command syntax but include provider provenance in JSON, diagnostics,
+  `agent-context`, and verbose human output.
+
+## Progress
+
+- [x] (2026-05-09) Read repository `AGENTS.md`, branch name, and skill
+      instructions for ExecPlans, roadmaps, and commits.
+- [x] (2026-05-09) Inspected `docs/weaver-design.md`, `docs/roadmap.md`,
+      `docs/users-guide.md`, `docs/ui-gap-analysis.md`,
+      `docs/repository-layout.md`, `docs/contents.md`, and `README.md`.
+- [x] (2026-05-09) Inspected ADRs 001, 004, and 006 to verify that the
+      capability-first plugin model already supports a provider-hidden public
+      command surface.
+- [x] (2026-05-09) Used a read-only wyvern agent to inventory current
+      documentation contradictions and supporting design material.
+- [x] (2026-05-09) Drafted this ExecPlan.
+- [x] (2026-05-09) Ran the plan-only gates: `make fmt`,
+      `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+      `make test`.
+- [ ] Obtain explicit approval before executing the planned documentation
+      overhaul.
+- [ ] Execute the documentation overhaul milestone by milestone, updating this
+      plan as discoveries occur.
+- [ ] Run documentation and repository gates.
+- [ ] Commit the completed overhaul after all required gates pass.
+
+## Surprises & Discoveries
+
+- Discovery: the current design already says the command catalogue should be
+  shared by the router, contextual help, `weaver help`, and tests. The reset
+  should promote that from help hygiene into the central schema-backed command
+  contract.
+
+- Discovery: `crates/weaver-cli/src/cli.rs` still has
+  `disable_help_subcommand = true` and a root `--output auto|human|json` model.
+  Those are useful evidence of prototype grammar that the design reset must
+  replace, not behaviours to carry forward.
+
+- Discovery: `docs/users-guide.md` still describes `act refactor` as requiring
+  `--provider`, even though the completed rename-symbol capability work makes
+  provider selection optional and capability-routed. The overhaul must remove
+  provider-first examples from ordinary workflows.
+
+- Discovery: `README.md` says the workspace has five crates and that the
+  Double-Lock safety harness is still under development. That conflicts with
+  `docs/repository-layout.md` and the completed roadmap entries, so the public
+  narrative already needs trust repair independent of the agent-native reset.
+
+- Discovery: ADR 001, ADR 004, and ADR 006 already justify the desired plugin
+  model. The planned work should refine and generalize those decisions rather
+  than reversing them.
+
+- Discovery: `make fmt` exposed a pre-existing Markdown wrapping problem in
+  `docs/developers-guide.md`. The plan-only change includes a narrow wording
+  cleanup there so the repository documentation gate can pass.
+
+## Decision Log
+
+- Decision: treat "scorched earth" as removal of accidental public grammar,
+  drift, and prototype compatibility, not removal of human usability.
+  Rationale: the user explicitly corrected that Weaver must remain friendly,
+  accessible, localizable, and grounded in community CLI conventions. Date:
+  2026-05-09.
+
+- Decision: design one generated command contract with two first-class
+  renderers. Rationale: humans and agents should share one source of truth,
+  while the default human renderer and `--json` machine renderer can optimize
+  for different consumers without drifting. Date: 2026-05-09.
+
+- Decision: replace public `observe` / `act` / `verify` domains with
+  resource-first commands in the 0.1.0 target documentation. Rationale:
+  resource-first names such as `definitions get`, `references list`,
+  `diagnostics list`, `symbols rename`, and `patches apply` better match
+  community CLI vocabulary and are easier for both humans and agents to guess.
+  Date: 2026-05-09.
+
+- Decision: remove root `--output` and operation-local `--format` from the
+  target contract. Rationale: `--json` should be the canonical machine switch;
+  default output should be human; `--plain`, `--color`, `--no-pager`, and
+  `--width` should control human rendering without changing protocol shape.
+  Date: 2026-05-09.
+
+- Decision: replace root `--capabilities` with explicit introspection
+  resources. Rationale: `weaver agent-context --json` should describe the full
+  command and workflow surface, while `weaver capabilities list --json` can
+  describe runtime capability availability. Date: 2026-05-09.
+
+- Decision: keep capability-based perceptor and actuator plugins as a core
+  design pillar. Rationale: the user asked whether this still fits; the answer
+  is yes, provided capability is public and providers remain implementation
+  details behind deterministic routing, refusal diagnostics, provenance, and
+  expert policy overrides. Date: 2026-05-09.
+
+- Decision: do not use Firecrawl for the initial plan draft. Rationale: the
+  full conversation and the target repository docs are available locally, and
+  the task is to encode the final decisions from that conversation into a
+  repository plan rather than to perform new web research. Date: 2026-05-09.
+
+## Context and orientation
+
+The files most likely to be edited when this plan is approved are:
+
+- `docs/adr-007-agent-native-command-surface.md`, a new ADR to record the
+  reset decision.
+- `docs/weaver-design.md`, the primary architecture and product rationale.
+- `docs/roadmap.md`, the implementation sequence that must be reordered around
+  the command-surface reset.
+- `docs/ui-gap-analysis.md`, the gap inventory that should become an
+  agent-native and human-friendly audit rather than a historical prototype
+  issue list.
+- `docs/users-guide.md`, the operator-facing guide and examples.
+- `docs/developers-guide.md`, the contributor-facing contract guidance.
+- `docs/repository-layout.md`, the ownership map for any planned
+  command-surface, agent-context, skill, profile, job, delivery, and feedback
+  components.
+- `docs/contents.md`, the documentation index.
+- `README.md`, the public summary that must stop contradicting implemented
+  safety and workspace status.
+- ADR 001, ADR 004, and ADR 006 if the new ADR needs cross-links or wording
+  that clarifies provider-hidden capability routing.
+
+The current source material to preserve includes these existing decisions:
+
+- ADR 001 says user intent should be represented by stable capability IDs,
+  provider choice should be resolved internally, provider internals should stay
+  out of normal workflows, and final edits should flow through the safety
+  harness.
+- ADR 004 says provider routing must be deterministic and refusal diagnostics
+  must be stable and machine-readable.
+- ADR 006 says plugins use one-shot JSONL execution with broker ownership and
+  do not own final commit behaviour.
+- `docs/weaver-design.md` already separates stable daemon reason codes from
+  localized CLI prose.
+- `docs/roadmap.md` already contains completed safety, atomic-edit,
+  capability-routing, and card/graph groundwork that should be reused rather
+  than redesigned.
+
+## Product rationale to encode
+
+The planned overhaul must state the product rationale before the mechanics.
+Weaver should be agent-native because agents increasingly use CLIs as primary
+interfaces, and every inconsistent flag, prompt, vague error, unbounded output,
+or hidden backend choice costs tokens, retries, and reliability. Weaver should
+also stay human-friendly because the best agent-native CLI practices are old
+CLI practices made explicit: predictable names, useful help, parseable output,
+good errors, bounded responses, standard streams, completions, manpages, and
+recoverable workflows.
+
+The reset should describe this as one product bet:
+
+```plaintext
+If Weaver defines one schema-backed command contract and generates both human
+and machine surfaces from it, the product can remain pleasant for terminal
+users while giving agents a stable, introspectable, recoverable interface.
+```
+
+The docs must make clear that this is not a Cloudflare or HeyGen clone. Weaver
+keeps its UNIX, daemon, JSONL, sandbox, semantic-fusion, and Double-Lock
+identity. The change is that the public command surface becomes generated,
+bounded, introspectable, state-aware, and capability-routed by construction.
+
+## Target command contract
+
+The design documents should replace the prototype public grammar with a
+resource-first command grammar. The exact command set can evolve during
+implementation, but the documentation reset should use these examples as the
+0.1.0 target:
+
+```sh
+weaver definitions get --uri file:///src/main.rs --position 10:5
+weaver references list --uri file:///src/main.rs --position 10:5
+weaver diagnostics list --workspace .
+weaver cards get --uri file:///src/main.rs --position 10:5
+weaver graph-slices get --uri file:///src/main.rs --position 10:5
+weaver symbols rename --uri file:///src/main.rs --position 10:5 --new-name run
+weaver symbols move --uri file:///src/main.rs --position 10:5 --to src/runner.rs
+weaver patches apply --file changes.patch --dry-run
+weaver jobs list --json
+weaver profiles list --json
+weaver feedback create "the enum error did not list valid values"
+```
+
+Canonical verbs are `get`, `list`, `create`, `update`, `delete`, `apply`,
+`run`, `prune`, `save`, `show`, and `rename`. Banned or non-canonical public
+forms include `info`, `ls`, `--skip-confirmations`, operation-local
+`--format=json`, root `--output json`, and provider-named commands such as
+`weaver rope rename`.
+
+The design should permit standard ancestral flags where the convention is
+strong:
+
+```plaintext
+-h, --help
+-V, --version
+-v, --verbose
+-q, --quiet
+```
+
+Global human rendering flags should include:
+
+```plaintext
+--plain
+--color auto|always|never
+--no-pager
+--width <columns>
+--locale <tag>
+```
+
+The canonical machine switch is:
+
+```plaintext
+--json
+```
+
+All data-returning commands accept `--json`. In JSON mode, success writes only
+the operation result to stdout. Failure writes a structured error object to
+stderr and exits with a stable non-zero exit class.
+
+## Capability and plugin model
+
+The docs must define four terms once and use them consistently:
+
+- A capability is a stable semantic contract, such as `definition.get`,
+  `references.list`, `diagnostics.list`, `symbol.rename`, `symbol.move`, or
+  `patch.apply`.
+- A perceptor is a read-only provider that observes the codebase and returns
+  facts, diagnostics, cards, graph slices, matches, or provenance.
+- An actuator is a mutation-planning provider that returns edits, diffs,
+  patches, plans, or workspace-change proposals. It never commits directly.
+- A provider is an implementation of one or more capabilities, such as Rope,
+  rust-analyzer, Tree-sitter, an LSP server, Sempai, or a Weaver built-in.
+
+The ordinary command path should be capability-first:
+
+```sh
+weaver symbols rename --uri file:///src/lib.rs --position 42:9 --new-name run
+```
+
+It should not be provider-first:
+
+```sh
+weaver act refactor --provider rust-analyzer --refactoring rename ...
+```
+
+Provider selection follows deterministic precedence:
+
+1. explicit CLI override,
+2. selected profile policy,
+3. environment or config policy,
+4. workspace policy,
+5. provider priority from manifests,
+6. deterministic tie-breaker,
+7. structured refusal if no provider qualifies.
+
+Expert overrides may exist, but they are advanced policy:
+
+```sh
+weaver symbols rename \
+  --uri file:///src/main.py \
+  --position 10:5 \
+  --new-name run \
+  --provider rope
+```
+
+Human output should hide providers during routine success unless `--verbose` is
+used. JSON output should include provider provenance because it matters for
+debugging and reproducibility. Failures should explain provider constraints
+when they affect the outcome, without requiring the caller to know provider
+internals ahead of time.
+
+## Required document changes
+
+### Milestone 1: Record the reset as a new ADR
+
+Create `docs/adr-007-agent-native-command-surface.md`.
+
+The ADR must decide that Weaver's 0.1.0 command surface is generated from one
+schema-backed command contract. That contract feeds CLI parsing, human help,
+localized text, manpage input, shell completions, daemon routing metadata,
+`agent-context`, capability metadata, skill validation, docs snippets, JSON
+schemas, vocabulary linting, and future Model Context Protocol (MCP) wrappers.
+
+The ADR must explicitly preserve human usability. It should say that the
+default command path is human-readable and localized, while `--json` is the
+stable machine path. It should state that accessibility, localization, and
+community CLI conventions are product requirements, not afterthoughts.
+
+The ADR must burn down these prototype surfaces for the 0.1.0 target:
+
+- public `observe` / `act` / `verify` domain grammar,
+- root `--output auto|human|json`,
+- operation-local `--format`,
+- root `--capabilities`,
+- provider-required `act refactor`,
+- hand-maintained command catalogues,
+- implicit prompts,
+- unbounded list output,
+- provider-specific public commands.
+
+Success criteria:
+
+- ADR 007 defines the dual-renderer command contract.
+- ADR 007 defines capability, perceptor, actuator, and provider.
+- ADR 007 links ADR 001, ADR 004, and ADR 006 as supporting decisions.
+- ADR 007 contains no compatibility promise for the prototype grammar.
+
+### Milestone 2: Rewrite the design around the new command contract
+
+Update `docs/weaver-design.md`.
+
+The executive summary and vision must describe Weaver as a human-friendly,
+agent-native semantic CLI rather than only an agent-friendly JSONL primitive.
+Keep the UNIX and JSONL rationale, but clarify that JSONL is an internal daemon
+and provider transport, while public CLI JSON mode uses stable operation result
+schemas.
+
+Replace the current command examples with the resource-first grammar from
+`Target command contract`. The design may mention old names only in a
+current-state or migration note.
+
+Add a section named `Agent-native command surface`. It must specify:
+
+- `weaver-command-surface` as the planned schema/source-of-truth component,
+  or another clearly named equivalent if maintainers choose differently.
+- The fields captured by the schema: command path, resource, verb, capability
+  ID, mutability class, async class, flags, flag types, enum values, defaults,
+  examples, output schemas, error schemas, profile fields, delivery support,
+  help message IDs, accessibility metadata, and skill references.
+- Generated or validated outputs: clap definitions, router metadata, localized
+  help, manpages, shell completions, docs snippets, `agent-context`, skill
+  manifests, JSON Schema fixtures, vocabulary linting, and tests.
+- The mechanical rule that adding or renaming a command requires one schema
+  change and CI fails on drift.
+
+Add sibling sections named `Human renderer contract` and
+`Machine renderer contract`.
+
+The human renderer contract must require:
+
+- localized default output,
+- `--plain`, `--color`, `--no-pager`, and `--width`,
+- no meaning conveyed by colour alone,
+- no spinner unless stderr is a terminal,
+- progress and diagnostics on stderr,
+- no pager in non-terminal contexts,
+- table headings and narrow-width labelled-block fallbacks,
+- Unicode decoration with ASCII fallbacks,
+- examples that can be copied and run.
+
+The machine renderer contract must require:
+
+- universal `--json`,
+- operation result JSON on stdout for success,
+- structured error JSON on stderr for failure,
+- non-localized field names, enum values, schema versions, and error codes,
+- stable exit-code taxonomy,
+- no localized prose required for an agent to decide its next action.
+
+Add a section named `Structured introspection and skills`. It must define:
+
+```sh
+weaver agent-context --json
+weaver capabilities list --json
+weaver skill-path
+```
+
+`agent-context` returns CLI version, schema version, commands, flags, enum
+values, output schemas, error taxonomy, installed capabilities, provider
+summaries, profiles, jobs, delivery schemes, feedback state, and skill paths.
+`capabilities list` returns runtime capability availability. `skill-path`
+returns the directory containing workflow `SKILL.md` manifests.
+
+Add a section named `Agent state and recoverable workflows`. It must define:
+
+- `weaver jobs list|get|prune`,
+- `--wait` on async-submitting commands,
+- a durable XDG state job ledger,
+- idempotency keys for mutations and async submissions,
+- `weaver profiles save|list|show|delete`,
+- root `--profile <name>`,
+- precedence
+  `built-in defaults < config files < selected profile < environment < flags`,
+- profile secrecy rules that expose names and metadata but not secrets.
+
+Add a section named `Two-way I/O`. It must define:
+
+- `--deliver stdout`,
+- `--deliver file:<path>` with atomic writes,
+- `--deliver webhook:<url>` with surfaced HTTP status,
+- structured refusal for unknown schemes,
+- `weaver feedback create|list|send`,
+- local JSONL feedback by default,
+- optional upstream feedback only when configured,
+- feedback availability in `agent-context`.
+
+Add a section named `Capability-routed perceptors and actuators`. It must
+generalize ADR 001, ADR 004, and ADR 006:
+
+- public commands map to capability IDs,
+- provider manifests declare capability support,
+- perceptors are read-only,
+- actuators produce proposed edits and never commit directly,
+- the broker owns routing, safety, idempotency, jobs, and final rendering,
+- provider provenance is available for debugging without making provider names
+  the normal command surface.
+
+Success criteria:
+
+- `docs/weaver-design.md` no longer presents `observe` / `act` / `verify` as
+  the future public grammar.
+- It clearly separates internal JSONL transport from public `--json` output.
+- It documents both human and machine rendering as generated schema outputs.
+- It explains why capability-first plugins still fit the design.
+
+### Milestone 3: Rewrite the roadmap around the build sequence
+
+Update `docs/roadmap.md` using the roadmap skill conventions. The roadmap
+should keep completed historical entries where useful, but the forward plan
+must be reordered around the reset.
+
+The first new forward phase should be foundational:
+
+```plaintext
+Human-friendly, agent-native 0.1.0 command surface reset
+```
+
+Its idea should be falsifiable:
+
+```plaintext
+If Weaver settles the generated command contract before more capabilities
+land, later Sempai, plugin, graph, and workflow slices can converge on one
+surface instead of repeatedly redesigning command grammar.
+```
+
+This phase must contain review-sized tasks for:
+
+- ADR 007 acceptance,
+- `weaver-command-surface` schema design,
+- vocabulary linting,
+- resource-first command mapping,
+- dual renderers,
+- universal `--json`,
+- stable exit-code taxonomy,
+- enumerating errors,
+- bounded list responses,
+- `agent-context`,
+- capability introspection,
+- skill manifests,
+- manpage and completion generation,
+- schema-to-router, schema-to-help, schema-to-docs, and schema-to-tests drift
+  gates.
+
+The next phase should deliver a useful vertical slice under the new grammar,
+not another layer. Candidate phase:
+
+```plaintext
+Resource command slice: definitions, references, diagnostics, and cards
+```
+
+This phase should prove that existing LSP, Tree-sitter, and cards work can be
+re-exposed through the new generated surface with both human and JSON output.
+
+The following phase should deliver safe mutation under the new grammar:
+
+```plaintext
+Capability-routed mutation slice: symbols and patches
+```
+
+This phase should include `symbols rename`, `symbols move` or
+`symbols extract`, `patches apply`, `--dry-run`, `--force`, idempotency,
+transaction IDs, provider provenance, Double-Lock integration, and structured
+refusals.
+
+Then add phases for:
+
+- async-aware execution and the durable jobs ledger,
+- profiles and persistent agent identity,
+- delivery sinks and feedback,
+- Sempai query and graph work under the new grammar,
+- plugin ecosystem expansion behind capability contracts,
+- deferred MCP and SDK generation if still out of scope for 0.1.0.
+
+Every task should cite the design or ADR section it implements and include
+observable success criteria. Unit and behavioural tests belong in the success
+criteria of implementation tasks; end-to-end and combinatorial command-surface
+tests are first-class tasks because this reset is primarily about interaction
+contracts.
+
+Success criteria:
+
+- Later Sempai, plugin, and graph tasks depend on the command-surface reset.
+- No future task asks implementers to add new public `observe` / `act` /
+  `verify` commands.
+- The roadmap explains the product-forward rationale for the chosen shape,
+  not only the mechanics.
+
+### Milestone 4: Convert the UI gap analysis into an agent-native audit
+
+Update `docs/ui-gap-analysis.md`.
+
+Replace the historical help-only framing with a 0.1.0 audit of the ten
+agent-native principles, plus human accessibility and localization
+requirements. The file should record current status, target status, design
+document changes, roadmap references, and acceptance tests.
+
+Cover these audit rows:
+
+- non-interactive by default,
+- structured parseable output,
+- errors that teach and enumerate,
+- safe retries and explicit mutation boundaries,
+- bounded responses,
+- cross-CLI vocabulary consistency,
+- three-layer introspection,
+- async-aware execution,
+- persistent identity through profiles,
+- two-way I/O,
+- localized human help,
+- accessible human rendering,
+- capability-routed provider abstraction.
+
+Success criteria:
+
+- The file no longer treats `list-plugins` or root `--capabilities` as the
+  primary target.
+- It points to `agent-context`, `capabilities list`, and capability-routed
+  public resources instead.
+- It names prototype surfaces to remove and the acceptance tests that prevent
+  drift from returning.
+
+### Milestone 5: Update user and developer-facing docs
+
+Update `docs/users-guide.md`.
+
+The guide should describe the 0.1.0 target command model, including:
+
+- default human output,
+- `--json`,
+- `--plain`,
+- resource-first commands,
+- non-interactive execution,
+- `--interactive` as explicit opt-in,
+- `--dry-run`,
+- `--force`,
+- `--wait`,
+- jobs,
+- profiles,
+- delivery,
+- feedback,
+- `agent-context`,
+- capability introspection,
+- provider provenance,
+- provider override as advanced policy only.
+
+Remove ordinary examples that require `--provider`. Replace `act refactor`
+examples with `symbols rename` and `symbols move` or `symbols extract`.
+
+Update `docs/developers-guide.md`.
+
+The developer guide should explain how contributors add or rename commands:
+
+1. edit the command-surface schema,
+2. declare or reuse a capability,
+3. provide human message IDs and examples,
+4. provide JSON success and error schemas,
+5. declare mutability, async, pagination, delivery, and profile behaviour,
+6. update or generate docs snippets,
+7. run drift and vocabulary gates.
+
+Update `README.md`.
+
+The README should stop claiming there are only five crates and should stop
+claiming the Double-Lock safety harness is still under development if the
+roadmap marks it complete. It should summarize Weaver as human-friendly and
+agent-native, then point readers to the design and roadmap for the 0.1.0 reset.
+
+Update `docs/repository-layout.md`.
+
+Add planned components for:
+
+- command-surface schema,
+- renderer generation,
+- `agent-context`,
+- skills,
+- job ledger,
+- profiles,
+- delivery,
+- feedback,
+- capability introspection.
+
+Update `docs/contents.md`.
+
+Add ADR 007 and any new design or skills documents.
+
+Success criteria:
+
+- Public docs no longer contradict the target command grammar.
+- Provider-specific details are presented as provenance and advanced policy,
+  not the ordinary workflow.
+- README, users guide, design, roadmap, and repository layout agree on what is
+  implemented, planned, and target 0.1.0 behaviour.
+
+### Milestone 6: Add drift gates to the documentation plan
+
+The planned docs must require future CI gates that make the principles
+mechanical rather than advisory. The design and roadmap should call for gates
+covering:
+
+- schema-to-clap consistency,
+- schema-to-router consistency,
+- schema-to-doc-snippet consistency,
+- schema-to-manpage and completion consistency,
+- banned vocabulary,
+- universal `--json` support for data commands,
+- stdout/stderr separation,
+- stable exit-code taxonomy,
+- enum errors that enumerate valid values,
+- bounded list responses,
+- mutation idempotency declarations,
+- destructive command `--force` declarations,
+- async `--wait` and jobs declarations,
+- profile-field declarations,
+- delivery-scheme declarations,
+- feedback state in `agent-context`,
+- provider provenance in JSON,
+- skill manifests that mention only real commands and flags,
+- generated tool-description token budgets for future MCP surfaces.
+
+Success criteria:
+
+- `docs/roadmap.md` has review-sized implementation tasks for the gates.
+- `docs/weaver-design.md` states which invariants are enforced at schema build
+  time rather than by manual review.
+
+## Implementation procedure for the document overhaul
+
+When this plan is approved, execute it in small commits.
+
+1. Create ADR 007 and update `docs/contents.md`.
+2. Rewrite the command-surface and renderer sections of
+   `docs/weaver-design.md`.
+3. Rewrite the capability and plugin sections of `docs/weaver-design.md`, then
+   cross-link ADR 001, ADR 004, and ADR 006.
+4. Rewrite `docs/roadmap.md` so the command-surface reset precedes additional
+   command growth.
+5. Rewrite `docs/ui-gap-analysis.md` into the agent-native audit.
+6. Update `docs/users-guide.md`, `docs/developers-guide.md`,
+   `docs/repository-layout.md`, and `README.md`.
+7. Run validation gates.
+8. Commit only after gates pass.
+
+Each commit should leave the documentation set internally consistent. If a
+commit changes command names in one public document, it must update any other
+public document that would otherwise contradict it.
+
+## Validation
+
+Run these commands sequentially from the repository root. Use sanitized log
+names because the branch name contains a slash.
+
+```sh
+set -o pipefail && make fmt 2>&1 | tee /tmp/fmt-weaver-feat-weaver-agent-roadmap.out
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/markdownlint-weaver-feat-weaver-agent-roadmap.out
+set -o pipefail && make nixie 2>&1 | tee /tmp/nixie-weaver-feat-weaver-agent-roadmap.out
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/check-fmt-weaver-feat-weaver-agent-roadmap.out
+set -o pipefail && make lint 2>&1 | tee /tmp/lint-weaver-feat-weaver-agent-roadmap.out
+set -o pipefail && make test 2>&1 | tee /tmp/test-weaver-feat-weaver-agent-roadmap.out
+```
+
+Expected result: every command exits 0. If any command fails, inspect the
+corresponding `/tmp` log, repair the documentation or code that caused the
+failure, update `Surprises & Discoveries` or `Decision Log` if the failure
+changes the plan, and rerun the failed gate before continuing.
+
+For this initial plan-only commit, the same gates should be run before commit
+unless an environmental problem blocks them. If a gate cannot run because of
+sandboxing, missing external tooling, or unrelated pre-existing failures,
+record the blocker and log path before committing.
+
+## Outcomes & Retrospective
+
+Not yet executed. This section must be filled in after the documentation
+overhaul is approved and completed.

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -267,6 +267,11 @@ teams a sequenced build plan.
       `62c9464`, ran `coderabbit review --agent --base-commit HEAD~1 --type
       committed` with zero findings, and pushed `feat/weaver-agent-roadmap` to
       `https://github.com/leynos/weaver.git`.
+- [x] (2026-05-13) Split the preserved prototype roadmap ledger into
+      `docs/archive/prototype-roadmap.md`, kept historical task numbers
+      `1` through `11`, renumbered the live forward roadmap as phases `12`
+      through `20`, and repointed historical ExecPlans and roadmap references
+      to the archive.
 - [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [x] Run documentation and repository gates.
@@ -1191,8 +1196,10 @@ command-contract work inside Weaver.
 
 Existing completed and planned Weaver roadmap work was not erased. Completed
 safety, atomic edit, capability-routing, card, graph, help, and configuration
-work is preserved as historical foundation, while relevant future work is
-migrated under the ADR 007 command grammar or marked superseded with rationale.
+work is preserved in `docs/archive/prototype-roadmap.md` as historical
+foundation. Relevant future work is migrated under the ADR 007 command grammar
+in live roadmap phases `12` through `20`, while historical ExecPlans keep their
+original archive task numbers.
 
 All final gates passed:
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -249,6 +249,10 @@ teams a sequenced build plan.
       command-surface section to `docs/users-guide.md` and labelling the
       remaining `observe` / `act` / `verify` command reference as the current
       prototype implementation rather than the future public grammar.
+- [x] (2026-05-12) Continued Milestone 5 by updating `README.md` and
+      `docs/repository-layout.md` so the public summary and planned-component
+      ownership reflect the current workspace, completed safety foundation,
+      ADR 007, the resource-first reset, and OrthoConfig dependency boundaries.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -34,6 +34,13 @@ and see one coherent product direction:
   orchestration, safety, and user-facing resource grammar.
 - Public commands are resource-first and community-consistent, not prototype
   `observe` / `act` / `verify` domains.
+- Sempai one-liner queries are a first-class selector syntax for referencing
+  one symbol or a collection of symbols anywhere a command accepts a symbol
+  reference.
+- Observe and act commands are composable: an observe command can emit bounded
+  structured selector results, those results can be filtered with ordinary UNIX
+  tools, and an act command can consume either the filtered stream or a direct
+  Sempai one-liner.
 - Capability is the public abstraction. Rope, rust-analyzer, Language Server
   Protocol (LSP) servers, Tree-sitter, Sempai, and future helpers are provider
   implementations behind stable perceptor and actuator capabilities.
@@ -75,6 +82,10 @@ teams a sequenced build plan.
 - Preserve the existing safety principles. All actuator output still flows
   through Weaver-owned transaction, sandbox, Double-Lock, atomic-write,
   idempotency, and rollback semantics.
+- Preserve UNIX composability as a product requirement. The redesigned public
+  grammar must support direct selectors, streamed selector input, filtering,
+  paging, and JSON mode without forcing agents or humans through hidden session
+  state.
 - Keep the docs self-consistent. Any new ADR, roadmap phase, crate/module
   name, command name, or storage path must be reflected in `docs/contents.md`,
   `docs/repository-layout.md`, `docs/users-guide.md`, `README.md`, and related
@@ -186,6 +197,10 @@ teams a sequenced build plan.
 - [x] (2026-05-11) Ran the amendment gates: `make fmt`,
       `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
       `make test`.
+- [x] (2026-05-11) Added first-class Sempai one-liner selector and
+      observe/filter/act pipeline requirements, then reran `make fmt`,
+      `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+      `make test`.
 - [ ] Obtain explicit approval before executing the planned documentation
       overhaul.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
@@ -272,6 +287,12 @@ teams a sequenced build plan.
   is yes, provided capability is public and providers remain implementation
   details behind deterministic routing, refusal diagnostics, provenance, and
   expert policy overrides. Date: 2026-05-09.
+
+- Decision: make Sempai one-liner queries a first-class selector form.
+  Rationale: the user clarified that one-liners must reference a symbol or
+  collection of symbols directly, and must compose with observe/filter/act
+  pipelines as well as direct act commands. Position references remain a peer
+  selector form, not the only first-class path. Date: 2026-05-11.
 
 - Decision: do not use Firecrawl for the initial plan draft. Rationale: the
   full conversation and the target repository docs are available locally, and
@@ -386,8 +407,13 @@ weaver references list --uri file:///src/main.rs --position 10:5
 weaver diagnostics list --workspace .
 weaver cards get --uri file:///src/main.rs --position 10:5
 weaver graph-slices get --uri file:///src/main.rs --position 10:5
+weaver symbols list --query 'fn $name(...)'
+weaver symbols rename --query 'fn process_request(...)' --new-name run_request
 weaver symbols rename --uri file:///src/main.rs --position 10:5 --new-name run
 weaver symbols move --uri file:///src/main.rs --position 10:5 --to src/runner.rs
+weaver symbols list --query 'fn $name(...)' --json \
+  | jq 'select(.name | test("_old$"))' \
+  | weaver symbols rename --from-stdin --suffix ""
 weaver patches apply --file changes.patch --dry-run
 weaver context --json
 weaver jobs list --json
@@ -430,6 +456,47 @@ The canonical machine switch is:
 All data-returning commands accept `--json`. In JSON mode, success writes only
 the operation result to stdout. Failure writes a structured error object to
 stderr and exits with a stable non-zero exit class.
+
+## Selector and pipeline model
+
+The planned design must define selectors as first-class inputs. A selector is
+any stable way to identify one symbol or a collection of symbols. The initial
+selector forms are:
+
+- Sempai one-liner queries, passed with a canonical flag such as
+  `--query <sempai-one-liner>`.
+- Position references, passed with `--uri` and `--position`.
+- Structured selector streams, read from stdin when `--from-stdin` or an
+  equivalent explicit stream flag is present.
+
+Sempai one-liners are not a secondary search feature. They are a peer to
+position references. Any command that acts on one or more symbols must state
+which selector forms it accepts and how it handles zero, one, and many matches.
+
+Observe commands must be able to emit selector records that act commands can
+consume without bespoke glue. The roadmap and design should preserve these
+composition shapes:
+
+```sh
+weaver symbols list --query 'fn $name(...)' --json \
+  | jq 'select(.name | startswith("old_"))' \
+  | weaver symbols rename --from-stdin --replace-prefix old_ --with-prefix new_
+
+weaver symbols rename --query 'fn process_request(...)' --new-name run_request
+
+weaver symbols rename \
+  --uri file:///src/main.rs \
+  --position 10:5 \
+  --new-name run_request
+
+weaver symbols list --query 'class $name' --json | less
+```
+
+The exact command and flag names may change during design review, but the
+capabilities may not collapse back to a position-only model. This requirement
+is about the interaction contract: observe results are useful downstream act
+inputs, act commands can resolve direct query selectors, and ordinary UNIX
+filters can sit between them.
 
 ## Capability and plugin model
 
@@ -563,8 +630,9 @@ Add a section named `Agent-native command surface`. It must specify:
   renderer, profile, delivery, feedback, and execution-ledger contracts.
 - A Weaver-owned command-surface adapter only for application-specific
   semantics: resource path, verb, capability ID, mutability class, async class,
-  provider selection policy, safety class, transaction behaviour, examples,
-  output schemas, error schemas, and skill references.
+  selector forms, stream input support, provider selection policy, safety
+  class, transaction behaviour, examples, output schemas, error schemas, and
+  skill references.
 - Generated or validated outputs: clap definitions, daemon router metadata,
   localized help, manpages, shell completions, docs snippets, `context --json`
   agent-context payloads, skill manifests, JSON Schema fixtures, vocabulary
@@ -573,6 +641,19 @@ Add a section named `Agent-native command surface`. It must specify:
   application schema or OrthoConfig metadata change, and CI fails on drift.
 - The fallback rule that any local generic command-contract code is temporary
   unless ADR 007 records why an OrthoConfig dependency cannot satisfy it.
+
+Add a section named `Selector and pipeline contract`. It must define:
+
+- Sempai one-liner selectors for one symbol or a symbol collection,
+- position-reference selectors for editor-style point operations,
+- structured selector streams for observe-to-act composition,
+- explicit stdin consumption through `--from-stdin` or the final canonical
+  equivalent,
+- JSON selector record schemas that preserve enough provenance for safe
+  mutation,
+- zero, one, and many match semantics for every selector-consuming command,
+- the invariant that observe command output can feed compatible act commands
+  after ordinary UNIX filtering.
 
 Add sibling sections named `Human renderer contract` and
 `Machine renderer contract`.
@@ -656,6 +737,10 @@ generalize ADR 001, ADR 004, and ADR 006:
 - provider manifests declare capability support,
 - perceptors are read-only,
 - actuators produce proposed edits and never commit directly,
+- perceptors that return symbol collections produce selector records suitable
+  for downstream actuator input,
+- actuators may accept Sempai one-liner selectors directly when their
+  capability supports query resolution,
 - the broker owns routing, safety, idempotency, jobs, and final rendering,
 - provider provenance is available for debugging without making provider names
   the normal command surface.
@@ -730,6 +815,8 @@ This phase must contain review-sized tasks for:
 - enumerating errors,
 - bounded list responses,
 - `context --json` agent-context payload,
+- Sempai one-liner selector support,
+- observe-to-act pipeline composition,
 - capability introspection,
 - skill manifests,
 - manpage and completion generation,
@@ -750,6 +837,9 @@ Resource command slice: definitions, references, diagnostics, and cards
 
 This phase should prove that existing LSP, Tree-sitter, and cards work can be
 re-exposed through the new generated surface with both human and JSON output.
+It should also prove that Sempai one-liner selectors can produce symbol
+collections that flow through `symbols list` or another observe-style resource
+command into ordinary UNIX filters.
 
 The following phase should deliver safe mutation under the new grammar:
 
@@ -760,7 +850,9 @@ Capability-routed mutation slice: symbols and patches
 This phase should include `symbols rename`, `symbols move` or
 `symbols extract`, `patches apply`, `--dry-run`, `--force`, idempotency,
 transaction IDs, provider provenance, Double-Lock integration, and structured
-refusals.
+refusals. It must include direct act commands using both Sempai one-liner
+selectors and position references, plus at least one observe-to-act pipeline
+where structured selector records are filtered before mutation.
 
 Then add phases for:
 
@@ -788,6 +880,10 @@ Success criteria:
 - Later Sempai, plugin, and graph tasks depend on the command-surface reset.
 - No future task asks implementers to add new public `observe` / `act` /
   `verify` commands.
+- Sempai one-liner queries are accepted as first-class symbol selectors in the
+  planned command surface.
+- Observe-style resource commands and act-style mutation commands have an
+  explicit structured pipeline contract.
 - The roadmap explains the product-forward rationale for the chosen shape,
   not only the mechanics.
 
@@ -814,7 +910,9 @@ Cover these audit rows:
 - two-way I/O,
 - localized human help,
 - accessible human rendering,
-- capability-routed provider abstraction.
+- capability-routed provider abstraction,
+- Sempai one-liner selectors,
+- observe/filter/act pipeline composition.
 
 Each row must include an `OrthoConfig dependency` column. Rows whose reusable
 metadata or linting belongs to OrthoConfig should cite the task number instead
@@ -843,6 +941,9 @@ The guide should describe the 0.1.0 target command model, including:
 - `--json`,
 - `--plain`,
 - resource-first commands,
+- Sempai one-liner selectors,
+- position-reference selectors,
+- observe-to-act pipelines through JSON selector streams,
 - non-interactive execution,
 - `--interactive` as explicit opt-in,
 - `--dry-run`,

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -233,6 +233,13 @@ teams a sequenced build plan.
 - [x] (2026-05-12) Closed the remaining Milestone 2 ambiguity by marking
       `act apply-patch` and the old design-roadmap section as current or
       historical context superseded by ADR 007 for the 0.1.0 public grammar.
+- [x] (2026-05-12) Completed Milestone 3 by rewriting `docs/roadmap.md`
+      around the 0.1.0 command-surface reset, explicit OrthoConfig
+      dependencies, resource-first command slices, selector-driven mutation,
+      capability-routed plugins, and a preserved historical roadmap ledger.
+- [x] (2026-05-12) Ran the Milestone 3 roadmap gates: `make fmt`,
+      `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+      `make test`.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.
@@ -283,6 +290,11 @@ teams a sequenced build plan.
   limit. Milestone validation should use
   `coderabbit review --agent --base-commit HEAD~1 --type committed` or another
   narrow comparison until the branch diff is small enough for whole-PR review.
+
+- Discovery: the fetched OrthoConfig roadmap confirms the dependency numbers
+  used by the Weaver roadmap rewrite: 5.2.3, 6.1.1, 6.1.2, 6.2.1 through 6.2.3,
+  6.3.1, 6.3.2, 7.1.1 through 7.1.3, 7.2.1 through 7.2.7, 8.1.1, 8.1.2, and
+  9.1.1 through 9.3.3.
 
 ## Decision Log
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -290,6 +290,10 @@ teams a sequenced build plan.
       added an archive relevance matrix showing which historical work is
       foundation, migrated live scope, conditional validation work, or
       superseded prototype grammar.
+- [x] (2026-05-13) Defined the temporary-adapter removal policy for roadmap
+      item `13.1.3` by adding an ADR 007 removal table for each local
+      command-surface helper and mirroring the OrthoConfig replacement tasks in
+      `crates/weaver-cli/src/command_surface.rs`.
 - [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [x] Run documentation and repository gates.
@@ -457,6 +461,12 @@ teams a sequenced build plan.
   as vertical validation slices under current command names, while the matrix
   makes the migration auditable and keeps superseded prototype spellings from
   re-entering the implementation backlog. Date: 2026-05-13.
+
+- Decision: record temporary adapter retirement in both ADR 007 and the code
+  comments on the local helpers. Rationale: `13.1.3` is a policy task, but the
+  policy must be visible at the maintenance point so future implementers do not
+  treat `command_surface.rs` as permanent generic infrastructure. Date:
+  2026-05-13.
 
 ## Context and orientation
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -294,6 +294,10 @@ teams a sequenced build plan.
       item `13.1.3` by adding an ADR 007 removal table for each local
       command-surface helper and mirroring the OrthoConfig replacement tasks in
       `crates/weaver-cli/src/command_surface.rs`.
+- [x] (2026-05-13) Corrected the live roadmap to stop conflating
+      `extricate-symbol` with `extract-method` and expanded the compressed
+      symbol-relocation slice back into separate Python and Rust extrication
+      workstreams.
 - [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [x] Run documentation and repository gates.
@@ -467,6 +471,13 @@ teams a sequenced build plan.
   policy must be visible at the maintenance point so future implementers do not
   treat `command_surface.rs` as permanent generic infrastructure. Date:
   2026-05-13.
+
+- Decision: treat `extricate-symbol` as symbol relocation exposed publicly as
+  `weaver symbols move`, and keep `extract-method` as a separate future
+  capability. Rationale: archived work 5.3 and 5.4 contained thirteen concrete
+  tasks for capability scaffolding, Python extrication, and Rust orchestration;
+  compressing that into a single viability task hid real risk and made the
+  public grammar ambiguous. Date: 2026-05-13.
 
 ## Context and orientation
 
@@ -1005,13 +1016,14 @@ The following phase should deliver safe mutation under the new grammar:
 Capability-routed mutation slice: symbols and patches
 ```
 
-This phase should include `symbols rename`, `symbols move` or
-`symbols extract`, `patches apply`, `--dry-run`, `--force`, idempotency,
+This phase should include `symbols rename`, `symbols move` for
+`extricate-symbol`, `patches apply`, `--dry-run`, `--force`, idempotency,
 transaction IDs, provider provenance, Double-Lock integration, and structured
 refusals. It must include direct act commands using both Sempai one-liner
 selectors and position references, plus at least one observe-to-act pipeline
 where structured selector records flow directly into mutation and one where
-they are filtered before mutation.
+they are filtered before mutation. `extract-method` is a separate future
+capability and must not be treated as completed by `symbols move`.
 
 Then add phases for:
 
@@ -1118,7 +1130,8 @@ The guide should describe the 0.1.0 target command model, including:
 - provider override as advanced policy only.
 
 Remove ordinary examples that require `--provider`. Replace `act refactor`
-examples with `symbols rename` and `symbols move` or `symbols extract`.
+examples with `symbols rename` and `symbols move`; keep any future
+`extract-method` examples under their own capability and command decision.
 
 Update `docs/developers-guide.md`.
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -27,6 +27,11 @@ and see one coherent product direction:
   for humans at a terminal.
 - `--json` gives agents and scripts a stable, non-localized, parseable
   protocol surface.
+- Weaver consumes reusable command-contract, documentation IR, agent-context,
+  policy, profile, delivery, feedback, and execution-ledger contracts from
+  OrthoConfig where that work exists or is already planned. Weaver only owns
+  the application-specific semantic editing, capability routing, provider
+  orchestration, safety, and user-facing resource grammar.
 - Public commands are resource-first and community-consistent, not prototype
   `observe` / `act` / `verify` domains.
 - Capability is the public abstraction. Rope, rust-analyzer, Language Server
@@ -54,6 +59,16 @@ teams a sequenced build plan.
 - Do not expose provider names as the normal user workflow. Users ask Weaver
   for semantic work through resources and capabilities; providers appear in
   provenance, diagnostics, `--verbose` output, policy, and expert overrides.
+- Do not duplicate work already planned in OrthoConfig. The revised Weaver
+  design and roadmap must cite OrthoConfig roadmap tasks as dependencies for
+  reusable command-contract machinery, and must keep Weaver's build tasks
+  scoped to application-specific behaviour.
+- Do not delete existing planned or historically completed Weaver roadmap work
+  just because the UI redesign changes the public grammar. Preserve completed
+  entries as historical foundation, re-home still-relevant planned work under
+  the new command surface, and only remove or supersede items when the redesign
+  makes them irrelevant to future functionality. Any removal must include a
+  short rationale in the roadmap.
 - Keep protocol identifiers stable and non-localized. Localize prose, help,
   human headings, examples, and recovery guidance, but not JSON field names,
   schema versions, error codes, enum values, capability IDs, or exit classes.
@@ -87,6 +102,12 @@ teams a sequenced build plan.
 - Roadmap: if the new roadmap cannot be sequenced so the command-surface reset
   lands before further Sempai, plugin, or graph command growth, stop and
   present the dependency conflict.
+- OrthoConfig: if a planned Weaver task appears to implement generic
+  functionality already assigned to OrthoConfig, stop and convert it into a
+  dependency, temporary adapter, or explicit divergence decision.
+- Roadmap history: if the revised roadmap would delete completed Weaver work,
+  or planned work that remains relevant after the UI redesign, stop and record
+  a preservation, migration, or supersession plan before editing.
 - Dependencies: if executing this documentation plan appears to require a new
   crate or external dependency immediately, stop and separate documentation
   planning from product implementation.
@@ -120,6 +141,18 @@ teams a sequenced build plan.
   Mitigation: keep the first reset phase foundational, then frame later phases
   as vertical slices that deliver usable resource commands end to end.
 
+- Risk: Weaver may duplicate OrthoConfig's planned generic CLI contract work,
+  creating two divergent schema and policy systems. Severity: high. Likelihood:
+  medium. Mitigation: make OrthoConfig task dependencies explicit in ADR 007,
+  `docs/weaver-design.md`, and `docs/roadmap.md`; define only Weaver-owned
+  adapters and semantic capability metadata locally.
+
+- Risk: the roadmap rewrite may erase useful historical or planned Weaver work
+  while replacing the UI grammar. Severity: high. Likelihood: medium.
+  Mitigation: preserve completed work as historical foundation, migrate
+  relevant future work into the new phase structure, and mark superseded work
+  with rationale instead of silently deleting it.
+
 - Risk: `agent-context`, skills, jobs, profiles, delivery, and feedback could
   be documented as isolated conveniences instead of parts of the agent-native
   product shape. Severity: medium. Likelihood: medium. Mitigation: describe
@@ -145,6 +178,12 @@ teams a sequenced build plan.
       documentation contradictions and supporting design material.
 - [x] (2026-05-09) Drafted this ExecPlan.
 - [x] (2026-05-09) Ran the plan-only gates: `make fmt`,
+      `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+      `make test`.
+- [x] (2026-05-11) Fetched the OrthoConfig roadmap and amended this plan so the
+      Weaver design and roadmap rewrite depends on OrthoConfig tasks rather
+      than duplicating reusable command-contract work.
+- [x] (2026-05-11) Ran the amendment gates: `make fmt`,
       `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
       `make test`.
 - [ ] Obtain explicit approval before executing the planned documentation
@@ -184,6 +223,16 @@ teams a sequenced build plan.
   `docs/developers-guide.md`. The plan-only change includes a narrow wording
   cleanup there so the repository documentation gate can pass.
 
+- Discovery: the active OrthoConfig roadmap already plans reusable
+  agent-native CLI infrastructure for downstream consumers including Weaver:
+  whole-CLI introspection, compact agent-context generation, downstream
+  `context --json` naming, skill manifest validation, vocabulary policy, dual
+  renderer metadata, JSON stream contracts, exit-code metadata, bounded-list
+  metadata, generic capability and provenance metadata, profile contracts,
+  delivery and feedback contracts, and execution-ledger contracts. Weaver's
+  plan must consume or depend on those tasks instead of reimplementing them as
+  local generic framework work.
+
 ## Decision Log
 
 - Decision: treat "scorched earth" as removal of accidental public grammar,
@@ -211,9 +260,12 @@ teams a sequenced build plan.
   Date: 2026-05-09.
 
 - Decision: replace root `--capabilities` with explicit introspection
-  resources. Rationale: `weaver agent-context --json` should describe the full
+  resources. Rationale: the agent-context payload should describe the full
   command and workflow surface, while `weaver capabilities list --json` can
-  describe runtime capability availability. Date: 2026-05-09.
+  describe runtime capability availability. The public context command name
+  should follow OrthoConfig roadmap task 6.2.3, which prefers
+  `<tool> context --json` before first release. Date: 2026-05-09. Updated:
+  2026-05-11.
 
 - Decision: keep capability-based perceptor and actuator plugins as a core
   design pillar. Rationale: the user asked whether this still fits; the answer
@@ -226,6 +278,22 @@ teams a sequenced build plan.
   the task is to encode the final decisions from that conversation into a
   repository plan rather than to perform new web research. Date: 2026-05-09.
 
+- Decision: make OrthoConfig the dependency for reusable command-contract
+  infrastructure and make Weaver the owner of semantic editing behaviour.
+  Rationale: the OrthoConfig roadmap explicitly assigns reusable documentation
+  IR, whole-CLI introspection, agent-context schema, policy linting, renderer
+  metadata, profile, delivery, feedback, and execution ledger contracts to
+  OrthoConfig, while naming Weaver as a downstream consumer. Weaver should not
+  fork that generic machinery unless a dependency is unavailable and an ADR
+  records the temporary adapter or divergence. Date: 2026-05-11.
+
+- Decision: preserve existing Weaver roadmap history during the redesign.
+  Rationale: the user explicitly required that existing planned work and
+  historical completed work not be deleted unless no longer relevant to future
+  functionality after the UI redesign. Completed safety, atomic-edit,
+  capability-routing, card, graph, and help work should be retained as
+  foundation or migrated into the new command grammar. Date: 2026-05-11.
+
 ## Context and orientation
 
 The files most likely to be edited when this plan is approved are:
@@ -234,7 +302,8 @@ The files most likely to be edited when this plan is approved are:
   reset decision.
 - `docs/weaver-design.md`, the primary architecture and product rationale.
 - `docs/roadmap.md`, the implementation sequence that must be reordered around
-  the command-surface reset.
+  the command-surface reset while preserving relevant completed and planned
+  work.
 - `docs/ui-gap-analysis.md`, the gap inventory that should become an
   agent-native and human-friendly audit rather than a historical prototype
   issue list.
@@ -242,7 +311,8 @@ The files most likely to be edited when this plan is approved are:
 - `docs/developers-guide.md`, the contributor-facing contract guidance.
 - `docs/repository-layout.md`, the ownership map for any planned
   command-surface, agent-context, skill, profile, job, delivery, and feedback
-  components.
+  components, including which pieces are OrthoConfig dependencies and which
+  pieces are Weaver-owned adapters.
 - `docs/contents.md`, the documentation index.
 - `README.md`, the public summary that must stop contradicting implemented
   safety and workspace status.
@@ -264,6 +334,20 @@ The current source material to preserve includes these existing decisions:
 - `docs/roadmap.md` already contains completed safety, atomic-edit,
   capability-routing, and card/graph groundwork that should be reused rather
   than redesigned.
+- OrthoConfig roadmap task 5.2.3 records the consumer boundary: OrthoConfig
+  owns reusable command-contract machinery, while Weaver owns semantic code
+  editing and execution.
+- OrthoConfig roadmap tasks 6.1 and 6.2 own recursive subcommand metadata,
+  compact agent-context output, and downstream context-command naming.
+- OrthoConfig roadmap task 6.3 owns reusable skill manifest metadata and
+  validation against real command paths and flags.
+- OrthoConfig roadmap tasks 7.1 and 7.2 own reusable vocabulary policy,
+  behavioural semantics, dual-renderer metadata, JSON mode stream contracts,
+  exit-code metadata, bounded-list metadata, and generic capability/provenance
+  metadata.
+- OrthoConfig roadmap tasks 9.1, 9.2, and 9.3 own reusable profile, delivery,
+  feedback, and execution-ledger contracts. Weaver owns the semantic contents,
+  storage policy choices, and safety integration for those surfaces.
 
 ## Product rationale to encode
 
@@ -305,6 +389,7 @@ weaver graph-slices get --uri file:///src/main.rs --position 10:5
 weaver symbols rename --uri file:///src/main.rs --position 10:5 --new-name run
 weaver symbols move --uri file:///src/main.rs --position 10:5 --to src/runner.rs
 weaver patches apply --file changes.patch --dry-run
+weaver context --json
 weaver jobs list --json
 weaver profiles list --json
 weaver feedback create "the enum error did not list valid values"
@@ -405,10 +490,27 @@ internals ahead of time.
 Create `docs/adr-007-agent-native-command-surface.md`.
 
 The ADR must decide that Weaver's 0.1.0 command surface is generated from one
-schema-backed command contract. That contract feeds CLI parsing, human help,
-localized text, manpage input, shell completions, daemon routing metadata,
-`agent-context`, capability metadata, skill validation, docs snippets, JSON
-schemas, vocabulary linting, and future Model Context Protocol (MCP) wrappers.
+schema-backed command contract. The ADR must state that Weaver depends on
+OrthoConfig for reusable command-contract, documentation IR, agent-context,
+policy, profile, delivery, feedback, and execution-ledger contracts wherever
+the OrthoConfig roadmap provides them. Weaver's local contract layer feeds CLI
+parsing, daemon routing metadata, semantic capability mapping, provider
+selection, safety policy, docs snippets, JSON schemas, and tests for
+Weaver-owned behaviour.
+
+The ADR must include an explicit dependency table:
+
+- OrthoConfig 5.2.3 for downstream consumer boundaries.
+- OrthoConfig 6.1 for recursive command metadata.
+- OrthoConfig 6.2 for compact agent-context output and public
+  `weaver context --json` naming.
+- OrthoConfig 6.3 for skill manifest metadata and validation.
+- OrthoConfig 7.1 for vocabulary policy.
+- OrthoConfig 7.2 for renderer, JSON stream, exit-code, bounded-list, and
+  generic capability/provenance metadata.
+- OrthoConfig 9.1 for profile contracts and redaction metadata.
+- OrthoConfig 9.2 for delivery and feedback contracts.
+- OrthoConfig 9.3 for execution-ledger contracts.
 
 The ADR must explicitly preserve human usability. It should say that the
 default command path is human-readable and localized, while `--json` is the
@@ -427,11 +529,18 @@ The ADR must burn down these prototype surfaces for the 0.1.0 target:
 - unbounded list output,
 - provider-specific public commands.
 
+The ADR must also state that the redesign preserves existing Weaver roadmap
+history. Completed work remains as foundation, relevant planned work is
+migrated under the new public grammar, and removed items must be marked
+superseded with rationale.
+
 Success criteria:
 
 - ADR 007 defines the dual-renderer command contract.
 - ADR 007 defines capability, perceptor, actuator, and provider.
 - ADR 007 links ADR 001, ADR 004, and ADR 006 as supporting decisions.
+- ADR 007 links the OrthoConfig roadmap tasks that Weaver depends on and does
+  not claim ownership of those reusable contracts.
 - ADR 007 contains no compatibility promise for the prototype grammar.
 
 ### Milestone 2: Rewrite the design around the new command contract
@@ -450,17 +559,20 @@ current-state or migration note.
 
 Add a section named `Agent-native command surface`. It must specify:
 
-- `weaver-command-surface` as the planned schema/source-of-truth component,
-  or another clearly named equivalent if maintainers choose differently.
-- The fields captured by the schema: command path, resource, verb, capability
-  ID, mutability class, async class, flags, flag types, enum values, defaults,
-  examples, output schemas, error schemas, profile fields, delivery support,
-  help message IDs, accessibility metadata, and skill references.
-- Generated or validated outputs: clap definitions, router metadata, localized
-  help, manpages, shell completions, docs snippets, `agent-context`, skill
-  manifests, JSON Schema fixtures, vocabulary linting, and tests.
-- The mechanical rule that adding or renaming a command requires one schema
-  change and CI fails on drift.
+- OrthoConfig as the owner of reusable documentation IR, agent-context, policy,
+  renderer, profile, delivery, feedback, and execution-ledger contracts.
+- A Weaver-owned command-surface adapter only for application-specific
+  semantics: resource path, verb, capability ID, mutability class, async class,
+  provider selection policy, safety class, transaction behaviour, examples,
+  output schemas, error schemas, and skill references.
+- Generated or validated outputs: clap definitions, daemon router metadata,
+  localized help, manpages, shell completions, docs snippets, `context --json`
+  agent-context payloads, skill manifests, JSON Schema fixtures, vocabulary
+  linting, and tests.
+- The mechanical rule that adding or renaming a Weaver command requires one
+  application schema or OrthoConfig metadata change, and CI fails on drift.
+- The fallback rule that any local generic command-contract code is temporary
+  unless ADR 007 records why an OrthoConfig dependency cannot satisfy it.
 
 Add sibling sections named `Human renderer contract` and
 `Machine renderer contract`.
@@ -489,16 +601,20 @@ The machine renderer contract must require:
 Add a section named `Structured introspection and skills`. It must define:
 
 ```sh
-weaver agent-context --json
+weaver context --json
 weaver capabilities list --json
 weaver skill-path
 ```
 
-`agent-context` returns CLI version, schema version, commands, flags, enum
-values, output schemas, error taxonomy, installed capabilities, provider
-summaries, profiles, jobs, delivery schemes, feedback state, and skill paths.
-`capabilities list` returns runtime capability availability. `skill-path`
-returns the directory containing workflow `SKILL.md` manifests.
+`context --json` returns the OrthoConfig-shaped agent-context payload: CLI
+version, schema version, commands, flags, enum values, output schemas, error
+taxonomy, installed capabilities, provider summaries, profiles, jobs, delivery
+schemes, feedback state, and skill paths. The design must call out its
+dependency on OrthoConfig 6.2.3 for public command naming and must not add a
+public `agent-context` alias before 0.1.0 unless ADR 007 records the reason.
+`capabilities list` returns Weaver runtime capability availability.
+`skill-path` returns the directory containing workflow `SKILL.md` manifests,
+with validation delegated to OrthoConfig 6.3 where possible.
 
 Add a section named `Agent state and recoverable workflows`. It must define:
 
@@ -512,6 +628,11 @@ Add a section named `Agent state and recoverable workflows`. It must define:
   `built-in defaults < config files < selected profile < environment < flags`,
 - profile secrecy rules that expose names and metadata but not secrets.
 
+This section must explicitly depend on OrthoConfig 9.1 for profile contract and
+redaction metadata, and OrthoConfig 9.3 for reusable execution-ledger metadata.
+Weaver owns the job record contents, workspace safety integration, idempotency
+semantics, storage path choice, and public `jobs` command behaviour.
+
 Add a section named `Two-way I/O`. It must define:
 
 - `--deliver stdout`,
@@ -521,7 +642,12 @@ Add a section named `Two-way I/O`. It must define:
 - `weaver feedback create|list|send`,
 - local JSONL feedback by default,
 - optional upstream feedback only when configured,
-- feedback availability in `agent-context`.
+- feedback availability in the `context --json` agent-context payload.
+
+This section must explicitly depend on OrthoConfig 9.2 for reusable delivery
+target parsing and feedback storage contracts. Weaver owns the semantic
+payloads, safety checks, webhook payload shape, and how delivered artefacts
+relate to code-edit transactions.
 
 Add a section named `Capability-routed perceptors and actuators`. It must
 generalize ADR 001, ADR 004, and ADR 006:
@@ -546,7 +672,36 @@ Success criteria:
 
 Update `docs/roadmap.md` using the roadmap skill conventions. The roadmap
 should keep completed historical entries where useful, but the forward plan
-must be reordered around the reset.
+must be reordered around the reset. The rewrite must not delete existing
+planned work or completed historical work unless the UI redesign makes that
+work irrelevant to future functionality. When work is superseded, the roadmap
+must say what superseded it and why.
+
+Before adding new Weaver tasks, add a dependency section named something like:
+
+```plaintext
+External reusable CLI-contract dependencies
+```
+
+That section must cite the OrthoConfig roadmap tasks Weaver depends on:
+
+- 5.2.3 for the Weaver/Netsuke downstream boundary.
+- 6.1 for recursive subcommand metadata.
+- 6.2.1 and 6.2.2 for compact agent-context generation and schema stability.
+- 6.2.3 for the public `weaver context --json` naming convention.
+- 6.3 for skill manifest metadata and validation.
+- 7.1 for canonical vocabulary policy.
+- 7.2.1 through 7.2.7 for non-interactive, mutation, renderer, JSON stream,
+  exit-code, bounded-list, and capability/provenance metadata.
+- 8.1 for the `cargo-orthohelp` reference CLI proving `--json` and
+  enumerating errors.
+- 9.1 for profile contracts and redaction metadata.
+- 9.2 for delivery and feedback contracts.
+- 9.3 for execution-ledger contracts.
+
+Each dependent Weaver task must say whether it is blocked by the OrthoConfig
+task, can proceed with a local adapter, or can proceed because the OrthoConfig
+contract is only needed for later validation.
 
 The first new forward phase should be foundational:
 
@@ -565,20 +720,26 @@ surface instead of repeatedly redesigning command grammar.
 This phase must contain review-sized tasks for:
 
 - ADR 007 acceptance,
-- `weaver-command-surface` schema design,
-- vocabulary linting,
+- OrthoConfig dependency mapping and adapter policy,
+- Weaver semantic command-surface adapter design,
+- vocabulary linting via OrthoConfig policy where available,
 - resource-first command mapping,
 - dual renderers,
 - universal `--json`,
 - stable exit-code taxonomy,
 - enumerating errors,
 - bounded list responses,
-- `agent-context`,
+- `context --json` agent-context payload,
 - capability introspection,
 - skill manifests,
 - manpage and completion generation,
 - schema-to-router, schema-to-help, schema-to-docs, and schema-to-tests drift
   gates.
+
+Tasks in this foundational phase must distinguish reusable OrthoConfig work
+from Weaver work. For example, Weaver may configure or consume vocabulary
+policy and renderer metadata, but it should not implement a second generic
+policy engine unless ADR 007 records a temporary adapter with a removal path.
 
 The next phase should deliver a useful vertical slice under the new grammar,
 not another layer. Candidate phase:
@@ -618,6 +779,12 @@ contracts.
 
 Success criteria:
 
+- The roadmap contains an explicit OrthoConfig dependency section.
+- Tasks that overlap OrthoConfig roadmap work are rewritten as dependencies,
+  adapters, or deliberate divergence decisions.
+- Existing completed Weaver work remains visible as historical foundation.
+- Existing planned Weaver work that still matters is migrated under the new
+  command grammar instead of deleted.
 - Later Sempai, plugin, and graph tasks depend on the command-surface reset.
 - No future task asks implementers to add new public `observe` / `act` /
   `verify` commands.
@@ -649,12 +816,20 @@ Cover these audit rows:
 - accessible human rendering,
 - capability-routed provider abstraction.
 
+Each row must include an `OrthoConfig dependency` column. Rows whose reusable
+metadata or linting belongs to OrthoConfig should cite the task number instead
+of assigning generic implementation work to Weaver. Rows whose behaviour is
+Weaver-owned should say what semantic, safety, or provider orchestration work
+remains local.
+
 Success criteria:
 
 - The file no longer treats `list-plugins` or root `--capabilities` as the
   primary target.
-- It points to `agent-context`, `capabilities list`, and capability-routed
+- It points to `context --json`, `capabilities list`, and capability-routed
   public resources instead.
+- It identifies which gaps are closed by consuming OrthoConfig work and which
+  gaps require Weaver implementation.
 - It names prototype surfaces to remove and the acceptance tests that prevent
   drift from returning.
 
@@ -677,7 +852,7 @@ The guide should describe the 0.1.0 target command model, including:
 - profiles,
 - delivery,
 - feedback,
-- `agent-context`,
+- `context --json`,
 - capability introspection,
 - provider provenance,
 - provider override as advanced policy only.
@@ -689,7 +864,7 @@ Update `docs/developers-guide.md`.
 
 The developer guide should explain how contributors add or rename commands:
 
-1. edit the command-surface schema,
+1. edit the OrthoConfig-backed command metadata or Weaver semantic adapter,
 2. declare or reuse a capability,
 3. provide human message IDs and examples,
 4. provide JSON success and error schemas,
@@ -708,9 +883,10 @@ Update `docs/repository-layout.md`.
 
 Add planned components for:
 
-- command-surface schema,
-- renderer generation,
-- `agent-context`,
+- OrthoConfig-backed command metadata integration,
+- Weaver semantic command-surface adapter,
+- renderer generation through OrthoConfig contracts where available,
+- `context --json` agent-context payload,
 - skills,
 - job ledger,
 - profiles,
@@ -729,6 +905,8 @@ Success criteria:
   not the ordinary workflow.
 - README, users guide, design, roadmap, and repository layout agree on what is
   implemented, planned, and target 0.1.0 behaviour.
+- Repository layout distinguishes OrthoConfig-owned reusable contracts from
+  Weaver-owned semantic adapters, safety integration, and provider routing.
 
 ### Milestone 6: Add drift gates to the documentation plan
 
@@ -736,31 +914,26 @@ The planned docs must require future CI gates that make the principles
 mechanical rather than advisory. The design and roadmap should call for gates
 covering:
 
-- schema-to-clap consistency,
-- schema-to-router consistency,
-- schema-to-doc-snippet consistency,
-- schema-to-manpage and completion consistency,
-- banned vocabulary,
-- universal `--json` support for data commands,
-- stdout/stderr separation,
-- stable exit-code taxonomy,
-- enum errors that enumerate valid values,
-- bounded list responses,
-- mutation idempotency declarations,
-- destructive command `--force` declarations,
-- async `--wait` and jobs declarations,
-- profile-field declarations,
-- delivery-scheme declarations,
-- feedback state in `agent-context`,
-- provider provenance in JSON,
-- skill manifests that mention only real commands and flags,
-- generated tool-description token budgets for future MCP surfaces.
+- OrthoConfig-provided policy gates for metadata, vocabulary, renderer
+  contracts, JSON stream contracts, exit-code taxonomy, bounded-list metadata,
+  profile fields, delivery schemes, feedback state, skill manifests, and
+  generic capability/provenance metadata.
+- Weaver-owned gates for semantic capability mapping, provider routing,
+  safety class declarations, transaction and idempotency behaviour,
+  schema-to-router consistency, generated docs snippets, runtime
+  `capabilities list`, provider provenance in JSON, and command examples that
+  use the resource-first public grammar.
+- A temporary-adapter gate that fails if Weaver keeps local generic
+  command-contract code after the corresponding OrthoConfig dependency is
+  available.
 
 Success criteria:
 
 - `docs/roadmap.md` has review-sized implementation tasks for the gates.
 - `docs/weaver-design.md` states which invariants are enforced at schema build
   time rather than by manual review.
+- The planned gates do not duplicate OrthoConfig checks except as temporary
+  adapters with removal criteria.
 
 ## Implementation procedure for the document overhaul
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: IN PROGRESS
+Status: COMPLETE
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root. It plans a documentation and roadmap overhaul only. It does
@@ -257,10 +257,20 @@ teams a sequenced build plan.
       to `docs/developers-guide.md` for adding or renaming public commands
       through OrthoConfig-backed metadata, Weaver semantic adapters,
       capability IDs, renderer schemas, introspection, skills, and drift gates.
-- [ ] Execute the documentation overhaul milestone by milestone, updating this
+- [x] (2026-05-12) Completed the documentation overhaul milestone by milestone,
+      with each completed milestone committed, gated, CodeRabbit-reviewed, and
+      pushed before proceeding.
+- [x] (2026-05-12) Ran documentation and repository gates for the final
+      developer-guide milestone: `make fmt`, `make markdownlint`,
+      `make nixie`, `make check-fmt`, `make lint`, and `make test`.
+- [x] (2026-05-12) Committed the final developer-guide milestone as
+      `62c9464`, ran `coderabbit review --agent --base-commit HEAD~1 --type
+      committed` with zero findings, and pushed `feat/weaver-agent-roadmap` to
+      `https://github.com/leynos/weaver.git`.
+- [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
-- [ ] Run documentation and repository gates.
-- [ ] Commit the completed overhaul after all required gates pass.
+- [x] Run documentation and repository gates.
+- [x] Commit the completed overhaul after all required gates pass.
 
 ## Surprises & Discoveries
 
@@ -1166,5 +1176,33 @@ record the blocker and log path before committing.
 
 ## Outcomes & Retrospective
 
-Not yet executed. This section must be filled in after the documentation
-overhaul is approved and completed.
+The documentation overhaul is complete. The branch now records Weaver's
+human-friendly, agent-native 0.1.0 command-surface reset in ADR 007,
+`docs/weaver-design.md`, `docs/roadmap.md`, `docs/ui-gap-analysis.md`,
+`docs/users-guide.md`, `docs/developers-guide.md`, `README.md`,
+`docs/repository-layout.md`, and `docs/contents.md`.
+
+The completed plan preserves the human interface, replaces prototype grammar
+with a resource-first target contract, makes Sempai one-liner selectors
+first-class, keeps observe-style resource output and act-style mutation input
+composable, retains capability-routed perceptor and actuator plugins, and
+states explicit OrthoConfig dependencies instead of duplicating reusable
+command-contract work inside Weaver.
+
+Existing completed and planned Weaver roadmap work was not erased. Completed
+safety, atomic edit, capability-routing, card, graph, help, and configuration
+work is preserved as historical foundation, while relevant future work is
+migrated under the ADR 007 command grammar or marked superseded with rationale.
+
+All final gates passed:
+
+- `make fmt`
+- `make markdownlint`
+- `make nixie`
+- `make check-fmt`
+- `make lint`
+- `make test`
+- `coderabbit review --agent --base-commit HEAD~1 --type committed`
+
+The full test gate reported 1364 nextest tests passed with 4 skipped, and the
+workspace doctests passed.

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -423,10 +423,12 @@ weaver feedback create "the enum error did not list valid values"
 ```
 
 Canonical verbs are `get`, `list`, `create`, `update`, `delete`, `apply`,
-`run`, `prune`, `save`, `show`, and `rename`. Banned or non-canonical public
-forms include `info`, `ls`, `--skip-confirmations`, operation-local
-`--format=json`, root `--output json`, and provider-named commands such as
-`weaver rope rename`.
+`run`, `prune`, `save`, `show`, `rename`, `move`, and `send`. The final
+vocabulary policy must include every verb used by target examples and planned
+resource commands, or must change those examples before the policy lands.
+Banned or non-canonical public forms include `info`, `ls`,
+`--skip-confirmations`, operation-local `--format=json`, root `--output json`,
+and provider-named commands such as `weaver rope rename`.
 
 The design should permit standard ancestral flags where the convention is
 strong:

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -253,6 +253,10 @@ teams a sequenced build plan.
       `docs/repository-layout.md` so the public summary and planned-component
       ownership reflect the current workspace, completed safety foundation,
       ADR 007, the resource-first reset, and OrthoConfig dependency boundaries.
+- [x] (2026-05-12) Completed Milestone 5 by adding contributor-facing guidance
+      to `docs/developers-guide.md` for adding or renaming public commands
+      through OrthoConfig-backed metadata, Weaver semantic adapters,
+      capability IDs, renderer schemas, introspection, skills, and drift gates.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -272,6 +272,13 @@ teams a sequenced build plan.
       `1` through `11`, renumbered the live forward roadmap as phases `12`
       through `20`, and repointed historical ExecPlans and roadmap references
       to the archive.
+- [x] (2026-05-13) Reassessed archive relevance against the current product
+      plan, marked the archive-assessment step complete, and recast
+      `docs/roadmap.md` as a fail-fast vertical-slice roadmap for the complete
+      product rather than a layer-by-layer infrastructure build.
+- [x] (2026-05-13) Updated the archive assessment note, repository layout
+      references, gap-analysis roadmap owners, and developer-guide roadmap
+      pointer to match the new live phase numbering.
 - [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [x] Run documentation and repository gates.
@@ -334,6 +341,12 @@ teams a sequenced build plan.
   literally. The revised gap analysis must therefore retain those observations
   as historical evidence while pointing implementation at ADR 007 and the new
   roadmap phases.
+
+- Discovery: the archived roadmap work maps more cleanly to product loops than
+  to implementation layers. LSP reads, Sempai selectors, selector-fed
+  mutations, graph impact, provider ecosystem, and workflow state each form a
+  falsifiable slice that can validate or invalidate the design before the next
+  investment.
 
 ## Decision Log
 
@@ -406,6 +419,19 @@ teams a sequenced build plan.
   Rationale: the active implementation instruction explicitly asks to proceed
   with the planned functionality and keep the ExecPlan current, which satisfies
   the plan's approval gate for this workstream. Date: 2026-05-11.
+
+- Decision: treat the archive as provenance and implementation evidence, not
+  a competing backlog. Rationale: the live roadmap now carries every relevant
+  unfinished product intent under resource-first, hypothesis-driven phases,
+  while superseded prototype spellings and provider-first workflows remain in
+  the archive only as historical context. Date: 2026-05-13.
+
+- Decision: keep one cohesive command-contract proving slice, then organize
+  the rest of the roadmap as vertical product validations. Rationale: the
+  OrthoConfig boundary and dual-renderer contract are unavoidable foundation,
+  but LSP reads, Sempai selectors, safe changes, graph impact, providers, and
+  agent workflow state can each fail fast against observable user workflows.
+  Date: 2026-05-13.
 
 ## Context and orientation
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -230,6 +230,9 @@ teams a sequenced build plan.
       `6de701f`, ran `coderabbit review --agent --base-commit HEAD~1 --type
       committed` with zero findings, and pushed `feat/weaver-agent-roadmap` to
       `https://github.com/leynos/weaver.git`.
+- [x] (2026-05-12) Closed the remaining Milestone 2 ambiguity by marking
+      `act apply-patch` and the old design-roadmap section as current or
+      historical context superseded by ADR 007 for the 0.1.0 public grammar.
 - [ ] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [ ] Run documentation and repository gates.

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: COMPLETE
+Status: IMPLEMENTATION FOLLOW-UP IN PROGRESS
 
 This document must be maintained in accordance with `AGENTS.md` at the
 repository root. It plans a documentation and roadmap overhaul only. It does
@@ -279,6 +279,17 @@ teams a sequenced build plan.
 - [x] (2026-05-13) Updated the archive assessment note, repository layout
       references, gap-analysis roadmap owners, and developer-guide roadmap
       pointer to match the new live phase numbering.
+- [x] (2026-05-13) Began implementation follow-up from the live roadmap by
+      targeting roadmap item `13.1.2`, the smallest command-surface adapter
+      slice after the documentation reset.
+- [x] (2026-05-13) Implemented a temporary Weaver-owned read-only
+      command-surface adapter for `definitions get`, with sibling metadata for
+      `references list`, and mapped the resource-first CLI command to the
+      existing `observe get-definition` daemon operation.
+- [x] (2026-05-13) Reassessed the archived prototype roadmap at step level and
+      added an archive relevance matrix showing which historical work is
+      foundation, migrated live scope, conditional validation work, or
+      superseded prototype grammar.
 - [x] Execute the documentation overhaul milestone by milestone, updating this
       plan as discoveries occur.
 - [x] Run documentation and repository gates.
@@ -432,6 +443,20 @@ teams a sequenced build plan.
   but LSP reads, Sempai selectors, safe changes, graph impact, providers, and
   agent workflow state can each fail fast against observable user workflows.
   Date: 2026-05-13.
+
+- Decision: implement `13.1.2` as a CLI-side adapter over the existing daemon
+  protocol instead of changing the daemon router first. Rationale: this proves
+  the resource-first public grammar and metadata shape while reusing the
+  already shipped `observe get-definition` handler; later tasks can replace the
+  legacy daemon operation name after the command contract stabilizes. Date:
+  2026-05-13.
+
+- Decision: keep the archived prototype roadmap in place but add a step-level
+  relevance matrix instead of moving every historical task body back into the
+  live roadmap. Rationale: the live roadmap already re-expresses relevant work
+  as vertical validation slices under current command names, while the matrix
+  makes the migration auditable and keeps superseded prototype spellings from
+  re-entering the implementation backlog. Date: 2026-05-13.
 
 ## Context and orientation
 

--- a/docs/execplans/weaver-agent-roadmap.md
+++ b/docs/execplans/weaver-agent-roadmap.md
@@ -38,9 +38,10 @@ and see one coherent product direction:
   one symbol or a collection of symbols anywhere a command accepts a symbol
   reference.
 - Observe and act commands are composable: an observe command can emit bounded
-  structured selector results, those results can be filtered with ordinary UNIX
-  tools, and an act command can consume either the filtered stream or a direct
-  Sempai one-liner.
+  structured selector results, those results can flow directly into an act
+  command or be filtered with ordinary UNIX tools first, and an act command can
+  consume either the direct stream, the filtered stream, or a direct Sempai
+  one-liner.
 - Capability is the public abstraction. Rope, rust-analyzer, Language Server
   Protocol (LSP) servers, Tree-sitter, Sempai, and future helpers are provider
   implementations behind stable perceptor and actuator capabilities.
@@ -479,6 +480,9 @@ composition shapes:
 
 ```sh
 weaver symbols list --query 'fn $name(...)' --json \
+  | weaver symbols rename --from-stdin --suffix _renamed
+
+weaver symbols list --query 'fn $name(...)' --json \
   | jq 'select(.name | startswith("old_"))' \
   | weaver symbols rename --from-stdin --replace-prefix old_ --with-prefix new_
 
@@ -496,7 +500,7 @@ The exact command and flag names may change during design review, but the
 capabilities may not collapse back to a position-only model. This requirement
 is about the interaction contract: observe results are useful downstream act
 inputs, act commands can resolve direct query selectors, and ordinary UNIX
-filters can sit between them.
+filters may sit between them when the caller wants narrowing or transformation.
 
 ## Capability and plugin model
 
@@ -653,7 +657,7 @@ Add a section named `Selector and pipeline contract`. It must define:
   mutation,
 - zero, one, and many match semantics for every selector-consuming command,
 - the invariant that observe command output can feed compatible act commands
-  after ordinary UNIX filtering.
+  either directly or after ordinary UNIX filtering.
 
 Add sibling sections named `Human renderer contract` and
 `Machine renderer contract`.
@@ -852,7 +856,8 @@ This phase should include `symbols rename`, `symbols move` or
 transaction IDs, provider provenance, Double-Lock integration, and structured
 refusals. It must include direct act commands using both Sempai one-liner
 selectors and position references, plus at least one observe-to-act pipeline
-where structured selector records are filtered before mutation.
+where structured selector records flow directly into mutation and one where
+they are filtered before mutation.
 
 Then add phases for:
 

--- a/docs/formal-verification-methods-in-weaver.md
+++ b/docs/formal-verification-methods-in-weaver.md
@@ -26,6 +26,11 @@ also excludes concurrency-heavy Rust patterns, which further supports keeping
 the initial proof effort inside bounded, deterministic control-plane logic
 rather than the daemon's general async orchestration.[^6]
 
+The forward roadmap now reserves task numbers `12` through `20` for the ADR 007
+command-surface build. Older Weaver roadmap references in this document, such
+as `6.1.4`, `7.2.5`, or `8.3.4`, point to the prototype roadmap archive unless
+they are part of the local formal-verification rollout checklist below.
+
 ## Current state
 
 Weaver is already a Cargo workspace. The root `Cargo.toml` enumerates workspace
@@ -338,7 +343,7 @@ That layering keeps the assurance story honest and maintainable.
           documented target.
   - [ ] 2.0.2. Add `#[cfg(kani)]` harnesses in
         `crates/weaverd/src/dispatch/act/apply_patch/`. Requires 2.0.1 and
-        6.1.4.
+        prototype archive 6.1.4.
     - [ ] Cover cursor monotonicity for ordered `SEARCH`/`REPLACE` blocks.
     - [ ] Cover whole-command abort on unmatched blocks.
     - [ ] Cover path normalization rejecting absolute and parent-escape
@@ -347,7 +352,8 @@ That layering keeps the assurance story honest and maintainable.
           smoke harnesses, and the checked properties map directly to the
           documented patch contract.
   - [ ] 2.0.3. Add `#[cfg(kani)]` harnesses in `crates/weaver-plugins/src/`
-        for capability resolution. Requires 1.0.2, 1.0.3, and 5.3.2.
+        for capability resolution. Requires 1.0.2, 1.0.3, and prototype
+        archive 5.3.2.
     - [ ] Prove the selected provider satisfies the requested language and
           capability.
     - [ ] Prove refusal is deterministic when no compatible provider exists.
@@ -409,16 +415,16 @@ That layering keeps the assurance story honest and maintainable.
           least one lemma for each invariant class.
 
 - [ ] 5.0. Phase 5: later expansion
-  - [ ] 5.0.1. Add Kani harnesses for graph-slice budgets after `7.2.5` lands.
-        Requires 7.2.5 and 2.0.4.
+  - [ ] 5.0.1. Add Kani harnesses for graph-slice budgets after prototype
+        archive `7.2.5` lands. Requires prototype archive 7.2.5 and 2.0.4.
     - [ ] Prove counters do not exceed accepted-card, edge, and token-budget
           caps on small graphs.
     - [ ] Acceptance criteria: smoke and full harnesses cover graph budgets
           separately from transaction suites, and the resulting checks run in
           `kani-full` rather than `kani`.
   - [ ] 5.0.2. Add Kani harnesses for `max_duplicates` and assignment
-        injectivity after `7.4.8` and `7.4.9` land. Requires 7.4.8, 7.4.9, and
-        2.0.4.
+        injectivity after prototype archive `7.4.8` and `7.4.9` land.
+        Requires prototype archive 7.4.8, prototype archive 7.4.9, and 2.0.4.
     - [ ] Prove injective assignments by default and many-to-one only under
           explicit split/merge modes.
     - [ ] Acceptance criteria: bounded matching harnesses exist for
@@ -453,8 +459,9 @@ current contracts can support.
   <https://github.com/leynos/weaver/blob/main/docs/weaver-design.md>
 [^2]: Weaver user's guide, two-phase verification:
   <https://github.com/leynos/weaver/blob/main/docs/users-guide.md>
-[^3]: Weaver roadmap, safety harness and atomic transaction tasks:
-  <https://github.com/leynos/weaver/blob/main/docs/roadmap.md>
+[^3]: Weaver prototype roadmap archive, safety harness and atomic transaction
+  tasks:
+  <https://github.com/leynos/weaver/blob/main/docs/archive/prototype-roadmap.md>
 [^4]: Weaver design document, testing conventions and behavioural tests:
   <https://github.com/leynos/weaver/blob/main/docs/weaver-design.md>
 [^5]: Weaver design document, `act apply-patch` and plugin orchestration:
@@ -477,11 +484,12 @@ current contracts can support.
   <https://verus-lang.github.io/verus/guide/>
 [^14]: Verus installation instructions:
   <https://github.com/verus-lang/verus/blob/main/INSTALL.md>
-[^15]: Weaver roadmap, `act apply-patch` requirements:
-  <https://github.com/leynos/weaver/blob/main/docs/roadmap.md>
-[^16]: Weaver roadmap and design document, plugin routing and refusal
-  diagnostics: <https://github.com/leynos/weaver/blob/main/docs/roadmap.md>
-[^17]: Weaver roadmap, graph-slice budget tasks:
-  <https://github.com/leynos/weaver/blob/main/docs/roadmap.md>
-[^18]: Weaver roadmap, matching guardrail tasks:
-  <https://github.com/leynos/weaver/blob/main/docs/roadmap.md>
+[^15]: Weaver prototype roadmap archive, `act apply-patch` requirements:
+  <https://github.com/leynos/weaver/blob/main/docs/archive/prototype-roadmap.md>
+[^16]: Weaver prototype roadmap archive and design document, plugin routing and
+  refusal diagnostics:
+  <https://github.com/leynos/weaver/blob/main/docs/archive/prototype-roadmap.md>
+[^17]: Weaver prototype roadmap archive, graph-slice budget tasks:
+  <https://github.com/leynos/weaver/blob/main/docs/archive/prototype-roadmap.md>
+[^18]: Weaver prototype roadmap archive, matching guardrail tasks:
+  <https://github.com/leynos/weaver/blob/main/docs/archive/prototype-roadmap.md>

--- a/docs/jacquard-card-first-symbol-graph-design.md
+++ b/docs/jacquard-card-first-symbol-graph-design.md
@@ -853,12 +853,12 @@ Response:
 }
 ```
 
-For roadmap item 7.2.1, the shipped runtime uses this stable response shape to
-return a deterministic same-file slice: the entry card plus any same-file
-symbol cards that fit within `budget.max_cards`, with `spillover` populated
-when additional local symbols are excluded. The stable edge schema is already
-locked, even though runtime edges are deferred to later milestones. Every edge
-will carry a `resolution_scope` set to one of `full_symbol_table`,
+For prototype archive roadmap item 7.2.1, the shipped runtime uses this stable
+response shape to return a deterministic same-file slice: the entry card plus
+any same-file symbol cards that fit within `budget.max_cards`, with `spillover`
+populated when additional local symbols are excluded. The stable edge schema is
+already locked, even though runtime edges are deferred to later milestones.
+Every edge will carry a `resolution_scope` set to one of `full_symbol_table`,
 `partial_symbol_table`, or `lsp`, but the runtime may legitimately emit an
 empty `edges` array until those milestones land.
 

--- a/docs/ortho-config-v0-6-0-migration-guide.md
+++ b/docs/ortho-config-v0-6-0-migration-guide.md
@@ -89,7 +89,7 @@ Once the imports are adjusted, prune redundant dependencies from each
 
 ## 3. Adopt declarative configuration discovery
 
-A new `#[ortho_config(discovery(...))]` attribute enables customised discovery
+A new `#[ortho_config(discovery(...))]` attribute enables customized discovery
 without bespoke builders for every CLI entry point.[^discovery-attr] This
 attribute mirrors the builder capabilities: specify the config file name,
 dotfile name, project-level override, the generated `--config` flag, and the

--- a/docs/ortho-config-v0-6-0-migration-guide.md
+++ b/docs/ortho-config-v0-6-0-migration-guide.md
@@ -270,5 +270,5 @@ and backs the format-specific branch of `parse_config_by_format`.
 [^hello-world-yaml]: Behavioural tests in `hello_world` create YAML fixtures,
 load them through `ortho_config::load_config_file`, and assert strict parsing
 behaviour.【F:examples/hello_world/src/cli/tests/overrides.rs†L125-L155】
-[^changelog]: The Unreleased changelog summarises the v0.6.0 additions and
+[^changelog]: The Unreleased changelog summarizes the v0.6.0 additions and
 behaviour changes discussed in this guide.【F:CHANGELOG.md†L6-L26】

--- a/docs/ortho-config-v0-8-0-migration-guide.md
+++ b/docs/ortho-config-v0-8-0-migration-guide.md
@@ -24,7 +24,7 @@ Before this migration, the workspace state was:
 - `crates/weaver-config/src/lib.rs` was the primary derive site, using
   `#[derive(OrthoConfig)]` with a declarative `#[ortho_config(discovery(...))]`
   attribute.
-- `crates/weaver-cli/src/localizer.rs` consumed the localisation APIs added in
+- `crates/weaver-cli/src/localizer.rs` consumed the localization APIs added in
   v0.7.0 (`FluentLocalizer`, `Localizer`, and `NoOpLocalizer`).
 - The repository still described the configuration stack as
   `ortho-config` v0.6.0 in several docs.

--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -538,7 +538,7 @@ re-parses the stored text into structured `Expr` values. Assignment literals
 are surfaced via `body_terms()` as `RuleBodyTerm::Assignment`, which stores a
 dedicated `Pattern` AST node rather than raw pattern text. Downstream analyses
 can therefore reason about rule bodies without rebuilding bespoke parsers or
-retokenising the source.
+retokenizing the source.
 
 ### 5.4.1 Atom adornments (`'` and `-<N>`)
 

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -99,23 +99,23 @@ implemented in this repository snapshot. The 0.1.0 command-surface reset means
 planned public commands should use the resource-first grammar from ADR 007 even
 when older designs mention `observe`, `act`, or `verify`.
 
-| Planned component                                                          | Intended location                                                          | Roadmap reference                                      |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
-| Weaver command-surface adapter for semantic code-editing metadata          | `crates/weaver-cli/`, `crates/weaverd/`, and Weaver-owned metadata modules | Roadmap 13.1; depends on OrthoConfig 5.2.3, 6.1, 7.2.7 |
-| Resource-first command handlers and examples                               | `crates/weaver-cli/`, `crates/weaverd/`, and `docs/`                       | Roadmap 13.2 through 15.3                              |
-| Human and machine renderer integration                                     | `crates/weaver-cli/` and shared output modules                             | Roadmap 13.3; depends on OrthoConfig 7.2 and 8.1       |
-| Structured context, capability, and skill surfaces                         | `crates/weaver-cli/`, `crates/weaverd/`, and future skill manifests        | Roadmap 13.4; depends on OrthoConfig 6.2 and 6.3       |
-| Sempai YAML, DSL, and Tree-sitter backend crates                           | `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/`       | Roadmap 17 and Sempai query language technical design  |
-| Sempai selector integration in resource commands                           | `crates/weaver-cli/`, `crates/weaverd/`, and Sempai crates                 | Roadmap 14.3, 15.2, and 17                             |
-| Rust `symbol.move` or `symbol.extract` actuator flow                       | `crates/weaver-plugin-rust-analyzer/` and `crates/weaverd/`                | Roadmap 15.1 and 18.1                                  |
-| Rust extricate plugin overlay and Rust Analyzer (RA) orchestration modules | `crates/weaver-plugin-rust-analyzer/src/lsp/` and related plugin modules   | Proposed in Rust extricate actuator technical design   |
-| Plugin capability metadata for symbol movement and extraction              | `crates/weaver-plugins/src/manifest/mod.rs`                                | Roadmap 18.1 and 18.2                                  |
-| `srgn` specialist plugin                                                   | `crates/weaver-plugin-srgn/` (expected new crate)                          | Roadmap 18.1                                           |
-| `jedi` specialist plugin                                                   | `crates/weaver-plugin-jedi/` (expected new crate)                          | Roadmap 18.2                                           |
-| Static analysis provider for `weaver-graph`                                | `crates/weaver-graph/` provider modules                                    | Roadmap 17.2 and prototype archive graph phases        |
-| Jobs, profiles, delivery, and feedback command support                     | `crates/weaver-cli/`, `crates/weaverd/`, and state/config modules          | Roadmap 16; depends on OrthoConfig 9.1 through 9.3     |
-| Onboarding and explicit interactive review flows                           | `crates/weaver-cli/` and `crates/weaverd/` command handlers                | Roadmap 20.1                                           |
-| Dynamic analysis ingestion provider                                        | `crates/weaver-graph/` provider modules                                    | Prototype archive advanced agent-support phases        |
+| Planned component                                                          | Intended location                                                          | Roadmap reference                                         |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Weaver command-surface adapter for semantic code-editing metadata          | `crates/weaver-cli/`, `crates/weaverd/`, and Weaver-owned metadata modules | Roadmap 13.1; depends on OrthoConfig 5.2.3, 6.1, 7.2.7    |
+| Resource-first command handlers and examples                               | `crates/weaver-cli/`, `crates/weaverd/`, and `docs/`                       | Roadmap 13.2 through 16.3                                 |
+| Human and machine renderer integration                                     | `crates/weaver-cli/` and shared output modules                             | Roadmap 13.2; depends on OrthoConfig 7.2 and 8.1          |
+| Structured context, capability, and skill surfaces                         | `crates/weaver-cli/`, `crates/weaverd/`, and future skill manifests        | Roadmap 13.3 and 18.2; depends on OrthoConfig 6.2 and 6.3 |
+| Sempai YAML, DSL, and Tree-sitter backend crates                           | `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/`       | Roadmap 15 and Sempai query language technical design     |
+| Sempai selector integration in resource commands                           | `crates/weaver-cli/`, `crates/weaverd/`, and Sempai crates                 | Roadmap 15.3 and 16.2                                     |
+| Rust `symbol.move` or `symbol.extract` actuator flow                       | `crates/weaver-plugin-rust-analyzer/` and `crates/weaverd/`                | Roadmap 16.3 and 20.2                                     |
+| Rust extricate plugin overlay and Rust Analyzer (RA) orchestration modules | `crates/weaver-plugin-rust-analyzer/src/lsp/` and related plugin modules   | Proposed in Rust extricate actuator technical design      |
+| Plugin capability metadata for symbol movement and extraction              | `crates/weaver-plugins/src/manifest/mod.rs`                                | Roadmap 18.1 and 18.2                                     |
+| `srgn` specialist plugin                                                   | `crates/weaver-plugin-srgn/` (expected new crate)                          | Roadmap 18.1                                              |
+| `jedi` specialist plugin                                                   | `crates/weaver-plugin-jedi/` (expected new crate)                          | Roadmap 18.1                                              |
+| Static analysis provider for `weaver-graph`                                | `crates/weaver-graph/` provider modules                                    | Roadmap 17.1 through 17.3                                 |
+| Jobs, profiles, delivery, and feedback command support                     | `crates/weaver-cli/`, `crates/weaverd/`, and state/config modules          | Roadmap 19.1; depends on OrthoConfig 9.1 through 9.3      |
+| Onboarding and explicit interactive review flows                           | `crates/weaver-cli/` and `crates/weaverd/` command handlers                | Roadmap 19.2                                              |
+| Dynamic analysis ingestion provider                                        | `crates/weaver-graph/` provider modules                                    | Roadmap 19.2 and 20.2                                     |
 
 _Table 3: Planned components and their expected repository placement._
 

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -113,6 +113,7 @@ when older designs mention `observe`, `act`, or `verify`.
 | `srgn` specialist plugin                                                   | `crates/weaver-plugin-srgn/` (expected new crate)                          | Roadmap 18.1                                              |
 | `jedi` specialist plugin                                                   | `crates/weaver-plugin-jedi/` (expected new crate)                          | Roadmap 18.1                                              |
 | Static analysis provider for `weaver-graph`                                | `crates/weaver-graph/` provider modules                                    | Roadmap 17.1 through 17.3                                 |
+| Graph history ledger cache                                                 | `crates/weaver-graph/` and state modules                                   | Roadmap 17.4                                              |
 | Jobs, profiles, delivery, and feedback command support                     | `crates/weaver-cli/`, `crates/weaverd/`, and state/config modules          | Roadmap 19.1; depends on OrthoConfig 9.1 through 9.3      |
 | Onboarding and explicit interactive review flows                           | `crates/weaver-cli/` and `crates/weaverd/` command handlers                | Roadmap 19.2                                              |
 | Dynamic analysis ingestion provider                                        | `crates/weaver-graph/` provider modules                                    | Roadmap 19.2 and 20.2                                     |

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -10,6 +10,9 @@ are defined in
 [sempai-query-language-design.md](sempai-query-language-design.md).
 Documentation conventions are defined in
 [documentation-style-guide.md](documentation-style-guide.md) and `AGENTS.md`.
+ADR 007 defines the pre-0.1.0 command-surface reset and the boundary between
+Weaver-owned semantic code-editing behaviour and reusable command-contract
+machinery that Weaver consumes from OrthoConfig.
 
 ## Layout goals
 
@@ -92,21 +95,27 @@ _Table 2: Implemented shared directories and their roles._
 ## Planned components
 
 Planned components are listed in `docs/roadmap.md` and are not yet fully
-implemented in this repository snapshot.
+implemented in this repository snapshot. The 0.1.0 command-surface reset means
+planned public commands should use the resource-first grammar from ADR 007 even
+when older designs mention `observe`, `act`, or `verify`.
 
-| Planned component                                                          | Intended location                                                        | Roadmap reference                                    |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------- |
-| Rust `extricate-symbol` actuator flow                                      | `crates/weaver-plugin-rust-analyzer/` and `crates/weaverd/`              | Proposed in Rust extricate actuator technical design |
-| Rust extricate plugin overlay and Rust Analyzer (RA) orchestration modules | `crates/weaver-plugin-rust-analyzer/src/lsp/` and related plugin modules | Proposed in Rust extricate actuator technical design |
-| Plugin capability metadata for extrication                                 | `crates/weaver-plugins/src/manifest/mod.rs`                              | Proposed in Rust extricate actuator technical design |
-| Sempai YAML, DSL, and Tree-sitter backend crates                           | `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/`     | Proposed in Sempai query language technical design   |
-| Sempai integration command surface (`observe`)                             | `crates/weaver-cli/` and `crates/weaverd/`                               | Proposed in Sempai query language technical design   |
-| `srgn` specialist plugin                                                   | `crates/weaver-plugin-srgn/` (expected new crate)                        | Phase 3, specialist actuator plugins                 |
-| `jedi` specialist plugin                                                   | `crates/weaver-plugin-jedi/` (expected new crate)                        | Phase 3, specialist sensor plugins                   |
-| Static analysis provider for `weaver-graph`                                | `crates/weaver-graph/` provider modules                                  | Phase 3, static analysis provider                    |
-| `onboard-project` command flow                                             | `crates/weaver-cli/` and `crates/weaverd/` command handlers              | Phase 4, advanced agent support                      |
-| Interactive review mode for lock failures                                  | `crates/weaver-cli/` plus daemon confirmation interfaces                 | Phase 4, human-in-the-loop mode                      |
-| Dynamic analysis ingestion provider                                        | `crates/weaver-graph/` provider modules                                  | Phase 4, dynamic analysis ingestion                  |
+| Planned component                                                          | Intended location                                                          | Roadmap reference                                     |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Weaver command-surface adapter for semantic code-editing metadata          | `crates/weaver-cli/`, `crates/weaverd/`, and Weaver-owned metadata modules | Roadmap 1.1; depends on OrthoConfig 5.2.3, 6.1, 7.2.7 |
+| Resource-first command handlers and examples                               | `crates/weaver-cli/`, `crates/weaverd/`, and `docs/`                       | Roadmap 1.2 through 3.4                               |
+| Human and machine renderer integration                                     | `crates/weaver-cli/` and shared output modules                             | Roadmap 1.3; depends on OrthoConfig 7.2 and 8.1       |
+| Structured context, capability, and skill surfaces                         | `crates/weaver-cli/`, `crates/weaverd/`, and future skill manifests        | Roadmap 1.4; depends on OrthoConfig 6.2 and 6.3       |
+| Sempai YAML, DSL, and Tree-sitter backend crates                           | `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/`       | Roadmap 5 and Sempai query language technical design  |
+| Sempai selector integration in resource commands                           | `crates/weaver-cli/`, `crates/weaverd/`, and Sempai crates                 | Roadmap 2.3, 3.1, and 5                               |
+| Rust `symbol.move` or `symbol.extract` actuator flow                       | `crates/weaver-plugin-rust-analyzer/` and `crates/weaverd/`                | Roadmap 3.1 and 6.2                                   |
+| Rust extricate plugin overlay and Rust Analyzer (RA) orchestration modules | `crates/weaver-plugin-rust-analyzer/src/lsp/` and related plugin modules   | Proposed in Rust extricate actuator technical design  |
+| Plugin capability metadata for symbol movement and extraction              | `crates/weaver-plugins/src/manifest/mod.rs`                                | Roadmap 6.1 and 6.2                                   |
+| `srgn` specialist plugin                                                   | `crates/weaver-plugin-srgn/` (expected new crate)                          | Roadmap 6.3                                           |
+| `jedi` specialist plugin                                                   | `crates/weaver-plugin-jedi/` (expected new crate)                          | Roadmap 6.3                                           |
+| Static analysis provider for `weaver-graph`                                | `crates/weaver-graph/` provider modules                                    | Roadmap 5.3 and historical graph phases               |
+| Jobs, profiles, delivery, and feedback command support                     | `crates/weaver-cli/`, `crates/weaverd/`, and state/config modules          | Roadmap 4; depends on OrthoConfig 9.1 through 9.3     |
+| Onboarding and explicit interactive review flows                           | `crates/weaver-cli/` and `crates/weaverd/` command handlers                | Roadmap 8.1                                           |
+| Dynamic analysis ingestion provider                                        | `crates/weaver-graph/` provider modules                                    | Historical advanced agent-support phases              |
 
 _Table 3: Planned components and their expected repository placement._
 

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -99,23 +99,23 @@ implemented in this repository snapshot. The 0.1.0 command-surface reset means
 planned public commands should use the resource-first grammar from ADR 007 even
 when older designs mention `observe`, `act`, or `verify`.
 
-| Planned component                                                          | Intended location                                                          | Roadmap reference                                     |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------- |
-| Weaver command-surface adapter for semantic code-editing metadata          | `crates/weaver-cli/`, `crates/weaverd/`, and Weaver-owned metadata modules | Roadmap 1.1; depends on OrthoConfig 5.2.3, 6.1, 7.2.7 |
-| Resource-first command handlers and examples                               | `crates/weaver-cli/`, `crates/weaverd/`, and `docs/`                       | Roadmap 1.2 through 3.4                               |
-| Human and machine renderer integration                                     | `crates/weaver-cli/` and shared output modules                             | Roadmap 1.3; depends on OrthoConfig 7.2 and 8.1       |
-| Structured context, capability, and skill surfaces                         | `crates/weaver-cli/`, `crates/weaverd/`, and future skill manifests        | Roadmap 1.4; depends on OrthoConfig 6.2 and 6.3       |
-| Sempai YAML, DSL, and Tree-sitter backend crates                           | `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/`       | Roadmap 5 and Sempai query language technical design  |
-| Sempai selector integration in resource commands                           | `crates/weaver-cli/`, `crates/weaverd/`, and Sempai crates                 | Roadmap 2.3, 3.1, and 5                               |
-| Rust `symbol.move` or `symbol.extract` actuator flow                       | `crates/weaver-plugin-rust-analyzer/` and `crates/weaverd/`                | Roadmap 3.1 and 6.2                                   |
-| Rust extricate plugin overlay and Rust Analyzer (RA) orchestration modules | `crates/weaver-plugin-rust-analyzer/src/lsp/` and related plugin modules   | Proposed in Rust extricate actuator technical design  |
-| Plugin capability metadata for symbol movement and extraction              | `crates/weaver-plugins/src/manifest/mod.rs`                                | Roadmap 6.1 and 6.2                                   |
-| `srgn` specialist plugin                                                   | `crates/weaver-plugin-srgn/` (expected new crate)                          | Roadmap 6.3                                           |
-| `jedi` specialist plugin                                                   | `crates/weaver-plugin-jedi/` (expected new crate)                          | Roadmap 6.3                                           |
-| Static analysis provider for `weaver-graph`                                | `crates/weaver-graph/` provider modules                                    | Roadmap 5.3 and historical graph phases               |
-| Jobs, profiles, delivery, and feedback command support                     | `crates/weaver-cli/`, `crates/weaverd/`, and state/config modules          | Roadmap 4; depends on OrthoConfig 9.1 through 9.3     |
-| Onboarding and explicit interactive review flows                           | `crates/weaver-cli/` and `crates/weaverd/` command handlers                | Roadmap 8.1                                           |
-| Dynamic analysis ingestion provider                                        | `crates/weaver-graph/` provider modules                                    | Historical advanced agent-support phases              |
+| Planned component                                                          | Intended location                                                          | Roadmap reference                                      |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Weaver command-surface adapter for semantic code-editing metadata          | `crates/weaver-cli/`, `crates/weaverd/`, and Weaver-owned metadata modules | Roadmap 13.1; depends on OrthoConfig 5.2.3, 6.1, 7.2.7 |
+| Resource-first command handlers and examples                               | `crates/weaver-cli/`, `crates/weaverd/`, and `docs/`                       | Roadmap 13.2 through 15.3                              |
+| Human and machine renderer integration                                     | `crates/weaver-cli/` and shared output modules                             | Roadmap 13.3; depends on OrthoConfig 7.2 and 8.1       |
+| Structured context, capability, and skill surfaces                         | `crates/weaver-cli/`, `crates/weaverd/`, and future skill manifests        | Roadmap 13.4; depends on OrthoConfig 6.2 and 6.3       |
+| Sempai YAML, DSL, and Tree-sitter backend crates                           | `crates/sempai-yaml/`, `crates/sempai-dsl/`, and `crates/sempai-ts/`       | Roadmap 17 and Sempai query language technical design  |
+| Sempai selector integration in resource commands                           | `crates/weaver-cli/`, `crates/weaverd/`, and Sempai crates                 | Roadmap 14.3, 15.2, and 17                             |
+| Rust `symbol.move` or `symbol.extract` actuator flow                       | `crates/weaver-plugin-rust-analyzer/` and `crates/weaverd/`                | Roadmap 15.1 and 18.1                                  |
+| Rust extricate plugin overlay and Rust Analyzer (RA) orchestration modules | `crates/weaver-plugin-rust-analyzer/src/lsp/` and related plugin modules   | Proposed in Rust extricate actuator technical design   |
+| Plugin capability metadata for symbol movement and extraction              | `crates/weaver-plugins/src/manifest/mod.rs`                                | Roadmap 18.1 and 18.2                                  |
+| `srgn` specialist plugin                                                   | `crates/weaver-plugin-srgn/` (expected new crate)                          | Roadmap 18.1                                           |
+| `jedi` specialist plugin                                                   | `crates/weaver-plugin-jedi/` (expected new crate)                          | Roadmap 18.2                                           |
+| Static analysis provider for `weaver-graph`                                | `crates/weaver-graph/` provider modules                                    | Roadmap 17.2 and prototype archive graph phases        |
+| Jobs, profiles, delivery, and feedback command support                     | `crates/weaver-cli/`, `crates/weaverd/`, and state/config modules          | Roadmap 16; depends on OrthoConfig 9.1 through 9.3     |
+| Onboarding and explicit interactive review flows                           | `crates/weaver-cli/` and `crates/weaverd/` command handlers                | Roadmap 20.1                                           |
+| Dynamic analysis ingestion provider                                        | `crates/weaver-graph/` provider modules                                    | Prototype archive advanced agent-support phases        |
 
 _Table 3: Planned components and their expected repository placement._
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,12 +8,13 @@ review-sized execution units with explicit dependencies and observable success
 criteria.
 
 The current forward plan is the source of truth for future work. The historical
-ledger at the end preserves completed foundation work and prior planned work so
-that it is not lost during the 0.1.0 command-surface reset. Historical entries
-that mention `observe`, `act`, or `verify` are retained as provenance, not as
-the future public grammar.
+ledger in [`docs/archive/prototype-roadmap.md`](archive/prototype-roadmap.md)
+preserves completed foundation work and prior planned work so that it is not
+lost during the 0.1.0 command-surface reset. Historical entries that mention
+`observe`, `act`, or `verify` are retained as provenance, not as the future
+public grammar.
 
-## 0. External reusable CLI-contract dependencies
+## 12. External reusable CLI-contract dependencies
 
 Idea: if Weaver consumes generic command-contract machinery from OrthoConfig
 instead of rebuilding it locally, Weaver can focus on semantic code
@@ -25,53 +26,53 @@ The dependency source is the OrthoConfig roadmap at
 command-contract implementation must either depend on the relevant OrthoConfig
 task or record a deliberate divergence in ADR 007.
 
-### 0.1. Track reusable dependency contracts
+### 12.1. Track reusable dependency contracts
 
 This step answers which command-contract pieces Weaver must consume from
 OrthoConfig and which ones Weaver may temporarily adapt while the shared
 contracts mature.
 
-- [ ] 0.1.1. Track the downstream consumer boundary.
+- [ ] 12.1.1. Track the downstream consumer boundary.
   - Depends on OrthoConfig 5.2.3.
   - Weaver dependency mode: blocked for final generic ownership decisions;
     local adapters may proceed when ADR 007 names the removal path.
   - Success: every Weaver command-contract task says whether it consumes
     OrthoConfig, wraps it, or intentionally diverges.
-- [ ] 0.1.2. Consume recursive command metadata.
+- [ ] 12.1.2. Consume recursive command metadata.
   - Depends on OrthoConfig 6.1.1 and 6.1.2.
   - Weaver dependency mode: local schema adapters may proceed, but generated
     help, manpage, completion, and context output must converge on the
     OrthoConfig recursive metadata shape.
-- [ ] 0.1.3. Consume compact agent-context output and naming.
+- [ ] 12.1.3. Consume compact agent-context output and naming.
   - Depends on OrthoConfig 6.2.1, 6.2.2, and 6.2.3.
   - Weaver dependency mode: `weaver context --json` is blocked on the naming
     convention for final acceptance; a local payload fixture may proceed for
     Weaver-specific capability fields.
-- [ ] 0.1.4. Consume skill manifest metadata and validation.
+- [ ] 12.1.4. Consume skill manifest metadata and validation.
   - Depends on OrthoConfig 6.3.1 and 6.3.2.
   - Weaver dependency mode: skill prose may be drafted locally, but validation
     must use OrthoConfig metadata when available.
-- [ ] 0.1.5. Consume canonical vocabulary policy.
+- [ ] 12.1.5. Consume canonical vocabulary policy.
   - Depends on OrthoConfig 7.1.1 through 7.1.3.
   - Weaver dependency mode: vocabulary linting is blocked for final CI gates;
     Weaver may maintain a temporary banned-name list for early migration.
-- [ ] 0.1.6. Consume behavioural metadata for agent-native commands.
+- [ ] 12.1.6. Consume behavioural metadata for agent-native commands.
   - Depends on OrthoConfig 7.2.1 through 7.2.7.
   - Weaver dependency mode: renderer, JSON, exit-code, bounded-list, mutation,
     non-interactive, capability, and provenance metadata should be configured
     or extended in Weaver, not reimplemented as another generic framework.
-- [ ] 0.1.7. Use `cargo-orthohelp` as the reference CLI for command contracts.
+- [ ] 12.1.7. Use `cargo-orthohelp` as the reference CLI for command contracts.
   - Depends on OrthoConfig 8.1.1 and 8.1.2.
   - Weaver dependency mode: this is a validation dependency; Weaver can build
     its own commands earlier, but must compare `--json` and enumerating-error
     behaviour against the reference CLI before 0.1.0.
-- [ ] 0.1.8. Consume compounding primitive contracts.
+- [ ] 12.1.8. Consume compounding primitive contracts.
   - Depends on OrthoConfig 9.1.1 through 9.3.3.
   - Weaver dependency mode: profile, delivery, feedback, and execution-ledger
     command semantics are Weaver-owned; reusable parsing, redaction, metadata,
     and ledger vocabulary come from OrthoConfig where available.
 
-## 1. Human-friendly, agent-native 0.1.0 command-surface reset
+## 13. Human-friendly, agent-native 0.1.0 command-surface reset
 
 Idea: if Weaver settles the generated command contract before more capabilities
 land, later Sempai, plugin, graph, and workflow slices can converge on one
@@ -81,19 +82,19 @@ This foundational phase retires the prototype public grammar for the 0.1.0
 target while preserving human usability, localization, accessibility, and the
 UNIX pipeline model.
 
-### 1.1. Ratify the reset boundary and adapter policy
+### 13.1. Ratify the reset boundary and adapter policy
 
 This step answers which contracts Weaver owns and which ones OrthoConfig owns.
 The outcome informs every command, renderer, and drift gate that follows. See
 `docs/adr-007-agent-native-command-surface.md` and `docs/weaver-design.md` §2.1.
 
-- [x] 1.1.1. Record the agent-native command-surface reset as ADR 007.
-  - Requires 0.1.
+- [x] 13.1.1. Record the agent-native command-surface reset as ADR 007.
+  - Requires 12.1.
   - Success: ADR 007 defines the dual renderer contract, capability routing,
     OrthoConfig dependencies, and the lack of compatibility promise for the
     prototype grammar.
-- [ ] 1.1.2. Implement the Weaver command-surface adapter design.
-  - Requires 1.1.1 and depends on OrthoConfig 5.2.3, 6.1, and 7.2.7.
+- [ ] 13.1.2. Implement the Weaver command-surface adapter design.
+  - Requires 13.1.1 and depends on OrthoConfig 5.2.3, 6.1, and 7.2.7.
   - Model resource path, verb, capability ID, mutability class, async class,
     selector forms, stream input support, provider policy, safety class,
     transaction behaviour, examples, output schemas, error schemas, and skill
@@ -101,89 +102,89 @@ The outcome informs every command, renderer, and drift gate that follows. See
   - Success: adding or renaming one Weaver command requires one adapter change
     and exposes enough metadata for router, help, docs, tests, and context
     fixtures.
-- [ ] 1.1.3. Define the temporary-adapter removal policy.
-  - Requires 1.1.2.
+- [ ] 13.1.3. Define the temporary-adapter removal policy.
+  - Requires 13.1.2.
   - Success: every local generic command-contract helper names the OrthoConfig
     task expected to replace it or records a permanent divergence in ADR 007.
 
-### 1.2. Enforce community vocabulary and resource-first commands
+### 13.2. Enforce community vocabulary and resource-first commands
 
 This step answers whether humans and agents can infer commands from common CLI
 knowledge rather than Weaver-only vocabulary. See ADR 007 and
 `docs/weaver-design.md` §§1.1 and 2.1.1.
 
-- [ ] 1.2.1. Map prototype domains to resource-first command paths.
-  - Requires 1.1.2.
+- [ ] 13.2.1. Map prototype domains to resource-first command paths.
+  - Requires 13.1.2.
   - Map definitions, references, diagnostics, cards, graph slices, symbols,
     patches, capabilities, context, jobs, profiles, and feedback.
   - Success: no current forward task requires adding a new public `observe`,
     `act`, or `verify` command.
-- [ ] 1.2.2. Configure vocabulary linting.
-  - Requires 1.2.1 and depends on OrthoConfig 7.1.1 through 7.1.3.
+- [ ] 13.2.2. Configure vocabulary linting.
+  - Requires 13.2.1 and depends on OrthoConfig 7.1.1 through 7.1.3.
   - Include canonical verbs such as `get`, `list`, `create`, `update`,
     `delete`, `apply`, `run`, `prune`, `save`, `show`, `rename`, `move`, and
     `send`.
   - Success: CI rejects off-policy verbs and flags unless ADR 007 explicitly
     grandfathers them as current-state compatibility.
-- [ ] 1.2.3. Migrate command examples in design and user-facing docs.
-  - Requires 1.2.1.
+- [ ] 13.2.3. Migrate command examples in design and user-facing docs.
+  - Requires 13.2.1.
   - Success: examples prefer `weaver definitions get`, `weaver references
     list`, `weaver diagnostics list`, `weaver symbols list`, `weaver symbols
     rename`, `weaver patches apply`, and `weaver context --json`.
 
-### 1.3. Deliver dual renderers and bounded machine contracts
+### 13.3. Deliver dual renderers and bounded machine contracts
 
 This step answers whether one command contract can serve accessible humans and
 reliable agents without forking command behaviour. See `docs/weaver-design.md`
 §§2.1.3 and 2.1.4.
 
-- [ ] 1.3.1. Implement the human renderer contract.
-  - Requires 1.1.2 and depends on OrthoConfig 7.2.2.
+- [ ] 13.3.1. Implement the human renderer contract.
+  - Requires 13.1.2 and depends on OrthoConfig 7.2.2.
   - Include localized default output, `--plain`, `--color`, `--no-pager`,
     `--width`, TTY-sensitive progress, table headings, narrow-width labelled
     blocks, and ASCII fallbacks.
   - Success: human output does not rely on colour alone and never emits pager
     or spinner control flow in non-terminal contexts.
-- [ ] 1.3.2. Implement universal `--json` and structured error output.
-  - Requires 1.3.1 and depends on OrthoConfig 7.2.3 through 7.2.5 and 8.1.
+- [ ] 13.3.2. Implement universal `--json` and structured error output.
+  - Requires 13.3.1 and depends on OrthoConfig 7.2.3 through 7.2.5 and 8.1.
   - Remove root `--output auto|human|json` and operation-local `--format` from
     the 0.1.0 target.
   - Success: success JSON is parseable on stdout, failure JSON is parseable on
     stderr, field names and error codes are non-localized, and exit classes are
     stable.
-- [ ] 1.3.3. Implement enumerating errors and bounded list responses.
-  - Requires 1.3.2 and depends on OrthoConfig 7.2.6 and 8.1.2.
+- [ ] 13.3.3. Implement enumerating errors and bounded list responses.
+  - Requires 13.3.2 and depends on OrthoConfig 7.2.6 and 8.1.2.
   - Success: enum, registry, capability, profile, provider, delivery, and job
     validation errors list valid values; list-style commands expose bounded
     defaults, `--limit`, cursors, truncation markers, and narrowing hints.
 
-### 1.4. Generate introspection, references, and drift gates
+### 13.4. Generate introspection, references, and drift gates
 
 This step answers whether the command contract can stay synchronized as the
 surface grows. See `docs/weaver-design.md` §2.1.4 and ADR 007.
 
-- [ ] 1.4.1. Implement `weaver context --json`.
-  - Requires 1.1.2 and depends on OrthoConfig 6.2.1 through 6.2.3.
+- [ ] 13.4.1. Implement `weaver context --json`.
+  - Requires 13.1.2 and depends on OrthoConfig 6.2.1 through 6.2.3.
   - Success: context output includes schema version, commands, flags, enum
     values, output schemas, error taxonomy, capabilities, provider summaries,
     profiles, jobs, delivery schemes, feedback state, and skill paths.
-- [ ] 1.4.2. Implement `weaver capabilities list --json`.
-  - Requires 1.4.1.
+- [ ] 13.4.2. Implement `weaver capabilities list --json`.
+  - Requires 13.4.1.
   - Success: runtime capability availability is separated from full command
     context and includes deterministic provider selection rationale.
-- [ ] 1.4.3. Implement `weaver skill-path` and initial skill manifests.
-  - Requires 1.4.1 and depends on OrthoConfig 6.3.
+- [ ] 13.4.3. Implement `weaver skill-path` and initial skill manifests.
+  - Requires 13.4.1 and depends on OrthoConfig 6.3.
   - Success: skills teach workflows rather than command catalogues, and
     validation fails when a skill mentions unknown commands or flags.
-- [ ] 1.4.4. Add generated artefact and drift gates.
-  - Requires steps 1.1-1.4.
+- [ ] 13.4.4. Add generated artefact and drift gates.
+  - Requires steps 13.1-13.4.
   - Generate or validate clap definitions, daemon router metadata, localized
     help, manpages, shell completions, docs snippets, JSON schema fixtures,
     vocabulary linting, and tests.
   - Success: CI fails when schema, router, help, docs, localization, context,
     skill manifests, or test fixtures drift.
 
-## 2. Resource command slice: definitions, references, diagnostics, and cards
+## 14. Resource command slice: definitions, references, diagnostics, and cards
 
 Idea: if existing LSP, Tree-sitter, and card foundations can be re-exposed
 through the new generated surface, Weaver proves the reset without waiting for
@@ -193,66 +194,66 @@ This slice migrates useful read-only commands first. It gives humans and agents
 immediate value while validating selectors, renderers, and capability
 introspection end to end.
 
-### 2.1. Re-expose LSP perceptors through resource commands
+### 14.1. Re-expose LSP perceptors through resource commands
 
 This step answers whether existing semantic backends fit the resource-first
 surface without provider-specific commands. See `docs/weaver-design.md` §§2.2,
 3.1, and 6.1.
 
-- [ ] 2.1.1. Implement `weaver definitions get`.
-  - Requires phase 1.
+- [ ] 14.1.1. Implement `weaver definitions get`.
+  - Requires phase 13.
   - Success: position references return localized human output by default and
     stable JSON under `--json`, with provider provenance in machine output.
-- [ ] 2.1.2. Implement `weaver references list`.
-  - Requires 2.1.1.
+- [ ] 14.1.2. Implement `weaver references list`.
+  - Requires 14.1.1.
   - Success: list output is bounded, cursor-aware, and suitable for downstream
     selector processing.
-- [ ] 2.1.3. Implement `weaver diagnostics list`.
-  - Requires 2.1.1.
+- [ ] 14.1.3. Implement `weaver diagnostics list`.
+  - Requires 14.1.1.
   - Success: diagnostics preserve source ranges, severity, provider
     provenance, and actionable error classes in both renderer modes.
 
-### 2.2. Re-expose card and graph-slice context
+### 14.2. Re-expose card and graph-slice context
 
 This step answers whether Jacquard-style cards and graph slices can become
 first-class resource commands while preserving existing completed work. See
 `docs/jacquard-card-first-symbol-graph-design.md` and `docs/weaver-design.md`
 §3.3.
 
-- [ ] 2.2.1. Implement `weaver cards get`.
-  - Requires 2.1.1 and historical work 7.1.1 through 7.1.4 in the ledger.
+- [ ] 14.2.1. Implement `weaver cards get`.
+  - Requires 14.1.1 and historical archive work 7.1.1 through 7.1.4.
   - Success: the command accepts position references and Sempai selectors where
     unambiguous, and returns stable card JSON with bounded enrichment.
-- [ ] 2.2.2. Implement `weaver graph-slices get`.
-  - Requires 2.2.1 and historical work 7.2.1.
+- [ ] 14.2.2. Implement `weaver graph-slices get`.
+  - Requires 14.2.1 and historical archive work 7.2.1.
   - Success: graph traversal exposes explicit budgets, truncation markers,
     provenance, and guidance for narrowing.
-- [ ] 2.2.3. Add combinatorial read-command E2E coverage.
-  - Requires steps 2.1-2.2.
+- [ ] 14.2.3. Add combinatorial read-command E2E coverage.
+  - Requires steps 14.1-14.2.
   - Success: the suite covers human output, `--json`, `--plain`, bounded
     output, invalid enum errors, missing capabilities, and provider
     unavailable cases across the resource read commands.
 
-### 2.3. Make Sempai one-liners first-class selectors
+### 14.3. Make Sempai one-liners first-class selectors
 
 This step answers whether the future Sempai DSL can select one symbol or a
 collection of symbols before full Sempai execution is complete. See
 `docs/sempai-query-language-design.md` and `docs/weaver-design.md` §2.1.2.
 
-- [ ] 2.3.1. Add selector record schemas for Sempai one-liners.
-  - Requires 1.4.4 and historical work 4.1.1 through 4.1.5.
+- [ ] 14.3.1. Add selector record schemas for Sempai one-liners.
+  - Requires 13.4.4 and historical archive work 4.1.1 through 4.1.5.
   - Success: selector records carry identity, range, language, query, capture,
     confidence, and provider provenance needed for safe downstream mutation.
-- [ ] 2.3.2. Implement `weaver symbols list --query`.
-  - Requires 2.3.1.
+- [ ] 14.3.2. Implement `weaver symbols list --query`.
+  - Requires 14.3.1.
   - Success: `weaver symbols list --query 'fn $name(...)' --json` emits a
     bounded selector stream that ordinary UNIX filters can process.
-- [ ] 2.3.3. Add selector stream compatibility checks.
-  - Requires 2.3.2.
+- [ ] 14.3.3. Add selector stream compatibility checks.
+  - Requires 14.3.2.
   - Success: commands consuming selector streams reject incompatible records
     with enumerating, structured errors rather than guessing.
 
-## 3. Capability-routed mutation slice: symbols and patches
+## 15. Capability-routed mutation slice: symbols and patches
 
 Idea: if symbol and patch mutations can run through one resource-first,
 capability-routed transaction path, Weaver proves that agent-native commands do
@@ -262,68 +263,68 @@ This slice migrates the implemented patch and rename foundations under the new
 grammar, then adds direct selector-based mutation and observe-to-act
 composition.
 
-### 3.1. Migrate patches and rename under the new grammar
+### 15.1. Migrate patches and rename under the new grammar
 
 This step answers whether existing safety-harness and actuator work can be
 reused without exposing provider-first commands. See `docs/weaver-design.md`
 §§4.1-4.3 and ADR 001.
 
-- [ ] 3.1.1. Implement `weaver patches apply`.
-  - Requires phase 1 and historical work 6.1.1 through 6.1.4.
+- [ ] 15.1.1. Implement `weaver patches apply`.
+  - Requires phase 13 and historical archive work 6.1.1 through 6.1.4.
   - Success: `patches apply` preserves Double-Lock verification, atomic
     transactions, `--dry-run`, structured safety results, and universal
     `--json`.
-- [ ] 3.1.2. Implement `weaver symbols rename` for position references.
-  - Requires 3.1.1 and historical work 5.2.1 through 5.2.5.
+- [ ] 15.1.2. Implement `weaver symbols rename` for position references.
+  - Requires 15.1.1 and historical archive work 5.2.1 through 5.2.5.
   - Success: provider routing remains capability-first, mutation results
     include transaction ID, affected paths, provider provenance, and safety
     outcome.
-- [ ] 3.1.3. Implement `weaver symbols move` or `weaver symbols extract`.
-  - Requires 3.1.2 and historical planned work 5.3 and 5.4.
+- [ ] 15.1.3. Implement `weaver symbols move` or `weaver symbols extract`.
+  - Requires 15.1.2 and historical archive work 5.3 and 5.4.
   - Success: the public verb is canonical, the internal capability captures
     the richer operation, and no provider-specific command is required.
 
-### 3.2. Prove selector-driven mutation and pipeline composition
+### 15.2. Prove selector-driven mutation and pipeline composition
 
 This step answers whether observe-style resource commands and act-style
 mutation commands compose through structured streams. See
 `docs/weaver-design.md` §2.1.2.
 
-- [ ] 3.2.1. Add direct Sempai selector support to symbol mutations.
-  - Requires 2.3.2 and 3.1.2.
+- [ ] 15.2.1. Add direct Sempai selector support to symbol mutations.
+  - Requires 14.3.2 and 15.1.2.
   - Success: `weaver symbols rename --query ...` handles zero, one, and many
     matches deterministically and requires explicit policy for ambiguous
     mutation.
-- [ ] 3.2.2. Add `--from-stdin` selector stream consumption.
-  - Requires 2.3.3 and 3.1.2.
+- [ ] 15.2.2. Add `--from-stdin` selector stream consumption.
+  - Requires 14.3.3 and 15.1.2.
   - Success: `weaver symbols list --query … --json | weaver symbols rename
     --from-stdin …` works without hidden state.
-- [ ] 3.2.3. Add filtered pipeline E2E coverage.
-  - Requires 3.2.2.
+- [ ] 15.2.3. Add filtered pipeline E2E coverage.
+  - Requires 15.2.2.
   - Success: at least one scenario pipes selector records through `jq` before
     mutation, and one scenario pipes observe-style output into a pager or other
     UNIX consumer without mutation.
 
-### 3.3. Harden mutation boundaries for retries and destructive operations
+### 15.3. Harden mutation boundaries for retries and destructive operations
 
 This step answers whether agents can retry safely and humans can preview
 consequential changes. See `docs/weaver-design.md` §§2.1.5 and 4.2.
 
-- [ ] 3.3.1. Add idempotency keys and mutation transaction IDs.
-  - Requires 3.1.1 and depends on OrthoConfig 7.2.1.
+- [ ] 15.3.1. Add idempotency keys and mutation transaction IDs.
+  - Requires 15.1.1 and depends on OrthoConfig 7.2.1.
   - Success: repeated equivalent mutation submissions return the existing
     transaction or refusal rather than duplicating work.
-- [ ] 3.3.2. Standardize `--dry-run` and `--force`.
-  - Requires 3.3.1 and depends on OrthoConfig 7.2.1.
+- [ ] 15.3.2. Standardize `--dry-run` and `--force`.
+  - Requires 15.3.1 and depends on OrthoConfig 7.2.1.
   - Success: all mutating commands declare preview and destructive-operation
     policy in the command-surface metadata.
-- [ ] 3.3.3. Add mutation combinatorial E2E coverage.
-  - Requires steps 3.1-3.3.
+- [ ] 15.3.3. Add mutation combinatorial E2E coverage.
+  - Requires steps 15.1-15.3.
   - Success: coverage combines selector forms, `--json`, `--dry-run`,
     idempotency, provider failures, syntactic failures, semantic failures, and
     rollback assertions.
 
-## 4. Async execution, profiles, delivery, and feedback
+## 16. Async execution, profiles, delivery, and feedback
 
 Idea: if Weaver gives agents durable identity, recoverable execution, and
 structured artefact routing, long-running workflows collapse into fewer
@@ -332,61 +333,61 @@ reliable turns without becoming hostile to humans.
 This phase adds compounding primitives after the core read and mutation loops
 are stable.
 
-### 4.1. Add durable jobs and `--wait`
+### 16.1. Add durable jobs and `--wait`
 
 This step answers whether async work can survive process loss and retry without
 duplicate submissions. See `docs/weaver-design.md` §2.1.5.
 
-- [ ] 4.1.1. Implement the Weaver job ledger.
-  - Requires 3.3.1 and depends on OrthoConfig 9.3.
+- [ ] 16.1.1. Implement the Weaver job ledger.
+  - Requires 15.3.1 and depends on OrthoConfig 9.3.
   - Success: XDG state stores job ID, command path, idempotency key, workspace,
     request hash, status, progress, timestamps, result pointer, and exit class.
-- [ ] 4.1.2. Implement `weaver jobs list|get|prune`.
-  - Requires 4.1.1.
+- [ ] 16.1.2. Implement `weaver jobs list|get|prune`.
+  - Requires 16.1.1.
   - Success: job lists are bounded, job lookup is structured, and prune is
     explicit and safe.
-- [ ] 4.1.3. Add `--wait` to async-submitting commands.
-  - Requires 4.1.2.
+- [ ] 16.1.3. Add `--wait` to async-submitting commands.
+  - Requires 16.1.2.
   - Success: submit-poll-collect workflows support backoff, jitter, timeout,
     cancellation, and ledger recovery.
 
-### 4.2. Add profiles and persistent identity
+### 16.2. Add profiles and persistent identity
 
 This step answers whether repeated agent and human workflows can share durable
 configuration without leaking secrets. See `docs/weaver-design.md` §2.1.5.
 
-- [ ] 4.2.1. Implement profile storage and redaction.
-  - Requires 1.4.1 and depends on OrthoConfig 9.1.
+- [ ] 16.2.1. Implement profile storage and redaction.
+  - Requires 13.4.1 and depends on OrthoConfig 9.1.
   - Success: profile names and metadata appear in `context --json`, while
     secret values remain redacted or represented as references.
-- [ ] 4.2.2. Implement `weaver profiles save|list|show|delete`.
-  - Requires 4.2.1.
+- [ ] 16.2.2. Implement `weaver profiles save|list|show|delete`.
+  - Requires 16.2.1.
   - Success: profile precedence is
     `built-in defaults < config files < selected profile < environment < flags`.
-- [ ] 4.2.3. Add root `--profile <name>`.
-  - Requires 4.2.2.
+- [ ] 16.2.3. Add root `--profile <name>`.
+  - Requires 16.2.2.
   - Success: explicit flags override profile values and invalid profile names
     enumerate available profiles.
 
-### 4.3. Add two-way I/O
+### 16.3. Add two-way I/O
 
 This step answers whether generated artefacts and friction reports can land
 where users and agents need them. See `docs/weaver-design.md` §2.1.6.
 
-- [ ] 4.3.1. Implement `--deliver stdout|file:<path>|webhook:<url>`.
-  - Requires 1.3.2 and depends on OrthoConfig 9.2.1.
+- [ ] 16.3.1. Implement `--deliver stdout|file:<path>|webhook:<url>`.
+  - Requires 13.3.2 and depends on OrthoConfig 9.2.1.
   - Success: file delivery is atomic, webhook delivery reports HTTP status,
     and unknown schemes enumerate valid schemes.
-- [ ] 4.3.2. Implement `weaver feedback create|list|send`.
-  - Requires 4.3.1 and depends on OrthoConfig 9.2.2.
+- [ ] 16.3.2. Implement `weaver feedback create|list|send`.
+  - Requires 16.3.1 and depends on OrthoConfig 9.2.2.
   - Success: local feedback writes JSONL by default, upstream send is optional
     and configured, and feedback availability appears in `context --json`.
-- [ ] 4.3.3. Add delivery and feedback E2E coverage.
-  - Requires 4.3.1 and 4.3.2.
+- [ ] 16.3.3. Add delivery and feedback E2E coverage.
+  - Requires 16.3.1 and 16.3.2.
   - Success: tests cover stdout, atomic file, webhook success, webhook failure,
     unknown delivery schemes, local feedback, and configured upstream send.
 
-## 5. Sempai and graph intelligence under the new grammar
+## 17. Sempai and graph intelligence under the new grammar
 
 Idea: if Sempai and graph expansion land after selectors and resource commands
 are stable, they strengthen the same user workflows instead of creating a
@@ -395,47 +396,47 @@ parallel query subsystem.
 This phase migrates the existing Sempai and Jacquard plans under `symbols`,
 `cards`, and `graph-slices`.
 
-### 5.1. Finish the Sempai execution engine
+### 17.1. Finish the Sempai execution engine
 
 This step answers whether the query language can execute with stable
 diagnostics and bounded behaviour. See `docs/sempai-query-language-design.md`.
 
-- [ ] 5.1.1. Implement the one-liner lexer, parser, and recovery path.
-  - Requires historical work 4.1.1 through 4.1.5.
+- [ ] 17.1.1. Implement the one-liner lexer, parser, and recovery path.
+  - Requires historical archive work 4.1.1 through 4.1.5.
   - Success: valid one-liners compile to canonical formula form, malformed
     input produces stable `E_SEMPAI_*` diagnostics, and recovery preserves
     partial anchors where safe.
-- [ ] 5.1.2. Implement the Tree-sitter backend.
-  - Requires 5.1.1 and historical planned work 4.2.
+- [ ] 17.1.2. Implement the Tree-sitter backend.
+  - Requires 17.1.1 and historical archive work 4.2.
   - Success: Rust, Python, and TypeScript profiles support Semgrep-compatible
     pattern matching, metavariable unification, ellipsis, constraints, focus,
     and bounded execution controls.
-- [ ] 5.1.3. Route Sempai execution through resource commands.
-  - Requires 2.3.2 and 5.1.2.
+- [ ] 17.1.3. Route Sempai execution through resource commands.
+  - Requires 14.3.2 and 17.1.2.
   - Success: query execution feeds `symbols list`, cards, and graph workflows
     without adding a future public `observe query` command.
 
-### 5.2. Complete graph-slice and history workflows
+### 17.2. Complete graph-slice and history workflows
 
 This step answers whether cards and graph slices can give agents compact,
 bounded context across code structure and history. See
 `docs/jacquard-card-first-symbol-graph-design.md`.
 
-- [ ] 5.2.1. Complete graph-slice extraction and traversal.
-  - Requires 2.2.2 and historical planned work 7.2.2 through 7.2.5.
+- [ ] 17.2.1. Complete graph-slice extraction and traversal.
+  - Requires 14.2.2 and historical archive work 7.2.2 through 7.2.5.
   - Success: Tree-sitter inventory, LSP call edges, import/config edges, and
     budgeted traversal produce bounded graph-slice JSON and useful human
     summaries.
-- [ ] 5.2.2. Implement graph history and risk deltas.
-  - Requires 5.2.1 and historical planned work 7.3.
+- [ ] 17.2.2. Implement graph history and risk deltas.
+  - Requires 17.2.1 and historical archive work 7.3.
   - Success: history mode reconstructs slices per commit, reports normalized
     deltas, and keeps defaults safe for large repositories.
-- [ ] 5.2.3. Implement probabilistic identity matching.
-  - Requires 5.2.2 and historical planned work 7.4.
+- [ ] 17.2.3. Implement probabilistic identity matching.
+  - Requires 17.2.2 and historical archive work 7.4.
   - Success: matching emits reason codes, duplicate-name guardrails, calibrated
     confidence, and assignment decisions suitable for agents to inspect.
 
-## 6. Plugin ecosystem behind capability contracts
+## 18. Plugin ecosystem behind capability contracts
 
 Idea: if Weaver keeps providers behind capability contracts, it can add
 specialist tools without forcing users or agents to learn backend-specific
@@ -444,45 +445,45 @@ commands.
 This phase expands perceptors and actuators after the resource and mutation
 contracts have proven the routing model.
 
-### 6.1. Normalize existing and planned actuator capabilities
+### 18.1. Normalize existing and planned actuator capabilities
 
 This step answers whether Rope, rust-analyzer, and later actuators can share
 one public contract. See ADR 001, ADR 004, and ADR 006.
 
-- [ ] 6.1.1. Publish capability migration notes for `symbol.rename`.
-  - Requires historical work 5.2.1 through 5.2.5.
+- [ ] 18.1.1. Publish capability migration notes for `symbol.rename`.
+  - Requires historical archive work 5.2.1 through 5.2.5.
   - Success: docs explain provider provenance, refusal semantics, and the
     resource-first replacement for provider-required refactor commands.
-- [ ] 6.1.2. Migrate extrication work to `symbol.move` or `symbol.extract`.
-  - Requires 3.1.3 and historical planned work 5.3 and 5.4.
+- [ ] 18.1.2. Migrate extrication work to `symbol.move` or `symbol.extract`.
+  - Requires 15.1.3 and historical archive work 5.3 and 5.4.
   - Success: public commands use canonical verbs while internal capabilities
     retain enough detail for Rope and rust-analyzer implementations.
-- [ ] 6.1.3. Add additional actuator providers behind manifests.
-  - Requires 6.1.2 and historical planned work 5.5.
+- [ ] 18.1.3. Add additional actuator providers behind manifests.
+  - Requires 18.1.2 and historical archive work 5.5.
   - Success: srgn or equivalent tools declare capability support without
     adding provider-specific public commands.
 
-### 6.2. Add specialist perceptors and capability discoverability
+### 18.2. Add specialist perceptors and capability discoverability
 
 This step answers whether read-only specialist providers improve results while
 remaining transparent to ordinary users. See `docs/weaver-design.md` §4.1.
 
-- [ ] 6.2.1. Deliver the first specialist perceptor provider.
-  - Requires 2.1.3 and historical planned work 5.6.
+- [ ] 18.2.1. Deliver the first specialist perceptor provider.
+  - Requires 14.1.3 and historical archive work 5.6.
   - Success: the provider enriches definitions, references, diagnostics,
     cards, or symbol matches through capability routing, not through a public
     provider command.
-- [ ] 6.2.2. Wire provider summaries into `capabilities list` and
+- [ ] 18.2.2. Wire provider summaries into `capabilities list` and
       `context --json`.
-  - Requires 1.4.2 and depends on OrthoConfig 7.2.7.
+  - Requires 13.4.2 and depends on OrthoConfig 7.2.7.
   - Success: agents can discover availability, selected provider, and refusal
     reasons without parsing backend-specific help.
-- [ ] 6.2.3. Refine graceful degradation guidance.
-  - Requires 6.2.2 and historical planned work 5.8.
+- [ ] 18.2.3. Refine graceful degradation guidance.
+  - Requires 18.2.2 and historical archive work 5.8.
   - Success: unsupported capability errors suggest resource-first fallback
     workflows and enumerate valid alternatives.
 
-## 7. Formal verification and safety hardening
+## 19. Formal verification and safety hardening
 
 Idea: if formal checks attach to the safety and routing kernels after their
 public contracts settle, Weaver can prove the invariants that matter without
@@ -491,1685 +492,84 @@ freezing prototype interfaces.
 This phase preserves the existing formal-verification plan while tying it to
 the new command contract and mutation slices.
 
-### 7.1. Establish verifier tooling and proof contracts
+### 19.1. Establish verifier tooling and proof contracts
 
 This step answers which invariants are proved and which external-tool
 behaviours remain trusted. See `docs/formal-verification-methods-in-weaver.md`.
 
-- [ ] 7.1.1. Add pinned Kani and Verus tooling.
-  - Requires phase 3.
-  - Migrates historical planned work 8.1.
+- [ ] 19.1.1. Add pinned Kani and Verus tooling.
+  - Requires phase 15.
+  - Migrates historical archive work 8.1.
   - Success: verifier installs are reproducible and normal Rust workflows are
     unaffected unless a formal target is invoked.
-- [ ] 7.1.2. Publish transaction, semantic-lock, and trust-boundary contracts.
-  - Requires 7.1.1.
-  - Migrates historical planned work 8.2.
+- [ ] 19.1.2. Publish transaction, semantic-lock, and trust-boundary contracts.
+  - Requires 19.1.1.
+  - Migrates historical archive work 8.2.
   - Success: docs distinguish verified orchestration from trusted providers,
     language servers, parsers, and filesystems.
 
-### 7.2. Verify the highest-risk owned kernels
+### 19.2. Verify the highest-risk owned kernels
 
 This step answers whether Weaver's own write and routing decisions satisfy the
 documented invariants. See `docs/weaver-design.md` §§4.2-4.3.
 
-- [ ] 7.2.1. Add Kani checks for transactions and patch matching.
-  - Requires 7.1.2 and migrates historical planned work 8.3.
+- [ ] 19.2.1. Add Kani checks for transactions and patch matching.
+  - Requires 19.1.2 and migrates historical archive work 8.3.
   - Success: smoke harnesses prove commit gating, rollback bookkeeping,
     bounded path guardrails, and whole-command abort on unmatched patch blocks.
-- [ ] 7.2.2. Add Kani and property checks for capability routing.
-  - Requires 6.2.2 and 7.1.2.
-  - Migrates historical planned work 8.4.
+- [ ] 19.2.2. Add Kani and property checks for capability routing.
+  - Requires 18.2.2 and 19.1.2.
+  - Migrates historical archive work 8.4.
   - Success: selected providers satisfy language and capability predicates,
     and refusal is deterministic over bounded routing tables.
-- [ ] 7.2.3. Add proof-only Verus kernels where they reduce long-term risk.
-  - Requires 7.2.1 and 7.2.2.
-  - Migrates historical planned work 8.5 and 8.6.
+- [ ] 19.2.3. Add proof-only Verus kernels where they reduce long-term risk.
+  - Requires 19.2.1 and 19.1.2.
+  - Migrates historical archive work 8.5 and 8.6.
   - Success: proof modules remain outside the production API and prove only
     stable abstractions that will survive the 0.1.0 command reset.
 
-## 8. Deferred extensions after the core 0.1.0 promise
+## 20. Deferred extensions after the core 0.1.0 promise
 
 Idea: if the core CLI contract is already trustworthy and boring to operate,
 the project can evaluate broader extensions on product value instead of letting
 them destabilize the main release.
 
-### 8.1. Re-evaluate onboarding and interactive workflows
+### 20.1. Re-evaluate onboarding and interactive workflows
 
 This step keeps useful agent workflow ideas without letting them bypass the
 non-interactive contract. See `docs/weaver-design.md` §6.2.
 
-- [ ] 8.1.1. Recast project onboarding under resource-first commands.
-  - Requires phases 2 and 5.
-  - Migrates historical planned work 6.2.1.
+- [ ] 20.1.1. Recast project onboarding under resource-first commands.
+  - Requires phases 14 and 17.
+  - Migrates historical archive work 6.2.1.
   - Success: onboarding consumes cards, graph slices, diagnostics, and
     dependency data without adding a parallel public command grammar.
-- [ ] 8.1.2. Design explicit interactive review workflows.
-  - Requires phase 3.
-  - Migrates historical planned work 6.2.2.
+- [ ] 20.1.2. Design explicit interactive review workflows.
+  - Requires phase 15.
+  - Migrates historical archive work 6.2.2.
   - Success: interaction is opt-in via `--interactive` or a dedicated review
     command and fails fast when stdin is not a terminal.
 
-### 8.2. Evaluate MCP, SDK, and runtime explorer generation
+### 20.2. Evaluate MCP, SDK, and runtime explorer generation
 
 This step defers generated integrations until the CLI contract they would wrap
 is stable. See ADR 007 and OrthoConfig 10.1.
 
-- [ ] 8.2.1. Decide whether to generate MCP descriptions from
+- [ ] 20.2.1. Decide whether to generate MCP descriptions from
       `context --json`.
-  - Requires phase 1 and depends on OrthoConfig 10.1.1.
+  - Requires phase 13 and depends on OrthoConfig 10.1.1.
   - Success: the decision compares generated MCP descriptions against the
     command-surface token budget and records whether the feature belongs in
     Weaver 0.1.x.
-- [ ] 8.2.2. Decide whether SDK or OpenAPI-shaped runtime explorers are in
+- [ ] 20.2.2. Decide whether SDK or OpenAPI-shaped runtime explorers are in
       scope.
-  - Requires 8.2.1 and depends on OrthoConfig 10.1.2.
+  - Requires 20.2.1 and depends on OrthoConfig 10.1.2.
   - Success: any accepted explorer uses the same command metadata and does not
     become a second source of truth.
 
-## 99. Historical roadmap ledger
-
-The entries below are preserved from the pre-ADR-007 roadmap so completed
-foundation work and still-relevant planned work remain visible. They are not
-the current forward build order. Unchecked entries are migrated into the
-current roadmap above when still relevant; entries using the prototype
-`observe`, `act`, or `verify` grammar must be implemented under the
-resource-first command contract instead.
-
-### 1. Foundation & tooling (complete)
-
-#### 1.1. Establish foundation and documentation baseline
-
-- [x] 1.1.1. Set up the project workspace, Continuous Integration and
-      Continuous Deployment (CI/CD) pipeline, and core
-      dependencies.
-- [x] 1.1.2. Normalize parser and Semgrep documentation style and navigation,
-      including
-      `docs/contents.md` and `docs/repository-layout.md`, as delivered in
-      `docs/execplans/sempai-design.md`.
-
-### 2. Core MVP & safety harness foundation
-
-*Goal: Establish the core client/daemon architecture, basic LSP integration,
-and the foundational security and verification mechanisms. The MVP must be safe
-for write operations from day one.*
-
-#### 2.1. Deliver CLI and daemon foundation
-
-*Outcome: Ship a pair of crates (`weaver-cli`, `weaverd`) that honour the
-design contract in `docs/weaver-design.md` and expose the lifecycle expected by
-`docs/documentation-style-guide.md`.*
-
-- [x] 2.1.1. Define the shared configuration schema for `weaver-cli` and
-      `weaverd`
-      in `weaver-config`, using `ortho-config` to merge config files,
-      environment overrides, and CLI flags for daemon sockets, logging, and the
-      capability matrix defaults.
-      - Acceptance criteria: Schema documented in crate docs, integration tests
-        demonstrate precedence order (file < env < CLI), and default sockets
-        align with the design doc.
-- [x] 2.1.2. Implement the `weaver-cli` executable as the thin JSON Lines
-      (JSONL)
-      client that
-      initializes configuration via `ortho-config`, exposes the
-      `--capabilities` probe, and streams requests to a running daemon over
-      standard IO.
-      - Acceptance criteria: CLI command surface mirrors the design table,
-        capability probe outputs the negotiated matrix, and JSONL framing is
-        validated with golden tests.
-- [x] 2.1.3. Implement the `weaverd` daemon bootstrap that consumes the shared
-      configuration, starts the Semantic Fusion backends lazily, and supervises
-      them with structured logging and error reporting.
-      - Acceptance criteria: Bootstrap performs health reporting hooks,
-        backends start only on demand, and failures propagate as structured
-        events.
-- [x] 2.1.4. Implement robust daemonization and process management for
-      `weaverd`,
-      including backgrounding with `daemonize-me`, PID/lock file handling,
-      health checks, and graceful shutdown on signals.
-      - Acceptance criteria: Background start creates PID and lock files,
-        duplicate starts fail fast, and signal handling shuts down within the
-        timeout budget.
-- [x] 2.1.5. Provide lifecycle commands in `weaver-cli` (for example,
-      `daemon start`,
-      `daemon stop`, `daemon status`) that manage the daemon process, verify
-      socket availability, and surface actionable errors when start-up fails.
-      - Acceptance criteria: Lifecycle commands call into shared helper logic,
-        refuse to start when sockets are bound, and emit recovery guidance for
-        the operator.
-
-- [x] 2.1.6. Implement the socket listener in `weaverd` to accept client
-      connections
-      on the configured Unix domain socket (or TCP socket on non-Unix
-      platforms).
-      - Acceptance criteria: Daemon binds to the socket path from configuration,
-        accepts concurrent connections, and gracefully handles connection errors
-        without crashing the daemon.
-
-- [x] 2.1.7. Implement the JSONL request dispatch loop in `weaverd` that reads
-      `CommandRequest` messages from connected clients, routes them to the
-      appropriate domain handler, and streams `CommandResponse` messages back.
-      - Acceptance criteria: Request parsing rejects malformed JSONL with
-        structured errors, domain routing covers `observe` and `act` commands,
-        and responses include the terminal `exit` message with appropriate
-        status codes.
-
-- [x] 2.1.8. Wire end-to-end domain command execution from CLI through daemon to
-      backend, starting with `observe get-definition` as the first complete
-      path.
-      - Acceptance criteria: `weaver observe get-definition` with a running
-        daemon returns LSP definition results, errors propagate with structured
-        messages, and the CLI exits with the daemon-provided status code.
-
-- [x] 2.1.9. Deliver the `weaver-lsp-host` crate with language-server
-    initialization, capability detection, and core Language Server Protocol
-    (LSP) operations for Rust, Python, and TypeScript.
-  - Acceptance criteria: `weaver-lsp-host` initializes and advertises
-    capabilities for all three languages; definition, references, and
-    diagnostics requests return structured success responses on valid inputs;
-    unsupported or pre-initialization requests return deterministic errors; and
-    integration tests cover one success case and one failure case per feature.
-
-- [x] 2.1.10. Implement process-based language server adapters for
-      `weaver-lsp-host`.
-    The `LspHost` currently requires external callers to register
-    `LanguageServer` implementations via `register_language()`. This step adds
-    concrete adapters that spawn real language server processes (e.g.,
-    `rust-analyzer`, `pyrefly`, `tsgo`).
-  - Acceptance criteria: `SemanticBackendProvider::start_backend()` registers
-    adapters for configured languages, adapters spawn server processes and
-    communicate via stdio, server shutdown is handled gracefully on daemon
-    stop, and missing server binaries produce clear diagnostic errors.
-
-- [x] 2.1.11. Add human-readable output rendering for commands that return code
-    locations or diagnostics, using `miette` or a compatible renderer to
-    show context blocks.
-  - Acceptance criteria: Definition, reference, diagnostics, and safety
-    harness failure outputs include file headers, line-numbered source
-    context, and caret spans in human-readable mode; JSONL output remains
-    unchanged; missing source content falls back to path-and-range with a
-    clear explanation.
-
-- [x] 2.1.12. Deliver the initial `weaver-sandbox` crate with enforced process
-    isolation for external tool execution.
-  - Acceptance criteria: Linux sandboxing enforces namespaces and seccomp-bpf
-    policies via `birdcage`; platform support matrix is documented for Linux
-    and non-Linux behaviour; forbidden syscalls and filesystem escapes are
-    rejected in tests; and sandbox validation tests run under `make test`.
-
-- [x] 2.1.13. Implement the full "Double-Lock" safety harness logic in
-      `weaverd`.
-    This is a critical, non-negotiable feature for the MVP. All `act` commands
-    must pass through this verification layer before committing to the
-    filesystem.
-  - Acceptance criteria: Edit transactions pass through syntactic and semantic
-    lock validation before commit, failures leave the filesystem untouched,
-    and behaviour-driven development (BDD) scenarios cover success, syntactic
-    failure, semantic failure, and backend unavailable error paths.
-
-- [x] 2.1.14. Implement atomic edits to ensure that multi-file changes either
-      succeed
-    or fail as a single transaction.
-  - Acceptance criteria: Two-phase commit with prepare (temp files) and commit
-    (atomic renames) phases, rollback restores original content on partial
-    failure, and new file creation properly tracks file existence for
-    rollback.
-
-#### 2.2. Deliver baseline command-line interface (CLI) discoverability
-
-*Outcome: Ship baseline guidance in the MVP so first-use command discovery
-does* *not require source inspection or external runbooks.*
-
-- [x] 2.2.1. Show short help when `weaver` is invoked without arguments.
-      See
-      [Level 0](ui-gap-analysis.md#level-0--bare-invocation-weaver)
-      and
-      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
-      (10d).
-  - [x] Replace bare missing-domain output with short help and a clear next
-        step.
-  - [x] Acceptance criteria: `weaver` with no arguments exits non-zero, prints
-        a `Usage:` line, lists the three valid domains (`observe`, `act`,
-        `verify`), and includes exactly one pointer to `weaver --help`.
-- [x] 2.2.2. List all domains and operations in top-level help output.
-      See
-      [Gap 1a](ui-gap-analysis.md#gap-1a--domains-not-enumerated)
-      and
-      [Gap 1b](ui-gap-analysis.md#gap-1b--operations-not-enumerated).
-  - [x] Add an `after_help` catalogue covering `observe`, `act`, and `verify`
-        operations.
-  - [x] Acceptance criteria: `weaver --help` lists all three domains and every
-        CLI-supported operation for each domain, and completes without daemon
-        startup or socket access.
-- [x] 2.2.3. Add top-level version output and long-form CLI description.
-      See
-      [Gap 1d](ui-gap-analysis.md#gap-1d--no---version-flag)
-      and
-      [Gap 1e](ui-gap-analysis.md#gap-1e--no-long-description-or-after-help-text).
-  - [x] Enable clap-provided `--version` and `-V` support.
-  - [x] Add a `long_about` quick-start block aligned with the
-        [user's guide](users-guide.md).
-  - [x] Acceptance criteria: `weaver --version` and `weaver -V` both exit 0
-        and emit the same version string, and `weaver --help` includes at
-        least one runnable quick-start command example, and `make check-fmt`,
-        `make markdownlint`, `make fmt`, `make lint`, and `make test` pass.
-- [x] 2.2.4. Provide contextual guidance when a domain is supplied without an
-      operation. See
-      [Level 2](ui-gap-analysis.md#level-2--domain-without-operation-weaver-observe)
-      and
-      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
-      (10e).
-  - [x] Print available operations for the provided domain and a follow-up help
-        command.
-  - [x] Acceptance criteria: `weaver <domain>` without an operation exits
-        non-zero, lists all operations registered for that domain, and includes
-        one concrete `weaver <domain> <operation> --help` hint.
-
-#### 2.3. Enrich validation and actionable error responses
-
-*Outcome: Ensure MVP error paths fail fast with deterministic, actionable*
-*operator guidance before daemon startup and during command routing.*
-
-- [x] 2.3.1. Validate domains client-side before daemon startup.
-      See
-      [Level 3](ui-gap-analysis.md#level-3--unknown-domain-weaver-bogus-something)
-      and
-      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
-      (10b).
-  - [x] Reject unknown domains with a valid-domain list.
-  - [x] Add edit-distance suggestions for close typos.
-  - [x] Acceptance criteria: invalid domains fail before daemon spawn, return
-        all three valid domains in the error body, and include a single
-        "did you mean" suggestion only when exactly one valid domain is within
-        edit distance 2.
-- [x] 2.3.2. Include valid operation alternatives for unknown operations.
-      See
-      [Level 4](ui-gap-analysis.md#level-4--unknown-operation-weaver-observe-nonexistent)
-      and
-      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
-      (10c).
-  - [x] Extend daemon and CLI error payloads to include known operations for
-        the domain.
-  - [x] Acceptance criteria: unknown-operation errors in both JSON and
-        human-readable output include the full known-operation set for the
-        domain, with a count equal to the router's `known_operations` length.
-- [x] 2.3.3. Standardize actionable guidance in startup and routing errors.
-      See
-      [Level 10](ui-gap-analysis.md#level-10--error-messages-and-exit-codes)
-      (10a-10e).
-  - [x] Apply a single error template: problem statement, valid alternatives,
-        and explicit next command.
-  - [x] Add startup failure guidance for `WEAVERD_BIN` and installation checks.
-  - [x] Acceptance criteria: each Level 10 path (10a through 10e) renders the
-        same three-part template (error, alternatives, next command), and
-        preserves stable non-zero exit-code semantics.
-- [x] 2.3.4. Return complete argument requirements for `act refactor`.
-      See
-      [Gap 5b](ui-gap-analysis.md#gap-5b--act-refactor-without-arguments).
-  - [x] List all required flags, valid provider names, and known refactoring
-        operations.
-  - [x] Acceptance criteria: `weaver act refactor` without arguments reports
-        all three required flags (`--provider`, `--refactoring`, `--file`) in
-        one response, plus at least one valid provider and refactoring value.
-
-### 3. Syntactic & relational intelligence
-
-*Goal: Add the Tree-sitter and call graph layers to provide deeper structural*
-*and relational understanding of code, and pair this with operation-level and*
-*localized help for dependable day-to-day operation.*
-
-#### 3.1. Deliver syntax and graph foundations
-
-- [x] 3.1.1. Create the `weaver-syntax` crate and implement the structural
-      search
-    engine for `observe grep` and `act apply-rewrite`, drawing inspiration from
-    ast-grep's pattern language.
-  - Acceptance criteria: `observe grep` and `act apply-rewrite` both execute
-    through `weaver-syntax`; structural queries return deterministic spans and
-    rewrites for Rust, Python, and TypeScript fixtures; invalid query syntax
-    returns structured parse diagnostics; and snapshot tests cover success and
-    failure paths.
-
-- [x] 3.1.2. Integrate the "Syntactic Lock" from `weaver-syntax` into the
-    "Double-Lock" harness.
-  - Acceptance criteria: all `act` write paths invoke syntactic verification
-    before commit; lock failures prevent on-disk writes; diagnostics include
-    file path and source location; and behaviour tests cover pass/fail paths.
-
-- [x] 3.1.3. Extend the `LanguageServer` trait with document sync methods
-    (`did_open`, `did_change`, `did_close`) to enable semantic validation
-    of modified content at real file paths without writing to disk.
-  - Acceptance criteria: trait implementations expose `did_open`,
-    `did_change`, and `did_close`; semantic validation paths use in-memory
-    document sync instead of disk writes; and integration tests verify
-    diagnostics for open-change-close sequences.
-
-- [x] 3.1.4. Create the `weaver-graph` crate and implement the LSP Provider for
-      call
-    graph generation, using the `textDocument/callHierarchy` request as the
-    initial data source.
-  - Acceptance criteria: call hierarchy provider returns incoming and outgoing
-    edges via `textDocument/callHierarchy`; responses include stable node IDs,
-    spans, and relationship direction; provider errors are surfaced as
-    structured diagnostics; and end-to-end tests validate graph output.
-
-#### 3.2. Expose configuration and operation-level help surfaces
-
-*Outcome: Make configuration and operation help directly discoverable from the*
-*CLI without requiring external documentation lookup.*
-
-- [x] 3.2.1. Surface configuration flags in clap help output.
-      Shipped: `locale` is now part of the shared configuration contract and is
-      visible as `--locale`, `WEAVER_LOCALE`, and the `locale` config-file key.
-      See
-      [Gap 1c](ui-gap-analysis.md#gap-1c--configuration-flags-invisible)
-      and
-      [Level 6](ui-gap-analysis.md#level-6--configuration-flags-invisible-in-help).
-      See
-      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces)
-      and
-      [weaver design §2.3.1](weaver-design.md#231-configuration-contract).
-  - [x] Register `--config-path`, `--daemon-socket`, `--log-filter`,
-        `--log-format`, `--capability-overrides`, and `--locale` as visible
-        global flags.
-  - [x] Acceptance criteria: all six flags appear in both `weaver --help` and
-        `weaver daemon start --help`, and existing precedence tests
-        (file < env < CLI) continue to pass.
-- [ ] 3.2.2. Extend `daemon start` help with config and environment guidance.
-      See
-      [Level 8](ui-gap-analysis.md#level-8--daemon-subcommand-help).
-  - [ ] Document `WEAVERD_BIN` and `WEAVER_FOREGROUND` in `long_about` or
-        `after_help`.
-  - [ ] Acceptance criteria: `weaver daemon start --help` documents both
-        environment variables and includes at least one startup example using
-        an override.
-- [ ] 3.2.3. Re-enable and extend the `help` subcommand.
-      See
-      [Gap 1f](ui-gap-analysis.md#gap-1f--help-subcommand-disabled)
-      and
-      [Level 12](ui-gap-analysis.md#level-12--weaver-help-subcommand).
-  - [ ] Remove `disable_help_subcommand = true`.
-  - [ ] Support topic help for domains and operations (`weaver help <topic>`).
-  - [ ] Acceptance criteria: `weaver help`, `weaver help observe`, and
-        `weaver help act refactor` all exit 0 and return topic-specific help
-        with no fallback to generic top-level output.
-- [ ] 3.2.4. Deliver operation-level help for required arguments.
-      Requires 3.2.3. See
-      [Gap 5a](ui-gap-analysis.md#gap-5a--observe-get-definition-without-arguments).
-  - [ ] Implement nested clap subcommands, or an equivalent schema-backed help
-        pipeline, so `weaver <domain> <operation> --help` is operation-specific.
-  - [ ] Acceptance criteria: every exposed operation supports
-        `weaver <domain> <operation> --help` and each help screen includes
-        required flags, argument types, and at least one concrete invocation.
-- [x] 3.2.5. Document ortho-config v0.8.0 behaviour in 3.2 guidance. See
-      [ortho-config v0.8.0 migration guide](ortho-config-v0-8-0-migration-guide.md).
-  - [x] Document the new dependency-graph model used by configuration loading
-        and precedence resolution.
-  - [x] Document fail-fast discovery behaviour when configuration files exist
-        but are invalid.
-  - [x] Document YAML 1.2 parsing semantics via `SaphyrYaml`, including known
-        compatibility warnings.
-  - [x] Update internal runbooks and user-facing documentation to reflect
-        `ortho-config` v0.8.0 operational behaviour.
-  - [x] Validate documentation quality gates and docs tests after updates.
-  - [x] Acceptance criteria: migration guide, runbooks, and user docs are
-        updated with explicit sections for dependency graph, fail-fast
-        discovery, and YAML 1.2 semantics; and `make markdownlint`,
-        `make fmt`, `make nixie`, and documentation tests pass.
-- [ ] 3.2.6. Adopt `cargo orthohelp` for CI man page generation and retire the
-      existing `clap_mangen` infrastructure.
-      See
-      [ortho-config user's guide: Generating IR with cargo-orthohelp](ortho-config-users-guide.md#generating-ir-with-cargo-orthohelp)
-      and
-      [ortho-config user's guide: Generating man pages](ortho-config-users-guide.md#generating-man-pages).
-      See
-      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
-  - [ ] Add `[package.metadata.ortho_config]` wiring for the Weaver CLI root
-        type and supported locales so `cargo orthohelp` can resolve schema and
-        Fluent metadata without a bespoke bridge.
-  - [ ] Replace the existing `clap_mangen`-based build/CI manpage generation
-        path with `cargo orthohelp --format man --locale en-US`, preserving the
-        current `en-US` packaging contract while leaving multi-locale emission
-        to roadmap item `5.7.3`.
-  - [ ] Validate that CI artefacts still land in the expected output paths and
-        that no manual post-processing is required after the switch.
-  - [ ] Acceptance criteria: CI generates the shipped `en-US` manpage via
-        `cargo orthohelp`, the `clap_mangen` infrastructure is removed, and the
-        resulting roff output still includes the full shared configuration
-        contract introduced in `3.2.1`.
-
-#### 3.3. Deliver localized CLI and reference outputs
-
-*Outcome: Let operators choose a locale once and receive consistent Fluent-*
-*backed help, error text, and generated reference artefacts across Weaver.*
-
-- [ ] 3.3.1. Apply resolved locale during CLI bootstrap.
-      See
-      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces)
-      and
-      [weaver design §2.3.1](weaver-design.md#231-configuration-contract).
-  - [ ] Add a pre-config bootstrap pass that honours `--locale` and
-        `WEAVER_LOCALE` before consulting `LC_ALL`, `LC_MESSAGES`, and `LANG`,
-        then rebuild the localizer if the resolved config locale differs.
-  - [ ] Acceptance criteria: `weaver --help` and other pre-config clap display
-        paths honour `--locale` and `WEAVER_LOCALE` immediately; malformed
-        `--locale` and `WEAVER_LOCALE` values fail fast; malformed ambient
-        `LC_*` or `LANG` values warn and fall back; file-backed locale settings
-        continue to apply after full config loading; and `en-US` remains the
-        guaranteed fallback.
-- [ ] 3.3.2. Localize clap help and parse errors through `ortho_config`.
-      Requires 3.3.1. See
-      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
-  - [ ] Drive clap help with `Cli::command().localize(&localizer)` and route
-        parse failures through `localize_clap_error_with_command`.
-  - [ ] Move bare-invocation help, lifecycle guidance, and other manual
-        operator text to Fluent message IDs with argument-aware rendering.
-  - [ ] Acceptance criteria: bare invocation, `weaver --help`, and common clap
-        validation failures render translated copy for supported locales
-        without changing existing exit-code semantics.
-- [ ] 3.3.3. Centralize the localized command and operation catalogue.
-      Requires 2.2.4 and 3.3.2. See
-      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
-  - [ ] Replace duplicated domain and operation tables with one structured
-        catalogue shared by the router, contextual-help renderer, and test
-        fixtures.
-  - [ ] Store message IDs, examples, and operation descriptions in that
-        catalogue instead of hard-coded padded English strings.
-  - [ ] Acceptance criteria: top-level help, domain-without-operation
-        guidance, and `weaver help <topic>` all read from the same catalogue,
-        and adding a new operation requires one metadata change rather than
-        parallel edits in help, tests, and routing.
-- [ ] 3.3.4. Generate localized reference artefacts from ortho-config
-      metadata. Requires 3.2.4 and 3.3.2. See
-      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
-  - [ ] Add stable documentation IDs to config-backed fields and expose
-        `OrthoConfigDocs` metadata for the generated help schema.
-  - [ ] Add `[package.metadata.ortho_config]` wiring and `cargo orthohelp`
-        generation for at least `en-US` and one secondary locale.
-  - [ ] Acceptance criteria: localized intermediate representation (IR) files
-        are generated per locale, `en-US` manpage packaging remains intact,
-        and artefact validation proves the generated help text matches the
-        runtime Fluent catalogue.
-
-### 4. Query language infrastructure (Sempai)
-
-*Goal: Deliver the Semgrep-compatible query language stack as a standalone
-phase* *with explicit parser, backend, and Weaver-integration milestones.*
-
-#### 4.1. Deliver Sempai core infrastructure
-
-*Outcome: Implement the Sempai front-end and normalization architecture from*
-*`docs/sempai-query-language-design.md`, including YAML parsing, one-liner*
-*domain-specific language (DSL) parsing, semantic validation, and stable*
-*diagnostic contracts.*
-
-- [x] 4.1.1. Scaffold `sempai_core` and `sempai` with stable public types and
-      facade entrypoints.
-  - Acceptance criteria: public API documentation builds for `sempai`, and
-    stable types cover language, span, match, capture, and diagnostics models.
-- [x] 4.1.2. Define structured diagnostics with stable `E_SEMPAI_*` error
-      codes and report schema.
-  - Acceptance criteria: diagnostics include code, message, primary span, and
-    notes, and JSON snapshots remain stable across parser and validator paths.
-- [x] 4.1.3. Implement YAML rule parsing via `saphyr` and `serde-saphyr` with
-      schema-aligned rule models.
-  - Acceptance criteria: rule metadata and query principals parse from
-    Semgrep-compatible YAML forms, and parse failures emit structured
-    diagnostics.
-- [x] 4.1.4. Implement mode-aware validation for `search`, `extract`, `taint`,
-      and `join`, with execution gating to supported modes.
-  - Acceptance criteria: unsupported execution modes return deterministic
-    `UnsupportedMode` diagnostics, and search mode validation enforces required
-    key combinations.
-- [x] 4.1.5. Implement legacy and v2 normalization into one canonical
-      `Formula` model with semantic constraint checks. Requires 4.1.3.
-  - Acceptance criteria: paired legacy and v2 fixtures normalize to equivalent
-    formulas, and semantic invalid states emit deterministic rule diagnostics.
-- [ ] 4.1.6. Implement `logos` tokenization and Chumsky Pratt parsing for the
-      one-liner DSL with Semgrep precedence mapping.
-  - Acceptance criteria: precedence tests match documented binding order, and
-    parser output round-trips for supported DSL forms.
-- [ ] 4.1.7. Implement DSL error recovery with delimiter anchors and partial
-      abstract syntax tree (AST) emission for best-effort diagnostics. Requires
-      4.1.6.
-  - Acceptance criteria: malformed DSL inputs produce partial parse output and
-    labelled diagnostics without parser panics.
-
-#### 4.2. Deliver Sempai Tree-sitter backend
-
-*Outcome: Implement the Tree-sitter-backed Sempai execution engine with*
-*Semgrep-token rewriting, pattern intermediate representation (IR), formula*
-*evaluation, and bounded matching semantics across supported languages.*
-
-- [ ] 4.2.1. Implement language profiles and wrapper registry for Rust, Python,
-      TypeScript, and Go, with optional HashiCorp Configuration Language (HCL)
-      support.
-  - Acceptance criteria: Rust, Python, TypeScript, and Go profiles each define
-    wrapper templates, list-shape mappings, and rewrite boundaries; optional
-    HCL profile loads only when the feature flag is enabled; profile selection
-    failures return deterministic diagnostics; and fixtures validate all profile
-    registrations.
-- [ ] 4.2.2. Implement Semgrep-token rewrite logic with language-safe boundaries
-      for metavariables, ellipsis, and deep ellipsis.
-  - Acceptance criteria: rewrite logic avoids substitutions in unsafe lexical
-    regions and produces deterministic placeholder mappings.
-- [ ] 4.2.3. Compile rewritten snippets into `PatNode`-based pattern IR with
-      span traceability.
-  - Acceptance criteria: compiled IR snapshots are stable, and wrapper/root
-    extraction metadata is preserved for diagnostics.
-- [ ] 4.2.4. Implement node-kind matching and metavariable unification over
-      Tree-sitter syntax trees.
-  - Acceptance criteria: repeated metavariables unify across compatible nodes,
-    and mismatches fail deterministically.
-- [ ] 4.2.5. Implement list-context ellipsis and ellipsis-variable matching
-      using bounded dynamic programming.
-  - Acceptance criteria: list-context fixtures pass across supported languages,
-    and runtime avoids exponential backtracking.
-- [ ] 4.2.6. Implement deep-ellipsis matching with bounded traversal controls.
-  - Acceptance criteria: deep matching respects configured node limits and
-    returns bounded, deterministic results.
-- [ ] 4.2.7. Compile normalized formulas into plan nodes with explicit anchor
-      and constraint separation. Requires 4.1.5.
-  - Acceptance criteria: conjunction plans enforce positive-term requirements,
-    and compiled plan shapes remain snapshot-stable.
-- [ ] 4.2.8. Implement conjunction, disjunction, and negative-constraint
-      execution semantics.
-  - Acceptance criteria: `not`, `inside`, and `anywhere` semantics align with
-    documented behaviour and pass regression fixtures.
-- [ ] 4.2.9. Implement metavariable `where`-clause constraint evaluation with
-      supported and unsupported outcomes.
-  - Acceptance criteria: supported constraints execute deterministically, and
-    unsupported constraints return stable diagnostic codes.
-- [ ] 4.2.10. Implement focus selection plus `as` and `fix` projection
-      behaviour in emitted matches.
-  - Acceptance criteria: focus and capture projection follow documented
-    precedence, and `fix` is surfaced as metadata without direct application.
-- [ ] 4.2.11. Implement Tree-sitter query escape hatch with capture-name
-      mapping into Semgrep-style capture keys.
-  - Acceptance criteria: raw Tree-sitter queries emit normalized captures and
-    focus behaviour consistent with Sempai match output contracts.
-- [ ] 4.2.12. Add execution safety controls for match caps, capture text caps,
-      deep-search bounds, and bounded alternation.
-  - Acceptance criteria: safety limits are configurable, deterministic, and
-    enforced across execution paths.
-
-#### 4.3. Deliver Sempai Weaver integration and readiness
-
-*Outcome: Integrate Sempai into Weaver observe flows with stable command and*
-*JSON Lines (JSONL) contracts, cache integration, diagnostics conformance, and*
-*release gates for default enablement.*
-
-- [ ] 4.3.1. Add Sempai execution routing in `weaverd` for `observe.query`.
-      Requires 4.2.12.
-  - Acceptance criteria: daemon execution paths compile and execute Sempai
-    plans for supported languages and return structured match streams.
-- [ ] 4.3.2. Add `weaver observe query` command surface with `--lang`, `--uri`,
-      and `--rule-file|--rule|--q` inputs. Requires 4.3.1.
-  - Acceptance criteria: CLI validates input combinations and supports YAML and
-    one-liner query workflows with stable error messaging.
-- [ ] 4.3.3. Define stable JSONL request and response schemas for Sempai query
-      operations, with snapshot coverage. Requires 4.3.2.
-  - Acceptance criteria: schema fixtures lock field names and payload shapes,
-    and streaming output remains deterministic.
-- [ ] 4.3.4. Integrate parse-cache adapter keyed by URI, language, and
-      revision, aligned with daemon document lifecycle.
-  - Acceptance criteria: cache keys use URI, language, and revision values;
-    repeated queries against unchanged revisions hit cache in integration tests;
-    revision changes invalidate cached parses deterministically; and cache
-    misses and invalidations preserve semantic correctness.
-- [ ] 4.3.5. Implement actuation handoff contract using focus-first selection
-      with span fallback and optional capture targeting. Requires 4.3.3.
-  - Acceptance criteria: downstream `act` commands can consume Sempai output
-    deterministically for target selection.
-- [ ] 4.3.6. Add diagnostics conformance suites for YAML, DSL, semantic,
-      compilation, and execution error categories.
-  - Acceptance criteria: each diagnostic category is covered by deterministic
-    snapshots and stable `E_SEMPAI_*` error codes.
-- [ ] 4.3.7. Add layered quality suites (unit, snapshot, corpus, property, and
-      fuzz) for parser and execution behaviour.
-  - Acceptance criteria: suites run under repository gates and include
-    representative language corpora and malformed-input coverage.
-- [ ] 4.3.8. Publish compatibility boundaries for supported operators, modes,
-      constraints, and escape-hatch behaviour in user-facing docs.
-  - Acceptance criteria: documentation clearly distinguishes supported,
-    unsupported, and parse-only behaviours with stable terminology.
-- [ ] 4.3.9. Define release gates for enabling Sempai by default, including
-      crash-free requirements, diagnostics parity, and documentation parity.
-  - Acceptance criteria: release checklist is codified in CI policy and blocks
-    default enablement when thresholds are not met.
-
-### 5. Plugin ecosystem & specialist tools
-
-*Goal: Build capability-driven plugin architecture in a dependency-first
-order:* *stabilize existing `rename-symbol` implementations, then extend to
-new* *capabilities and specialist providers.*
-
-#### 5.1. Establish plugin platform foundation
-
-- [x] 5.1.1. Design and implement the `weaver-plugins` crate, including the
-      secure
-    IPC protocol between the `weaverd` broker and sandboxed plugin processes.
-    *(Phase 5.1.1 — see `docs/execplans/3-1-1-weaver-plugins-crate.md`)*
-  - Acceptance criteria: plugin broker and sandboxed plugin process establish
-    authenticated IPC sessions; request and response envelopes validate against
-    crate-level schemas; protocol errors return deterministic failure codes; and
-    behaviour tests cover handshake success, schema rejection, and timeout
-    cases.
-
-#### 5.2. Migrate existing actuator plugins to `rename-symbol` capability
-
-*Outcome: Bring the existing Python and Rust actuator plugins into the new*
-*plugin architecture as first-class implementations of the `rename-symbol`*
-*capability, with deterministic routing and compatibility guarantees.*
-
-- [x] 5.2.1. Define the `rename-symbol` capability contract for actuator
-      plugins, including request schema, response schema, and refusal
-      diagnostics. Requires 5.1.1.
-  - Acceptance criteria: capability contract is versioned, broker validation
-    enforces schema shape, and refusal diagnostics use stable reason codes.
-- [x] 5.2.2. Update `weaver-plugin-rope` manifest and runtime handshake to
-      declare and serve `rename-symbol` through the capability interface.
-      Requires 5.2.1.
-  - Acceptance criteria: plugin advertises `rename-symbol` in capability probes,
-    request payloads conform to schema, and response payloads conform to schema.
-    Legacy provider routing is not required for Python rename flows.
-- [x] 5.2.3. Update `weaver-plugin-rust-analyzer` manifest and runtime
-      handshake to declare and serve `rename-symbol` through the capability
-      interface. Requires 5.2.1.
-  - Acceptance criteria: plugin advertises `rename-symbol` in capability probes,
-    request payloads conform to schema, and response payloads conform to schema.
-    Rust rename flows are capability-routed.
-- [x] 5.2.4. Implement daemon capability resolution for `rename-symbol` so
-      plugin selection is language-aware and policy-driven. Requires 5.2.2 and
-      5.2.3.
-  - Acceptance criteria: routing selects the correct plugin per language,
-    fallback and refusal paths are deterministic, and routing decisions include
-    machine-readable rationale.
-- [x] 5.2.5. Add unit, behavioural, and end-to-end coverage for Python and Rust
-      `rename-symbol` under the new capability architecture. Requires 5.2.4.
-  - Acceptance criteria: tests cover success paths, refusal paths, and rollback
-    guarantees, and both plugins pass shared contract fixtures.
-- [ ] 5.2.6. Publish migration notes for `rename-symbol` capability routing and
-      deprecate legacy provider-specific command paths. Requires 5.2.5.
-  - Acceptance criteria: docs and CLI guidance identify capability-based
-    behaviour as the default path, and deprecation messaging is stable.
-
-#### 5.3. Deliver capability-first `act extricate`
-
-*Outcome: Implement the cross-language `extricate-symbol` capability model,*
-*command contract, and plugin-selection foundation defined in*
-*`docs/adr-001-plugin-capability-model-and-act-extricate.md`, including
-initial* *Python delivery and shared failure semantics.*
-
-- [ ] 5.3.1. Add capability ID scaffolding and resolver policy for actuator
-    capabilities (`rename-symbol`, `extricate-symbol`, `extract-method`,
-    `replace-body`, `extract-predicate`). Requires 5.2.4.
-  - Acceptance criteria: capability IDs are strongly typed in daemon routing,
-    and resolution output includes language, selected provider, and policy
-    rationale.
-- [ ] 5.3.2. Extend plugin manifest schema and broker loading to support
-      capability
-    declarations and capability-aware selection.
-  - Acceptance criteria: manifest validation enforces capability fields, and
-    provider selection respects language plus capability compatibility.
-- [ ] 5.3.3. Add the `weaver act extricate --uri --position --to` command
-      contract and
-    wire capability discovery output for `extricate-symbol`.
-  - Acceptance criteria: CLI request shape is stable across providers, and
-    capability probe output reports extrication support by language.
-- [ ] 5.3.4. Extend the Rope plugin with `extricate-symbol` support for Python.
-  - Acceptance criteria: plugin returns unified diffs through existing patch
-    application flow and preserves symbol semantics for supported Python shapes.
-- [ ] 5.3.5. Extend plugin and daemon failure schemas with deterministic refusal
-    diagnostics and hard rollback guarantees.
-  - Acceptance criteria: refusal paths emit structured `PluginDiagnostic`
-    payloads, include stable error codes, and leave the filesystem unchanged.
-- [ ] 5.3.6. Add unit, behavioural, and end-to-end coverage for capability
-    resolution and Python extrication baseline paths.
-  - Acceptance criteria: tests assert capability negotiation, refusal behaviour,
-    incomplete payload failures, and deterministic patch output.
-
-#### 5.4. Deliver Rust `extricate-symbol` actuator
-
-*Outcome: Implement Rust `extricate-symbol` as a standalone actuator programme*
-*in line with `docs/rust-extricate-actuator-plugin-technical-design.md`, with*
-*safe orchestration, deterministic repair loops, and release-grade validation.*
-
-- [ ] 5.4.1. Define Rust extrication orchestration contracts and transaction
-      boundaries in `weaverd`, including capability ownership and stage
-      interfaces. Requires 5.3.3.
-  - Acceptance criteria: stage boundaries are explicit, rollback semantics are
-    codified per stage, and orchestration contracts are covered by unit tests.
-- [ ] 5.4.2. Implement Rust symbol planning pipeline using rust-analyzer
-      definition, references, and call-site discovery for move planning.
-      Requires 5.4.1.
-  - Acceptance criteria: planner identifies extraction scope deterministically,
-    and unsupported symbol shapes emit structured diagnostics.
-- [ ] 5.4.3. Implement staged Rust transformation execution via
-      `weaver-plugin-rust-analyzer`, including extraction edits, path updates,
-      and patch bundling. Requires 5.4.2.
-  - Acceptance criteria: staged execution emits unified diffs, preserves
-    deterministic operation order, and reports stage-level failures.
-- [ ] 5.4.4. Implement import and module-graph repair loops, including ambiguous
-      import handling and code-action follow-up passes. Requires 5.4.3.
-  - Acceptance criteria: common import breakages are auto-repaired, ambiguous
-    repairs return deterministic refusal diagnostics, and no partial writes are
-    committed.
-- [ ] 5.4.5. Integrate semantic verification and rollback enforcement for Rust
-      extrication transactions before commit. Requires 5.4.4 and 5.3.5.
-  - Acceptance criteria: semantic lock failures abort the transaction, rollback
-    is complete across all touched files, and diagnostics identify failed
-    verification stage.
-- [ ] 5.4.6. Add Rust-specific unit, behavioural, and end-to-end coverage for
-      extrication scenarios, including nested module moves, trait impl updates,
-      and macro-adjacent boundaries. Requires 5.4.5.
-  - Acceptance criteria: tests assert meaning-preservation probes, module graph
-    updates, rollback guarantees, and deterministic failure semantics.
-- [ ] 5.4.7. Publish Rust `extricate-symbol` compatibility boundaries and
-      operator guidance in docs and capability probe output. Requires 5.4.6.
-  - Acceptance criteria: docs and capability surfaces use stable terminology for
-    supported, partial, and unsupported Rust shapes.
-
-#### 5.5. Deliver additional actuator plugins
-
-*Outcome: Extend actuator coverage beyond `rename-symbol` and*
-*`extricate-symbol` with precision syntactic editing support.*
-
-- [ ] 5.5.1. Deliver the `srgn` actuator plugin to provide high-performance,
-      precision syntactic editing via capability-routed patch generation.
-  - Acceptance criteria: plugin declares capability metadata in its manifest,
-    emits deterministic unified diffs for supported edit operations, rejects
-    unsupported inputs with structured diagnostics, and passes unit plus
-    integration coverage through the plugin broker.
-
-#### 5.6. Deliver first specialist sensor plugin
-
-- [ ] 5.6.1. Deliver the `jedi` specialist sensor plugin to provide
-      supplementary Python static-analysis signals through the plugin broker.
-  - Acceptance criteria: plugin loads through `weaver-plugins`, returns
-    deterministic Python analysis payloads for supported files, rejects
-    unsupported languages with structured diagnostics, and integration tests
-    verify success and refusal paths.
-
-#### 5.7. Deliver plugin and capability discoverability coverage
-
-*Outcome: Provide discoverability for plugin inventory and runtime capability*
-*negotiation directly from CLI help and introspection commands.*
-
-- [ ] 5.7.1. Add plugin introspection commands.
-      See
-      [Gap 1g](ui-gap-analysis.md#gap-1g--plugin-listing-absent)
-      and
-      [Level 7](ui-gap-analysis.md#level-7--plugin-discoverability).
-  - [ ] Implement `weaver list-plugins` with `--kind` and `--language`
-        filters.
-  - [ ] Show plugin name, kind, language support, version, and timeout data.
-  - [ ] Acceptance criteria: users can discover valid `act refactor`
-        providers from CLI output alone, and table output includes the five
-        fields `NAME`, `KIND`, `LANGUAGES`, `VERSION`, and `TIMEOUT`.
-- [ ] 5.7.2. Wire plugin introspection into refactor guidance paths.
-      Requires 5.7.1. See
-      [Gap 5b](ui-gap-analysis.md#gap-5b--act-refactor-without-arguments)
-      and
-      [Level 7](ui-gap-analysis.md#level-7--plugin-discoverability).
-  - [ ] Reference `weaver list-plugins` in refactor-related help and errors.
-  - [ ] Acceptance criteria: every provider-related error points users to a
-        discoverability command by including the exact string
-        `weaver list-plugins`.
-- [ ] 5.7.3. Regenerate and validate localized manpages from the schema-backed
-      help model. Requires 2.2.2, 3.2.1, 3.2.3, and 3.3.4. See
-      [Level 11](ui-gap-analysis.md#level-11--manpage).
-      See
-      [weaver design §2.1.5](weaver-design.md#215-localized-help-and-reference-surfaces).
-  - [ ] Verify that domain listings, operation listings, global config flags,
-        locale-aware help text, and help-topic content render in troff output.
-  - [ ] Acceptance criteria: generated manpages include all updated help
-        surfaces with no manual post-processing, ship `en-US` by default, and
-        can be emitted for additional supported locales including all six
-        global config flags.
-
-Capability probe discoverability tasks:
-
-- [ ] 5.7.4. Clarify current `--capabilities` output semantics.
-      See
-      [Level 9](ui-gap-analysis.md#level-9----capabilities-output).
-  - [ ] Annotate output and help text that current data represents overrides
-        unless runtime capability data is merged.
-  - [ ] Acceptance criteria: users can distinguish override configuration from
-        runtime-negotiated capability support via an explicit output marker and
-        matching help-text note.
-- [ ] 5.7.5. Merge runtime capability negotiation into the capabilities probe.
-      Requires daemon capability query support. See
-      [Level 9](ui-gap-analysis.md#level-9----capabilities-output).
-  - [ ] Query daemon-supported capabilities and combine them with configured
-        overrides into one matrix.
-  - [ ] Acceptance criteria: `weaver --capabilities` returns a complete matrix
-        for each configured language and operation, and includes source labels
-        for runtime capability versus override values.
-
-#### 5.8. Refine graceful degradation guidance
-
-- [ ] 5.8.1. Refine the graceful degradation logic to suggest specific
-      plugin-based
-    solutions when core LSP features are missing.
-  - Acceptance criteria: missing core LSP features produce actionable fallback
-    suggestions naming compatible plugins; suggestions include command hints and
-    capability rationale; unavailable plugin paths return deterministic
-    diagnostics; and regression tests cover at least three degradation
-    scenarios.
-
-#### 5.9. Deliver static analysis provider integration
-
-- [ ] 5.9.1. Implement the Static Analysis Provider for `weaver-graph` (for
-      example, wrapping PyCG) as the first major graph plugin.
-  - Acceptance criteria: provider ingests static-analysis call graphs into
-    `weaver-graph` with stable node and edge schemas; unsupported languages
-    return structured diagnostics; and integration tests validate successful
-    ingestion and refusal paths.
-
-### 6. Agent workflows & advanced support
-
-*Goal: Deliver advanced agent-facing workflows after core query and plugin*
-*infrastructure is in place, with explicit dependencies on earlier phases.*
-
-#### 6.1. Deliver `act apply-patch` command
-
-*Outcome: Provide a safety-locked patch application path that mirrors the*
-*`apply_patch` semantics for agents and integrates with the Double-Lock
-harness.*
-
-- [x] 6.1.1. Add JSONL request/response types and a `weaver act apply-patch`
-      command
-    that reads the patch stream from standard input (STDIN) and forwards it to
-    the daemon.
-  - Acceptance criteria: CLI streams raw patch input, returns non-zero exit
-    codes on failure, and surfaces structured errors.
-- [x] 6.1.2. Implement the patch parser and matcher in `weaverd` to support
-      modify,
-    create, and delete operations, including fuzzy matching, line-ending
-    normalization, and path traversal checks.
-  - Acceptance criteria: patch application is atomic per command, missing
-    hunks are rejected, and parent directories are created for new files.
-- [x] 6.1.3. Integrate apply-patch with the safety harness using syntactic and
-    semantic locks, ensuring no on-disk writes on lock failure.
-  - Acceptance criteria: Tree-sitter validates modified/new files, LSP
-    diagnostics are compared against the pre-edit baseline, and failures
-    leave the filesystem untouched.
-- [x] 6.1.4. Add unit, BDD, and end-to-end tests covering create/modify/delete
-      and
-    failure paths (missing hunk, invalid header, traversal attempt).
-  - Acceptance criteria: tests pass under `make test` and error messaging is
-    asserted for each failure mode.
-
-#### 6.2. Deliver advanced agent workflow foundations
-
-*Outcome: Add onboarding and interactive orchestration paths that build on*
-*completed command discoverability and plugin-capability infrastructure.*
-*Prerequisites: complete 2.2 and 2.3 for CLI help baselines, and complete 5.2*
-*and 5.7 for capability routing plus discoverability surfaces.*
-
-- [ ] 6.2.1. Deliver the `onboard-project` command that orchestrates existing
-      Weaver components to generate a deterministic `PROJECT.dna` summary
-      artefact.
-  - Acceptance criteria: command ingests repository metadata and analysis
-    outputs into one `PROJECT.dna` file; output schema is versioned and stable;
-    reruns on unchanged inputs produce byte-identical output; and failure paths
-    emit structured diagnostics with actionable remediation hints.
-
-- [ ] 6.2.2. Deliver a hybrid interactive mode (`--interactive`) that presents
-      lock-failure diffs and diagnostics for explicit human approval or
-      rejection before write operations continue.
-  - Acceptance criteria: interactive mode displays proposed diff plus syntactic
-    and semantic lock diagnostics; approval resumes execution and rejection
-    aborts without filesystem changes; timeout or non-interactive environments
-    fail closed; and behaviour tests cover approve, reject, and timeout flows.
-
-- [ ] 6.2.3. Deliver the Dynamic Analysis Ingestion provider for
-      `weaver-graph` to consume and merge profiling data from tools such as
-      `gprof` and `callgrind`.
-  - Acceptance criteria: provider ingests at least `gprof` and `callgrind`
-    traces into a normalized graph schema; merge logic preserves source
-    identity and call-edge attribution; malformed trace inputs return structured
-    ingestion diagnostics; and integration tests validate multi-source merges.
-
-### 7. Cards-first symbol context (Jacquard)
-
-*Goal: Deliver small, structured “symbol cards” and bounded symbol graph slices
-as first-class `observe` operations, then extend them to deterministic,
-budgeted history diffs over recent commits. This phase operationalizes the
-design in
-[`jacquard-card-first-symbol-graph-design.md`](jacquard-card-first-symbol-graph-design.md)
- within Weaver’s existing Semantic Fusion architecture.*
-
-#### 7.1. Deliver `observe get-card` (Tree-sitter first)
-
-*Outcome: Provide a deterministic, cacheable symbol card payload that defaults
-to Tree-sitter extraction and optionally enriches via LSP when available. See
-`docs/jacquard-card-first-symbol-graph-design.md` §9.1-§9.3 and §10.1-§10.3.*
-
-- [x] 7.1.1. Define stable JSONL request and response schemas for
-      `observe get-card`, including versioning, provenance fields, and
-      progressive detail levels. Requires 2.1.7 and 3.1.1.
-  - [x] Include attachment bundling and interstitial payloads in the schema
-        (doc comments, decorators, import blocks, and bundle rules).
-  - [x] Add schema fixtures and snapshot coverage for success and refusal
-        payloads.
-  - [x] Acceptance criteria: schema fixtures lock field names and payload
-        shapes, including attachments and interstitials; responses include
-        provenance for non-trivial fields; and the default output is stable
-        (byte-identical) for unchanged inputs.
-- [x] 7.1.2. Implement Tree-sitter symbol card extraction for the initial
-      supported languages (Rust, Python, and TypeScript). Requires 3.1.1.
-  - [x] Add an entity/interstitial region pass and attach interstitials to the
-        relevant cards (file/module or interstitial cards).
-  - [x] Bundle doc comments and decorator/annotation blocks onto symbol cards
-        using deterministic backwards-scanning rules.
-  - [x] Enforce nested entity filtering so locals/closures do not enter the
-        entity table by default.
-  - [x] Acceptance criteria: unit tests cover at least three symbol kinds per
-        language; extracted ranges are deterministic; comment/decorator
-        bundling is stable under whitespace edits; nested locals never appear
-        as entities; and whitespace-only edits do not change `SymbolId`
-        fingerprints.
-- [x] 7.1.3. Implement optional LSP enrichment for `observe get-card` when
-      `--detail semantic` (or higher) is requested. Requires 2.1.9 and 3.1.3.
-  - [x] Enrich cards with hover/type and deprecation metadata where supported.
-  - [x] Acceptance criteria: enrichment is gated by capability negotiation; LSP
-        unavailability degrades to the Tree-sitter-only card with explicit
-        provenance; and integration tests cover both enriched and degraded
-        behaviour.
-- [x] 7.1.4. Add cache integration for card extraction keyed by URI, language,
-      and document revision. Requires 7.1.2.
-  - [x] Reuse Tree-sitter parser registries and cache extracted entity tables
-        with an LRU (Least Recently Used) policy keyed by repo, ref, file path,
-        and blob hash.
-  - [x] Avoid unnecessary string cloning in card and region extraction; prefer
-        borrowing or interning for hot paths.
-  - [x] Acceptance criteria: repeated `get-card` requests for unchanged
-        revisions hit cache in integration tests; revision changes invalidate
-        deterministically; and cache misses preserve correctness.
-
-#### 7.2. Deliver `observe graph-slice` (budgeted traversal)
-
-*Outcome: Return a bounded subgraph rooted at an entry symbol, with typed edges
-(`call`, `import`, and `config`) and explicit budget constraints. See
-`docs/jacquard-card-first-symbol-graph-design.md` §12.1-§12.3.*
-
-- [x] 7.2.1. Define stable JSONL request and response schemas for
-      `observe graph-slice`, including budgets, spillover metadata, and
-      provenance for edges. Requires 2.1.7.
-  - [x] Acceptance criteria: schema fixtures lock `budget` semantics and
-    default values; responses are deterministic for a fixed repo revision; and
-    spillover metadata is present when traversal is truncated; and edges carry
-    resolution scope (`full_symbol_table`, `partial_symbol_table`, or `lsp`).
-- [ ] 7.2.2. Implement a two-pass Tree-sitter extraction pipeline that builds a
-      symbol table before resolving edges.
-  - [ ] Acceptance criteria: edge extraction uses a full or partial symbol
-    table and marks resolution scope on each edge; unresolved references are
-    preserved as external nodes with explicit confidence.
-- [ ] 7.2.3. Implement call-edge slice expansion using the existing LSP call
-      hierarchy provider via `weaver-graph`. Requires 3.1.4 and 2.1.9.
-  - [ ] Acceptance criteria: `call` edges include explicit provenance; depth
-    limits are enforced; and end-to-end tests validate a depth-2 traversal on a
-    fixture repository.
-- [ ] 7.2.4. Implement baseline `import` and `config` edge extraction using
-      Tree-sitter interstitial passes and per-language queries. Requires 3.1.1.
-  - [ ] Acceptance criteria: extracted edges include confidence values and
-    provenance; edge extraction is bounded by the slice budget; and at least
-    one test per language asserts both `import` and `config` edge behaviour.
-- [ ] 7.2.5. Implement budgeted traversal using a priority-queue expansion
-      strategy with explicit `max_cards`, `max_edges`, and
-      `max_estimated_tokens` enforcement.
-  - [ ] Acceptance criteria: traversal never exceeds configured caps; rejection
-    reasons are emitted when `--debug` is enabled; and behaviour-driven
-    development (BDD) tests cover fan-out explosion and budget truncation
-    cases.
-
-#### 7.3. Deliver `observe graph-history` in `snapshots_on_demand` mode
-
-*Outcome: Diff a slice over the last N commits without requiring a working tree
-checkout, producing deterministic output suitable for caching and regression
-tests. See `docs/jacquard-card-first-symbol-graph-design.md` §13.1-§13.2 and
-§22.*
-
-- [ ] 7.3.1. Implement git-backed blob loading for historical revisions without
-      checkout, scoped to only the files required by the slice budget.
-  - [ ] Add explicit operational limits for blob size, parse time per file,
-        total files per commit, and partial-parse thresholds, with fallback
-        reasons recorded in the output (`timeout`, `blob_too_large`,
-        `partial_parse`, `unsupported_grammar`).
-  - [ ] Acceptance criteria: history queries never invoke `git checkout`;
-    missing blobs return structured diagnostics; and the file loader is covered
-    by unit tests for typical path and revision scenarios.
-- [ ] 7.3.2. Implement slice reconstruction per commit with explicit data
-      quality metadata and partial symbol table resolution. Requires 7.2.5.
-  - [ ] Acceptance criteria: `--commits 5` returns a stable set of commits and
-    per-commit slice payloads with `quality.resolution_scope` and
-    `quality.fallbacks`; delta payloads include added/removed/changed nodes and
-    edges; and BDD tests validate output against a curated git fixture
-    repository.
-- [ ] 7.3.3. Implement delta computation normalization and change taxonomy
-      classification for nodes and edges.
-  - [ ] Treat import blocks and decorators as commutative sets for deltas, and
-        persist normalized representations alongside raw text.
-  - [ ] Acceptance criteria: import/decorator reordering is classified as
-        `text` change; taxonomy output includes confidence; and fixtures cover
-        comment-only and signature-only edits.
-- [ ] 7.3.4. Implement semantic risk warnings on history deltas for
-      dependency/dependent changes in the slice neighbourhood.
-  - [ ] Expose `--warning-depth` to widen the dependency neighbourhood scanned
-        for warnings.
-  - [ ] Acceptance criteria: warnings include edge paths and confidence;
-    `text`-only deltas emit lower-risk warnings; and curated fixtures validate
-    both warning types.
-- [ ] 7.3.5. Implement history-mode gating and safe defaults, with LSP
-      enrichment disabled by default for history queries.
-  - [ ] Acceptance criteria: default mode uses Tree-sitter-only extraction for
-    historical commits; enabling enrichment is explicit and documented; and
-    degraded behaviour is made visible via provenance fields.
-
-#### 7.4. Deliver probabilistic matching and “reason codes”
-
-*Outcome: Map symbols across commits probabilistically when identifiers drift,
-exposing confidence and alternates rather than hiding ambiguity. See
-`docs/jacquard-card-first-symbol-graph-design.md` §14.1-§14.8.*
-
-- [ ] 7.4.1. Implement phase 1 stable-identity matching (type, name, container,
-      file hint), with explicit confidence output.
-  - [ ] Acceptance criteria: match outputs include the winning phase and
-    confidence; non-matching candidates are rejected rather than forced; and
-    fixtures include rename/move cases that must not match in phase 1.
-- [ ] 7.4.2. Implement phase 2 body-hash matching for rename detection.
-      Requires 7.4.1.
-  - [ ] Acceptance criteria: match outputs include the winning phase and
-    confidence; low-confidence matches are rejected rather than forced; and
-    fixtures cover rename scenarios with unchanged bodies.
-- [ ] 7.4.3. Implement phase 3 structural-hash matching on AST-normalized
-      shapes. Requires 7.4.2.
-  - [ ] Acceptance criteria: match outputs include the winning phase and
-    confidence; low-confidence matches are rejected rather than forced; and
-    fixtures cover move scenarios with formatting-only edits.
-- [ ] 7.4.4. Implement phase 4 fuzzy similarity matching (token overlap and
-      shingles). Requires 7.4.3.
-  - [ ] Acceptance criteria: match outputs include the winning phase and
-    confidence; low-confidence matches are rejected rather than forced; and
-    fixtures cover rename and move scenarios with minor body edits.
-- [ ] 7.4.5. Implement phase 5 graph refinement and global assignment
-      refinement. Requires 7.4.4.
-  - [ ] Acceptance criteria: match outputs include the winning phase and
-    confidence; low-confidence matches are rejected rather than forced; and
-    fixtures cover rename/move scenarios resolved by neighbourhood evidence.
-- [ ] 7.4.6. Implement feature extraction for cross-commit matching using
-      signature, AST-shape, docstring fingerprints, attachments, and
-      neighbourhood sketches.
-  - [ ] Acceptance criteria: feature extraction is deterministic for identical
-    inputs; unit tests cover feature stability under whitespace-only edits and
-    alpha-renaming of locals; and failures emit structured diagnostics.
-- [ ] 7.4.7. Implement candidate generation and scoring with calibrated
-      probabilities, emitting top-K alternates and “reason codes”. Requires
-      7.4.6.
-  - [ ] Acceptance criteria: response payloads always include `best_match` plus
-    alternates up to the requested cap; reason codes are stable enumerations;
-    and debug output surfaces the top contributing features.
-- [ ] 7.4.8. Implement duplicate-name guardrails (`max_duplicates`) that force
-      ambiguous mappings or fallback matching when homonyms explode.
-  - [ ] Acceptance criteria: `--max-duplicates` returns explicit “ambiguous
-    mapping” responses; observability counters capture guardrail triggers; and
-    fixtures with same-name functions avoid false renames.
-- [ ] 7.4.9. Implement assignment across the slice using a solver that avoids
-      mapping multiple sources to one target unless explicitly enabled.
-  - [ ] Acceptance criteria: property tests prevent illegal many-to-one
-    mappings by default; a feature flag enables split/merge experimentation;
-    and deterministic test fixtures cover rename and move scenarios.
-
-#### 7.5. Optional ledger cache and richer edge types
-
-*Outcome: Add a persisted ledger keyed by commit hash for faster history
-queries and broader edge coverage once `snapshots_on_demand` is proven
-reliable. This step is intentionally staged behind the on-demand
-implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
-§18.1-§18.2.*
-
-- [ ] 7.5.1. Define a versioned on-disk ledger format for cards, edges, and
-      deltas keyed by commit hash. Requires 7.3.2.
-  - [ ] Acceptance criteria: format is forward-compatible via explicit version
-    fields; corruption is detected with checksums; and schema changes are gated
-    behind migrations.
-- [ ] 7.5.2. Implement incremental ledger population and invalidation rules.
-  - [ ] Acceptance criteria: ledger writes are atomic; invalidation occurs when
-    inputs change; and performance benchmarks show a measurable improvement for
-    repeated history queries.
-
-### 8. Formal verification and proof tooling
-
-*Goal: Add bounded formal verification checks for Weaver-owned transactional,*
-*patching, routing, and guardrail invariants without replacing the existing*
-*test stack. See `docs/formal-verification-methods-in-weaver.md`.*
-
-#### 8.1. Establish formal verification tooling
-
-*Outcome: Add pinned verifier installation, explicit make targets, and staged*
-*Continuous Integration (CI) entry points for Kani and Verus.*
-
-- [ ] 8.1.1. Add pinned verifier version files and install scripts for Kani and
-      Verus. See `docs/formal-verification-methods-in-weaver.md`
-      "Repository layout and tooling".
-  - [ ] Add `tools/kani/VERSION`.
-  - [ ] Add `tools/verus/VERSION` and `tools/verus/SHA256SUMS`.
-  - [ ] Add `scripts/install-kani.sh`, `scripts/install-verus.sh`, and
-        `scripts/run-verus.sh`.
-  - [ ] Acceptance criteria: local installs are reproducible from pinned
-        versions, scripts fail fast on version or checksum mismatch, and the
-        normal Rust toolchain workflow remains unchanged unless a formal target
-        is invoked.
-- [ ] 8.1.2. Add explicit `make kani`, `make kani-full`, `make verus`,
-      `make formal-pr`, and `make formal-nightly` targets. Requires 8.1.1.
-  - [ ] Keep the Kani smoke harness list explicit rather than scan-based.
-  - [ ] Keep Verus execution outside Cargo through `scripts/run-verus.sh`.
-  - [ ] Acceptance criteria: `make kani` runs only smoke harnesses,
-        `make kani-full` runs all checked-in Kani harnesses, `make verus`
-        executes the proof entrypoint, and the new targets are documented in
-        the `Makefile`.
-- [ ] 8.1.3. Add staged CI jobs for formal verification. Requires 8.1.2.
-  - [ ] Add `kani-smoke` to pull-request validation after the first smoke
-        harnesses land.
-  - [ ] Add `verus-proofs` as manual or nightly validation first, then promote
-        only if the proof set remains stable.
-  - [ ] Acceptance criteria: the existing `build-test` job remains intact,
-        formal jobs install their own tools, and slow proof suites are isolated
-        from the default pull-request path.
-
-#### 8.2. Clarify proof contracts before gating
-
-*Outcome: Define the exact assurances that Kani and Verus are expected to*
-*prove, including filesystem assumptions and trust boundaries.*
-
-- [ ] 8.2.1. Publish the transaction atomicity contract for the Double-Lock
-      path. See `docs/formal-verification-methods-in-weaver.md`
-      "Atomicity contract".
-  - [ ] State the filesystem assumptions that define "all changes applied or
-        original state restored".
-  - [ ] State catastrophic failure conditions that are outside the verified
-        model.
-  - [ ] Acceptance criteria: the design document and user's guide describe the
-        same atomicity promise using one shared contract.
-- [ ] 8.2.2. Define the semantic-lock contract precisely. Requires 8.2.1. See
-      `docs/formal-verification-methods-in-weaver.md`
-      "Semantic-lock contract".
-  - [ ] Specify severity handling, provider normalization, baseline scope, and
-        backend-unavailable semantics.
-  - [ ] Acceptance criteria: implementation docs, CLI behaviour, and future
-        proof harnesses can refer to one explicit semantic-lock definition
-        without relying on inferred behaviour.
-- [ ] 8.2.3. Document the formal-verification trust boundary. Requires 8.2.2.
-      See `docs/formal-verification-methods-in-weaver.md` "Trust boundary".
-  - [ ] Separate verified orchestration invariants from trusted external-tool
-        assumptions.
-  - [ ] Acceptance criteria: docs name the verified kernel, list unverified
-        dependencies explicitly, and avoid claiming semantic correctness for
-        third-party tools.
-
-#### 8.3. Add Kani checks for the transaction and patch kernels
-
-*Outcome: Add bounded model-checking coverage for the highest-risk write path*
-*that Weaver owns directly.*
-
-- [ ] 8.3.1. Add Kani smoke harnesses for Double-Lock transaction ordering in
-      `crates/weaverd/src/safety_harness/`. Requires 8.1.2 and 8.2.1.
-  - [ ] Prove commit is reachable only when both locks pass.
-  - [ ] Prove lock-failure and backend-unavailable states are non-committing.
-  - [ ] Acceptance criteria: `make kani` executes transaction smoke harnesses,
-        and counterexamples are reproducible through the documented target.
-- [ ] 8.3.2. Add Kani smoke harnesses for rollback bookkeeping and bounded file
-      traces in `crates/weaverd/src/safety_harness/`. Requires 8.3.1.
-  - [ ] Cover bounded create, modify, and delete combinations.
-  - [ ] Cover commit-phase failure that restores the pre-state under the
-        documented assumptions.
-  - [ ] Acceptance criteria: harnesses assert file-set preservation and
-        rollback restoration over bounded traces.
-- [ ] 8.3.3. Add Kani smoke harnesses for `act apply-patch` matching and path
-      guardrails in `crates/weaverd/src/dispatch/act/apply_patch/`.
-      Requires 8.3.1 and 6.1.4.
-  - [ ] Cover cursor monotonicity for ordered `SEARCH`/`REPLACE` blocks.
-  - [ ] Cover whole-command abort on unmatched blocks.
-  - [ ] Cover path normalization rejecting absolute and parent-escape paths.
-  - [ ] Acceptance criteria: `make kani` includes apply-patch smoke harnesses,
-        and the checked properties map directly to the documented patch
-        contract.
-- [ ] 8.3.4. Promote larger transaction and patch harnesses to `make kani-full`
-      once the smoke harnesses are stable. Requires 8.3.2 and 8.3.3.
-  - [ ] Expand touched-file counts and mixed-operation sequences.
-  - [ ] Keep smoke and full harnesses separate.
-  - [ ] Acceptance criteria: `make kani-full` exercises larger bounded traces
-        than the pull-request smoke set, and scheduled runs record stable pass
-        or fail outcomes.
-
-#### 8.4. Add Kani checks for capability routing and refusal semantics
-
-*Outcome: Verify bounded capability-selection invariants in the plugin control*
-*plane before expanding proof coverage elsewhere.*
-
-- [ ] 8.4.1. Add Kani smoke harnesses for capability-resolution soundness in
-      `crates/weaver-plugins/src/`. Requires 8.1.2, 5.3.2, and 8.2.3.
-  - [ ] Prove the selected provider satisfies the requested language and
-        capability.
-  - [ ] Prove refusal is deterministic when no compatible provider exists.
-  - [ ] Acceptance criteria: `make kani` runs capability-routing smoke
-        harnesses, and refusal semantics are asserted over bounded routing
-        tables.
-- [ ] 8.4.2. Add property-based tests for refusal-code stability, path-policy
-      helpers, and bounded routing tables. Requires 8.4.1.
-  - [ ] Acceptance criteria: generated tests complement the Kani harnesses by
-        exploring larger input spaces without widening the verified kernel
-        claims.
-
-#### 8.5. Add a proof-only Verus kernel
-
-*Outcome: Prove the smallest stable invariants in proof-only modules outside*
-*the main Cargo build.*
-
-- [ ] 8.5.1. Add a proof-only Verus workspace under `verus/` with
-      `weaver_proofs.rs` as the entrypoint. Requires 8.1.2 and 8.2.3.
-  - [ ] Add `transaction_kernel.rs`, `capability_routing.rs`, and
-        `apply_patch_paths.rs`.
-  - [ ] Acceptance criteria: `make verus` executes the proof entrypoint, and
-        the proof modules use proof-specific types rather than widening the
-        production API.
-- [ ] 8.5.2. Prove transaction-gating and rollback-restoration lemmas over a
-      modelled workspace state. Requires 8.5.1 and 8.2.1.
-  - [ ] Acceptance criteria: proofs establish that commit requires both locks
-        and that documented rollback restoration holds under the chosen model
-        assumptions.
-- [ ] 8.5.3. Prove capability-resolution soundness over an abstract resolver.
-      Requires 8.5.1 and 8.2.3.
-  - [ ] Acceptance criteria: proofs establish that successful resolution
-        satisfies language, capability, and policy predicates, and that refusal
-        occurs instead of silent fallback when no provider qualifies.
-
-#### 8.6. Extend formal verification coverage after later roadmap features land
-
-*Outcome: Expand proof coverage only when the underlying contracts and kernels*
-*are implemented and stable.*
-
-- [ ] 8.6.1. Add Kani harnesses for graph-slice budget enforcement after 7.2.5
-      lands. Requires 7.2.5 and 8.3.4.
-  - [ ] Acceptance criteria: bounded graph harnesses prove counters do not
-        exceed accepted-card, edge, and token-budget caps on small graphs.
-- [ ] 8.6.2. Add Kani harnesses for duplicate-name guardrails and assignment
-      injectivity after 7.4.8 and 7.4.9 land. Requires 7.4.8, 7.4.9, and
-      8.3.4.
-  - [ ] Acceptance criteria: bounded matching harnesses prove injective
-        assignments by default and prove many-to-one assignments remain gated
-        behind explicit split or merge modes.
-- [ ] 8.6.3. Add Kani harnesses for Sempai semantic constraints only after the
-      planned parser and backend crates exist. Requires 4.2 and 4.3.
-  - [ ] Acceptance criteria: formal checks cover deterministic matcher and
-        normalization kernels without trying to verify external parser or
-        runtime dependencies wholesale.
-
-*Prerequisites note: Phases 9–11 depend on tasks from earlier phases (e.g.
-"Requires 4.1.5" or "Requires 7.2.3"). Each prerequisite uses the dotted-number
-identifier from its parent phase above — search this document for the number to
-locate the full task description and its own dependency chain.*
-
-### 9. Vertical slice (Sempai → Jacquard → one-hop traversal)
-
-*Goal: Cut one thin, end-to-end path from a Sempai query through canonical
-symbol resolution to a JacquardCard with one navigable relation, proving the
-core Weaver loop in an agent-consumable CLI surface. The definition of done is:
-an agent sends a symbol-ish query to Sempai, receives a canonical JacquardCard
-over the CLI, then follows one returned relation to a second card, with no
-interactive prompts.[^1][^2][^3]*
-
-#### 9.1. Deliver minimal Sempai `search` execution (YAML only)
-
-*Outcome: Execute a minimal positive-anchor Semgrep-compatible `search` query
-from a YAML rule file, returning deterministic match spans for one language.
-This deliberately limits scope to YAML input (not the one-liner DSL), a single
-`pattern` or `match.pattern` principal, and no conjunctions, negation, ellipsis
-families, or `where` clauses.[^1]*
-
-- [ ] 9.1.1. Implement minimal positive-anchor normalization into
-      a canonical `Formula::Atom(Pattern)` form for `pattern` and
-      `match.pattern` principals. Requires 4.1.5.
-  - [ ] Acceptance criteria: paired legacy `pattern` and v2
-        `match.pattern` fixtures normalize to equivalent
-        `Formula::Atom` values; unsupported operators (`patterns`,
-        `pattern-either`, `pattern-not`, `inside`, `where`) return
-        deterministic `E_SEMPAI_*` diagnostics; and no ellipsis,
-        deep-ellipsis, or conjunction forms are accepted.
-- [ ] 9.1.2. Implement token rewriting and pattern intermediate
-      representation (IR) compilation for a single language (Rust
-      or Python). Requires 9.1.1 and 4.2.1.
-  - [ ] Acceptance criteria: rewritten snippets compile into
-        `PatNode`-based IR with span traceability; metavariables
-        `$X` and `$_` are supported; ellipsis and deep-ellipsis
-        forms are rejected with structured diagnostics; and
-        snapshot tests lock IR shapes for positive-anchor patterns.
-- [ ] 9.1.3. Implement node-kind matching and metavariable
-      unification over Tree-sitter syntax trees for the chosen
-      first language. Requires 9.1.2 and 4.2.4.
-  - [ ] Acceptance criteria: repeated metavariables unify across
-        compatible nodes; mismatches fail deterministically; and
-        end-to-end match output includes `uri`, `span`, and
-        default `focus` fields.
-- [ ] 9.1.4. Add Sempai execution routing in `weaverd` for
-      `observe query` limited to the minimal `search` subset.
-      Requires 9.1.3.
-  - [ ] Acceptance criteria: daemon routes `observe.query`
-        requests through the minimal Sempai pipeline; responses
-        are deterministic JSONL match streams with `uri`, `span`,
-        and `focus`; unsupported query forms return structured
-        diagnostics without daemon failure.
-- [ ] 9.1.5. Add `weaver observe query --lang --uri --rule-file`
-      command surface for the minimal `search` subset.
-      Requires 9.1.4.
-  - [ ] Acceptance criteria: CLI validates input combinations;
-        `--rule-file` accepts YAML rule files; `--rule` accepts
-        inline YAML; `--q` is explicitly absent from this step;
-        and stable error messaging covers missing file,
-        unsupported mode, and parse failure paths.
-
-#### 9.2. Deliver symbol-first card retrieval
-
-*Outcome: Allow agents to retrieve a JacquardCard by symbol name or
-qualified-name selector, without requiring a line-and-column position. This
-bridges the gap between Sempai match output and the existing position-based
-`observe get-card` path.[^2]*
-
-- [ ] 9.2.1. Add a `--symbol` selector to `observe get-card` that
-      accepts symbol names, qualified names, and path-qualified
-      names. Requires 7.1.2.
-  - [ ] Acceptance criteria: `weaver observe get-card --uri <URI>
-        --symbol <NAME>` resolves a symbol by name within the
-        file's entity table and returns the same
-        `GetCardResponse` envelope as the position-based path;
-        ambiguous matches return a structured refusal listing
-        candidates with positions; and the position-based
-        `--position` path remains unchanged.
-- [ ] 9.2.2. Add path-qualified disambiguation for `--symbol`
-      selectors. Requires 9.2.1.
-  - [ ] Acceptance criteria: selectors of the form `path:Symbol`
-        and `path:Parent.Symbol` filter the entity table by file
-        path pattern before name matching; and disambiguation
-        tests cover multi-file workspaces with identically named
-        symbols.
-- [ ] 9.2.3. Wire Sempai match output into symbol-first card
-      retrieval so `observe query` results can feed
-      `observe get-card` without manual position extraction.
-      Requires 9.1.5 and 9.2.1.
-  - [ ] Acceptance criteria: a Sempai match span resolves to a
-        card via both the `--position` and `--symbol` paths; an
-        end-to-end test demonstrates the query-to-card loop for
-        a single fixture using `--symbol`; and the test asserts
-        that the `GetCardResponse` envelope is identical
-        regardless of which selector path is used.
-
-#### 9.3. Deliver one-hop relation traversal
-
-*Outcome: Include exactly one navigable relation type in card output so that an
-agent can follow a returned `symbol_id` back into the same command path. This
-is the thinnest useful slice of JacquardWeave.[^2]*
-
-- [ ] 9.3.1. Add a `relations` field to `SymbolCard` containing a
-      small ranked list of related `SymbolRef` values for one
-      relation type (references, containment, or
-      callers/callees). Requires 7.1.2 and 3.1.4.
-  - [ ] Acceptance criteria: the chosen relation type is populated
-        from the existing LSP or Tree-sitter substrate; related
-        items are stable `SymbolRef` values that can be fed back
-        into `observe get-card --position`; the `relations` field
-        is absent (not empty) when no relations are found; and
-        schema fixtures lock the new field shape.
-- [ ] 9.3.2. Implement the query-to-card-to-relation loop as a
-      documented agent workflow. Requires 9.2.3 and 9.3.1.
-  - [ ] Acceptance criteria: an end-to-end test demonstrates the
-        full loop (query → resolve → card → related symbol →
-        second card) using CLI commands; the workflow is documented
-        in the user's guide[^5]; and no interactive prompts are
-        required at any step.
-
-### 10. Leta parity for supported languages
-
-*Goal: Ship the high-frequency semantic navigation verbs that an agent needs
-every few minutes, bringing Weaver's public CLI surface to parity with
-[Leta](https://github.com/andreasjansson/leta) for Rust, Python, and
-TypeScript. This phase prioritizes the everyday agent navigation loop — find,
-show, trace, search, rename — over exotic analysis. Each operation must honour
-Weaver's existing JSONL envelope, exit-code contract, and human-readable
-rendering conventions.[^3][^4][^5]*
-
-#### 10.1. Deliver `observe find-references` end-to-end
-
-*Outcome: Expose LSP `textDocument/references` as a stable, end-to-end CLI
-operation with human-readable and JSONL output. The underlying LSP substrate
-already supports references in `weaver-lsp-host`.[^5]*
-
-- [ ] 10.1.1. Wire `observe find-references` daemon dispatch to
-      the existing `LspHost::references()` method, returning
-      structured location arrays. Requires 2.1.8 and 2.1.9.
-  - [ ] Acceptance criteria: `weaver observe find-references
-        --uri <URI> --position <LINE:COL>` returns a JSONL
-        response containing an array of reference locations; empty
-        results return an empty array (not an error); unsupported
-        languages return a structured diagnostic; and
-        human-readable output renders context blocks with line
-        numbers.
-- [ ] 10.1.2. Add unit, behavioural, and end-to-end coverage for
-      `observe find-references`. Requires 10.1.1.
-  - [ ] Acceptance criteria: tests cover success paths (single
-        and multiple references), empty-result paths,
-        unsupported-language refusal, and pre-initialization error
-        paths for Rust, Python, and TypeScript fixtures.
-
-#### 10.2. Deliver symbol-first `observe show`
-
-*Outcome: Provide a `show` equivalent that accepts a symbol-ish selector and
-returns the full definition body, mirroring Leta's `show` command. This builds
-on the symbol-first card retrieval from 9.2 and the existing `observe get-card`
-infrastructure.[^2]*
-
-- [ ] 10.2.1. Add an `observe show` command that accepts
-      `--symbol` (or positional symbol name), resolves it via the
-      entity table, and returns the full symbol body with
-      surrounding context. Requires 9.2.1.
-  - [ ] Acceptance criteria: `weaver observe show <SYMBOL>
-        --uri <URI>` returns the complete symbol definition
-        including doc comments and decorators; `--context <N>`
-        adds surrounding lines; human-readable output includes
-        file path, line numbers, and syntax-highlighted source;
-        JSONL output includes `uri`, `range`, `source_text`, and
-        `symbol` identity fields; and ambiguous symbols return a
-        structured disambiguation response.
-- [ ] 10.2.2. Add qualified-name and path-filter support for
-      `observe show`. Requires 10.2.1 and 9.2.2.
-  - [ ] Acceptance criteria: selectors of the form
-        `Parent.Symbol`, `path:Symbol`, and `path:Parent.Symbol`
-        resolve correctly; and tests cover disambiguation across
-        multiple files with identically named symbols.
-
-#### 10.3. Deliver `observe call-hierarchy` end-to-end
-
-*Outcome: Expose the existing `weaver-graph` call hierarchy provider as a
-stable CLI operation with configurable direction and depth. The internal
-`CallGraph` provider is complete.[^5][^2]*
-
-- [ ] 10.3.1. Wire `observe call-hierarchy` daemon dispatch to
-      the existing `weaver-graph` call hierarchy provider with
-      `--direction` and `--max-depth` flags. Requires 2.1.8,
-      2.1.9, and 3.1.4.
-  - [ ] Acceptance criteria: `weaver observe call-hierarchy
-        --uri <URI> --position <LINE:COL>` returns a JSONL
-        response containing `nodes` and `edges` arrays;
-        `--direction` supports `incoming`, `outgoing`, and `both`;
-        `--max-depth` limits traversal; provenance and call-site
-        positions are included on edges; and human-readable output
-        renders a tree view.
-- [ ] 10.3.2. Add unit, behavioural, and end-to-end coverage for
-      `observe call-hierarchy`. Requires 10.3.1.
-  - [ ] Acceptance criteria: tests cover outgoing calls, incoming
-        calls, bidirectional traversal, depth limiting, empty
-        results, and unsupported-language refusal for Rust,
-        Python, and TypeScript fixtures.
-
-#### 10.4. Deliver `observe grep` end-to-end
-
-*Outcome: Expose the existing `weaver-syntax` structural search engine as a
-stable CLI operation for semantic symbol search with kind filtering. The
-underlying engine is complete.[^3]*
-
-- [ ] 10.4.1. Wire `observe grep` daemon dispatch to
-      `weaver-syntax` with `--pattern`, `--kind`, `--uri`, and
-      `--lang` flags. Requires 2.1.8 and 3.1.1.
-  - [ ] Acceptance criteria: `weaver observe grep --pattern
-        <PATTERN> --lang <LANG>` returns a JSONL response
-        containing match locations with symbol kind, name, and
-        span; `--kind` filters by symbol kind; `--uri` scopes to
-        a specific file; human-readable output renders matches
-        with file path, line number, kind, and name; and invalid
-        patterns return structured parse diagnostics.
-- [ ] 10.4.2. Add unit, behavioural, and end-to-end coverage for
-      `observe grep`. Requires 10.4.1.
-  - [ ] Acceptance criteria: tests cover pattern matching, kind
-        filtering, file scoping, invalid pattern diagnostics, and
-        empty-result paths for Rust, Python, and TypeScript
-        fixtures.
-
-#### 10.5. Deliver `act rename-symbol` end-to-end
-
-*Outcome: Expose the existing capability-routed `rename-symbol` plugins as a
-stable, end-to-end CLI operation with safety-harness integration. The
-capability contract and plugin implementations are in place (5.2.1–5.2.4).[^6]*
-
-- [ ] 10.5.1. Wire `act rename-symbol` as a first-class CLI
-      command with `--uri`, `--position`, and `--new-name` flags,
-      routing through capability-based plugin selection.
-      Requires 5.2.4.
-  - [ ] Acceptance criteria: `weaver act rename-symbol --uri <URI>
-        --position <LINE:COL> --new-name <NAME>` applies a
-        workspace-wide rename through the Double-Lock safety
-        harness; JSONL output includes the list of modified files
-        and applied edits; human-readable output shows a unified
-        diff; refusal paths (unsupported language, symbol not
-        found) return structured diagnostics; and the filesystem
-        is unchanged on lock failure.
-- [ ] 10.5.2. Add unit, behavioural, and end-to-end coverage for
-      `act rename-symbol`. Requires 10.5.1 and 5.2.5.
-  - [ ] Acceptance criteria: tests cover successful rename for
-        Python and Rust, refusal paths, rollback guarantees, and
-        safety-harness integration.
-
-### 11. Weaver unique selling proposition (USP): composable agent-grade CLI primitives
-
-*Goal: Deliver the capabilities that make Weaver more than a Leta clone. Where
-Phase 10 reaches parity, this phase delivers Weaver's USP: budgeted graph-slice
-traversal, card-driven exploration, deterministic CLI contracts for agent tool
-loops, and the safety harness that makes write operations trustworthy. These
-are the features that justify choosing Weaver over a thinner LSP
-wrapper.[^3][^2][^7]*
-
-#### 11.1. Deliver `observe graph-slice` traversal
-
-*Outcome: Wire the budgeted graph traversal from 7.2.5 into a stable CLI
-command with the full flag set from the design document. This is the first
-Weaver-specific differentiator beyond Leta's `graph` command. Requires the
-schema work from 7.2.1.[^2]*
-
-- [ ] 11.1.1. Wire `observe graph-slice` as a stable CLI command
-      consuming the traversal engine from 7.2.5, the schema from
-      7.2.1, and the call-edge provider from 7.2.3.
-      Requires 7.2.1, 7.2.3, and 7.2.5.
-  - [ ] Acceptance criteria: `weaver observe graph-slice
-        --uri <URI> --position <LINE:COL>` returns a JSONL
-        response containing `cards`, `edges`, and `spillover`
-        fields; all budget flags (`--max-cards`, `--max-edges`,
-        `--max-estimated-tokens`, `--depth`, `--direction`,
-        `--edge-types`, `--min-confidence`, `--entry-detail`,
-        `--node-detail`) are exposed; human-readable output
-        renders a tree with depth markers; and exit-code semantics
-        distinguish success from truncation.
-
-#### 11.2. Deliver card-driven traversal workflow
-
-*Outcome: Enable agents to navigate from one symbol card to related symbols
-through structured relation data, completing the "postcard to loom" loop.[^2]*
-
-- [ ] 11.2.1. Extend the `relations` field from 9.3.1 to support
-      multiple relation types (references, containment, and
-      callers/callees). Requires 9.3.1.
-  - [ ] Acceptance criteria: cards include relations from all
-        available providers; each relation carries a `type` field
-        and a ranked list of `SymbolRef` values; relation types
-        are explicitly enumerated in the schema; and empty
-        relation types are omitted rather than included as empty
-        arrays.
-- [ ] 11.2.2. Add dependency and dependent fan metrics to
-      `full`-detail cards. Requires 11.2.1 and 7.1.3.
-  - [ ] Acceptance criteria: `--detail full` cards include
-        `fan_in` and `fan_out` counts sourced from
-        `weaver-graph`; provenance marks the data source (`lsp`,
-        `tree_sitter`, or `static_analysis`); and metrics are
-        absent (not zero) when the underlying provider is
-        unavailable.
-
-#### 11.3. Deliver agent-grade CLI contract hardening
-
-*Outcome: Harden the CLI surface so that Weaver behaves as a reliable primitive
-for agent tool loops (Codex CLI, Claude Code, and similar). The contract must
-be deterministic, non-interactive, and machine-readable.[^3]*
-
-- [ ] 11.3.1. Enforce deterministic stdout/stderr separation
-      across all `observe` and `act` commands.
-  - [ ] Acceptance criteria: `stdout` contains only the result
-        payload (JSONL or human-readable); `stderr` carries logs,
-        progress, and diagnostics; no command writes diagnostic
-        text to `stdout`; and regression tests assert separation
-        for every implemented command.
-- [ ] 11.3.2. Add explicit `schema_version` to all JSONL response
-      envelopes.
-  - [ ] Acceptance criteria: every JSONL response includes a
-        top-level `schema_version` field; version values are
-        stable across patch releases; and snapshot tests lock the
-        version for each response type.
-- [ ] 11.3.3. Standardize exit codes across all commands to
-      distinguish `resolved`, `ambiguous`, `not_found`, and
-      `backend_unavailable`.
-  - [ ] Acceptance criteria: exit-code semantics are documented
-        in the user's guide[^5]; every command uses the shared
-        exit-code enumeration; and BDD tests assert each exit
-        code for at least one command.
-- [ ] 11.3.4. Ensure compact output by default with opt-in
-      expansion for all `observe` commands.
-  - [ ] Acceptance criteria: default output stays within a
-        configurable token budget; `--detail` or `--expand` flags
-        opt into richer output; and agents can rely on bounded
-        response sizes without explicit truncation.
-
-#### 11.4. Deliver safety-harness integration as a visible differentiator
-
-*Outcome: Surface the Double-Lock safety harness as a visible, documented
-feature that agents and operators can rely on for trustworthy write operations.
-This is a key Weaver differentiator.[^7][^8]*
-
-- [ ] 11.4.1. Add structured safety-harness result metadata to
-      all `act` command JSONL responses. Requires 2.1.13.
-  - [ ] Acceptance criteria: every `act` response includes a
-        `safety_harness` field reporting syntactic-lock and
-        semantic-lock outcomes; lock failures include diagnostic
-        spans and reasons; and the field is present even on
-        success (reporting `passed`).
-- [ ] 11.4.2. Document the safety-harness contract for agent
-      consumption in the user's guide[^5]. Requires 11.4.1.
-  - [ ] Acceptance criteria: the user's guide includes a
-        dedicated section explaining the Double-Lock model, what
-        agents can rely on, and how to interpret lock-failure
-        diagnostics; and the section references the formal
-        verification design document for deeper guarantees.
-
-[^1]: [`sempai-query-language-design.md`](sempai-query-language-design.md)
-[^2]: [`jacquard-card-first-symbol-graph-design.md`](jacquard-card-first-symbol-graph-design.md)
-[^3]: [`weaver-design.md`](weaver-design.md)
-[^4]: [`ui-gap-analysis.md`](ui-gap-analysis.md)
-[^5]: [`users-guide.md`](users-guide.md)
-[^6]: [`adr-001-plugin-capability-model-and-act-extricate.md`](adr-001-plugin-capability-model-and-act-extricate.md)
-[^7]: [`weaver-design.md`](weaver-design.md) §5.1 and §6.1
-[^8]: [`formal-verification-methods-in-weaver.md`](formal-verification-methods-in-weaver.md)
+## Archive
+
+Historical prototype roadmap entries live in
+[`docs/archive/prototype-roadmap.md`](archive/prototype-roadmap.md). Those
+entries keep numbers `1` through `11`; this live roadmap reserves numbers `12`
+through `20` for the forward ADR 007 build sequence.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -330,13 +330,17 @@ than remaining search output. It migrates prototype archive work 4.3.1 through
 
 ## 16. Safe change loop slice
 
-Idea: if the same selector records can drive safe patches, renames, and
-extract-or-move refactors through capability-routed actuators, Weaver proves
-that agent-native composition does not weaken the Double-Lock safety model.
+Idea: if the same selector records can drive safe patches, renames, and symbol
+relocation through capability-routed actuators, Weaver proves that agent-native
+composition does not weaken the Double-Lock safety model.
 
 This phase validates the first end-to-end observe-to-act loop. It migrates
-archive work from apply-patch, rename-symbol, extrication, selector handoff,
-mutation metadata, and visible safety-harness reporting.
+archive work from apply-patch, rename-symbol, `extricate-symbol`, selector
+handoff, mutation metadata, and visible safety-harness reporting. In this
+roadmap, `extricate-symbol` means moving a selected symbol to another module or
+file while preserving meaning. It is distinct from `extract-method`, which
+extracts a selected code region into a new callable and is not compressed into
+the symbol-relocation tasks below.
 
 ### 16.1. Prove patch application under the new command contract
 
@@ -386,32 +390,107 @@ through 5.2.6, 10.5.1 through 10.5.2, and 4.3.5. See ADR 001 and ADR 004.
     idempotency, provider failures, syntactic failures, semantic failures, and
     rollback assertions.
 
-### 16.3. Decide whether move/extract is viable for the core product
+### 16.3. Prove the `extricate-symbol` contract with Python first
 
-This step answers whether extrication is a dependable product differentiator or
-an attractive but unstable refactor. It migrates prototype archive work 5.3.1
-through 5.4.7 under canonical public verbs. See
+This step answers whether symbol relocation can be expressed as one stable
+capability and public command before Weaver invests in Rust-specific
+orchestration. It migrates prototype archive work 5.3.1 through 5.3.6 under the
+canonical public command `weaver symbols move`. See ADR 001 and ADR 004.
+`extract-method`, `replace-body`, and `extract-predicate` may be declared as
+distinct capability IDs, but this step does not implement those operations.
+
+- [ ] 16.3.1. Add capability ID scaffolding and resolver policy for actuator
+      capabilities.
+  - Requires 16.2.1.
+  - Success: `rename-symbol`, `extricate-symbol`, `extract-method`,
+    `replace-body`, and `extract-predicate` are distinct typed capability IDs;
+    resolver output includes language, selected provider, and policy rationale;
+    no task treats `extract-method` as an alias for `extricate-symbol`.
+- [ ] 16.3.2. Extend plugin manifests and broker loading for capability-aware
+      selection.
+  - Requires 16.3.1.
+  - Success: manifest validation enforces capability fields, and provider
+    selection respects language plus capability compatibility without exposing
+    provider-specific commands.
+- [ ] 16.3.3. Add the `weaver symbols move --uri --position --to` command
+      contract and discovery output for `extricate-symbol`.
+  - Requires 13.3.2, 16.3.2, and depends on OrthoConfig 7.2.7.
+  - Success: CLI request shape is stable across providers, `context --json`
+    and `capabilities list --json` report support by language, and the public
+    verb remains `move` while the internal capability remains
+    `extricate-symbol`.
+- [ ] 16.3.4. Extend the Rope plugin with narrow Python `extricate-symbol`
+      support.
+  - Requires 16.3.3.
+  - Success: Rope returns unified diffs through the existing patch application
+    flow for supported Python symbol moves and emits structured refusals for
+    unsupported symbol shapes.
+- [ ] 16.3.5. Extend plugin and daemon failure schemas with deterministic
+      refusal diagnostics and rollback guarantees for extrication.
+  - Requires 16.1.3 and 16.3.4.
+  - Success: refusal paths emit structured diagnostics, include stable reason
+    codes, enumerate valid alternatives where possible, and leave the
+    filesystem unchanged.
+- [ ] 16.3.6. Add unit, behavioural, and end-to-end coverage for capability
+      resolution and Python extrication baseline paths.
+  - Requires 16.3.5.
+  - Success: tests assert capability negotiation, refusal behaviour,
+    incomplete payload failures, deterministic patch output, rollback, and
+    `--json` plus human-renderer behaviour.
+
+### 16.4. Prove Rust `extricate-symbol` with explicit orchestration gates
+
+This step answers whether Rust symbol relocation is realistic without reducing
+the safety bar or hiding complexity inside a single "move" task. It migrates
+prototype archive work 5.4.1 through 5.4.7. See
 `docs/rust-extricate-actuator-plugin-technical-design.md`.
 
-- [ ] 16.3.1. Implement the `symbol.move` or `symbol.extract` capability
-      contract and refusal vocabulary.
-  - Requires 16.2.1.
-  - Success: the public command uses canonical verbs while the internal
-    capability captures transaction, import-repair, and provider constraints.
-- [ ] 16.3.2. Prototype Python symbol extraction through Rope.
-  - Requires 16.3.1.
-  - Success: a narrow class of Python moves either commits safely through the
-    Double-Lock path or records refusal reasons that invalidate the approach.
-- [ ] 16.3.3. Prototype Rust symbol movement through rust-analyzer.
-  - Requires 16.3.1.
-  - Success: a narrow class of Rust moves either commits safely with
-    import/module repair or records compatibility limits that defer the
-    feature.
-- [ ] 16.3.4. Decide whether move/extract graduates from the core roadmap.
-  - Requires 16.3.2 and 16.3.3.
-  - Success: the roadmap records one of three outcomes: graduate both
-    languages, graduate one language with clear limits, or defer the capability
-    out of the 0.1.0 core.
+- [ ] 16.4.1. Define Rust extrication orchestration contracts and transaction
+      boundaries in `weaverd`.
+  - Requires 16.3.3.
+  - Success: stage boundaries, capability ownership, rollback semantics, and
+    daemon/plugin responsibilities are explicit and covered by unit tests.
+- [ ] 16.4.2. Implement the Rust symbol planning pipeline using
+      rust-analyzer definition, references, and call-site discovery.
+  - Requires 16.4.1.
+  - Success: the planner identifies relocation scope deterministically, records
+    required file payloads, and returns structured diagnostics for unsupported
+    symbol shapes.
+- [ ] 16.4.3. Implement staged Rust transformation execution through the
+      rust-analyzer actuator path.
+  - Requires 16.4.2.
+  - Success: staged execution emits unified diffs, preserves deterministic
+    operation order, reports stage-level failures, and makes the prototype
+    viability of Rust extrication visible before repair hardening begins.
+- [ ] 16.4.4. Implement import and module-graph repair loops.
+  - Requires 16.4.3.
+  - Success: common import breakages are auto-repaired, ambiguous repairs
+    return deterministic refusal diagnostics, and no partial writes are
+    committed.
+- [ ] 16.4.5. Integrate semantic verification and rollback enforcement for
+      Rust extrication transactions.
+  - Requires 16.3.5 and 16.4.4.
+  - Success: semantic lock failures abort the transaction, rollback is complete
+    across all touched files, and diagnostics identify the failed verification
+    stage.
+- [ ] 16.4.6. Add Rust-specific unit, behavioural, and end-to-end coverage for
+      extrication scenarios.
+  - Requires 16.4.5.
+  - Success: coverage includes nested module moves, trait implementation
+    updates, macro-adjacent boundaries, module graph updates, rollback
+    guarantees, and deterministic failure semantics.
+- [ ] 16.4.7. Publish Rust `extricate-symbol` compatibility boundaries and
+      operator guidance.
+  - Requires 16.4.6.
+  - Success: docs, human output, and capability surfaces use stable terminology
+    for supported, partial, and unsupported Rust shapes.
+- [ ] 16.4.8. Decide whether `extricate-symbol` graduates from the core
+      roadmap.
+  - Requires 16.3.6 and 16.4.7.
+  - Success: the roadmap records one of three outcomes: graduate Python and
+    Rust, graduate one language with clear limits, or defer the capability out
+    of the 0.1.0 core. `extract-method` is assessed separately and cannot be
+    marked complete by this decision.
 
 ## 17. Impact and history slice
 
@@ -531,8 +610,8 @@ prototype archive work 5.7.1 through 5.7.5 and 5.2.6. See
   - Success: agents can discover availability, selected provider, refusal
     reasons, and profile-driven policy without parsing backend-specific help.
 - [ ] 18.2.2. Publish capability migration notes for `symbol.rename` and
-      move/extract decisions.
-  - Requires 16.3.4.
+      `extricate-symbol` decisions.
+  - Requires 16.4.8.
   - Success: docs explain provider provenance, refusal semantics, resource
     command replacements, and any deferred provider-specific limits.
 - [ ] 18.2.3. Add provider-matrix E2E coverage.
@@ -660,10 +739,12 @@ OrthoConfig 10.1.
 This step answers whether experiments invalidated by earlier slices deserve a
 new design rather than quiet re-entry into the core roadmap.
 
-- [ ] 20.2.1. Reassess deferred move/extract language support.
-  - Requires 16.3.4.
+- [ ] 20.2.1. Reassess deferred `extricate-symbol` language support and
+      `extract-method` experiments.
+  - Requires 16.4.8.
   - Success: unsupported languages or symbol kinds either gain new provider
-    evidence or remain explicitly out of scope.
+    evidence, `extract-method` gains its own evidence-backed slice, or both
+    remain explicitly out of scope.
 - [ ] 20.2.2. Reassess deferred dynamic-analysis ingestion.
   - Requires 19.2.3.
   - Success: runtime trace ingestion either has bounded trust semantics and a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,7 +121,7 @@ OrthoConfig command contracts without duplicating them. See ADR 007 and
   - Success: resource path, verb, capability ID, selector forms, output
     schemas, error schemas, mutability, provider policy, examples, and skill
     references all flow from one adapter record.
-- [ ] 13.1.3. Define the temporary-adapter removal policy.
+- [x] 13.1.3. Define the temporary-adapter removal policy.
   - Requires 13.1.2.
   - Success: every local generic helper names the OrthoConfig task expected to
     replace it or records a permanent divergence in ADR 007.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,6 +16,14 @@ archive work has been moved into this live roadmap under resource-first command
 names; prototype `observe`, `act`, and `verify` spellings are not future public
 grammar unless a live task explicitly reintroduces them.
 
+The plan is intentionally validation-led. Each phase after the dependency
+boundary is a product hypothesis that can fail: the result may graduate,
+narrow, or defer a design rather than forcing every archived idea into the core
+release. The archive remains useful evidence, but the live sequence favours
+vertical slices such as "read a symbol", "select with Sempai and compose with
+cards", "mutate from the same selectors", and "explain impact" over building
+one horizontal layer at a time.
+
 ## 12. Dependency boundaries and archive assessment
 
 Idea: if Weaver consumes reusable command-contract machinery from OrthoConfig
@@ -65,6 +73,8 @@ either hidden scope or a competing implementation plan.
 - [x] 12.2.1. Classify archive tasks as shipped foundation, migrated product
       scope, or superseded prototype grammar.
   - See `docs/archive/prototype-roadmap.md`.
+  - The archive relevance matrix maps each archived step to a live destination
+    or a supersession reason.
   - Success: every unchecked archive step has a live roadmap destination or an
     explicit reason it is no longer active implementation guidance.
 - [x] 12.2.2. Preserve completed prototype foundation as implementation
@@ -103,7 +113,7 @@ OrthoConfig command contracts without duplicating them. See ADR 007 and
   - Success: ADR 007 defines the dual renderer contract, capability routing,
     OrthoConfig dependencies, and lack of compatibility promise for the
     prototype grammar.
-- [ ] 13.1.2. Implement the Weaver command-surface adapter for one read-only
+- [x] 13.1.2. Implement the Weaver command-surface adapter for one read-only
       command family.
   - Requires 13.1.1 and depends on OrthoConfig 5.2.3, 6.1, and 7.2.7.
   - Start with `definitions get` plus the metadata needed to add

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -261,10 +261,10 @@ Idea: if Sempai one-liners can select symbols and immediately feed cards plus
 one-hop graph context, Weaver proves that query language work pays off as a
 composable product loop rather than as a standalone parser layer.
 
-This phase deliberately validates the narrowest useful Sempai workflow before
-building the full Semgrep-compatible backend. It migrates archive work from
-Sempai DSL parsing, Tree-sitter execution, query routing, symbol-first cards,
-and the Sempai-to-Jacquard vertical slice.
+This phase validates Sempai as a selector engine without reducing the original
+backend and integration scope to a vague parser task. It migrates archive work
+from Sempai DSL parsing, Tree-sitter execution, query routing, symbol-first
+cards, and the Sempai-to-Jacquard vertical slice.
 
 ### 15.1. Prove a minimal one-liner selector with honest diagnostics
 
@@ -285,45 +285,148 @@ without overbuilding the full query engine. It migrates prototype archive work
     confidence, and provider provenance needed for safe downstream context or
     mutation.
 
-### 15.2. Prove Tree-sitter execution on the smallest useful language set
+### 15.2. Prove the Sempai Tree-sitter backend
 
 This step answers whether Semgrep-style matching can run accurately enough on
-real syntax before the full operator matrix lands. It migrates prototype
-archive work 4.2.1 through 4.2.12 and 9.1.2 through 9.1.3. See
-`docs/sempai-query-language-design.md` §§7-12.
+real syntax with bounded execution semantics. It preserves prototype archive
+work 4.2.1 through 4.2.12 instead of compressing the backend into a single
+"matching" task. See `docs/sempai-query-language-design.md` §§7-12.
 
-- [ ] 15.2.1. Implement language profiles and snippet wrapping for Rust and
-      Python.
+- [ ] 15.2.1. Implement language profiles and wrapper registry for Rust,
+      Python, TypeScript, and Go, with optional HashiCorp Configuration
+      Language (HCL) support.
   - Requires 15.1.2.
-  - Success: the profiles support safe snippet parsing, wrapper provenance,
-    and clear refusal for unsupported languages.
-- [ ] 15.2.2. Implement node-kind matching, metavariable unification, and
-      bounded ellipsis for the pilot profiles.
+  - Success: Rust, Python, TypeScript, and Go profiles each define wrapper
+    templates, list-shape mappings, and rewrite boundaries; optional HCL loads
+    only behind its feature flag; profile selection failures return
+    deterministic diagnostics; and fixtures validate all profile
+    registrations.
+- [ ] 15.2.2. Implement Semgrep-token rewrite logic with language-safe
+      boundaries for metavariables, ellipsis, and deep ellipsis.
   - Requires 15.2.1.
-  - Success: positive-pattern fixtures match expected symbols, execution caps
-    prevent runaway matches, and unsupported operators enumerate alternatives.
-- [ ] 15.2.3. Decide whether TypeScript joins the first Sempai slice.
+  - Success: rewrite logic avoids substitutions in unsafe lexical regions and
+    produces deterministic placeholder mappings.
+- [ ] 15.2.3. Compile rewritten snippets into `PatNode`-based pattern
+      intermediate representation (IR) with span traceability.
   - Requires 15.2.2.
-  - Success: TypeScript either passes the same selector fixtures or is deferred
-    with a documented blocker and fallback behaviour.
+  - Success: compiled IR snapshots are stable, and wrapper/root extraction
+    metadata is preserved for diagnostics.
+- [ ] 15.2.4. Implement node-kind matching and metavariable unification over
+      Tree-sitter syntax trees.
+  - Requires 15.2.3.
+  - Success: repeated metavariables unify across compatible nodes, mismatches
+    fail deterministically, and the first-language vertical fixtures from
+    archive work 9.1.2 through 9.1.3 pass through the same matcher.
+- [ ] 15.2.5. Implement list-context ellipsis and ellipsis-variable matching
+      using bounded dynamic programming.
+  - Requires 15.2.4.
+  - Success: list-context fixtures pass across supported languages, and runtime
+    avoids exponential backtracking.
+- [ ] 15.2.6. Implement deep-ellipsis matching with bounded traversal controls.
+  - Requires 15.2.5.
+  - Success: deep matching respects configured node limits and returns bounded,
+    deterministic results.
+- [ ] 15.2.7. Compile normalized formulas into plan nodes with explicit anchor
+      and constraint separation.
+  - Requires 15.1.2, 15.2.4, and completed archive work 4.1.5.
+  - Success: conjunction plans enforce positive-term requirements, and
+    compiled plan shapes remain snapshot-stable.
+- [ ] 15.2.8. Implement conjunction, disjunction, and negative-constraint
+      execution semantics.
+  - Requires 15.2.7.
+  - Success: `not`, `inside`, and `anywhere` semantics align with documented
+    behaviour and pass regression fixtures.
+- [ ] 15.2.9. Implement metavariable `where`-clause constraint evaluation with
+      supported and unsupported outcomes.
+  - Requires 15.2.8.
+  - Success: supported constraints execute deterministically, and unsupported
+    constraints return stable diagnostic codes.
+- [ ] 15.2.10. Implement focus selection plus `as` and `fix` projection
+      behaviour in emitted matches.
+  - Requires 15.2.9.
+  - Success: focus and capture projection follow documented precedence, and
+    `fix` is surfaced as metadata without direct application.
+- [ ] 15.2.11. Implement Tree-sitter query escape hatch with capture-name
+      mapping into Semgrep-style capture keys.
+  - Requires 15.2.10.
+  - Success: raw Tree-sitter queries emit normalized captures and focus
+    behaviour consistent with Sempai match output contracts.
+- [ ] 15.2.12. Add execution safety controls for match caps, capture text caps,
+      deep-search bounds, and bounded alternation.
+  - Requires 15.2.11.
+  - Success: safety limits are configurable, deterministic, and enforced
+    across execution paths.
 
-### 15.3. Prove query output composes with context commands
+### 15.3. Prove Sempai Weaver integration and readiness
+
+This step answers whether the backend can be exposed through Weaver's
+resource-first command surface with stable schemas, cache behaviour,
+diagnostics, quality gates, and default-enablement rules. It preserves
+prototype archive work 4.3.1 through 4.3.9 under the new public command shape.
+See `docs/weaver-design.md` §2.1.2.
+
+- [ ] 15.3.1. Add Sempai execution routing in `weaverd` for selector-backed
+      `symbols list`.
+  - Requires 15.2.12.
+  - Success: daemon execution paths compile and execute Sempai plans for
+    supported languages and return structured match streams.
+- [ ] 15.3.2. Add `weaver symbols list --query` with `--lang`, `--uri`, and
+      `--rule-file|--rule|--query` inputs.
+  - Requires 15.3.1 and 14.2.1.
+  - Success: the CLI validates input combinations and supports YAML rule files,
+    inline YAML rules, and one-liner query workflows with stable error
+    messaging. `weaver observe query` remains archive provenance only.
+- [ ] 15.3.3. Define stable JSONL request and response schemas for Sempai query
+      operations, with snapshot coverage.
+  - Requires 15.3.2.
+  - Success: schema fixtures lock field names and payload shapes, and streaming
+    output remains deterministic.
+- [ ] 15.3.4. Integrate parse-cache adapter keyed by URI, language, and
+      revision, aligned with daemon document lifecycle.
+  - Requires 15.3.3.
+  - Success: repeated queries against unchanged revisions hit cache in
+    integration tests, revision changes invalidate cached parses
+    deterministically, and cache misses or invalidations preserve semantic
+    correctness.
+- [ ] 15.3.5. Implement actuation handoff contract using focus-first selection
+      with span fallback and optional capture targeting.
+  - Requires 15.3.3.
+  - Success: downstream mutation commands can consume Sempai output
+    deterministically for target selection without hidden state.
+- [ ] 15.3.6. Add diagnostics conformance suites for YAML, domain-specific
+      language (DSL), semantic, compilation, and execution error categories.
+  - Requires 15.3.3.
+  - Success: each diagnostic category is covered by deterministic snapshots and
+    stable `E_SEMPAI_*` error codes.
+- [ ] 15.3.7. Add layered quality suites for parser and execution behaviour.
+  - Requires 15.3.6.
+  - Success: unit, snapshot, corpus, property, and fuzz suites run under
+    repository gates and include representative language corpora plus
+    malformed-input coverage.
+- [ ] 15.3.8. Publish compatibility boundaries for supported operators, modes,
+      constraints, and escape-hatch behaviour.
+  - Requires 15.3.7.
+  - Success: user-facing docs distinguish supported, unsupported, and
+    parse-only behaviours with stable terminology.
+- [ ] 15.3.9. Define release gates for enabling Sempai by default.
+  - Requires 15.3.8.
+  - Success: crash-free requirements, diagnostics parity, and documentation
+    parity are codified in CI policy and block default enablement when
+    thresholds are not met.
+
+### 15.4. Prove query output composes with context commands
 
 This step answers whether one-liner selectors can feed product commands rather
-than remaining search output. It migrates prototype archive work 4.3.1 through
-4.3.9, 9.1.4 through 9.3.2, and 11.2.1. See `docs/weaver-design.md` §2.1.2.
+than remaining search output. It migrates prototype archive work 9.1.4 through
+9.3.2 and 11.2.1. See `docs/weaver-design.md` §2.1.2.
 
-- [ ] 15.3.1. Implement `weaver symbols list --query`.
-  - Requires 15.2.2 and 14.2.1.
-  - Success: `symbols list --query 'fn $name(...)' --json` emits bounded
-    selector records that ordinary UNIX filters can preserve.
-- [ ] 15.3.2. Allow `cards get` and one-hop relation summaries to consume
+- [ ] 15.4.1. Allow `cards get` and one-hop relation summaries to consume
       Sempai selectors.
-  - Requires 15.3.1 and 14.2.3.
+  - Requires 15.3.5 and 14.2.3.
   - Success: one query-to-card-to-relation workflow works in one command and
     in a pipeline, with deterministic zero-, one-, and many-match behaviour.
-- [ ] 15.3.3. Add Sempai selector conformance and pipeline E2E coverage.
-  - Requires 15.3.2.
+- [ ] 15.4.2. Add Sempai selector conformance and pipeline E2E coverage.
+  - Requires 15.4.1.
   - Success: suites cover YAML-backed and one-liner selectors, malformed query
     recovery, `jq` filtering, pager consumption, bounded output, and invalid
     selector-stream rejection.
@@ -376,12 +479,12 @@ through 5.2.6, 10.5.1 through 10.5.2, and 4.3.5. See ADR 001 and ADR 004.
     include transaction ID, affected paths, provider provenance, and safety
     outcome.
 - [ ] 16.2.2. Add direct Sempai selector support to `symbols rename`.
-  - Requires 15.3.1 and 16.2.1.
+  - Requires 15.3.5 and 16.2.1.
   - Success: `symbols rename --query ...` handles zero, one, and many matches
     deterministically and requires explicit policy for ambiguous mutation.
 - [ ] 16.2.3. Add `--from-stdin` selector stream consumption to mutation
       commands.
-  - Requires 15.3.3 and 16.2.2.
+  - Requires 15.3.3, 15.3.5, and 16.2.2.
   - Success: `weaver symbols list --query … --json | jq … | weaver symbols
     rename --from-stdin …` works without hidden state.
 - [ ] 16.2.4. Add rename and selector-mutation combinatorial E2E coverage.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,204 +1,193 @@
 # Weaver roadmap
 
 This roadmap translates `docs/weaver-design.md`,
-`docs/adr-007-agent-native-command-surface.md`, and the existing ADR set into
-an outcome-oriented delivery sequence. It does not promise dates. Phases carry
-testable product ideas, steps answer sequencing questions, and tasks are
-review-sized execution units with explicit dependencies and observable success
-criteria.
+`docs/adr-007-agent-native-command-surface.md`,
+`docs/sempai-query-language-design.md`,
+`docs/jacquard-card-first-symbol-graph-design.md`, and the existing ADR set
+into an outcome-oriented delivery sequence. It does not promise dates. Phases
+carry testable product ideas, steps validate or falsify those ideas, and tasks
+are review-sized execution units with explicit dependencies and observable
+success criteria.
 
 The current forward plan is the source of truth for future work. The historical
 ledger in [`docs/archive/prototype-roadmap.md`](archive/prototype-roadmap.md)
-preserves completed foundation work and prior planned work so that it is not
-lost during the 0.1.0 command-surface reset. Historical entries that mention
-`observe`, `act`, or `verify` are retained as provenance, not as the future
-public grammar.
+preserves task numbers `1` through `11` as provenance. Relevant unfinished
+archive work has been moved into this live roadmap under resource-first command
+names; prototype `observe`, `act`, and `verify` spellings are not future public
+grammar unless a live task explicitly reintroduces them.
 
-## 12. External reusable CLI-contract dependencies
+## 12. Dependency boundaries and archive assessment
 
-Idea: if Weaver consumes generic command-contract machinery from OrthoConfig
-instead of rebuilding it locally, Weaver can focus on semantic code
-capabilities while still inheriting consistent human and agent interfaces.
+Idea: if Weaver consumes reusable command-contract machinery from OrthoConfig
+and treats the prototype archive as evidence rather than a second backlog, the
+product can move quickly without rebuilding generic CLI infrastructure or
+losing completed work.
 
-The dependency source is the OrthoConfig roadmap at
-<https://raw.githubusercontent.com/leynos/ortho-config/refs/heads/main/docs/roadmap.md>.
- Weaver may build temporary adapters where needed, but any generic
-command-contract implementation must either depend on the relevant OrthoConfig
-task or record a deliberate divergence in ADR 007.
+This phase is the minimum unavoidable foundation. It does not validate a user
+workflow directly; it validates the build boundary and prevents later slices
+from rediscovering the same dependency and migration questions.
 
-### 12.1. Track reusable dependency contracts
+### 12.1. Confirm reusable contracts that Weaver must not duplicate
 
-This step answers which command-contract pieces Weaver must consume from
-OrthoConfig and which ones Weaver may temporarily adapt while the shared
-contracts mature.
+This step answers which generic command-contract pieces come from OrthoConfig
+and which temporary Weaver adapters are allowed. Its outcome informs every
+command-surface and renderer task. See ADR 007 and the OrthoConfig roadmap.
 
 - [ ] 12.1.1. Track the downstream consumer boundary.
   - Depends on OrthoConfig 5.2.3.
-  - Weaver dependency mode: blocked for final generic ownership decisions;
-    local adapters may proceed when ADR 007 names the removal path.
-  - Success: every Weaver command-contract task says whether it consumes
-    OrthoConfig, wraps it, or intentionally diverges.
+  - Success: every command-contract task says whether it consumes OrthoConfig,
+    wraps it temporarily, or records a deliberate divergence in ADR 007.
 - [ ] 12.1.2. Consume recursive command metadata.
   - Depends on OrthoConfig 6.1.1 and 6.1.2.
-  - Weaver dependency mode: local schema adapters may proceed, but generated
-    help, manpage, completion, and context output must converge on the
-    OrthoConfig recursive metadata shape.
-- [ ] 12.1.3. Consume compact agent-context output and naming.
-  - Depends on OrthoConfig 6.2.1, 6.2.2, and 6.2.3.
-  - Weaver dependency mode: `weaver context --json` is blocked on the naming
-    convention for final acceptance; a local payload fixture may proceed for
-    Weaver-specific capability fields.
-- [ ] 12.1.4. Consume skill manifest metadata and validation.
-  - Depends on OrthoConfig 6.3.1 and 6.3.2.
-  - Weaver dependency mode: skill prose may be drafted locally, but validation
-    must use OrthoConfig metadata when available.
-- [ ] 12.1.5. Consume canonical vocabulary policy.
-  - Depends on OrthoConfig 7.1.1 through 7.1.3.
-  - Weaver dependency mode: vocabulary linting is blocked for final CI gates;
-    Weaver may maintain a temporary banned-name list for early migration.
-- [ ] 12.1.6. Consume behavioural metadata for agent-native commands.
-  - Depends on OrthoConfig 7.2.1 through 7.2.7.
-  - Weaver dependency mode: renderer, JSON, exit-code, bounded-list, mutation,
-    non-interactive, capability, and provenance metadata should be configured
-    or extended in Weaver, not reimplemented as another generic framework.
-- [ ] 12.1.7. Use `cargo-orthohelp` as the reference CLI for command contracts.
-  - Depends on OrthoConfig 8.1.1 and 8.1.2.
-  - Weaver dependency mode: this is a validation dependency; Weaver can build
-    its own commands earlier, but must compare `--json` and enumerating-error
-    behaviour against the reference CLI before 0.1.0.
-- [ ] 12.1.8. Consume compounding primitive contracts.
+  - Success: generated help, manpage, completion, and context output converge
+    on the OrthoConfig recursive metadata shape.
+- [ ] 12.1.3. Consume compact context and skill metadata.
+  - Depends on OrthoConfig 6.2.1 through 6.3.2.
+  - Success: Weaver-specific capability fields extend the reusable context and
+    skill shapes instead of forking them.
+- [ ] 12.1.4. Consume canonical vocabulary and behavioural metadata.
+  - Depends on OrthoConfig 7.1.1 through 7.2.7 and 8.1.1 through 8.1.2.
+  - Success: renderer, JSON, exit-code, bounded-list, mutation,
+    non-interactive, capability, provenance, and reference-CLI checks point at
+    OrthoConfig-owned contracts where those contracts exist.
+- [ ] 12.1.5. Consume compounding primitive contracts.
   - Depends on OrthoConfig 9.1.1 through 9.3.3.
-  - Weaver dependency mode: profile, delivery, feedback, and execution-ledger
-    command semantics are Weaver-owned; reusable parsing, redaction, metadata,
-    and ledger vocabulary come from OrthoConfig where available.
+  - Success: profile, delivery, feedback, and execution-ledger command
+    semantics are Weaver-owned, while reusable parsing, redaction, metadata,
+    and ledger vocabulary come from OrthoConfig.
 
-## 13. Human-friendly, agent-native 0.1.0 command-surface reset
+### 12.2. Assess the prototype ledger and migrate active scope
 
-Idea: if Weaver settles the generated command contract before more capabilities
-land, later Sempai, plugin, graph, and workflow slices can converge on one
-surface instead of repeatedly redesigning command grammar.
+This step answers which archived tasks still matter to the product after the
+0.1.0 command reset. Its outcome prevents archived prototype work from becoming
+either hidden scope or a competing implementation plan.
 
-This foundational phase retires the prototype public grammar for the 0.1.0
-target while preserving human usability, localization, accessibility, and the
-UNIX pipeline model.
+- [x] 12.2.1. Classify archive tasks as shipped foundation, migrated product
+      scope, or superseded prototype grammar.
+  - See `docs/archive/prototype-roadmap.md`.
+  - Success: every unchecked archive step has a live roadmap destination or an
+    explicit reason it is no longer active implementation guidance.
+- [x] 12.2.2. Preserve completed prototype foundation as implementation
+      evidence.
+  - Requires 12.2.1.
+  - Success: completed archive work for configuration, daemon transport, JSONL,
+    sandboxing, Double-Lock safety, LSP hosting, plugin routing, cards, graph
+    scaffolding, Sempai normalization, and patch application is referenced by
+    the live tasks that reuse it.
+- [x] 12.2.3. Mark prototype command spellings as provenance only.
+  - Requires 12.2.1.
+  - Success: unchecked archive tasks that mention `observe`, `act`, `verify`,
+    provider-first commands, or root `--output` are not executable backlog
+    items; their product intent is carried by resource-first live tasks.
 
-### 13.1. Ratify the reset boundary and adapter policy
+## 13. Command contract proving slice
 
-This step answers which contracts Weaver owns and which ones OrthoConfig owns.
-The outcome informs every command, renderer, and drift gate that follows. See
-`docs/adr-007-agent-native-command-surface.md` and `docs/weaver-design.md` §2.1.
+Idea: if Weaver can expose one tiny resource-first command loop through the
+generated command contract, with human and machine renderers, introspection,
+help, localization, and drift gates, later semantic slices can reuse the same
+surface instead of rebuilding command grammar.
+
+This phase validates the command contract with the smallest useful public
+slice: a read-only semantic query. It deliberately pulls relevant archive work
+from help, localization, operation guidance, manpage generation, capability
+introspection, and agent-grade CLI hardening into one acceptance surface.
+
+### 13.1. Ratify the reset boundary and command-surface adapter
+
+This step answers whether Weaver-specific semantic metadata can sit on top of
+OrthoConfig command contracts without duplicating them. See ADR 007 and
+`docs/weaver-design.md` §§2.1.1-2.1.4.
 
 - [x] 13.1.1. Record the agent-native command-surface reset as ADR 007.
-  - Requires 12.1.
+  - Records the forward OrthoConfig dependency boundary that 12.1 validates.
   - Success: ADR 007 defines the dual renderer contract, capability routing,
-    OrthoConfig dependencies, and the lack of compatibility promise for the
+    OrthoConfig dependencies, and lack of compatibility promise for the
     prototype grammar.
-- [ ] 13.1.2. Implement the Weaver command-surface adapter design.
+- [ ] 13.1.2. Implement the Weaver command-surface adapter for one read-only
+      command family.
   - Requires 13.1.1 and depends on OrthoConfig 5.2.3, 6.1, and 7.2.7.
-  - Model resource path, verb, capability ID, mutability class, async class,
-    selector forms, stream input support, provider policy, safety class,
-    transaction behaviour, examples, output schemas, error schemas, and skill
-    references.
-  - Success: adding or renaming one Weaver command requires one adapter change
-    and exposes enough metadata for router, help, docs, tests, and context
-    fixtures.
+  - Start with `definitions get` plus the metadata needed to add
+    `references list` without a second path.
+  - Success: resource path, verb, capability ID, selector forms, output
+    schemas, error schemas, mutability, provider policy, examples, and skill
+    references all flow from one adapter record.
 - [ ] 13.1.3. Define the temporary-adapter removal policy.
   - Requires 13.1.2.
-  - Success: every local generic command-contract helper names the OrthoConfig
-    task expected to replace it or records a permanent divergence in ADR 007.
+  - Success: every local generic helper names the OrthoConfig task expected to
+    replace it or records a permanent divergence in ADR 007.
 
-### 13.2. Enforce community vocabulary and resource-first commands
+### 13.2. Prove the dual renderer on a real command
 
-This step answers whether humans and agents can infer commands from common CLI
-knowledge rather than Weaver-only vocabulary. See ADR 007 and
-`docs/weaver-design.md` §§1.1 and 2.1.1.
+This step answers whether the same command contract can serve humans and agents
+without forking command behaviour. It migrates prototype archive work 3.2.2
+through 3.3.4 and 11.3.1 through 11.3.4. See `docs/weaver-design.md` §§2.1.3,
+2.1.7, 2.1.10, and 2.1.11.
 
-- [ ] 13.2.1. Map prototype domains to resource-first command paths.
-  - Requires 13.1.2.
-  - Map definitions, references, diagnostics, cards, graph slices, symbols,
-    patches, capabilities, context, jobs, profiles, and feedback.
-  - Success: no current forward task requires adding a new public `observe`,
-    `act`, or `verify` command.
-- [ ] 13.2.2. Configure vocabulary linting.
-  - Requires 13.2.1 and depends on OrthoConfig 7.1.1 through 7.1.3.
-  - Include canonical verbs such as `get`, `list`, `create`, `update`,
-    `delete`, `apply`, `run`, `prune`, `save`, `show`, `rename`, `move`, and
-    `send`.
-  - Success: CI rejects off-policy verbs and flags unless ADR 007 explicitly
-    grandfathers them as current-state compatibility.
-- [ ] 13.2.3. Migrate command examples in design and user-facing docs.
-  - Requires 13.2.1.
-  - Success: examples prefer `weaver definitions get`, `weaver references
-    list`, `weaver diagnostics list`, `weaver symbols list`, `weaver symbols
-    rename`, `weaver patches apply`, and `weaver context --json`.
-
-### 13.3. Deliver dual renderers and bounded machine contracts
-
-This step answers whether one command contract can serve accessible humans and
-reliable agents without forking command behaviour. See `docs/weaver-design.md`
-§§2.1.3 and 2.1.4.
-
-- [ ] 13.3.1. Implement the human renderer contract.
+- [ ] 13.2.1. Implement the localized human renderer for `definitions get`.
   - Requires 13.1.2 and depends on OrthoConfig 7.2.2.
-  - Include localized default output, `--plain`, `--color`, `--no-pager`,
-    `--width`, TTY-sensitive progress, table headings, narrow-width labelled
-    blocks, and ASCII fallbacks.
+  - Include `--plain`, `--color`, `--no-pager`, `--width`, TTY-sensitive
+    progress, table headings, narrow-width labelled blocks, and ASCII
+    fallbacks.
   - Success: human output does not rely on colour alone and never emits pager
-    or spinner control flow in non-terminal contexts.
-- [ ] 13.3.2. Implement universal `--json` and structured error output.
-  - Requires 13.3.1 and depends on OrthoConfig 7.2.3 through 7.2.5 and 8.1.
-  - Remove root `--output auto|human|json` and operation-local `--format` from
-    the 0.1.0 target.
+    or spinner control flow outside terminal contexts.
+- [ ] 13.2.2. Implement universal `--json` and structured errors for
+      `definitions get`.
+  - Requires 13.2.1 and depends on OrthoConfig 7.2.3 through 7.2.5 and 8.1.
   - Success: success JSON is parseable on stdout, failure JSON is parseable on
     stderr, field names and error codes are non-localized, and exit classes are
     stable.
-- [ ] 13.3.3. Implement enumerating errors and bounded list responses.
-  - Requires 13.3.2 and depends on OrthoConfig 7.2.6 and 8.1.2.
-  - Success: enum, registry, capability, profile, provider, delivery, and job
-    validation errors list valid values; list-style commands expose bounded
-    defaults, `--limit`, cursors, truncation markers, and narrowing hints.
+- [ ] 13.2.3. Implement enumerating errors and bounded responses for the
+      command-family pilot.
+  - Requires 13.2.2 and depends on OrthoConfig 7.2.6.
+  - Success: invalid selectors, languages, providers, detail levels, and
+    capability IDs enumerate valid values; collection outputs expose bounds,
+    cursors, truncation markers, and narrowing hints.
 
-### 13.4. Generate introspection, references, and drift gates
+### 13.3. Validate discoverability and drift prevention
 
-This step answers whether the command contract can stay synchronized as the
-surface grows. See `docs/weaver-design.md` §2.1.4 and ADR 007.
+This step answers whether humans and agents can discover the command contract
+from generated surfaces instead of hard-coded catalogues. It migrates prototype
+archive work 3.2.3 through 3.2.6, 5.7.1 through 5.7.5, and 11.3.2. See
+`docs/weaver-design.md` §§2.1.4 and 6.1.
 
-- [ ] 13.4.1. Implement `weaver context --json`.
-  - Requires 13.1.2 and depends on OrthoConfig 6.2.1 through 6.2.3.
+- [ ] 13.3.1. Implement `weaver context --json` for the pilot command family.
+  - Requires 13.2.3 and depends on OrthoConfig 6.2.1 through 6.2.3.
   - Success: context output includes schema version, commands, flags, enum
-    values, output schemas, error taxonomy, capabilities, provider summaries,
-    profiles, jobs, delivery schemes, feedback state, and skill paths.
-- [ ] 13.4.2. Implement `weaver capabilities list --json`.
-  - Requires 13.4.1.
-  - Success: runtime capability availability is separated from full command
-    context and includes deterministic provider selection rationale.
-- [ ] 13.4.3. Implement `weaver skill-path` and initial skill manifests.
-  - Requires 13.4.1 and depends on OrthoConfig 6.3.
-  - Success: skills teach workflows rather than command catalogues, and
-    validation fails when a skill mentions unknown commands or flags.
-- [ ] 13.4.4. Add generated artefact and drift gates.
-  - Requires steps 13.1-13.4.
-  - Generate or validate clap definitions, daemon router metadata, localized
-    help, manpages, shell completions, docs snippets, JSON schema fixtures,
-    vocabulary linting, and tests.
-  - Success: CI fails when schema, router, help, docs, localization, context,
-    skill manifests, or test fixtures drift.
+    values, output schemas, error taxonomy, capabilities, selected-provider
+    summaries, and skill paths.
+- [ ] 13.3.2. Implement `weaver capabilities list --json` from runtime
+      provider state.
+  - Requires 13.3.1.
+  - Success: capability availability is separated from full command context
+    and includes deterministic provider selection rationale.
+- [ ] 13.3.3. Implement `weaver help`, command help, manpage input, shell
+      completions, and `weaver skill-path` from the same metadata.
+  - Requires 13.3.1 and depends on OrthoConfig 6.3 and 8.1.
+  - Success: generated references, localized help, skills, and completion
+    fixtures fail CI when they mention unknown commands or flags.
+- [ ] 13.3.4. Add command-surface drift gates for the pilot.
+  - Requires steps 13.1-13.3.
+  - Success: CI rejects schema, router, help, docs, localization, context,
+    skill, vocabulary, stdout/stderr, and JSON-schema drift for the pilot
+    command family.
 
-## 14. Resource command slice: definitions, references, diagnostics, and cards
+## 14. Code-reading loop slice
 
-Idea: if existing LSP, Tree-sitter, and card foundations can be re-exposed
-through the new generated surface, Weaver proves the reset without waiting for
-new semantic engines.
+Idea: if Weaver can answer common code-reading questions through the new
+command surface, using existing LSP, Tree-sitter, cards, and bounded graph
+foundations, the redesign proves immediate value before advanced query or
+mutation work lands.
 
-This slice migrates useful read-only commands first. It gives humans and agents
-immediate value while validating selectors, renderers, and capability
-introspection end to end.
+This phase validates the first real product workflow: ask where a symbol is,
+where it is used, what diagnostics surround it, and what compact context an
+agent should read next. It migrates archive work from LSP command parity,
+cards-first context, same-file graph slices, and agent-grade compact output.
 
-### 14.1. Re-expose LSP perceptors through resource commands
+### 14.1. Prove LSP-backed resource commands
 
 This step answers whether existing semantic backends fit the resource-first
-surface without provider-specific commands. See `docs/weaver-design.md` §§2.2,
-3.1, and 6.1.
+surface without provider-specific commands. It migrates prototype archive work
+10.1.1 through 10.3.2. See `docs/weaver-design.md` §§2.2, 3.1, and 6.1.
 
 - [ ] 14.1.1. Implement `weaver definitions get`.
   - Requires phase 13.
@@ -206,370 +195,478 @@ surface without provider-specific commands. See `docs/weaver-design.md` §§2.2,
     stable JSON under `--json`, with provider provenance in machine output.
 - [ ] 14.1.2. Implement `weaver references list`.
   - Requires 14.1.1.
-  - Success: list output is bounded, cursor-aware, and suitable for downstream
-    selector processing.
+  - Success: reference lists are bounded, cursor-aware, provider-provenanced,
+    and suitable for downstream selector processing.
 - [ ] 14.1.3. Implement `weaver diagnostics list`.
   - Requires 14.1.1.
   - Success: diagnostics preserve source ranges, severity, provider
     provenance, and actionable error classes in both renderer modes.
+- [ ] 14.1.4. Add combinatorial read-command E2E coverage.
+  - Requires 14.1.1 through 14.1.3.
+  - Success: one suite covers human output, `--json`, `--plain`, bounded
+    output, invalid selectors, invalid enum values, missing capabilities, and
+    provider-unavailable cases.
 
-### 14.2. Re-expose card and graph-slice context
+### 14.2. Prove card-first context is useful before full graph traversal
 
-This step answers whether Jacquard-style cards and graph slices can become
-first-class resource commands while preserving existing completed work. See
-`docs/jacquard-card-first-symbol-graph-design.md` and `docs/weaver-design.md`
-§3.3.
+This step answers whether compact symbol cards are enough to guide a user or
+agent to the next useful read. It migrates prototype archive work 7.1.1 through
+7.1.4, 9.2.1 through 9.2.3, and 10.2.1 through 10.2.2. See
+`docs/jacquard-card-first-symbol-graph-design.md` §§5-11.
 
-- [ ] 14.2.1. Implement `weaver cards get`.
-  - Requires 14.1.1 and historical archive work 7.1.1 through 7.1.4.
-  - Success: the command accepts position references and Sempai selectors where
-    unambiguous, and returns stable card JSON with bounded enrichment.
-- [ ] 14.2.2. Implement `weaver graph-slices get`.
-  - Requires 14.2.1 and historical archive work 7.2.1.
-  - Success: graph traversal exposes explicit budgets, truncation markers,
-    provenance, and guidance for narrowing.
-- [ ] 14.2.3. Add combinatorial read-command E2E coverage.
-  - Requires steps 14.1-14.2.
-  - Success: the suite covers human output, `--json`, `--plain`, bounded
-    output, invalid enum errors, missing capabilities, and provider
-    unavailable cases across the resource read commands.
+- [ ] 14.2.1. Implement `weaver cards get` for position references.
+  - Requires 14.1.1 and reuses prototype archive work 7.1.1 through 7.1.4.
+  - Success: cards expose stable JSON, bounded enrichment, detail levels,
+    cache provenance, and useful human summaries.
+- [ ] 14.2.2. Add qualified symbol selectors to `cards get`.
+  - Requires 14.2.1.
+  - Success: symbol, path, and container qualifiers disambiguate common cases;
+    ambiguous selectors fail with enumerating alternatives.
+- [ ] 14.2.3. Add one-hop relation summaries to cards.
+  - Requires 14.2.2 and reuses prototype archive work 3.1.4 and 9.3.1.
+  - Success: cards can include bounded callers, callees, imports, dependencies,
+    or dependents without invoking a full graph-slice command.
 
-### 14.3. Make Sempai one-liners first-class selectors
+### 14.3. Decide whether static search belongs in the first code-reading loop
 
-This step answers whether the future Sempai DSL can select one symbol or a
-collection of symbols before full Sempai execution is complete. See
-`docs/sempai-query-language-design.md` and `docs/weaver-design.md` §2.1.2.
+This step answers whether structural grep should graduate now or wait for the
+Sempai selector slice. It migrates the product intent of prototype archive work
+10.4.1 through 10.4.2 and 5.5.1 without forcing provider-specific commands.
 
-- [ ] 14.3.1. Add selector record schemas for Sempai one-liners.
-  - Requires 13.4.4 and historical archive work 4.1.1 through 4.1.5.
-  - Success: selector records carry identity, range, language, query, capture,
-    confidence, and provider provenance needed for safe downstream mutation.
-- [ ] 14.3.2. Implement `weaver symbols list --query`.
+- [ ] 14.3.1. Prototype `weaver symbols list --pattern` over `weaver-syntax`
+      and optional `srgn`.
+  - Requires 13.3.2 and 14.1.1.
+  - Success: the prototype either returns bounded selector records across Rust,
+    Python, and TypeScript, or records why pattern search must wait for the
+    Sempai slice.
+- [ ] 14.3.2. Decide whether the static-search pilot graduates into the live
+      command contract.
   - Requires 14.3.1.
-  - Success: `weaver symbols list --query 'fn $name(...)' --json` emits a
-    bounded selector stream that ordinary UNIX filters can process.
-- [ ] 14.3.3. Add selector stream compatibility checks.
-  - Requires 14.3.2.
-  - Success: commands consuming selector streams reject incompatible records
-    with enumerating, structured errors rather than guessing.
+  - Success: ADR 007 or the roadmap records one of three outcomes: graduate as
+    `symbols list --pattern`, fold into `symbols list --query`, or defer.
 
-## 15. Capability-routed mutation slice: symbols and patches
+## 15. Sempai selector-to-context slice
 
-Idea: if symbol and patch mutations can run through one resource-first,
-capability-routed transaction path, Weaver proves that agent-native commands do
-not weaken its safety model.
+Idea: if Sempai one-liners can select symbols and immediately feed cards plus
+one-hop graph context, Weaver proves that query language work pays off as a
+composable product loop rather than as a standalone parser layer.
 
-This slice migrates the implemented patch and rename foundations under the new
-grammar, then adds direct selector-based mutation and observe-to-act
-composition.
+This phase deliberately validates the narrowest useful Sempai workflow before
+building the full Semgrep-compatible backend. It migrates archive work from
+Sempai DSL parsing, Tree-sitter execution, query routing, symbol-first cards,
+and the Sempai-to-Jacquard vertical slice.
 
-### 15.1. Migrate patches and rename under the new grammar
+### 15.1. Prove a minimal one-liner selector with honest diagnostics
 
-This step answers whether existing safety-harness and actuator work can be
-reused without exposing provider-first commands. See `docs/weaver-design.md`
-§§4.1-4.3 and ADR 001.
+This step answers whether the target one-liner grammar can select real symbols
+without overbuilding the full query engine. It migrates prototype archive work
+4.1.6 through 4.1.7, 4.3.3, and 9.1.1. See
+`docs/sempai-query-language-design.md` §§3-6.
 
-- [ ] 15.1.1. Implement `weaver patches apply`.
-  - Requires phase 13 and historical archive work 6.1.1 through 6.1.4.
+- [ ] 15.1.1. Implement one-liner tokenization and Pratt parsing for positive
+      symbol patterns.
+  - Requires 13.2.2.
+  - Success: valid one-liners compile to canonical formula form, malformed
+    input produces stable `E_SEMPAI_*` diagnostics, and recovery preserves
+    partial anchors where safe.
+- [ ] 15.1.2. Define selector record schemas for one-liner matches.
+  - Requires 15.1.1.
+  - Success: selector records carry identity, range, language, query, capture,
+    confidence, and provider provenance needed for safe downstream context or
+    mutation.
+
+### 15.2. Prove Tree-sitter execution on the smallest useful language set
+
+This step answers whether Semgrep-style matching can run accurately enough on
+real syntax before the full operator matrix lands. It migrates prototype
+archive work 4.2.1 through 4.2.12 and 9.1.2 through 9.1.3. See
+`docs/sempai-query-language-design.md` §§7-12.
+
+- [ ] 15.2.1. Implement language profiles and snippet wrapping for Rust and
+      Python.
+  - Requires 15.1.2.
+  - Success: the profiles support safe snippet parsing, wrapper provenance,
+    and clear refusal for unsupported languages.
+- [ ] 15.2.2. Implement node-kind matching, metavariable unification, and
+      bounded ellipsis for the pilot profiles.
+  - Requires 15.2.1.
+  - Success: positive-pattern fixtures match expected symbols, execution caps
+    prevent runaway matches, and unsupported operators enumerate alternatives.
+- [ ] 15.2.3. Decide whether TypeScript joins the first Sempai slice.
+  - Requires 15.2.2.
+  - Success: TypeScript either passes the same selector fixtures or is deferred
+    with a documented blocker and fallback behaviour.
+
+### 15.3. Prove query output composes with context commands
+
+This step answers whether one-liner selectors can feed product commands rather
+than remaining search output. It migrates prototype archive work 4.3.1 through
+4.3.9, 9.1.4 through 9.3.2, and 11.2.1. See `docs/weaver-design.md` §2.1.2.
+
+- [ ] 15.3.1. Implement `weaver symbols list --query`.
+  - Requires 15.2.2 and 14.2.1.
+  - Success: `symbols list --query 'fn $name(...)' --json` emits bounded
+    selector records that ordinary UNIX filters can preserve.
+- [ ] 15.3.2. Allow `cards get` and one-hop relation summaries to consume
+      Sempai selectors.
+  - Requires 15.3.1 and 14.2.3.
+  - Success: one query-to-card-to-relation workflow works in one command and
+    in a pipeline, with deterministic zero-, one-, and many-match behaviour.
+- [ ] 15.3.3. Add Sempai selector conformance and pipeline E2E coverage.
+  - Requires 15.3.2.
+  - Success: suites cover YAML-backed and one-liner selectors, malformed query
+    recovery, `jq` filtering, pager consumption, bounded output, and invalid
+    selector-stream rejection.
+
+## 16. Safe change loop slice
+
+Idea: if the same selector records can drive safe patches, renames, and
+extract-or-move refactors through capability-routed actuators, Weaver proves
+that agent-native composition does not weaken the Double-Lock safety model.
+
+This phase validates the first end-to-end observe-to-act loop. It migrates
+archive work from apply-patch, rename-symbol, extrication, selector handoff,
+mutation metadata, and visible safety-harness reporting.
+
+### 16.1. Prove patch application under the new command contract
+
+This step answers whether the completed patch and Double-Lock foundations fit
+the resource-first grammar. It migrates prototype archive work 6.1.1 through
+6.1.4 and 11.4.1 through 11.4.2. See `docs/weaver-design.md` §§4.2-4.3.
+
+- [ ] 16.1.1. Implement `weaver patches apply`.
+  - Requires phase 13 and reuses prototype archive work 6.1.1 through 6.1.4.
   - Success: `patches apply` preserves Double-Lock verification, atomic
-    transactions, `--dry-run`, structured safety results, and universal
-    `--json`.
-- [ ] 15.1.2. Implement `weaver symbols rename` for position references.
-  - Requires 15.1.1 and historical archive work 5.2.1 through 5.2.5.
+    transactions, `--dry-run`, structured safety results, universal `--json`,
+    and human-readable safety summaries.
+- [ ] 16.1.2. Add idempotency keys, transaction IDs, and retry matching for
+      patch application.
+  - Requires 16.1.1 and depends on OrthoConfig 7.2.1.
+  - Success: repeated equivalent patch submissions return the existing
+    transaction or refusal instead of duplicating work.
+- [ ] 16.1.3. Standardize mutation `--dry-run`, `--force`, and structured
+      safety metadata.
+  - Requires 16.1.2 and depends on OrthoConfig 7.2.1.
+  - Success: mutating commands declare preview, destructive-operation, and
+    safety-harness policy in command-surface metadata.
+
+### 16.2. Prove capability-routed rename from positions and selectors
+
+This step answers whether provider-hidden actuators can mutate safely from both
+direct references and Sempai streams. It migrates prototype archive work 5.2.1
+through 5.2.6, 10.5.1 through 10.5.2, and 4.3.5. See ADR 001 and ADR 004.
+
+- [ ] 16.2.1. Implement `weaver symbols rename` for position references.
+  - Requires 16.1.3 and reuses prototype archive work 5.2.1 through 5.2.5.
   - Success: provider routing remains capability-first, mutation results
     include transaction ID, affected paths, provider provenance, and safety
     outcome.
-- [ ] 15.1.3. Implement `weaver symbols move` or `weaver symbols extract`.
-  - Requires 15.1.2 and historical archive work 5.3 and 5.4.
-  - Success: the public verb is canonical, the internal capability captures
-    the richer operation, and no provider-specific command is required.
-
-### 15.2. Prove selector-driven mutation and pipeline composition
-
-This step answers whether observe-style resource commands and act-style
-mutation commands compose through structured streams. See
-`docs/weaver-design.md` §2.1.2.
-
-- [ ] 15.2.1. Add direct Sempai selector support to symbol mutations.
-  - Requires 14.3.2 and 15.1.2.
-  - Success: `weaver symbols rename --query ...` handles zero, one, and many
-    matches deterministically and requires explicit policy for ambiguous
-    mutation.
-- [ ] 15.2.2. Add `--from-stdin` selector stream consumption.
-  - Requires 14.3.3 and 15.1.2.
-  - Success: `weaver symbols list --query … --json | weaver symbols rename
-    --from-stdin …` works without hidden state.
-- [ ] 15.2.3. Add filtered pipeline E2E coverage.
-  - Requires 15.2.2.
-  - Success: at least one scenario pipes selector records through `jq` before
-    mutation, and one scenario pipes observe-style output into a pager or other
-    UNIX consumer without mutation.
-
-### 15.3. Harden mutation boundaries for retries and destructive operations
-
-This step answers whether agents can retry safely and humans can preview
-consequential changes. See `docs/weaver-design.md` §§2.1.5 and 4.2.
-
-- [ ] 15.3.1. Add idempotency keys and mutation transaction IDs.
-  - Requires 15.1.1 and depends on OrthoConfig 7.2.1.
-  - Success: repeated equivalent mutation submissions return the existing
-    transaction or refusal rather than duplicating work.
-- [ ] 15.3.2. Standardize `--dry-run` and `--force`.
-  - Requires 15.3.1 and depends on OrthoConfig 7.2.1.
-  - Success: all mutating commands declare preview and destructive-operation
-    policy in the command-surface metadata.
-- [ ] 15.3.3. Add mutation combinatorial E2E coverage.
-  - Requires steps 15.1-15.3.
+- [ ] 16.2.2. Add direct Sempai selector support to `symbols rename`.
+  - Requires 15.3.1 and 16.2.1.
+  - Success: `symbols rename --query ...` handles zero, one, and many matches
+    deterministically and requires explicit policy for ambiguous mutation.
+- [ ] 16.2.3. Add `--from-stdin` selector stream consumption to mutation
+      commands.
+  - Requires 15.3.3 and 16.2.2.
+  - Success: `weaver symbols list --query … --json | jq … | weaver symbols
+    rename --from-stdin …` works without hidden state.
+- [ ] 16.2.4. Add rename and selector-mutation combinatorial E2E coverage.
+  - Requires 16.2.3.
   - Success: coverage combines selector forms, `--json`, `--dry-run`,
     idempotency, provider failures, syntactic failures, semantic failures, and
     rollback assertions.
 
-## 16. Async execution, profiles, delivery, and feedback
+### 16.3. Decide whether move/extract is viable for the core product
 
-Idea: if Weaver gives agents durable identity, recoverable execution, and
-structured artefact routing, long-running workflows collapse into fewer
-reliable turns without becoming hostile to humans.
+This step answers whether extrication is a dependable product differentiator or
+an attractive but unstable refactor. It migrates prototype archive work 5.3.1
+through 5.4.7 under canonical public verbs. See
+`docs/rust-extricate-actuator-plugin-technical-design.md`.
 
-This phase adds compounding primitives after the core read and mutation loops
-are stable.
-
-### 16.1. Add durable jobs and `--wait`
-
-This step answers whether async work can survive process loss and retry without
-duplicate submissions. See `docs/weaver-design.md` §2.1.5.
-
-- [ ] 16.1.1. Implement the Weaver job ledger.
-  - Requires 15.3.1 and depends on OrthoConfig 9.3.
-  - Success: XDG state stores job ID, command path, idempotency key, workspace,
-    request hash, status, progress, timestamps, result pointer, and exit class.
-- [ ] 16.1.2. Implement `weaver jobs list|get|prune`.
-  - Requires 16.1.1.
-  - Success: job lists are bounded, job lookup is structured, and prune is
-    explicit and safe.
-- [ ] 16.1.3. Add `--wait` to async-submitting commands.
-  - Requires 16.1.2.
-  - Success: submit-poll-collect workflows support backoff, jitter, timeout,
-    cancellation, and ledger recovery.
-
-### 16.2. Add profiles and persistent identity
-
-This step answers whether repeated agent and human workflows can share durable
-configuration without leaking secrets. See `docs/weaver-design.md` §2.1.5.
-
-- [ ] 16.2.1. Implement profile storage and redaction.
-  - Requires 13.4.1 and depends on OrthoConfig 9.1.
-  - Success: profile names and metadata appear in `context --json`, while
-    secret values remain redacted or represented as references.
-- [ ] 16.2.2. Implement `weaver profiles save|list|show|delete`.
+- [ ] 16.3.1. Implement the `symbol.move` or `symbol.extract` capability
+      contract and refusal vocabulary.
   - Requires 16.2.1.
-  - Success: profile precedence is
-    `built-in defaults < config files < selected profile < environment < flags`.
-- [ ] 16.2.3. Add root `--profile <name>`.
-  - Requires 16.2.2.
-  - Success: explicit flags override profile values and invalid profile names
-    enumerate available profiles.
+  - Success: the public command uses canonical verbs while the internal
+    capability captures transaction, import-repair, and provider constraints.
+- [ ] 16.3.2. Prototype Python symbol extraction through Rope.
+  - Requires 16.3.1.
+  - Success: a narrow class of Python moves either commits safely through the
+    Double-Lock path or records refusal reasons that invalidate the approach.
+- [ ] 16.3.3. Prototype Rust symbol movement through rust-analyzer.
+  - Requires 16.3.1.
+  - Success: a narrow class of Rust moves either commits safely with
+    import/module repair or records compatibility limits that defer the
+    feature.
+- [ ] 16.3.4. Decide whether move/extract graduates from the core roadmap.
+  - Requires 16.3.2 and 16.3.3.
+  - Success: the roadmap records one of three outcomes: graduate both
+    languages, graduate one language with clear limits, or defer the capability
+    out of the 0.1.0 core.
 
-### 16.3. Add two-way I/O
+## 17. Impact and history slice
 
-This step answers whether generated artefacts and friction reports can land
-where users and agents need them. See `docs/weaver-design.md` §2.1.6.
+Idea: if graph slices, history reconstruction, and probabilistic matching can
+explain the blast radius of a proposed change with bounded output, Weaver moves
+beyond point queries into decision support without overwhelming agent context.
 
-- [ ] 16.3.1. Implement `--deliver stdout|file:<path>|webhook:<url>`.
-  - Requires 13.3.2 and depends on OrthoConfig 9.2.1.
-  - Success: file delivery is atomic, webhook delivery reports HTTP status,
-    and unknown schemes enumerate valid schemes.
-- [ ] 16.3.2. Implement `weaver feedback create|list|send`.
-  - Requires 16.3.1 and depends on OrthoConfig 9.2.2.
-  - Success: local feedback writes JSONL by default, upstream send is optional
-    and configured, and feedback availability appears in `context --json`.
-- [ ] 16.3.3. Add delivery and feedback E2E coverage.
-  - Requires 16.3.1 and 16.3.2.
-  - Success: tests cover stdout, atomic file, webhook success, webhook failure,
-    unknown delivery schemes, local feedback, and configured upstream send.
+This phase validates richer graph work only after the read and mutation loops
+exist. It migrates archive work from graph-slice traversal, graph-history,
+probabilistic matching, static-analysis provider integration, optional ledger
+cache, and card-driven traversal.
 
-## 17. Sempai and graph intelligence under the new grammar
+### 17.1. Prove graph slices add useful context beyond cards
 
-Idea: if Sempai and graph expansion land after selectors and resource commands
-are stable, they strengthen the same user workflows instead of creating a
-parallel query subsystem.
+This step answers whether graph traversal gives enough extra value to justify
+its complexity. It migrates prototype archive work 7.2.2 through 7.2.5, 11.1.1,
+and 11.2.2. See `docs/jacquard-card-first-symbol-graph-design.md` §§12-13.
 
-This phase migrates the existing Sempai and Jacquard plans under `symbols`,
-`cards`, and `graph-slices`.
+- [ ] 17.1.1. Implement `weaver graph-slices get` with Tree-sitter inventory
+      and LSP call edges.
+  - Requires 14.2.3.
+  - Success: graph slices include bounded cards, typed edges, provenance,
+    truncation markers, and useful human summaries.
+- [ ] 17.1.2. Add import, config, dependency, and dependent edge extraction.
+  - Requires 17.1.1 and reuses prototype archive work 5.9.1.
+  - Success: static-analysis and graph providers enrich slices without adding
+    provider-specific public commands.
+- [ ] 17.1.3. Implement budgeted priority traversal and graph-slice E2E
+      coverage.
+  - Requires 17.1.2.
+  - Success: tests prove edge, card, depth, and token budgets across mixed
+    edge types; truncated responses include narrowing hints.
 
-### 17.1. Finish the Sempai execution engine
+### 17.2. Prove history mode before investing in probabilistic matching
 
-This step answers whether the query language can execute with stable
-diagnostics and bounded behaviour. See `docs/sempai-query-language-design.md`.
+This step answers whether historical graph reconstruction is stable enough to
+support change-risk narratives. It migrates prototype archive work 7.3.1
+through 7.3.5. See `docs/jacquard-card-first-symbol-graph-design.md` §§16-17.
 
-- [ ] 17.1.1. Implement the one-liner lexer, parser, and recovery path.
-  - Requires historical archive work 4.1.1 through 4.1.5.
-  - Success: valid one-liners compile to canonical formula form, malformed
-    input produces stable `E_SEMPAI_*` diagnostics, and recovery preserves
-    partial anchors where safe.
-- [ ] 17.1.2. Implement the Tree-sitter backend.
-  - Requires 17.1.1 and historical archive work 4.2.
-  - Success: Rust, Python, and TypeScript profiles support Semgrep-compatible
-    pattern matching, metavariable unification, ellipsis, constraints, focus,
-    and bounded execution controls.
-- [ ] 17.1.3. Route Sempai execution through resource commands.
-  - Requires 14.3.2 and 17.1.2.
-  - Success: query execution feeds `symbols list`, cards, and graph workflows
-    without adding a future public `observe query` command.
+- [ ] 17.2.1. Implement git-backed graph-slice reconstruction per commit.
+  - Requires 17.1.3.
+  - Success: history mode loads blobs without mutating the worktree, reports
+    explicit data quality, and keeps defaults safe for large repositories.
+- [ ] 17.2.2. Implement normalized graph delta computation and risk warnings.
+  - Requires 17.2.1.
+  - Success: added, removed, changed, moved, and uncertain nodes or edges have
+    stable reason codes and useful human summaries.
+- [ ] 17.2.3. Decide whether a versioned graph ledger belongs in core.
+  - Requires 17.2.2 and migrates prototype archive work 7.5.1 through 7.5.2.
+  - Success: the decision either adds cache population and invalidation to the
+    core plan or defers it with measured performance evidence.
 
-### 17.2. Complete graph-slice and history workflows
+### 17.3. Prove probabilistic matching only where history needs it
 
-This step answers whether cards and graph slices can give agents compact,
-bounded context across code structure and history. See
-`docs/jacquard-card-first-symbol-graph-design.md`.
+This step answers whether fuzzy matching improves history explanations enough
+to carry its complexity. It migrates prototype archive work 7.4.1 through 7.4.9
+and 8.6.2. See `docs/jacquard-card-first-symbol-graph-design.md` §§14-15.
 
-- [ ] 17.2.1. Complete graph-slice extraction and traversal.
-  - Requires 14.2.2 and historical archive work 7.2.2 through 7.2.5.
-  - Success: Tree-sitter inventory, LSP call edges, import/config edges, and
-    budgeted traversal produce bounded graph-slice JSON and useful human
-    summaries.
-- [ ] 17.2.2. Implement graph history and risk deltas.
-  - Requires 17.2.1 and historical archive work 7.3.
-  - Success: history mode reconstructs slices per commit, reports normalized
-    deltas, and keeps defaults safe for large repositories.
-- [ ] 17.2.3. Implement probabilistic identity matching.
-  - Requires 17.2.2 and historical archive work 7.4.
-  - Success: matching emits reason codes, duplicate-name guardrails, calibrated
-    confidence, and assignment decisions suitable for agents to inspect.
+- [ ] 17.3.1. Implement stable-identity, body-hash, and structural-hash
+      matching phases.
+  - Requires 17.2.2.
+  - Success: exact and structural matches produce reason codes and reject
+    duplicate-name ambiguity by default.
+- [ ] 17.3.2. Prototype fuzzy similarity and graph-refinement matching.
+  - Requires 17.3.1.
+  - Success: fuzzy matches improve fixture accuracy without exceeding bounded
+    candidate or token budgets; otherwise the fuzzy phase is disabled by
+    default.
+- [ ] 17.3.3. Add assignment guardrails and matching E2E coverage.
+  - Requires 17.3.2.
+  - Success: assignments are injective by default, split/merge modes are
+    explicit, and confidence scores are calibrated against fixture evidence.
 
-## 18. Plugin ecosystem behind capability contracts
+## 18. Provider ecosystem slice
 
-Idea: if Weaver keeps providers behind capability contracts, it can add
-specialist tools without forcing users or agents to learn backend-specific
-commands.
+Idea: if specialist perceptors and actuators can improve concrete workflows
+while remaining hidden behind capability contracts, Weaver can grow an
+ecosystem without forcing users or agents to learn provider-specific commands.
 
-This phase expands perceptors and actuators after the resource and mutation
-contracts have proven the routing model.
+This phase validates additional plugins only after the core command, selector,
+mutation, and graph loops exist. It migrates archive work from additional
+actuators, specialist sensors, plugin introspection, graceful degradation, and
+capability discoverability.
 
-### 18.1. Normalize existing and planned actuator capabilities
+### 18.1. Prove providers remain implementation details during success
 
-This step answers whether Rope, rust-analyzer, and later actuators can share
-one public contract. See ADR 001, ADR 004, and ADR 006.
+This step answers whether Rope, rust-analyzer, `srgn`, `jedi`, static analysis,
+and future providers can share one public capability contract. It migrates
+prototype archive work 5.5.1, 5.6.1, and 5.8.1. See ADR 001, ADR 004, and ADR
+006.
 
-- [ ] 18.1.1. Publish capability migration notes for `symbol.rename`.
-  - Requires historical archive work 5.2.1 through 5.2.5.
-  - Success: docs explain provider provenance, refusal semantics, and the
-    resource-first replacement for provider-required refactor commands.
-- [ ] 18.1.2. Migrate extrication work to `symbol.move` or `symbol.extract`.
-  - Requires 15.1.3 and historical archive work 5.3 and 5.4.
-  - Success: public commands use canonical verbs while internal capabilities
-    retain enough detail for Rope and rust-analyzer implementations.
-- [ ] 18.1.3. Add additional actuator providers behind manifests.
-  - Requires 18.1.2 and historical archive work 5.5.
-  - Success: srgn or equivalent tools declare capability support without
-    adding provider-specific public commands.
-
-### 18.2. Add specialist perceptors and capability discoverability
-
-This step answers whether read-only specialist providers improve results while
-remaining transparent to ordinary users. See `docs/weaver-design.md` §4.1.
-
-- [ ] 18.2.1. Deliver the first specialist perceptor provider.
-  - Requires 14.1.3 and historical archive work 5.6.
+- [ ] 18.1.1. Add `srgn` or equivalent as an actuator or selector provider
+      behind manifests.
+  - Requires 16.2.1.
+  - Success: the provider declares capability support without adding a
+    provider-specific public command.
+- [ ] 18.1.2. Add `jedi` or equivalent as the first specialist perceptor
+      provider.
+  - Requires 14.1.3.
   - Success: the provider enriches definitions, references, diagnostics,
-    cards, or symbol matches through capability routing, not through a public
-    provider command.
-- [ ] 18.2.2. Wire provider summaries into `capabilities list` and
-      `context --json`.
-  - Requires 13.4.2 and depends on OrthoConfig 7.2.7.
-  - Success: agents can discover availability, selected provider, and refusal
-    reasons without parsing backend-specific help.
-- [ ] 18.2.3. Refine graceful degradation guidance.
-  - Requires 18.2.2 and historical archive work 5.8.
+    cards, or symbol matches through capability routing.
+- [ ] 18.1.3. Refine graceful degradation guidance for provider failures.
+  - Requires 18.1.1 and 18.1.2.
   - Success: unsupported capability errors suggest resource-first fallback
     workflows and enumerate valid alternatives.
 
-## 19. Formal verification and safety hardening
+### 18.2. Prove provider state is discoverable without leaking into workflow
 
-Idea: if formal checks attach to the safety and routing kernels after their
-public contracts settle, Weaver can prove the invariants that matter without
-freezing prototype interfaces.
+This step answers whether humans and agents can debug provider selection when
+needed without making provider names normal command syntax. It migrates
+prototype archive work 5.7.1 through 5.7.5 and 5.2.6. See
+`docs/weaver-design.md` §6.1.
 
-This phase preserves the existing formal-verification plan while tying it to
-the new command contract and mutation slices.
+- [ ] 18.2.1. Wire provider summaries into `capabilities list` and
+      `context --json`.
+  - Requires 13.3.2 and depends on OrthoConfig 7.2.7.
+  - Success: agents can discover availability, selected provider, refusal
+    reasons, and profile-driven policy without parsing backend-specific help.
+- [ ] 18.2.2. Publish capability migration notes for `symbol.rename` and
+      move/extract decisions.
+  - Requires 16.3.4.
+  - Success: docs explain provider provenance, refusal semantics, resource
+    command replacements, and any deferred provider-specific limits.
+- [ ] 18.2.3. Add provider-matrix E2E coverage.
+  - Requires 18.2.1 and 18.2.2.
+  - Success: one suite proves selected-provider reporting, fallback refusal,
+    missing-provider guidance, profile overrides, and JSON provenance across
+    read and write capabilities.
 
-### 19.1. Establish verifier tooling and proof contracts
+## 19. Agent workflow and assurance slice
 
-This step answers which invariants are proved and which external-tool
-behaviours remain trusted. See `docs/formal-verification-methods-in-weaver.md`.
+Idea: if durable execution state, profiles, delivery, feedback, onboarding, and
+formal checks can wrap the established read/write loops, Weaver becomes a
+dependable agent tool rather than a set of clever commands.
 
-- [ ] 19.1.1. Add pinned Kani and Verus tooling.
-  - Requires phase 15.
-  - Migrates historical archive work 8.1.
-  - Success: verifier installs are reproducible and normal Rust workflows are
-    unaffected unless a formal target is invoked.
-- [ ] 19.1.2. Publish transaction, semantic-lock, and trust-boundary contracts.
-  - Requires 19.1.1.
-  - Migrates historical archive work 8.2.
+This phase validates compounding agent-native primitives against real Weaver
+workflows instead of shipping them as abstract infrastructure. It migrates
+archive work from onboarding, interactive review, dynamic analysis ingestion,
+formal verification, output delivery, feedback, profiles, and jobs.
+
+### 19.1. Prove persistent workflow state on real commands
+
+This step answers whether profiles, jobs, and delivery reduce repeated agent
+turns without making human usage worse. It migrates the product intent of ADR
+007 compounding primitives and prototype archive work 6.2.1. See
+`docs/weaver-design.md` §§2.1.5-2.1.6.
+
+- [ ] 19.1.1. Implement profile storage, redaction, and root `--profile`.
+  - Requires 13.3.1 and depends on OrthoConfig 9.1.
+  - Success: profile names and metadata appear in `context --json`, secret
+    values stay redacted, and precedence is
+    `built-in defaults < config files < selected profile < environment < flags`.
+- [ ] 19.1.2. Implement durable job ledger support for long-running graph,
+      history, and mutation commands.
+  - Requires 16.1.2 and 17.2.1 and depends on OrthoConfig 9.3.
+  - Success: job records store command path, idempotency key, workspace,
+    request hash, status, progress, timestamps, result pointer, and exit class.
+- [ ] 19.1.3. Implement `--wait`, `jobs list|get|prune`, and delivery sinks on
+      at least one read workflow and one write workflow.
+  - Requires 19.1.2 and depends on OrthoConfig 9.2.1.
+  - Success: submit-poll-collect workflows support recovery, atomic file
+    delivery, webhook delivery, and structured refusal for unknown schemes.
+- [ ] 19.1.4. Implement `feedback create|list|send`.
+  - Requires 19.1.3 and depends on OrthoConfig 9.2.2.
+  - Success: local feedback writes JSONL by default, upstream send is optional
+    and configured, and feedback availability appears in `context --json`.
+
+### 19.2. Prove onboarding and optional interaction do not break automation
+
+This step answers whether richer human workflows can exist without weakening
+the non-interactive agent contract. It migrates prototype archive work 6.2.1
+through 6.2.3. See `docs/weaver-design.md` §§5-6.
+
+- [ ] 19.2.1. Recast project onboarding as a composition of resource-first
+      commands.
+  - Requires phases 14, 15, and 17.
+  - Success: onboarding consumes cards, graph slices, diagnostics, dependency
+    data, and optional dynamic-analysis inputs without adding a parallel
+    public command grammar.
+- [ ] 19.2.2. Implement explicit interactive review as an opt-in workflow.
+  - Requires 16.1.3.
+  - Success: interaction is available through `--interactive` or a dedicated
+    review command and fails fast when stdin is not a terminal.
+- [ ] 19.2.3. Decide whether dynamic-analysis ingestion belongs in core.
+  - Requires 17.1.2 and 19.2.1.
+  - Success: runtime traces either enrich graph slices with provenance and
+    bounded trust semantics or move to deferred extensions with rationale.
+
+### 19.3. Prove the owned safety kernels, not the external tools
+
+This step answers whether formal and property-based checks catch regressions in
+Weaver-owned invariants. It migrates prototype archive work 8.1.1 through
+8.6.3. See `docs/formal-verification-methods-in-weaver.md` and ADR 005.
+
+- [ ] 19.3.1. Add pinned Kani and Verus tooling plus explicit formal targets.
+  - Requires 16.1.1.
+  - Success: verifier installs are reproducible, normal Rust workflows are
+    unaffected, and slow proof suites stay out of default pull-request gates
+    until stable.
+- [ ] 19.3.2. Publish transaction, semantic-lock, and verification
+      trust-boundary contracts.
+  - Requires 19.3.1.
   - Success: docs distinguish verified orchestration from trusted providers,
-    language servers, parsers, and filesystems.
-
-### 19.2. Verify the highest-risk owned kernels
-
-This step answers whether Weaver's own write and routing decisions satisfy the
-documented invariants. See `docs/weaver-design.md` §§4.2-4.3.
-
-- [ ] 19.2.1. Add Kani checks for transactions and patch matching.
-  - Requires 19.1.2 and migrates historical archive work 8.3.
-  - Success: smoke harnesses prove commit gating, rollback bookkeeping,
-    bounded path guardrails, and whole-command abort on unmatched patch blocks.
-- [ ] 19.2.2. Add Kani and property checks for capability routing.
-  - Requires 18.2.2 and 19.1.2.
-  - Migrates historical archive work 8.4.
-  - Success: selected providers satisfy language and capability predicates,
-    and refusal is deterministic over bounded routing tables.
-- [ ] 19.2.3. Add proof-only Verus kernels where they reduce long-term risk.
-  - Requires 19.2.1 and 19.1.2.
-  - Migrates historical archive work 8.5 and 8.6.
+    language servers, parsers, operating systems, and filesystems.
+- [ ] 19.3.3. Add Kani checks for transaction, patch, routing, and bounded
+      graph kernels.
+  - Requires 19.3.2 and 17.1.3.
+  - Success: smoke harnesses cover commit gating, rollback bookkeeping,
+    bounded path guardrails, whole-command abort on unmatched patch blocks,
+    selected-provider predicates, refusal determinism, and graph budgets.
+- [ ] 19.3.4. Add proof-only Verus kernels where they reduce long-term risk.
+  - Requires 19.3.3.
   - Success: proof modules remain outside the production API and prove only
-    stable abstractions that will survive the 0.1.0 command reset.
+    stable abstractions that survived the read, mutation, and graph slices.
 
-## 20. Deferred extensions after the core 0.1.0 promise
+## 20. Deferred extensions after the core product promise
 
-Idea: if the core CLI contract is already trustworthy and boring to operate,
-the project can evaluate broader extensions on product value instead of letting
-them destabilize the main release.
+Idea: if the core CLI contract and semantic workflows are already trustworthy
+and boring to operate, the project can evaluate broader integrations on product
+value instead of letting them destabilize the main release.
 
-### 20.1. Re-evaluate onboarding and interactive workflows
+This phase is not a hiding place for relevant product work. Items land here
+only when the preceding slices can invalidate or defer them without weakening
+the core Weaver promise.
 
-This step keeps useful agent workflow ideas without letting them bypass the
-non-interactive contract. See `docs/weaver-design.md` §6.2.
+### 20.1. Evaluate generated integrations
 
-- [ ] 20.1.1. Recast project onboarding under resource-first commands.
-  - Requires phases 14 and 17.
-  - Migrates historical archive work 6.2.1.
-  - Success: onboarding consumes cards, graph slices, diagnostics, and
-    dependency data without adding a parallel public command grammar.
-- [ ] 20.1.2. Design explicit interactive review workflows.
-  - Requires phase 15.
-  - Migrates historical archive work 6.2.2.
-  - Success: interaction is opt-in via `--interactive` or a dedicated review
-    command and fails fast when stdin is not a terminal.
+This step answers whether external integration surfaces are wrappers over the
+same command metadata or a distracting second product. See ADR 007 and
+OrthoConfig 10.1.
 
-### 20.2. Evaluate MCP, SDK, and runtime explorer generation
-
-This step defers generated integrations until the CLI contract they would wrap
-is stable. See ADR 007 and OrthoConfig 10.1.
-
-- [ ] 20.2.1. Decide whether to generate MCP descriptions from
+- [ ] 20.1.1. Decide whether to generate MCP descriptions from
       `context --json`.
   - Requires phase 13 and depends on OrthoConfig 10.1.1.
   - Success: the decision compares generated MCP descriptions against the
     command-surface token budget and records whether the feature belongs in
     Weaver 0.1.x.
-- [ ] 20.2.2. Decide whether SDK or OpenAPI-shaped runtime explorers are in
+- [ ] 20.1.2. Decide whether SDK or OpenAPI-shaped runtime explorers are in
       scope.
-  - Requires 20.2.1 and depends on OrthoConfig 10.1.2.
+  - Requires 20.1.1 and depends on OrthoConfig 10.1.2.
   - Success: any accepted explorer uses the same command metadata and does not
     become a second source of truth.
+
+### 20.2. Evaluate deferred provider and analysis experiments
+
+This step answers whether experiments invalidated by earlier slices deserve a
+new design rather than quiet re-entry into the core roadmap.
+
+- [ ] 20.2.1. Reassess deferred move/extract language support.
+  - Requires 16.3.4.
+  - Success: unsupported languages or symbol kinds either gain new provider
+    evidence or remain explicitly out of scope.
+- [ ] 20.2.2. Reassess deferred dynamic-analysis ingestion.
+  - Requires 19.2.3.
+  - Success: runtime trace ingestion either has bounded trust semantics and a
+    graph integration point or remains out of the core product.
+- [ ] 20.2.3. Reassess optional graph ledger caching.
+  - Requires 17.2.3.
+  - Success: cache work resumes only if measured repository-scale performance
+    makes it necessary for the core workflows.
 
 ## Archive
 
 Historical prototype roadmap entries live in
 [`docs/archive/prototype-roadmap.md`](archive/prototype-roadmap.md). Those
 entries keep numbers `1` through `11`; this live roadmap reserves numbers `12`
-through `20` for the forward ADR 007 build sequence.
+through `20` for the forward ADR 007 build sequence. The archive is not an
+active implementation backlog.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -603,69 +603,172 @@ beyond point queries into decision support without overwhelming agent context.
 
 This phase validates richer graph work only after the read and mutation loops
 exist. It migrates archive work from graph-slice traversal, graph-history,
-probabilistic matching, static-analysis provider integration, optional ledger
-cache, and card-driven traversal.
+probabilistic matching, static-analysis provider integration, conditional
+ledger caching, and card-driven traversal.
 
 ### 17.1. Prove graph slices add useful context beyond cards
 
 This step answers whether graph traversal gives enough extra value to justify
-its complexity. It migrates prototype archive work 7.2.2 through 7.2.5, 11.1.1,
-and 11.2.2. See `docs/jacquard-card-first-symbol-graph-design.md` §§12-13.
+its complexity. It preserves the completed prototype archive schema work 7.2.1
+and migrates prototype archive work 7.2.2 through 7.2.5, 11.1.1, and 11.2.2.
+See `docs/jacquard-card-first-symbol-graph-design.md` §12.1 through §12.3.
 
-- [ ] 17.1.1. Implement `weaver graph-slices get` with Tree-sitter inventory
-      and LSP call edges.
-  - Requires 14.2.3.
-  - Success: graph slices include bounded cards, typed edges, provenance,
-    truncation markers, and useful human summaries.
-- [ ] 17.1.2. Add import, config, dependency, and dependent edge extraction.
-  - Requires 17.1.1 and reuses prototype archive work 5.9.1.
-  - Success: static-analysis and graph providers enrich slices without adding
-    provider-specific public commands.
-- [ ] 17.1.3. Implement budgeted priority traversal and graph-slice E2E
-      coverage.
-  - Requires 17.1.2.
-  - Success: tests prove edge, card, depth, and token budgets across mixed
-    edge types; truncated responses include narrowing hints.
+- [ ] 17.1.1. Implement a two-pass Tree-sitter extraction pipeline for graph
+      slices.
+  - Requires 14.2.3 and uses completed prototype archive work 7.2.1.
+  - Success: edge extraction builds a full or partial symbol table before
+    resolving edges, every edge carries resolution scope
+    (`full_symbol_table`, `partial_symbol_table`, or `lsp`), and unresolved
+    references are preserved as external nodes with explicit confidence.
+- [ ] 17.1.2. Implement call-edge slice expansion through `weaver-graph`.
+  - Requires 17.1.1.
+  - Success: `call` edges use the existing LSP call hierarchy provider,
+    include explicit provenance, enforce depth limits, and have end-to-end
+    coverage for a depth-2 traversal on a fixture repository.
+- [ ] 17.1.3. Implement baseline `import` and `config` edge extraction.
+  - Requires 17.1.1.
+  - Success: Tree-sitter interstitial passes and per-language queries emit
+    bounded `import` and `config` edges with confidence values, provenance,
+    and at least one test per supported language.
+- [ ] 17.1.4. Add dependency and dependent edge enrichment without leaking
+      provider-specific commands.
+  - Requires 17.1.3 and reuses prototype archive work 5.9.1.
+  - Success: static-analysis and graph providers enrich slices with
+    dependency and dependent edges through capability routing, preserve
+    provenance, and degrade visibly when a provider is unavailable.
+- [ ] 17.1.5. Implement budgeted priority traversal and graph-slice command
+      integration.
+  - Requires 17.1.2, 17.1.3, and 17.1.4.
+  - Success: `weaver graph-slices get` consumes the completed schema from
+    prototype archive work 7.2.1, never exceeds explicit `max_cards`,
+    `max_edges`, or `max_estimated_tokens` caps, emits debug rejection reasons
+    when requested, and includes behaviour-driven tests for fan-out explosions
+    and budget truncation.
 
 ### 17.2. Prove history mode before investing in probabilistic matching
 
 This step answers whether historical graph reconstruction is stable enough to
 support change-risk narratives. It migrates prototype archive work 7.3.1
-through 7.3.5. See `docs/jacquard-card-first-symbol-graph-design.md` §§16-17.
+through 7.3.5. See `docs/jacquard-card-first-symbol-graph-design.md` §13.1,
+§13.2, and §22.
 
-- [ ] 17.2.1. Implement git-backed graph-slice reconstruction per commit.
-  - Requires 17.1.3.
-  - Success: history mode loads blobs without mutating the worktree, reports
-    explicit data quality, and keeps defaults safe for large repositories.
-- [ ] 17.2.2. Implement normalized graph delta computation and risk warnings.
+- [ ] 17.2.1. Implement git-backed blob loading for historical revisions
+      without checkout.
+  - Requires 17.1.5.
+  - Success: history queries never invoke `git checkout`, load only files
+    required by the slice budget, enforce blob size, parse-time, file-count,
+    and partial-parse limits, and record fallback reasons such as `timeout`,
+    `blob_too_large`, `partial_parse`, and `unsupported_grammar`.
+- [ ] 17.2.2. Implement slice reconstruction per commit with data-quality
+      metadata.
   - Requires 17.2.1.
-  - Success: added, removed, changed, moved, and uncertain nodes or edges have
-    stable reason codes and useful human summaries.
-- [ ] 17.2.3. Decide whether a versioned graph ledger belongs in core.
-  - Requires 17.2.2 and migrates prototype archive work 7.5.1 through 7.5.2.
-  - Success: the decision either adds cache population and invalidation to the
-    core plan or defers it with measured performance evidence.
+  - Success: `--commits 5` returns a stable set of commits and per-commit
+    slice payloads with `quality.resolution_scope` and `quality.fallbacks`;
+    delta payloads include added, removed, and changed nodes and edges; and
+    curated git fixtures cover deterministic output.
+- [ ] 17.2.3. Implement delta normalization and change taxonomy
+      classification.
+  - Requires 17.2.2.
+  - Success: import blocks and decorators are treated as commutative sets for
+    deltas, normalized representations are persisted alongside raw text,
+    import or decorator reordering is classified as `text` change, taxonomy
+    output includes confidence, and fixtures cover comment-only and
+    signature-only edits.
+- [ ] 17.2.4. Implement semantic risk warnings on history deltas.
+  - Requires 17.2.3.
+  - Success: `--warning-depth` widens the dependency neighbourhood scanned for
+    warnings, warnings include edge paths and confidence, `text`-only deltas
+    emit lower-risk warnings, and curated fixtures validate dependency and
+    dependent warning types.
+- [ ] 17.2.5. Implement history-mode gating and safe defaults.
+  - Requires 17.2.4.
+  - Success: default history mode uses Tree-sitter-only extraction for
+    historical commits, LSP enrichment is disabled unless explicitly enabled
+    and documented, and degraded behaviour is visible through provenance
+    fields.
 
 ### 17.3. Prove probabilistic matching only where history needs it
 
 This step answers whether fuzzy matching improves history explanations enough
 to carry its complexity. It migrates prototype archive work 7.4.1 through 7.4.9
-and 8.6.2. See `docs/jacquard-card-first-symbol-graph-design.md` §§14-15.
+and 8.6.2. See `docs/jacquard-card-first-symbol-graph-design.md` §14.1 through
+§14.8.
 
-- [ ] 17.3.1. Implement stable-identity, body-hash, and structural-hash
-      matching phases.
-  - Requires 17.2.2.
-  - Success: exact and structural matches produce reason codes and reject
-    duplicate-name ambiguity by default.
-- [ ] 17.3.2. Prototype fuzzy similarity and graph-refinement matching.
+- [ ] 17.3.1. Implement phase 1 stable-identity matching.
+  - Requires 17.2.5.
+  - Success: matching uses type, name, container, and file hints; outputs
+    include winning phase and confidence; non-matching candidates are rejected;
+    and fixtures include rename and move cases that must not match in phase 1.
+- [ ] 17.3.2. Implement phase 2 body-hash matching for rename detection.
   - Requires 17.3.1.
-  - Success: fuzzy matches improve fixture accuracy without exceeding bounded
-    candidate or token budgets; otherwise the fuzzy phase is disabled by
-    default.
-- [ ] 17.3.3. Add assignment guardrails and matching E2E coverage.
+  - Success: unchanged-body renames match with explicit phase and confidence,
+    low-confidence matches are rejected rather than forced, and fixtures cover
+    rename scenarios with unchanged bodies.
+- [ ] 17.3.3. Implement phase 3 structural-hash matching on normalized AST
+      shapes.
   - Requires 17.3.2.
-  - Success: assignments are injective by default, split/merge modes are
-    explicit, and confidence scores are calibrated against fixture evidence.
+  - Success: formatting-only moves match through structural evidence, outputs
+    include phase and confidence, and low-confidence matches remain rejected.
+- [ ] 17.3.4. Implement phase 4 fuzzy similarity matching.
+  - Requires 17.3.3.
+  - Success: token-overlap and shingle matching improves rename and move
+    fixtures with minor body edits without exceeding bounded candidate or token
+    budgets, and low-confidence matches remain rejected.
+- [ ] 17.3.5. Implement phase 5 graph refinement and global assignment
+      refinement.
+  - Requires 17.3.4.
+  - Success: neighbourhood evidence resolves supported rename and move
+    scenarios, outputs include phase and confidence, and low-confidence matches
+    remain rejected.
+- [ ] 17.3.6. Implement deterministic feature extraction for cross-commit
+      matching.
+  - Requires 17.3.5.
+  - Success: feature extraction covers signature, AST-shape, docstring
+    fingerprints, attachments, and neighbourhood sketches; identical inputs
+    produce identical features; unit tests cover whitespace-only edits and
+    alpha-renaming of locals; and failures emit structured diagnostics.
+- [ ] 17.3.7. Implement candidate generation and calibrated scoring with reason
+      codes.
+  - Requires 17.3.6.
+  - Success: response payloads always include `best_match` plus top-K
+    alternates up to the requested cap, reason codes are stable enumerations,
+    and debug output surfaces the top contributing features.
+- [ ] 17.3.8. Implement duplicate-name guardrails.
+  - Requires 17.3.7.
+  - Success: `--max-duplicates` forces explicit ambiguous-mapping responses or
+    fallback matching when homonyms explode, observability counters capture
+    guardrail triggers, and same-name fixtures avoid false renames.
+- [ ] 17.3.9. Implement injective assignment across the slice.
+  - Requires 17.3.8.
+  - Success: the solver avoids mapping multiple sources to one target unless
+    explicitly enabled, property tests prevent illegal many-to-one mappings by
+    default, a feature flag gates split or merge experimentation, and
+    deterministic fixtures cover rename and move scenarios.
+
+### 17.4. Prove the optional graph ledger after on-demand history
+
+This step answers whether persisted graph history caching is necessary after
+`snapshots_on_demand` history is measured. It migrates prototype archive work
+7.5.1 through 7.5.2. See `docs/jacquard-card-first-symbol-graph-design.md`
+§13.2, §18.1, and §18.2.
+
+- [ ] 17.4.1. Validate whether a persisted graph ledger belongs in the core
+      product.
+  - Requires 17.2.5.
+  - Success: the decision compares repeated history-query performance against
+    the on-demand baseline and either accepts a core ledger with measured
+    evidence or defers it without weakening history-mode correctness.
+- [ ] 17.4.2. Define a versioned on-disk ledger format for cards, edges, and
+      deltas.
+  - Requires 17.4.1 accepting a core ledger.
+  - Success: the ledger is keyed by commit hash, includes explicit version
+    fields, detects corruption with checksums, and gates schema changes behind
+    migrations.
+- [ ] 17.4.3. Implement incremental ledger population and invalidation rules.
+  - Requires 17.4.2.
+  - Success: ledger writes are atomic, invalidation occurs when inputs change,
+    and performance benchmarks show a measurable improvement for repeated
+    history queries.
 
 ## 18. Provider ecosystem slice
 
@@ -748,7 +851,7 @@ turns without making human usage worse. It migrates the product intent of ADR
     `built-in defaults < config files < selected profile < environment < flags`.
 - [ ] 19.1.2. Implement durable job ledger support for long-running graph,
       history, and mutation commands.
-  - Requires 16.1.2 and 17.2.1 and depends on OrthoConfig 9.3.
+  - Requires 16.1.2 and 17.2.5 and depends on OrthoConfig 9.3.
   - Success: job records store command path, idempotency key, workspace,
     request hash, status, progress, timestamps, result pointer, and exit class.
 - [ ] 19.1.3. Implement `--wait`, `jobs list|get|prune`, and delivery sinks on
@@ -778,7 +881,7 @@ through 6.2.3. See `docs/weaver-design.md` §§5-6.
   - Success: interaction is available through `--interactive` or a dedicated
     review command and fails fast when stdin is not a terminal.
 - [ ] 19.2.3. Decide whether dynamic-analysis ingestion belongs in core.
-  - Requires 17.1.2 and 19.2.1.
+  - Requires 17.1.4 and 19.2.1.
   - Success: runtime traces either enrich graph slices with provenance and
     bounded trust semantics or move to deferred extensions with rationale.
 
@@ -800,7 +903,7 @@ Weaver-owned invariants. It migrates prototype archive work 8.1.1 through
     language servers, parsers, operating systems, and filesystems.
 - [ ] 19.3.3. Add Kani checks for transaction, patch, routing, and bounded
       graph kernels.
-  - Requires 19.3.2 and 17.1.3.
+  - Requires 19.3.2 and 17.1.5.
   - Success: smoke harnesses cover commit gating, rollback bookkeeping,
     bounded path guardrails, whole-command abort on unmatched patch blocks,
     selected-provider predicates, refusal determinism, and graph budgets.
@@ -852,10 +955,11 @@ new design rather than quiet re-entry into the core roadmap.
   - Requires 19.2.3.
   - Success: runtime trace ingestion either has bounded trust semantics and a
     graph integration point or remains out of the core product.
-- [ ] 20.2.3. Reassess optional graph ledger caching.
-  - Requires 17.2.3.
-  - Success: cache work resumes only if measured repository-scale performance
-    makes it necessary for the core workflows.
+- [ ] 20.2.3. Reassess graph ledger extensions beyond the core cache.
+  - Requires 17.4.3.
+  - Success: further cache work resumes only if measured repository-scale
+    performance shows the core ledger is insufficient for the supported
+    history workflows.
 
 ## Archive
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
       - Acceptance criteria: Bootstrap performs health reporting hooks,
         backends start only on demand, and failures propagate as structured
         events.
-- [x] 2.1.4. Implement robust daemonisation and process management for
+- [x] 2.1.4. Implement robust daemonization and process management for
       `weaverd`,
       including backgrounding with `daemonize-me`, PID/lock file handling,
       health checks, and graceful shutdown on signals.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,583 @@
-# Roadmap
+# Weaver roadmap
 
-## 1. Foundation & tooling (complete)
+This roadmap translates `docs/weaver-design.md`,
+`docs/adr-007-agent-native-command-surface.md`, and the existing ADR set into
+an outcome-oriented delivery sequence. It does not promise dates. Phases carry
+testable product ideas, steps answer sequencing questions, and tasks are
+review-sized execution units with explicit dependencies and observable success
+criteria.
 
-### 1.1. Establish foundation and documentation baseline
+The current forward plan is the source of truth for future work. The historical
+ledger at the end preserves completed foundation work and prior planned work so
+that it is not lost during the 0.1.0 command-surface reset. Historical entries
+that mention `observe`, `act`, or `verify` are retained as provenance, not as
+the future public grammar.
+
+## 0. External reusable CLI-contract dependencies
+
+Idea: if Weaver consumes generic command-contract machinery from OrthoConfig
+instead of rebuilding it locally, Weaver can focus on semantic code
+capabilities while still inheriting consistent human and agent interfaces.
+
+The dependency source is the OrthoConfig roadmap at
+<https://raw.githubusercontent.com/leynos/ortho-config/refs/heads/main/docs/roadmap.md>.
+ Weaver may build temporary adapters where needed, but any generic
+command-contract implementation must either depend on the relevant OrthoConfig
+task or record a deliberate divergence in ADR 007.
+
+### 0.1. Track reusable dependency contracts
+
+This step answers which command-contract pieces Weaver must consume from
+OrthoConfig and which ones Weaver may temporarily adapt while the shared
+contracts mature.
+
+- [ ] 0.1.1. Track the downstream consumer boundary.
+  - Depends on OrthoConfig 5.2.3.
+  - Weaver dependency mode: blocked for final generic ownership decisions;
+    local adapters may proceed when ADR 007 names the removal path.
+  - Success: every Weaver command-contract task says whether it consumes
+    OrthoConfig, wraps it, or intentionally diverges.
+- [ ] 0.1.2. Consume recursive command metadata.
+  - Depends on OrthoConfig 6.1.1 and 6.1.2.
+  - Weaver dependency mode: local schema adapters may proceed, but generated
+    help, manpage, completion, and context output must converge on the
+    OrthoConfig recursive metadata shape.
+- [ ] 0.1.3. Consume compact agent-context output and naming.
+  - Depends on OrthoConfig 6.2.1, 6.2.2, and 6.2.3.
+  - Weaver dependency mode: `weaver context --json` is blocked on the naming
+    convention for final acceptance; a local payload fixture may proceed for
+    Weaver-specific capability fields.
+- [ ] 0.1.4. Consume skill manifest metadata and validation.
+  - Depends on OrthoConfig 6.3.1 and 6.3.2.
+  - Weaver dependency mode: skill prose may be drafted locally, but validation
+    must use OrthoConfig metadata when available.
+- [ ] 0.1.5. Consume canonical vocabulary policy.
+  - Depends on OrthoConfig 7.1.1 through 7.1.3.
+  - Weaver dependency mode: vocabulary linting is blocked for final CI gates;
+    Weaver may maintain a temporary banned-name list for early migration.
+- [ ] 0.1.6. Consume behavioural metadata for agent-native commands.
+  - Depends on OrthoConfig 7.2.1 through 7.2.7.
+  - Weaver dependency mode: renderer, JSON, exit-code, bounded-list, mutation,
+    non-interactive, capability, and provenance metadata should be configured
+    or extended in Weaver, not reimplemented as another generic framework.
+- [ ] 0.1.7. Use `cargo-orthohelp` as the reference CLI for command contracts.
+  - Depends on OrthoConfig 8.1.1 and 8.1.2.
+  - Weaver dependency mode: this is a validation dependency; Weaver can build
+    its own commands earlier, but must compare `--json` and enumerating-error
+    behaviour against the reference CLI before 0.1.0.
+- [ ] 0.1.8. Consume compounding primitive contracts.
+  - Depends on OrthoConfig 9.1.1 through 9.3.3.
+  - Weaver dependency mode: profile, delivery, feedback, and execution-ledger
+    command semantics are Weaver-owned; reusable parsing, redaction, metadata,
+    and ledger vocabulary come from OrthoConfig where available.
+
+## 1. Human-friendly, agent-native 0.1.0 command-surface reset
+
+Idea: if Weaver settles the generated command contract before more capabilities
+land, later Sempai, plugin, graph, and workflow slices can converge on one
+surface instead of repeatedly redesigning command grammar.
+
+This foundational phase retires the prototype public grammar for the 0.1.0
+target while preserving human usability, localization, accessibility, and the
+UNIX pipeline model.
+
+### 1.1. Ratify the reset boundary and adapter policy
+
+This step answers which contracts Weaver owns and which ones OrthoConfig owns.
+The outcome informs every command, renderer, and drift gate that follows. See
+`docs/adr-007-agent-native-command-surface.md` and `docs/weaver-design.md` §2.1.
+
+- [x] 1.1.1. Record the agent-native command-surface reset as ADR 007.
+  - Requires 0.1.
+  - Success: ADR 007 defines the dual renderer contract, capability routing,
+    OrthoConfig dependencies, and the lack of compatibility promise for the
+    prototype grammar.
+- [ ] 1.1.2. Implement the Weaver command-surface adapter design.
+  - Requires 1.1.1 and depends on OrthoConfig 5.2.3, 6.1, and 7.2.7.
+  - Model resource path, verb, capability ID, mutability class, async class,
+    selector forms, stream input support, provider policy, safety class,
+    transaction behaviour, examples, output schemas, error schemas, and skill
+    references.
+  - Success: adding or renaming one Weaver command requires one adapter change
+    and exposes enough metadata for router, help, docs, tests, and context
+    fixtures.
+- [ ] 1.1.3. Define the temporary-adapter removal policy.
+  - Requires 1.1.2.
+  - Success: every local generic command-contract helper names the OrthoConfig
+    task expected to replace it or records a permanent divergence in ADR 007.
+
+### 1.2. Enforce community vocabulary and resource-first commands
+
+This step answers whether humans and agents can infer commands from common CLI
+knowledge rather than Weaver-only vocabulary. See ADR 007 and
+`docs/weaver-design.md` §§1.1 and 2.1.1.
+
+- [ ] 1.2.1. Map prototype domains to resource-first command paths.
+  - Requires 1.1.2.
+  - Map definitions, references, diagnostics, cards, graph slices, symbols,
+    patches, capabilities, context, jobs, profiles, and feedback.
+  - Success: no current forward task requires adding a new public `observe`,
+    `act`, or `verify` command.
+- [ ] 1.2.2. Configure vocabulary linting.
+  - Requires 1.2.1 and depends on OrthoConfig 7.1.1 through 7.1.3.
+  - Include canonical verbs such as `get`, `list`, `create`, `update`,
+    `delete`, `apply`, `run`, `prune`, `save`, `show`, `rename`, `move`, and
+    `send`.
+  - Success: CI rejects off-policy verbs and flags unless ADR 007 explicitly
+    grandfathers them as current-state compatibility.
+- [ ] 1.2.3. Migrate command examples in design and user-facing docs.
+  - Requires 1.2.1.
+  - Success: examples prefer `weaver definitions get`, `weaver references
+    list`, `weaver diagnostics list`, `weaver symbols list`, `weaver symbols
+    rename`, `weaver patches apply`, and `weaver context --json`.
+
+### 1.3. Deliver dual renderers and bounded machine contracts
+
+This step answers whether one command contract can serve accessible humans and
+reliable agents without forking command behaviour. See `docs/weaver-design.md`
+§§2.1.3 and 2.1.4.
+
+- [ ] 1.3.1. Implement the human renderer contract.
+  - Requires 1.1.2 and depends on OrthoConfig 7.2.2.
+  - Include localized default output, `--plain`, `--color`, `--no-pager`,
+    `--width`, TTY-sensitive progress, table headings, narrow-width labelled
+    blocks, and ASCII fallbacks.
+  - Success: human output does not rely on colour alone and never emits pager
+    or spinner control flow in non-terminal contexts.
+- [ ] 1.3.2. Implement universal `--json` and structured error output.
+  - Requires 1.3.1 and depends on OrthoConfig 7.2.3 through 7.2.5 and 8.1.
+  - Remove root `--output auto|human|json` and operation-local `--format` from
+    the 0.1.0 target.
+  - Success: success JSON is parseable on stdout, failure JSON is parseable on
+    stderr, field names and error codes are non-localized, and exit classes are
+    stable.
+- [ ] 1.3.3. Implement enumerating errors and bounded list responses.
+  - Requires 1.3.2 and depends on OrthoConfig 7.2.6 and 8.1.2.
+  - Success: enum, registry, capability, profile, provider, delivery, and job
+    validation errors list valid values; list-style commands expose bounded
+    defaults, `--limit`, cursors, truncation markers, and narrowing hints.
+
+### 1.4. Generate introspection, references, and drift gates
+
+This step answers whether the command contract can stay synchronized as the
+surface grows. See `docs/weaver-design.md` §2.1.4 and ADR 007.
+
+- [ ] 1.4.1. Implement `weaver context --json`.
+  - Requires 1.1.2 and depends on OrthoConfig 6.2.1 through 6.2.3.
+  - Success: context output includes schema version, commands, flags, enum
+    values, output schemas, error taxonomy, capabilities, provider summaries,
+    profiles, jobs, delivery schemes, feedback state, and skill paths.
+- [ ] 1.4.2. Implement `weaver capabilities list --json`.
+  - Requires 1.4.1.
+  - Success: runtime capability availability is separated from full command
+    context and includes deterministic provider selection rationale.
+- [ ] 1.4.3. Implement `weaver skill-path` and initial skill manifests.
+  - Requires 1.4.1 and depends on OrthoConfig 6.3.
+  - Success: skills teach workflows rather than command catalogues, and
+    validation fails when a skill mentions unknown commands or flags.
+- [ ] 1.4.4. Add generated artefact and drift gates.
+  - Requires steps 1.1-1.4.
+  - Generate or validate clap definitions, daemon router metadata, localized
+    help, manpages, shell completions, docs snippets, JSON schema fixtures,
+    vocabulary linting, and tests.
+  - Success: CI fails when schema, router, help, docs, localization, context,
+    skill manifests, or test fixtures drift.
+
+## 2. Resource command slice: definitions, references, diagnostics, and cards
+
+Idea: if existing LSP, Tree-sitter, and card foundations can be re-exposed
+through the new generated surface, Weaver proves the reset without waiting for
+new semantic engines.
+
+This slice migrates useful read-only commands first. It gives humans and agents
+immediate value while validating selectors, renderers, and capability
+introspection end to end.
+
+### 2.1. Re-expose LSP perceptors through resource commands
+
+This step answers whether existing semantic backends fit the resource-first
+surface without provider-specific commands. See `docs/weaver-design.md` §§2.2,
+3.1, and 6.1.
+
+- [ ] 2.1.1. Implement `weaver definitions get`.
+  - Requires phase 1.
+  - Success: position references return localized human output by default and
+    stable JSON under `--json`, with provider provenance in machine output.
+- [ ] 2.1.2. Implement `weaver references list`.
+  - Requires 2.1.1.
+  - Success: list output is bounded, cursor-aware, and suitable for downstream
+    selector processing.
+- [ ] 2.1.3. Implement `weaver diagnostics list`.
+  - Requires 2.1.1.
+  - Success: diagnostics preserve source ranges, severity, provider
+    provenance, and actionable error classes in both renderer modes.
+
+### 2.2. Re-expose card and graph-slice context
+
+This step answers whether Jacquard-style cards and graph slices can become
+first-class resource commands while preserving existing completed work. See
+`docs/jacquard-card-first-symbol-graph-design.md` and `docs/weaver-design.md`
+§3.3.
+
+- [ ] 2.2.1. Implement `weaver cards get`.
+  - Requires 2.1.1 and historical work 7.1.1 through 7.1.4 in the ledger.
+  - Success: the command accepts position references and Sempai selectors where
+    unambiguous, and returns stable card JSON with bounded enrichment.
+- [ ] 2.2.2. Implement `weaver graph-slices get`.
+  - Requires 2.2.1 and historical work 7.2.1.
+  - Success: graph traversal exposes explicit budgets, truncation markers,
+    provenance, and guidance for narrowing.
+- [ ] 2.2.3. Add combinatorial read-command E2E coverage.
+  - Requires steps 2.1-2.2.
+  - Success: the suite covers human output, `--json`, `--plain`, bounded
+    output, invalid enum errors, missing capabilities, and provider
+    unavailable cases across the resource read commands.
+
+### 2.3. Make Sempai one-liners first-class selectors
+
+This step answers whether the future Sempai DSL can select one symbol or a
+collection of symbols before full Sempai execution is complete. See
+`docs/sempai-query-language-design.md` and `docs/weaver-design.md` §2.1.2.
+
+- [ ] 2.3.1. Add selector record schemas for Sempai one-liners.
+  - Requires 1.4.4 and historical work 4.1.1 through 4.1.5.
+  - Success: selector records carry identity, range, language, query, capture,
+    confidence, and provider provenance needed for safe downstream mutation.
+- [ ] 2.3.2. Implement `weaver symbols list --query`.
+  - Requires 2.3.1.
+  - Success: `weaver symbols list --query 'fn $name(...)' --json` emits a
+    bounded selector stream that ordinary UNIX filters can process.
+- [ ] 2.3.3. Add selector stream compatibility checks.
+  - Requires 2.3.2.
+  - Success: commands consuming selector streams reject incompatible records
+    with enumerating, structured errors rather than guessing.
+
+## 3. Capability-routed mutation slice: symbols and patches
+
+Idea: if symbol and patch mutations can run through one resource-first,
+capability-routed transaction path, Weaver proves that agent-native commands do
+not weaken its safety model.
+
+This slice migrates the implemented patch and rename foundations under the new
+grammar, then adds direct selector-based mutation and observe-to-act
+composition.
+
+### 3.1. Migrate patches and rename under the new grammar
+
+This step answers whether existing safety-harness and actuator work can be
+reused without exposing provider-first commands. See `docs/weaver-design.md`
+§§4.1-4.3 and ADR 001.
+
+- [ ] 3.1.1. Implement `weaver patches apply`.
+  - Requires phase 1 and historical work 6.1.1 through 6.1.4.
+  - Success: `patches apply` preserves Double-Lock verification, atomic
+    transactions, `--dry-run`, structured safety results, and universal
+    `--json`.
+- [ ] 3.1.2. Implement `weaver symbols rename` for position references.
+  - Requires 3.1.1 and historical work 5.2.1 through 5.2.5.
+  - Success: provider routing remains capability-first, mutation results
+    include transaction ID, affected paths, provider provenance, and safety
+    outcome.
+- [ ] 3.1.3. Implement `weaver symbols move` or `weaver symbols extract`.
+  - Requires 3.1.2 and historical planned work 5.3 and 5.4.
+  - Success: the public verb is canonical, the internal capability captures
+    the richer operation, and no provider-specific command is required.
+
+### 3.2. Prove selector-driven mutation and pipeline composition
+
+This step answers whether observe-style resource commands and act-style
+mutation commands compose through structured streams. See
+`docs/weaver-design.md` §2.1.2.
+
+- [ ] 3.2.1. Add direct Sempai selector support to symbol mutations.
+  - Requires 2.3.2 and 3.1.2.
+  - Success: `weaver symbols rename --query ...` handles zero, one, and many
+    matches deterministically and requires explicit policy for ambiguous
+    mutation.
+- [ ] 3.2.2. Add `--from-stdin` selector stream consumption.
+  - Requires 2.3.3 and 3.1.2.
+  - Success: `weaver symbols list --query … --json | weaver symbols rename
+    --from-stdin …` works without hidden state.
+- [ ] 3.2.3. Add filtered pipeline E2E coverage.
+  - Requires 3.2.2.
+  - Success: at least one scenario pipes selector records through `jq` before
+    mutation, and one scenario pipes observe-style output into a pager or other
+    UNIX consumer without mutation.
+
+### 3.3. Harden mutation boundaries for retries and destructive operations
+
+This step answers whether agents can retry safely and humans can preview
+consequential changes. See `docs/weaver-design.md` §§2.1.5 and 4.2.
+
+- [ ] 3.3.1. Add idempotency keys and mutation transaction IDs.
+  - Requires 3.1.1 and depends on OrthoConfig 7.2.1.
+  - Success: repeated equivalent mutation submissions return the existing
+    transaction or refusal rather than duplicating work.
+- [ ] 3.3.2. Standardize `--dry-run` and `--force`.
+  - Requires 3.3.1 and depends on OrthoConfig 7.2.1.
+  - Success: all mutating commands declare preview and destructive-operation
+    policy in the command-surface metadata.
+- [ ] 3.3.3. Add mutation combinatorial E2E coverage.
+  - Requires steps 3.1-3.3.
+  - Success: coverage combines selector forms, `--json`, `--dry-run`,
+    idempotency, provider failures, syntactic failures, semantic failures, and
+    rollback assertions.
+
+## 4. Async execution, profiles, delivery, and feedback
+
+Idea: if Weaver gives agents durable identity, recoverable execution, and
+structured artefact routing, long-running workflows collapse into fewer
+reliable turns without becoming hostile to humans.
+
+This phase adds compounding primitives after the core read and mutation loops
+are stable.
+
+### 4.1. Add durable jobs and `--wait`
+
+This step answers whether async work can survive process loss and retry without
+duplicate submissions. See `docs/weaver-design.md` §2.1.5.
+
+- [ ] 4.1.1. Implement the Weaver job ledger.
+  - Requires 3.3.1 and depends on OrthoConfig 9.3.
+  - Success: XDG state stores job ID, command path, idempotency key, workspace,
+    request hash, status, progress, timestamps, result pointer, and exit class.
+- [ ] 4.1.2. Implement `weaver jobs list|get|prune`.
+  - Requires 4.1.1.
+  - Success: job lists are bounded, job lookup is structured, and prune is
+    explicit and safe.
+- [ ] 4.1.3. Add `--wait` to async-submitting commands.
+  - Requires 4.1.2.
+  - Success: submit-poll-collect workflows support backoff, jitter, timeout,
+    cancellation, and ledger recovery.
+
+### 4.2. Add profiles and persistent identity
+
+This step answers whether repeated agent and human workflows can share durable
+configuration without leaking secrets. See `docs/weaver-design.md` §2.1.5.
+
+- [ ] 4.2.1. Implement profile storage and redaction.
+  - Requires 1.4.1 and depends on OrthoConfig 9.1.
+  - Success: profile names and metadata appear in `context --json`, while
+    secret values remain redacted or represented as references.
+- [ ] 4.2.2. Implement `weaver profiles save|list|show|delete`.
+  - Requires 4.2.1.
+  - Success: profile precedence is
+    `built-in defaults < config files < selected profile < environment < flags`.
+- [ ] 4.2.3. Add root `--profile <name>`.
+  - Requires 4.2.2.
+  - Success: explicit flags override profile values and invalid profile names
+    enumerate available profiles.
+
+### 4.3. Add two-way I/O
+
+This step answers whether generated artefacts and friction reports can land
+where users and agents need them. See `docs/weaver-design.md` §2.1.6.
+
+- [ ] 4.3.1. Implement `--deliver stdout|file:<path>|webhook:<url>`.
+  - Requires 1.3.2 and depends on OrthoConfig 9.2.1.
+  - Success: file delivery is atomic, webhook delivery reports HTTP status,
+    and unknown schemes enumerate valid schemes.
+- [ ] 4.3.2. Implement `weaver feedback create|list|send`.
+  - Requires 4.3.1 and depends on OrthoConfig 9.2.2.
+  - Success: local feedback writes JSONL by default, upstream send is optional
+    and configured, and feedback availability appears in `context --json`.
+- [ ] 4.3.3. Add delivery and feedback E2E coverage.
+  - Requires 4.3.1 and 4.3.2.
+  - Success: tests cover stdout, atomic file, webhook success, webhook failure,
+    unknown delivery schemes, local feedback, and configured upstream send.
+
+## 5. Sempai and graph intelligence under the new grammar
+
+Idea: if Sempai and graph expansion land after selectors and resource commands
+are stable, they strengthen the same user workflows instead of creating a
+parallel query subsystem.
+
+This phase migrates the existing Sempai and Jacquard plans under `symbols`,
+`cards`, and `graph-slices`.
+
+### 5.1. Finish the Sempai execution engine
+
+This step answers whether the query language can execute with stable
+diagnostics and bounded behaviour. See `docs/sempai-query-language-design.md`.
+
+- [ ] 5.1.1. Implement the one-liner lexer, parser, and recovery path.
+  - Requires historical work 4.1.1 through 4.1.5.
+  - Success: valid one-liners compile to canonical formula form, malformed
+    input produces stable `E_SEMPAI_*` diagnostics, and recovery preserves
+    partial anchors where safe.
+- [ ] 5.1.2. Implement the Tree-sitter backend.
+  - Requires 5.1.1 and historical planned work 4.2.
+  - Success: Rust, Python, and TypeScript profiles support Semgrep-compatible
+    pattern matching, metavariable unification, ellipsis, constraints, focus,
+    and bounded execution controls.
+- [ ] 5.1.3. Route Sempai execution through resource commands.
+  - Requires 2.3.2 and 5.1.2.
+  - Success: query execution feeds `symbols list`, cards, and graph workflows
+    without adding a future public `observe query` command.
+
+### 5.2. Complete graph-slice and history workflows
+
+This step answers whether cards and graph slices can give agents compact,
+bounded context across code structure and history. See
+`docs/jacquard-card-first-symbol-graph-design.md`.
+
+- [ ] 5.2.1. Complete graph-slice extraction and traversal.
+  - Requires 2.2.2 and historical planned work 7.2.2 through 7.2.5.
+  - Success: Tree-sitter inventory, LSP call edges, import/config edges, and
+    budgeted traversal produce bounded graph-slice JSON and useful human
+    summaries.
+- [ ] 5.2.2. Implement graph history and risk deltas.
+  - Requires 5.2.1 and historical planned work 7.3.
+  - Success: history mode reconstructs slices per commit, reports normalized
+    deltas, and keeps defaults safe for large repositories.
+- [ ] 5.2.3. Implement probabilistic identity matching.
+  - Requires 5.2.2 and historical planned work 7.4.
+  - Success: matching emits reason codes, duplicate-name guardrails, calibrated
+    confidence, and assignment decisions suitable for agents to inspect.
+
+## 6. Plugin ecosystem behind capability contracts
+
+Idea: if Weaver keeps providers behind capability contracts, it can add
+specialist tools without forcing users or agents to learn backend-specific
+commands.
+
+This phase expands perceptors and actuators after the resource and mutation
+contracts have proven the routing model.
+
+### 6.1. Normalize existing and planned actuator capabilities
+
+This step answers whether Rope, rust-analyzer, and later actuators can share
+one public contract. See ADR 001, ADR 004, and ADR 006.
+
+- [ ] 6.1.1. Publish capability migration notes for `symbol.rename`.
+  - Requires historical work 5.2.1 through 5.2.5.
+  - Success: docs explain provider provenance, refusal semantics, and the
+    resource-first replacement for provider-required refactor commands.
+- [ ] 6.1.2. Migrate extrication work to `symbol.move` or `symbol.extract`.
+  - Requires 3.1.3 and historical planned work 5.3 and 5.4.
+  - Success: public commands use canonical verbs while internal capabilities
+    retain enough detail for Rope and rust-analyzer implementations.
+- [ ] 6.1.3. Add additional actuator providers behind manifests.
+  - Requires 6.1.2 and historical planned work 5.5.
+  - Success: srgn or equivalent tools declare capability support without
+    adding provider-specific public commands.
+
+### 6.2. Add specialist perceptors and capability discoverability
+
+This step answers whether read-only specialist providers improve results while
+remaining transparent to ordinary users. See `docs/weaver-design.md` §4.1.
+
+- [ ] 6.2.1. Deliver the first specialist perceptor provider.
+  - Requires 2.1.3 and historical planned work 5.6.
+  - Success: the provider enriches definitions, references, diagnostics,
+    cards, or symbol matches through capability routing, not through a public
+    provider command.
+- [ ] 6.2.2. Wire provider summaries into `capabilities list` and
+      `context --json`.
+  - Requires 1.4.2 and depends on OrthoConfig 7.2.7.
+  - Success: agents can discover availability, selected provider, and refusal
+    reasons without parsing backend-specific help.
+- [ ] 6.2.3. Refine graceful degradation guidance.
+  - Requires 6.2.2 and historical planned work 5.8.
+  - Success: unsupported capability errors suggest resource-first fallback
+    workflows and enumerate valid alternatives.
+
+## 7. Formal verification and safety hardening
+
+Idea: if formal checks attach to the safety and routing kernels after their
+public contracts settle, Weaver can prove the invariants that matter without
+freezing prototype interfaces.
+
+This phase preserves the existing formal-verification plan while tying it to
+the new command contract and mutation slices.
+
+### 7.1. Establish verifier tooling and proof contracts
+
+This step answers which invariants are proved and which external-tool
+behaviours remain trusted. See `docs/formal-verification-methods-in-weaver.md`.
+
+- [ ] 7.1.1. Add pinned Kani and Verus tooling.
+  - Requires phase 3.
+  - Migrates historical planned work 8.1.
+  - Success: verifier installs are reproducible and normal Rust workflows are
+    unaffected unless a formal target is invoked.
+- [ ] 7.1.2. Publish transaction, semantic-lock, and trust-boundary contracts.
+  - Requires 7.1.1.
+  - Migrates historical planned work 8.2.
+  - Success: docs distinguish verified orchestration from trusted providers,
+    language servers, parsers, and filesystems.
+
+### 7.2. Verify the highest-risk owned kernels
+
+This step answers whether Weaver's own write and routing decisions satisfy the
+documented invariants. See `docs/weaver-design.md` §§4.2-4.3.
+
+- [ ] 7.2.1. Add Kani checks for transactions and patch matching.
+  - Requires 7.1.2 and migrates historical planned work 8.3.
+  - Success: smoke harnesses prove commit gating, rollback bookkeeping,
+    bounded path guardrails, and whole-command abort on unmatched patch blocks.
+- [ ] 7.2.2. Add Kani and property checks for capability routing.
+  - Requires 6.2.2 and 7.1.2.
+  - Migrates historical planned work 8.4.
+  - Success: selected providers satisfy language and capability predicates,
+    and refusal is deterministic over bounded routing tables.
+- [ ] 7.2.3. Add proof-only Verus kernels where they reduce long-term risk.
+  - Requires 7.2.1 and 7.2.2.
+  - Migrates historical planned work 8.5 and 8.6.
+  - Success: proof modules remain outside the production API and prove only
+    stable abstractions that will survive the 0.1.0 command reset.
+
+## 8. Deferred extensions after the core 0.1.0 promise
+
+Idea: if the core CLI contract is already trustworthy and boring to operate,
+the project can evaluate broader extensions on product value instead of letting
+them destabilize the main release.
+
+### 8.1. Re-evaluate onboarding and interactive workflows
+
+This step keeps useful agent workflow ideas without letting them bypass the
+non-interactive contract. See `docs/weaver-design.md` §6.2.
+
+- [ ] 8.1.1. Recast project onboarding under resource-first commands.
+  - Requires phases 2 and 5.
+  - Migrates historical planned work 6.2.1.
+  - Success: onboarding consumes cards, graph slices, diagnostics, and
+    dependency data without adding a parallel public command grammar.
+- [ ] 8.1.2. Design explicit interactive review workflows.
+  - Requires phase 3.
+  - Migrates historical planned work 6.2.2.
+  - Success: interaction is opt-in via `--interactive` or a dedicated review
+    command and fails fast when stdin is not a terminal.
+
+### 8.2. Evaluate MCP, SDK, and runtime explorer generation
+
+This step defers generated integrations until the CLI contract they would wrap
+is stable. See ADR 007 and OrthoConfig 10.1.
+
+- [ ] 8.2.1. Decide whether to generate MCP descriptions from
+      `context --json`.
+  - Requires phase 1 and depends on OrthoConfig 10.1.1.
+  - Success: the decision compares generated MCP descriptions against the
+    command-surface token budget and records whether the feature belongs in
+    Weaver 0.1.x.
+- [ ] 8.2.2. Decide whether SDK or OpenAPI-shaped runtime explorers are in
+      scope.
+  - Requires 8.2.1 and depends on OrthoConfig 10.1.2.
+  - Success: any accepted explorer uses the same command metadata and does not
+    become a second source of truth.
+
+## 99. Historical roadmap ledger
+
+The entries below are preserved from the pre-ADR-007 roadmap so completed
+foundation work and still-relevant planned work remain visible. They are not
+the current forward build order. Unchecked entries are migrated into the
+current roadmap above when still relevant; entries using the prototype
+`observe`, `act`, or `verify` grammar must be implemented under the
+resource-first command contract instead.
+
+### 1. Foundation & tooling (complete)
+
+#### 1.1. Establish foundation and documentation baseline
 
 - [x] 1.1.1. Set up the project workspace, Continuous Integration and
       Continuous Deployment (CI/CD) pipeline, and core
@@ -12,13 +587,13 @@
       `docs/contents.md` and `docs/repository-layout.md`, as delivered in
       `docs/execplans/sempai-design.md`.
 
-## 2. Core MVP & safety harness foundation
+### 2. Core MVP & safety harness foundation
 
 *Goal: Establish the core client/daemon architecture, basic LSP integration,
 and the foundational security and verification mechanisms. The MVP must be safe
 for write operations from day one.*
 
-### 2.1. Deliver CLI and daemon foundation
+#### 2.1. Deliver CLI and daemon foundation
 
 *Outcome: Ship a pair of crates (`weaver-cli`, `weaverd`) that honour the
 design contract in `docs/weaver-design.md` and expose the lifecycle expected by
@@ -139,7 +714,7 @@ design contract in `docs/weaver-design.md` and expose the lifecycle expected by
     failure, and new file creation properly tracks file existence for
     rollback.
 
-### 2.2. Deliver baseline command-line interface (CLI) discoverability
+#### 2.2. Deliver baseline command-line interface (CLI) discoverability
 
 *Outcome: Ship baseline guidance in the MVP so first-use command discovery
 does* *not require source inspection or external runbooks.*
@@ -189,7 +764,7 @@ does* *not require source inspection or external runbooks.*
         non-zero, lists all operations registered for that domain, and includes
         one concrete `weaver <domain> <operation> --help` hint.
 
-### 2.3. Enrich validation and actionable error responses
+#### 2.3. Enrich validation and actionable error responses
 
 *Outcome: Ensure MVP error paths fail fast with deterministic, actionable*
 *operator guidance before daemon startup and during command routing.*
@@ -236,13 +811,13 @@ does* *not require source inspection or external runbooks.*
         all three required flags (`--provider`, `--refactoring`, `--file`) in
         one response, plus at least one valid provider and refactoring value.
 
-## 3. Syntactic & relational intelligence
+### 3. Syntactic & relational intelligence
 
 *Goal: Add the Tree-sitter and call graph layers to provide deeper structural*
 *and relational understanding of code, and pair this with operation-level and*
 *localized help for dependable day-to-day operation.*
 
-### 3.1. Deliver syntax and graph foundations
+#### 3.1. Deliver syntax and graph foundations
 
 - [x] 3.1.1. Create the `weaver-syntax` crate and implement the structural
       search
@@ -277,7 +852,7 @@ does* *not require source inspection or external runbooks.*
     spans, and relationship direction; provider errors are surfaced as
     structured diagnostics; and end-to-end tests validate graph output.
 
-### 3.2. Expose configuration and operation-level help surfaces
+#### 3.2. Expose configuration and operation-level help surfaces
 
 *Outcome: Make configuration and operation help directly discoverable from the*
 *CLI without requiring external documentation lookup.*
@@ -362,7 +937,7 @@ does* *not require source inspection or external runbooks.*
         resulting roff output still includes the full shared configuration
         contract introduced in `3.2.1`.
 
-### 3.3. Deliver localized CLI and reference outputs
+#### 3.3. Deliver localized CLI and reference outputs
 
 *Outcome: Let operators choose a locale once and receive consistent Fluent-*
 *backed help, error text, and generated reference artefacts across Weaver.*
@@ -415,12 +990,12 @@ does* *not require source inspection or external runbooks.*
         and artefact validation proves the generated help text matches the
         runtime Fluent catalogue.
 
-## 4. Query language infrastructure (Sempai)
+### 4. Query language infrastructure (Sempai)
 
 *Goal: Deliver the Semgrep-compatible query language stack as a standalone
 phase* *with explicit parser, backend, and Weaver-integration milestones.*
 
-### 4.1. Deliver Sempai core infrastructure
+#### 4.1. Deliver Sempai core infrastructure
 
 *Outcome: Implement the Sempai front-end and normalization architecture from*
 *`docs/sempai-query-language-design.md`, including YAML parsing, one-liner*
@@ -459,7 +1034,7 @@ phase* *with explicit parser, backend, and Weaver-integration milestones.*
   - Acceptance criteria: malformed DSL inputs produce partial parse output and
     labelled diagnostics without parser panics.
 
-### 4.2. Deliver Sempai Tree-sitter backend
+#### 4.2. Deliver Sempai Tree-sitter backend
 
 *Outcome: Implement the Tree-sitter-backed Sempai execution engine with*
 *Semgrep-token rewriting, pattern intermediate representation (IR), formula*
@@ -517,7 +1092,7 @@ phase* *with explicit parser, backend, and Weaver-integration milestones.*
   - Acceptance criteria: safety limits are configurable, deterministic, and
     enforced across execution paths.
 
-### 4.3. Deliver Sempai Weaver integration and readiness
+#### 4.3. Deliver Sempai Weaver integration and readiness
 
 *Outcome: Integrate Sempai into Weaver observe flows with stable command and*
 *JSON Lines (JSONL) contracts, cache integration, diagnostics conformance, and*
@@ -562,13 +1137,13 @@ phase* *with explicit parser, backend, and Weaver-integration milestones.*
   - Acceptance criteria: release checklist is codified in CI policy and blocks
     default enablement when thresholds are not met.
 
-## 5. Plugin ecosystem & specialist tools
+### 5. Plugin ecosystem & specialist tools
 
 *Goal: Build capability-driven plugin architecture in a dependency-first
 order:* *stabilize existing `rename-symbol` implementations, then extend to
 new* *capabilities and specialist providers.*
 
-### 5.1. Establish plugin platform foundation
+#### 5.1. Establish plugin platform foundation
 
 - [x] 5.1.1. Design and implement the `weaver-plugins` crate, including the
       secure
@@ -580,7 +1155,7 @@ new* *capabilities and specialist providers.*
     behaviour tests cover handshake success, schema rejection, and timeout
     cases.
 
-### 5.2. Migrate existing actuator plugins to `rename-symbol` capability
+#### 5.2. Migrate existing actuator plugins to `rename-symbol` capability
 
 *Outcome: Bring the existing Python and Rust actuator plugins into the new*
 *plugin architecture as first-class implementations of the `rename-symbol`*
@@ -618,7 +1193,7 @@ new* *capabilities and specialist providers.*
   - Acceptance criteria: docs and CLI guidance identify capability-based
     behaviour as the default path, and deprecation messaging is stable.
 
-### 5.3. Deliver capability-first `act extricate`
+#### 5.3. Deliver capability-first `act extricate`
 
 *Outcome: Implement the cross-language `extricate-symbol` capability model,*
 *command contract, and plugin-selection foundation defined in*
@@ -653,7 +1228,7 @@ initial* *Python delivery and shared failure semantics.*
   - Acceptance criteria: tests assert capability negotiation, refusal behaviour,
     incomplete payload failures, and deterministic patch output.
 
-### 5.4. Deliver Rust `extricate-symbol` actuator
+#### 5.4. Deliver Rust `extricate-symbol` actuator
 
 *Outcome: Implement Rust `extricate-symbol` as a standalone actuator programme*
 *in line with `docs/rust-extricate-actuator-plugin-technical-design.md`, with*
@@ -694,7 +1269,7 @@ initial* *Python delivery and shared failure semantics.*
   - Acceptance criteria: docs and capability surfaces use stable terminology for
     supported, partial, and unsupported Rust shapes.
 
-### 5.5. Deliver additional actuator plugins
+#### 5.5. Deliver additional actuator plugins
 
 *Outcome: Extend actuator coverage beyond `rename-symbol` and*
 *`extricate-symbol` with precision syntactic editing support.*
@@ -706,7 +1281,7 @@ initial* *Python delivery and shared failure semantics.*
     unsupported inputs with structured diagnostics, and passes unit plus
     integration coverage through the plugin broker.
 
-### 5.6. Deliver first specialist sensor plugin
+#### 5.6. Deliver first specialist sensor plugin
 
 - [ ] 5.6.1. Deliver the `jedi` specialist sensor plugin to provide
       supplementary Python static-analysis signals through the plugin broker.
@@ -715,7 +1290,7 @@ initial* *Python delivery and shared failure semantics.*
     unsupported languages with structured diagnostics, and integration tests
     verify success and refusal paths.
 
-### 5.7. Deliver plugin and capability discoverability coverage
+#### 5.7. Deliver plugin and capability discoverability coverage
 
 *Outcome: Provide discoverability for plugin inventory and runtime capability*
 *negotiation directly from CLI help and introspection commands.*
@@ -771,7 +1346,7 @@ Capability probe discoverability tasks:
         for each configured language and operation, and includes source labels
         for runtime capability versus override values.
 
-### 5.8. Refine graceful degradation guidance
+#### 5.8. Refine graceful degradation guidance
 
 - [ ] 5.8.1. Refine the graceful degradation logic to suggest specific
       plugin-based
@@ -782,7 +1357,7 @@ Capability probe discoverability tasks:
     diagnostics; and regression tests cover at least three degradation
     scenarios.
 
-### 5.9. Deliver static analysis provider integration
+#### 5.9. Deliver static analysis provider integration
 
 - [ ] 5.9.1. Implement the Static Analysis Provider for `weaver-graph` (for
       example, wrapping PyCG) as the first major graph plugin.
@@ -791,12 +1366,12 @@ Capability probe discoverability tasks:
     return structured diagnostics; and integration tests validate successful
     ingestion and refusal paths.
 
-## 6. Agent workflows & advanced support
+### 6. Agent workflows & advanced support
 
 *Goal: Deliver advanced agent-facing workflows after core query and plugin*
 *infrastructure is in place, with explicit dependencies on earlier phases.*
 
-### 6.1. Deliver `act apply-patch` command
+#### 6.1. Deliver `act apply-patch` command
 
 *Outcome: Provide a safety-locked patch application path that mirrors the*
 *`apply_patch` semantics for agents and integrates with the Double-Lock
@@ -825,7 +1400,7 @@ harness.*
   - Acceptance criteria: tests pass under `make test` and error messaging is
     asserted for each failure mode.
 
-### 6.2. Deliver advanced agent workflow foundations
+#### 6.2. Deliver advanced agent workflow foundations
 
 *Outcome: Add onboarding and interactive orchestration paths that build on*
 *completed command discoverability and plugin-capability infrastructure.*
@@ -856,7 +1431,7 @@ harness.*
     identity and call-edge attribution; malformed trace inputs return structured
     ingestion diagnostics; and integration tests validate multi-source merges.
 
-## 7. Cards-first symbol context (Jacquard)
+### 7. Cards-first symbol context (Jacquard)
 
 *Goal: Deliver small, structured “symbol cards” and bounded symbol graph slices
 as first-class `observe` operations, then extend them to deterministic,
@@ -865,7 +1440,7 @@ design in
 [`jacquard-card-first-symbol-graph-design.md`](jacquard-card-first-symbol-graph-design.md)
  within Weaver’s existing Semantic Fusion architecture.*
 
-### 7.1. Deliver `observe get-card` (Tree-sitter first)
+#### 7.1. Deliver `observe get-card` (Tree-sitter first)
 
 *Outcome: Provide a deterministic, cacheable symbol card payload that defaults
 to Tree-sitter extraction and optionally enriches via LSP when available. See
@@ -913,7 +1488,7 @@ to Tree-sitter extraction and optionally enriches via LSP when available. See
         revisions hit cache in integration tests; revision changes invalidate
         deterministically; and cache misses preserve correctness.
 
-### 7.2. Deliver `observe graph-slice` (budgeted traversal)
+#### 7.2. Deliver `observe graph-slice` (budgeted traversal)
 
 *Outcome: Return a bounded subgraph rooted at an entry symbol, with typed edges
 (`call`, `import`, and `config`) and explicit budget constraints. See
@@ -949,7 +1524,7 @@ to Tree-sitter extraction and optionally enriches via LSP when available. See
     development (BDD) tests cover fan-out explosion and budget truncation
     cases.
 
-### 7.3. Deliver `observe graph-history` in `snapshots_on_demand` mode
+#### 7.3. Deliver `observe graph-history` in `snapshots_on_demand` mode
 
 *Outcome: Diff a slice over the last N commits without requiring a working tree
 checkout, producing deterministic output suitable for caching and regression
@@ -992,7 +1567,7 @@ tests. See `docs/jacquard-card-first-symbol-graph-design.md` §13.1-§13.2 and
     historical commits; enabling enrichment is explicit and documented; and
     degraded behaviour is made visible via provenance fields.
 
-### 7.4. Deliver probabilistic matching and “reason codes”
+#### 7.4. Deliver probabilistic matching and “reason codes”
 
 *Outcome: Map symbols across commits probabilistically when identifiers drift,
 exposing confidence and alternates rather than hiding ambiguity. See
@@ -1046,7 +1621,7 @@ exposing confidence and alternates rather than hiding ambiguity. See
     mappings by default; a feature flag enables split/merge experimentation;
     and deterministic test fixtures cover rename and move scenarios.
 
-### 7.5. Optional ledger cache and richer edge types
+#### 7.5. Optional ledger cache and richer edge types
 
 *Outcome: Add a persisted ledger keyed by commit hash for faster history
 queries and broader edge coverage once `snapshots_on_demand` is proven
@@ -1064,13 +1639,13 @@ implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
     inputs change; and performance benchmarks show a measurable improvement for
     repeated history queries.
 
-## 8. Formal verification and proof tooling
+### 8. Formal verification and proof tooling
 
 *Goal: Add bounded formal verification checks for Weaver-owned transactional,*
 *patching, routing, and guardrail invariants without replacing the existing*
 *test stack. See `docs/formal-verification-methods-in-weaver.md`.*
 
-### 8.1. Establish formal verification tooling
+#### 8.1. Establish formal verification tooling
 
 *Outcome: Add pinned verifier installation, explicit make targets, and staged*
 *Continuous Integration (CI) entry points for Kani and Verus.*
@@ -1103,7 +1678,7 @@ implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
         formal jobs install their own tools, and slow proof suites are isolated
         from the default pull-request path.
 
-### 8.2. Clarify proof contracts before gating
+#### 8.2. Clarify proof contracts before gating
 
 *Outcome: Define the exact assurances that Kani and Verus are expected to*
 *prove, including filesystem assumptions and trust boundaries.*
@@ -1133,7 +1708,7 @@ implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
         dependencies explicitly, and avoid claiming semantic correctness for
         third-party tools.
 
-### 8.3. Add Kani checks for the transaction and patch kernels
+#### 8.3. Add Kani checks for the transaction and patch kernels
 
 *Outcome: Add bounded model-checking coverage for the highest-risk write path*
 *that Weaver owns directly.*
@@ -1168,7 +1743,7 @@ implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
         than the pull-request smoke set, and scheduled runs record stable pass
         or fail outcomes.
 
-### 8.4. Add Kani checks for capability routing and refusal semantics
+#### 8.4. Add Kani checks for capability routing and refusal semantics
 
 *Outcome: Verify bounded capability-selection invariants in the plugin control*
 *plane before expanding proof coverage elsewhere.*
@@ -1187,7 +1762,7 @@ implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
         exploring larger input spaces without widening the verified kernel
         claims.
 
-### 8.5. Add a proof-only Verus kernel
+#### 8.5. Add a proof-only Verus kernel
 
 *Outcome: Prove the smallest stable invariants in proof-only modules outside*
 *the main Cargo build.*
@@ -1210,7 +1785,7 @@ implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
         satisfies language, capability, and policy predicates, and that refusal
         occurs instead of silent fallback when no provider qualifies.
 
-### 8.6. Extend formal verification coverage after later roadmap features land
+#### 8.6. Extend formal verification coverage after later roadmap features land
 
 *Outcome: Expand proof coverage only when the underlying contracts and kernels*
 *are implemented and stable.*
@@ -1236,7 +1811,7 @@ implementation. See `docs/jacquard-card-first-symbol-graph-design.md` §13.2 and
 identifier from its parent phase above — search this document for the number to
 locate the full task description and its own dependency chain.*
 
-## 9. Vertical slice (Sempai → Jacquard → one-hop traversal)
+### 9. Vertical slice (Sempai → Jacquard → one-hop traversal)
 
 *Goal: Cut one thin, end-to-end path from a Sempai query through canonical
 symbol resolution to a JacquardCard with one navigable relation, proving the
@@ -1245,7 +1820,7 @@ an agent sends a symbol-ish query to Sempai, receives a canonical JacquardCard
 over the CLI, then follows one returned relation to a second card, with no
 interactive prompts.[^1][^2][^3]*
 
-### 9.1. Deliver minimal Sempai `search` execution (YAML only)
+#### 9.1. Deliver minimal Sempai `search` execution (YAML only)
 
 *Outcome: Execute a minimal positive-anchor Semgrep-compatible `search` query
 from a YAML rule file, returning deterministic match spans for one language.
@@ -1294,7 +1869,7 @@ families, or `where` clauses.[^1]*
         and stable error messaging covers missing file,
         unsupported mode, and parse failure paths.
 
-### 9.2. Deliver symbol-first card retrieval
+#### 9.2. Deliver symbol-first card retrieval
 
 *Outcome: Allow agents to retrieve a JacquardCard by symbol name or
 qualified-name selector, without requiring a line-and-column position. This
@@ -1329,7 +1904,7 @@ bridges the gap between Sempai match output and the existing position-based
         that the `GetCardResponse` envelope is identical
         regardless of which selector path is used.
 
-### 9.3. Deliver one-hop relation traversal
+#### 9.3. Deliver one-hop relation traversal
 
 *Outcome: Include exactly one navigable relation type in card output so that an
 agent can follow a returned `symbol_id` back into the same command path. This
@@ -1353,7 +1928,7 @@ is the thinnest useful slice of JacquardWeave.[^2]*
         in the user's guide[^5]; and no interactive prompts are
         required at any step.
 
-## 10. Leta parity for supported languages
+### 10. Leta parity for supported languages
 
 *Goal: Ship the high-frequency semantic navigation verbs that an agent needs
 every few minutes, bringing Weaver's public CLI surface to parity with
@@ -1363,7 +1938,7 @@ show, trace, search, rename — over exotic analysis. Each operation must honour
 Weaver's existing JSONL envelope, exit-code contract, and human-readable
 rendering conventions.[^3][^4][^5]*
 
-### 10.1. Deliver `observe find-references` end-to-end
+#### 10.1. Deliver `observe find-references` end-to-end
 
 *Outcome: Expose LSP `textDocument/references` as a stable, end-to-end CLI
 operation with human-readable and JSONL output. The underlying LSP substrate
@@ -1386,7 +1961,7 @@ already supports references in `weaver-lsp-host`.[^5]*
         unsupported-language refusal, and pre-initialization error
         paths for Rust, Python, and TypeScript fixtures.
 
-### 10.2. Deliver symbol-first `observe show`
+#### 10.2. Deliver symbol-first `observe show`
 
 *Outcome: Provide a `show` equivalent that accepts a symbol-ish selector and
 returns the full definition body, mirroring Leta's `show` command. This builds
@@ -1412,7 +1987,7 @@ infrastructure.[^2]*
         resolve correctly; and tests cover disambiguation across
         multiple files with identically named symbols.
 
-### 10.3. Deliver `observe call-hierarchy` end-to-end
+#### 10.3. Deliver `observe call-hierarchy` end-to-end
 
 *Outcome: Expose the existing `weaver-graph` call hierarchy provider as a
 stable CLI operation with configurable direction and depth. The internal
@@ -1436,7 +2011,7 @@ stable CLI operation with configurable direction and depth. The internal
         results, and unsupported-language refusal for Rust,
         Python, and TypeScript fixtures.
 
-### 10.4. Deliver `observe grep` end-to-end
+#### 10.4. Deliver `observe grep` end-to-end
 
 *Outcome: Expose the existing `weaver-syntax` structural search engine as a
 stable CLI operation for semantic symbol search with kind filtering. The
@@ -1459,7 +2034,7 @@ underlying engine is complete.[^3]*
         empty-result paths for Rust, Python, and TypeScript
         fixtures.
 
-### 10.5. Deliver `act rename-symbol` end-to-end
+#### 10.5. Deliver `act rename-symbol` end-to-end
 
 *Outcome: Expose the existing capability-routed `rename-symbol` plugins as a
 stable, end-to-end CLI operation with safety-harness integration. The
@@ -1483,7 +2058,7 @@ capability contract and plugin implementations are in place (5.2.1–5.2.4).[^6]
         Python and Rust, refusal paths, rollback guarantees, and
         safety-harness integration.
 
-## 11. Weaver unique selling proposition (USP): composable agent-grade CLI primitives
+### 11. Weaver unique selling proposition (USP): composable agent-grade CLI primitives
 
 *Goal: Deliver the capabilities that make Weaver more than a Leta clone. Where
 Phase 10 reaches parity, this phase delivers Weaver's USP: budgeted graph-slice
@@ -1492,7 +2067,7 @@ loops, and the safety harness that makes write operations trustworthy. These
 are the features that justify choosing Weaver over a thinner LSP
 wrapper.[^3][^2][^7]*
 
-### 11.1. Deliver `observe graph-slice` traversal
+#### 11.1. Deliver `observe graph-slice` traversal
 
 *Outcome: Wire the budgeted graph traversal from 7.2.5 into a stable CLI
 command with the full flag set from the design document. This is the first
@@ -1513,7 +2088,7 @@ schema work from 7.2.1.[^2]*
         renders a tree with depth markers; and exit-code semantics
         distinguish success from truncation.
 
-### 11.2. Deliver card-driven traversal workflow
+#### 11.2. Deliver card-driven traversal workflow
 
 *Outcome: Enable agents to navigate from one symbol card to related symbols
 through structured relation data, completing the "postcard to loom" loop.[^2]*
@@ -1536,7 +2111,7 @@ through structured relation data, completing the "postcard to loom" loop.[^2]*
         absent (not zero) when the underlying provider is
         unavailable.
 
-### 11.3. Deliver agent-grade CLI contract hardening
+#### 11.3. Deliver agent-grade CLI contract hardening
 
 *Outcome: Harden the CLI surface so that Weaver behaves as a reliable primitive
 for agent tool loops (Codex CLI, Claude Code, and similar). The contract must
@@ -1569,7 +2144,7 @@ be deterministic, non-interactive, and machine-readable.[^3]*
         opt into richer output; and agents can rely on bounded
         response sizes without explicit truncation.
 
-### 11.4. Deliver safety-harness integration as a visible differentiator
+#### 11.4. Deliver safety-harness integration as a visible differentiator
 
 *Outcome: Surface the Double-Lock safety harness as a visible, documented
 feature that agents and operators can rely on for trustworthy write operations.

--- a/docs/rust-extricate-actuator-plugin-technical-design.md
+++ b/docs/rust-extricate-actuator-plugin-technical-design.md
@@ -266,7 +266,7 @@ This approach prevents accidental capture of similarly named types in scope.
 Module path computation must use RA `experimental/parentModule` recursion
 rather than filesystem heuristics.
 
-Destination materialisation rules:
+Destination materialization rules:
 
 - create destination module file when missing and policy allows creation,
 - insert `mod` declaration in the correct parent module file,

--- a/docs/sempai-query-language-design.md
+++ b/docs/sempai-query-language-design.md
@@ -82,7 +82,7 @@ Weaver integration code should live in `weaverd` (backend execution) and
 ## System overview
 
 For screen readers: the following diagram shows the flow from rule input (YAML
-or one-liner domain-specific language (DSL)) to a normalised query plan and
+or one-liner domain-specific language (DSL)) to a normalized query plan and
 execution against a Tree-sitter parse tree, producing matches and captures.
 
 ```mermaid
@@ -457,7 +457,7 @@ but the shorter form is acceptable given local scope.
 ### Syntax overview
 
 The DSL provides a compact expression form for interactive usage and for CLI
-flags. It maps directly to the normalised formula model.
+flags. It maps directly to the normalized formula model.
 
 Atoms:
 
@@ -505,7 +505,7 @@ operator tables.[^5]
 
 ### Error recovery
 
-Error recovery must prioritise interactive usability:
+Error recovery must prioritize interactive usability:
 
 - Token stream parsing with accurate spans.[^4]
 - Recovery anchors on delimiters `)`, `}`, and `,`.[^4]
@@ -663,7 +663,7 @@ to language-defined leaf kinds (identifiers, literals).
 `MetaVar` binds the target node to a name. Subsequent occurrences must unify:
 
 - Kind equality is enforced if the original binding is kind-specific.
-- Textual equality is enforced by default using the source slice normalised for
+- Textual equality is enforced by default using the source slice normalized for
   whitespace.
 - Span equality is not required across occurrences.
 
@@ -770,7 +770,7 @@ Conjunction execution proceeds:
 Disjunction is union of branch results:
 
 - Each branch is evaluated independently.
-- Duplicates are deduplicated by `(span, captures)` after normalising capture
+- Duplicates are deduplicated by `(span, captures)` after normalizing capture
   ordering.
 
 ### Negative constraints
@@ -782,7 +782,7 @@ Negative constraints require careful scoping to avoid surprising results:
 - `pattern-not-inside` semantics filter anchor matches if anchor span is within
   a negative context match.
 
-Both forms are present in the legacy schema.[^1] The normalised form must
+Both forms are present in the legacy schema.[^1] The normalized form must
 preserve the distinction.
 
 ## Where clauses, focus, and actuation
@@ -1137,7 +1137,7 @@ mirrored into `sempai_fixtures` as local test inputs.[^7]
     query keys.[^1]
 - [ ] 1.2.2. Implement legacy and v2 parsing paths and normalization.
 
-  - Success criteria: normalised formula output snapshots for paired legacy/v2
+  - Success criteria: normalized formula output snapshots for paired legacy/v2
     examples.[^2][^3]
 
 ### 1.3. One-liner DSL

--- a/docs/sempai-query-language-design.md
+++ b/docs/sempai-query-language-design.md
@@ -184,7 +184,7 @@ engine focused on feature extraction.
 The facade crate `sempai` is the only semver-stable entrypoint. Internal crates
 may evolve, but the facade must preserve:
 
-- Type names and serialisation formats of public structs.
+- Type names and serialization formats of public structs.
 - Behaviour of core methods within documented constraints.
 - Backwards compatibility of the one-liner DSL within a minor release line.
 
@@ -376,8 +376,8 @@ The one-liner Pratt binding powers must follow the provided table.[^3]
 ### YAML parser stack
 
 - `saphyr` parses YAML into a value model with location info.
-- `serde-saphyr` deserialises to Rust structs.
-- A custom deserialisation layer handles:
+- `serde-saphyr` deserializes to Rust structs.
+- A custom deserialization layer handles:
 
   - Union shapes (string vs object).
   - Forward-compatible unknown keys on the rule object
@@ -1069,7 +1069,7 @@ using the guidance in the Rust parser testing document.[^6]
 - Lexer unit tests (`logos`) using `rstest` tables.[^6]
 - DSL precedence tests using a small operator matrix, mirroring the Semgrep
   binding power table.[^3]
-- YAML deserialisation tests using minimal schema-aligned rule objects.[^1]
+- YAML deserialization tests using minimal schema-aligned rule objects.[^1]
 
 ### Snapshot tests
 
@@ -1133,7 +1133,7 @@ mirrored into `sempai_fixtures` as local test inputs.[^7]
 
 - [ ] 1.2.1. Implement rule file parsing via `saphyr` and `serde-saphyr`.
 
-  - Success criteria: schema-aligned deserialisation for rule metadata and
+  - Success criteria: schema-aligned deserialization for rule metadata and
     query keys.[^1]
 - [ ] 1.2.2. Implement legacy and v2 parsing paths and normalization.
 
@@ -1142,7 +1142,7 @@ mirrored into `sempai_fixtures` as local test inputs.[^7]
 
 ### 1.3. One-liner DSL
 
-- [ ] 1.3.1. Implement `logos` tokeniser and Chumsky Pratt parser.
+- [ ] 1.3.1. Implement `logos` tokenizer and Chumsky Pratt parser.
 
   - Success criteria: precedence tests match the Semgrep binding power
     table.[^3]

--- a/docs/ui-gap-analysis.md
+++ b/docs/ui-gap-analysis.md
@@ -1,532 +1,345 @@
-# Weaver command-line interface (CLI) user-interface gap analysis
+# Weaver command-interface gap analysis
 
-This document records a comprehensive audit of the `weaver` CLI's
-discoverability and help surfaces, identifies concrete gaps, and proposes
-remedies for each. The guiding principle is that **a user must never feel at a
-loss as to what to do next**: every level of the command hierarchy must
-advertise the available subcommands, domains, operations, plugins, and
-parameters so that the tool is self-documenting.
+This document audits the gap between Weaver's current pre-0.1.0 command-line
+interface and the target human-friendly, agent-native command contract defined
+by [ADR 007](adr-007-agent-native-command-surface.md), the
+[design document](weaver-design.md), and the [roadmap](roadmap.md).
 
-## Methodology
+The previous version of this document focused on discoverability defects in the
+prototype `observe` / `act` / `verify` grammar. Those findings remain useful
+evidence of why the reset is necessary, but the future target is no longer to
+polish that prototype grammar. The target is one generated command contract
+with two first-class renderers:
 
-The analysis was conducted by:
+- a localized, accessible, human-friendly default renderer; and
+- a stable `--json` renderer for agents, scripts, and UNIX pipelines.
 
-1. Reading every help surface the binary exposes today (`--help`, `-h`,
-   `help`, bare invocation, per-subcommand help).
-2. Tracing the clap definition in
-   [`crates/weaver-cli/src/cli.rs`](../crates/weaver-cli/src/cli.rs) and the
-   domain router in
-   [`crates/weaverd/src/dispatch/router.rs`](../crates/weaverd/src/dispatch/router.rs).
-3. Exercising error paths for unknown domains, unknown operations,
-   missing arguments, and missing operations.
-4. Reviewing the plugin registry, the daemon dispatch table, and the
-   output-rendering pipeline.
-5. Cross-referencing against the user's guide
-   ([`docs/users-guide.md`](users-guide.md)) and the generated manual page.
+The audit below therefore treats legacy command names, root `--output`,
+operation-local `--format`, root `--capabilities`, provider-first mutation
+commands, and hand-maintained catalogues as current-state evidence rather than
+future contract details.
 
-The sections below are ordered from the outermost user interaction (bare
-invocation) inward to the deepest (individual operation arguments).
+## Current evidence
 
-______________________________________________________________________
+The prototype interface still exposes several concrete gaps that motivated the
+reset:
 
-## Level 0 — bare invocation (`weaver`)
+- `crates/weaver-cli/src/cli.rs` still models the public command as positional
+  `DOMAIN`, `OPERATION`, and trailing `ARG` tokens. That keeps operation-level
+  help and validation out of the schema that clap can render.
+- The top-level command still has `disable_help_subcommand = true`, so
+  `weaver help` is not a normal help entrypoint.
+- The top-level machine-output control is `--output auto|human|json`, while
+  the target contract requires one canonical `--json` switch.
+- Some operation documentation still references operation-local formatting
+  flags or provider-first workflows, both of which are superseded by ADR 007.
+- Unknown-domain, unknown-operation, missing-argument, and missing-provider
+  paths have improved in recent roadmap work, but the current surface does not
+  yet provide universal enum enumeration, stable exit classes, or structured
+  failure JSON for every command.
+- Plugin and capability information exists in the implementation and ADRs, but
+  ordinary users still encounter provider concepts too early in some current
+  documentation and workflows.
 
-Running `weaver` with no arguments currently produces:
+These are not separate defects to fix one by one under the old grammar. They
+are acceptance evidence for the command-surface reset in roadmap phase 1.
 
-```plaintext
-the command domain must be provided
+## Principle gap matrix
+
+### Non-interactive by default
+
+Current status: most implemented commands are scriptable, and the safety
+harness avoids implicit commits.
+
+Shortfall: future interactive review work could accidentally add prompts, and
+destructive and mutating semantics are not yet declared in one command schema.
+
+Target contract: no command prompts unless `--interactive` or a review command
+is used; non-TTY paths fail fast; destructive operations require `--force`;
+mutating commands declare `--dry-run` and idempotency policy.
+
+Roadmap owner: `roadmap.md` 1.3, 3.2, 3.3, and 4.1.
+
+### Structured, parseable output
+
+Current status: Weaver uses JSONL internally and exposes root `--output json`.
+
+Shortfall: `--output json` is not the target community convention; JSON mode is
+not universal, operation-local `--format` exists in older docs, and
+stdout/stderr/error schema rules are not yet universal.
+
+Target contract: every data-returning command accepts `--json`; success JSON
+goes to stdout; structured error JSON goes to stderr; protocol identifiers are
+non-localized.
+
+Roadmap owner: `roadmap.md` 1.3.2.
+
+### Errors that teach and enumerate
+
+Current status: ADR 004 and prior roadmap work define stable routing refusals
+and better alternatives for some errors.
+
+Shortfall: enumeration is not universal across enums, registries, providers,
+profiles, jobs, delivery schemes, selector forms, and capability IDs.
+
+Target contract: every enum-shaped rejection includes the invalid value, valid
+values, source registry, stable error code, exit class, and a working next
+command.
+
+Roadmap owner: `roadmap.md` 1.3.3.
+
+### Safe retries and mutation boundaries
+
+Current status: Double-Lock, syntactic verification, atomic edits, and
+capability-routed mutation work are substantial foundations.
+
+Shortfall: mutations do not yet share one target contract for idempotency keys,
+transaction IDs, retry matching, dry-run coverage, and selector-stream
+provenance.
+
+Target contract: actuator output is always planned, verified, committed
+atomically, and reported with transaction metadata; retries reuse idempotency
+keys or safe natural keys.
+
+Roadmap owner: `roadmap.md` 3.2 and 3.3.
+
+### Bounded responses
+
+Current status: graph-slice work already has explicit budgets such as card and
+edge limits.
+
+Shortfall: bounded output is not yet a command-surface invariant for every
+collection command or future tool description.
+
+Target contract: lists expose `--limit`, cursor or continuation state,
+truncation markers, budget metadata, and narrowing hints.
+
+Roadmap owner: `roadmap.md` 1.3.3 and 2.2.
+
+### Cross-CLI vocabulary consistency
+
+Current status: current docs and code still mix prototype domains, provider
+terms, and older flags.
+
+Shortfall: canonical verbs and banned names are not yet enforced mechanically.
+
+Target contract: resource-first commands use canonical verbs including `get`,
+`list`, `create`, `update`, `delete`, `apply`, `run`, `prune`, `save`, `show`,
+`rename`, `move`, and `send`; CI rejects off-policy names.
+
+Roadmap owner: `roadmap.md` 1.2.
+
+### Three-layer introspection
+
+Current status: help and generated manpage work exist, and prior roadmap
+entries improved help.
+
+Shortfall: the target `weaver context --json`, capability availability command,
+and workflow skills are missing.
+
+Target contract: human help, structured `context --json`,
+`capabilities list --json`, and `skill-path` all derive from or validate
+against the same command contract.
+
+Roadmap owner: `roadmap.md` 1.4.
+
+### Async-aware execution
+
+Current status: ADR 006 defines broker-owned plugin execution, but it
+deliberately keeps one-shot JSONL execution narrow.
+
+Shortfall: no public `--wait` contract or durable jobs ledger exists for
+recoverable long-running workflows.
+
+Target contract: async-submit commands support `--wait`; `weaver jobs list`,
+`weaver jobs get`, and `weaver jobs prune` expose a durable ledger and retry
+recovery.
+
+Roadmap owner: `roadmap.md` 4.1.
+
+### Persistent identity through profiles
+
+Current status: Weaver has layered configuration, including config files,
+environment, and flags.
+
+Shortfall: named profiles are not yet a first-class command-surface state
+primitive or exposed through context metadata.
+
+Target contract: `weaver profiles save`, `weaver profiles list`,
+`weaver profiles show`, `weaver profiles delete`, and root `--profile` provide
+named agent and human identities with redaction and explicit precedence.
+
+Roadmap owner: `roadmap.md` 4.2.
+
+### Two-way I/O
+
+Current status: Weaver has stdout/stderr discipline and internal JSONL
+transport.
+
+Shortfall: artifact delivery sinks and agent feedback are not yet first-class,
+discoverable, or schema-backed.
+
+Target contract: `--deliver stdout`, `--deliver file:<path>`, and
+`--deliver webhook:<url>` handle artefact routing; `weaver feedback create`,
+`weaver feedback list`, and `weaver feedback send` record local and optional
+upstream friction reports.
+
+Roadmap owner: `roadmap.md` 4.3 and 4.4.
+
+## Human-interface gaps
+
+The reset must not turn Weaver into an agent-only appliance. The current
+prototype still lacks several human-facing guarantees that the target command
+contract must supply:
+
+- Default output must remain readable and localized. Humans should not need
+  `jq` for ordinary success or failure paths.
+- Help must be available through `weaver --help`, `weaver help`, command-level
+  help, generated manpages, shell completions, and copy-pasteable examples.
+- `--plain`, `--color auto|always|never`, `--no-pager`, `--width`, and
+  `--locale` must be stable human-renderer controls rather than alternate
+  protocol shapes.
+- Human output must not rely on colour alone. Tables need headings, narrow
+  terminals need labelled-block fallbacks, Unicode decoration needs ASCII
+  fallbacks, and progress belongs on stderr only when stderr is a terminal.
+- Interactive review remains valuable, but it must be explicit through
+  `--interactive` or a dedicated review command and must fail fast without a
+  terminal.
+
+These gaps are primarily owned by `roadmap.md` 1.3.1. They depend on
+OrthoConfig behavioural metadata, but the human layouts and recovery text are
+Weaver-owned because they must explain semantic code work.
+
+## Agent-interface gaps
+
+The current interface is agent-friendly in important ways, especially its JSONL
+foundations, daemon model, safety harness, and capability ADRs. It is not yet
+agent-native by construction. The missing pieces are:
+
+- one canonical `--json` switch instead of root `--output json`;
+- stable success and failure schemas for every public command;
+- stable exit-code classes;
+- bounded collection defaults and continuation metadata;
+- structured selector records that can flow from observe-style commands into
+  act-style commands;
+- Sempai one-liner selectors as peers of `--uri` plus `--position`;
+- `weaver context --json` for whole-command introspection;
+- `weaver capabilities list --json` for runtime capability availability;
+- workflow skills discoverable through `weaver skill-path`;
+- recoverable job state for long-running workflows;
+- named profiles for repeated agent identity;
+- delivery sinks for artefacts; and
+- feedback commands for reporting friction.
+
+These gaps are distributed across roadmap phases 1 through 4. They are not a
+request to duplicate OrthoConfig. The reusable metadata, naming, renderer,
+profile, delivery, feedback, and ledger contracts remain explicit dependencies
+on OrthoConfig; Weaver owns the semantic editing and safety integration.
+
+## Capability and provider gaps
+
+Weaver's existing ADRs already point in the correct direction:
+
+- ADR 001 says user intent is represented by stable capability IDs and provider
+  selection is internal.
+- ADR 004 requires deterministic routing and stable refusal diagnostics.
+- ADR 006 keeps plugin execution broker-owned and prevents plugins from owning
+  final commit behaviour.
+
+The gap is that the ordinary public surface and some current documentation
+still leak provider-first thinking. The target command surface must present
+capabilities as the public abstraction:
+
+```sh
+weaver symbols rename --uri file:///src/lib.rs --position 42:9 --new-name run
 ```
 
-Exit code 1. No further guidance.
+Provider-specific commands such as `weaver rope rename` or workflows that
+require `--provider` by default are out of contract. Provider IDs remain useful
+in JSON provenance, verbose diagnostics, policy, profiles, and expert
+overrides. They are not the everyday grammar.
 
-A newcomer receives only a terse error message. There is no hint that `--help`
-is available, no listing of domains, no mention of `daemon`, and no pointer to
-documentation. The message does not explain what a "domain" is.
+Roadmap phase 6 owns this migration behind the command-surface adapter defined
+in phase 1.
 
-**Recommended remedy.** When neither a domain nor a structured subcommand is
-supplied, emit the short help text (`-h` form) automatically instead of an
-unadorned error string. This is the behaviour users expect from every
-mainstream CLI tool.
+## Selector and pipeline gaps
 
-*Alternative:* print a purpose-built "getting started" block that lists
-domains, the `daemon` subcommand, and the `--help` flag.
+Sempai one-liner queries must be first-class selectors, not a search-only side
+feature. Position references and selector streams are peer selector forms. The
+target interactions include:
 
-______________________________________________________________________
+```sh
+weaver symbols list --query 'fn $name(...)' --json \
+  | weaver symbols rename --from-stdin --suffix _renamed
 
-## Level 1 — top-level help (`weaver --help` / `weaver -h`)
+weaver symbols list --query 'fn $name(...)' --json \
+  | jq 'select(.name | startswith("old_"))' \
+  | weaver symbols rename --from-stdin --replace-prefix old_ --with-prefix new_
 
-Running `weaver --help` currently produces:
+weaver symbols rename --query 'fn process_request(...)' --new-name run_request
 
-```plaintext
-Command-line interface for the Weaver semantic code tool
+weaver symbols rename \
+  --uri file:///src/main.rs \
+  --position 10:5 \
+  --new-name run_request
 
-Usage: weaver [OPTIONS] [DOMAIN] [OPERATION] [ARG]...
-
-Commands:
-  daemon  Runs daemon lifecycle commands
-
-Arguments:
-  [DOMAIN]     The command domain (for example `observe`)
-  [OPERATION]  The command operation (for example `get-definition`)
-  [ARG]...     Additional arguments passed to the daemon
-
-Options:
-      --capabilities     Prints the negotiated capability matrix …
-      --output <OUTPUT>  Controls how daemon output is rendered …
-  -h, --help             Print help
+weaver symbols list --query 'class $name' --json | less
 ```
 
-### Gap 1a — domains not enumerated
-
-The help text gives one example (`observe`) but never lists all three domains
-(`observe`, `act`, `verify`). The user must already know the domain names or
-consult external documentation.
-
-**Remedy.** Add a `long_about` or `after_help` block to `Cli` that lists all
-three domains with a one-line description for each.
-
-### Gap 1b — operations not enumerated
-
-Only `get-definition` appears as a parenthetical example. The user cannot
-discover that `find-references`, `apply-patch`, `refactor`, etc. exist.
-
-**Recommended remedy.** Include the full operation list per domain in the same
-after-help block used for gap 1a.
-
-*Alternative:* add a `weaver list-operations` introspection command.
-
-### Gap 1c — configuration flags invisible
-
-The five `ortho-config` flags (`--config-path`, `--daemon-socket`,
-`--log-filter`, `--log-format`, `--capability-overrides`) are stripped before
-clap parses and therefore never appear in help output. See
-[Level 6](#level-6--configuration-flags-invisible-in-help) for the full
-analysis and remedy.
-
-### Gap 1d — no `--version` flag
-
-The `Cli` struct does not derive or declare a version. Running
-`weaver --version` produces:
-
-```plaintext
-error: unexpected argument '--version' found
-```
-
-Standard CLI expectation violated; packaging and bug-reporting workflows are
-harder.
-
-**Remedy.** Add `version` to the `#[command(...)]` attribute on `Cli` so clap
-auto-generates `--version` / `-V`.
-
-### Gap 1e — no long description or after-help text
-
-There is no `about`, `long_about`, or `after_help` on the top-level `Cli`
-struct that would describe Weaver's purpose, architecture, or give a
-quick-start example.
-
-**Remedy.** Add `about` and `long_about` attributes describing Weaver's purpose
-and a one-line quick-start example.
-
-### Gap 1f — `help` subcommand disabled
-
-`disable_help_subcommand = true` means `weaver help` is parsed as
-`DOMAIN = "help"`, which fails with "the command operation must be provided".
-Users accustomed to `<tool> help <topic>` patterns get a confusing error.
-
-**Recommended remedy.** Re-enable the `help` subcommand (remove
-`disable_help_subcommand = true`).
-
-*Alternative:* intercept the `help` domain token in the CLI and print
-contextual help.
-
-### Gap 1g — plugin listing absent
-
-There is no mechanism to list registered plugins (actuators, sensors), their
-supported languages, or their available refactoring operations. Users must
-guess provider names (e.g. `rope`, `rust-analyzer`) or read the source.
-
-**Remedy.** Add a `weaver list-plugins` (or `weaver plugins`) introspection
-subcommand. It should query the daemon (or a static registry) and print plugin
-name, kind, languages, and version.
-
-______________________________________________________________________
-
-## Level 2 — domain without operation (`weaver observe`)
-
-Running `weaver observe`, `weaver act`, or `weaver verify` without an operation
-currently produces:
-
-```plaintext
-the command operation must be provided
-```
-
-Exit code 1. No further guidance.
-
-The user has correctly identified a domain but receives no indication of which
-operations exist within it. The error is generated client-side in
-[`command.rs`](../crates/weaver-cli/src/command.rs)
-(`AppError::MissingOperation`) before any daemon communication occurs, so the
-daemon's knowledge of valid operations is not surfaced.
-
-**Recommended remedy.** When a domain is provided without an operation, emit a
-contextual help block listing the valid operations for that domain. The
-recommended approach is a hard-coded table in the CLI mirroring the daemon's
-`DomainRoutingContext::known_operations`, since this avoids a daemon
-round-trip. The message should follow the pattern:
-
-```plaintext
-error: operation required for domain 'observe'
-
-Available operations:
-  get-definition   Retrieve the definition location for a symbol
-  find-references  Find all references to a symbol
-  grep             Structural pattern search
-  diagnostics      Retrieve compiler diagnostics
-  call-hierarchy   Show the call graph for a symbol
-
-Run 'weaver observe <operation> --help' for operation details.
-```
-
-______________________________________________________________________
-
-## Level 3 — unknown domain (`weaver bogus something`)
-
-The CLI sends the request to the daemon (or attempts auto-start). If the daemon
-is not running, the user sees:
-
-```plaintext
-Waiting for daemon start...
-failed to spawn weaverd binary '"weaverd"': No such file or directory
-```
-
-If the daemon is running, it returns:
-
-```plaintext
-unknown domain: bogus
-```
-
-The unknown-domain error does not suggest valid domains. A typo (e.g. `observe`
-vs `obsrve`) produces an opaque rejection with no "did you mean?" hint.
-Additionally, the error is only available at the daemon layer — the CLI could
-validate the domain before attempting a daemon connection or auto-start.
-
-**Recommended remedy.** Validate the domain client-side before connecting to
-the daemon and include the list of valid domains in the error output:
-
-```plaintext
-error: unknown domain 'obsrve'
-
-Valid domains: observe, act, verify
-```
-
-This avoids unnecessary auto-start attempts for clearly invalid input.
-
-*Alternative:* additionally apply edit-distance matching to suggest the closest
-valid domain (e.g. "did you mean 'observe'?").
-
-______________________________________________________________________
-
-## Level 4 — unknown operation (`weaver observe nonexistent`)
-
-When the daemon is running, it returns:
-
-```plaintext
-unknown operation 'nonexistent' for domain 'observe'
-```
-
-Exit code 1. The error does not list valid operations for the domain. The
-daemon has all the information needed (it holds the `known_operations` arrays)
-but does not include it in the error response.
-
-**Remedy.** Extend the `DispatchError::UnknownOperation` path to include the
-known operations list:
-
-```plaintext
-error: unknown operation 'get-def' for domain 'observe'
-
-Available operations: get-definition, find-references, grep,
-diagnostics, call-hierarchy
-```
-
-______________________________________________________________________
-
-## Level 5 — operation without required arguments
-
-### Gap 5a — `observe get-definition` without arguments
-
-Running `weaver observe get-definition` (without `--uri` and `--position`)
-attempts a daemon connection or auto-start. If the daemon is available, it
-returns:
-
-```plaintext
-observe get-definition requires --uri and --position arguments
-```
-
-Two sub-problems exist:
-
-- **No client-side pre-validation.** The CLI does not know what
-  arguments each operation needs, so it cannot catch missing parameters before
-  contacting the daemon.
-- **No `--help` at operation level.** Running
-  `weaver observe get-definition --help` prints the *top-level* help because
-  `--help` is consumed by clap before the trailing arguments reach the daemon.
-  The user has no way to discover operation parameters from the CLI.
-
-**Recommended remedy.** Model each domain as a clap subcommand containing its
-own subcommands (one per operation). This gives full clap-generated help at
-every level — including `weaver observe get-definition --help` — and is the
-most thorough approach, though it requires significant restructuring of
-[`cli.rs`](../crates/weaver-cli/src/cli.rs).
-
-*Alternatives (lighter-weight):*
-
-- **Daemon-side `--help` interception.** When the daemon receives an
-  operation with `--help` in the arguments, respond with a help payload instead
-  of executing the operation.
-- **Introspection subcommand.** A `weaver help observe get-definition`
-  command that queries the daemon (or a static schema) and prints the expected
-  arguments, types, and examples.
-
-### Gap 5b — `act refactor` without arguments
-
-Running `weaver act refactor` (without flags) produces:
-
-```plaintext
-act refactor requires --provider <plugin-name>
-```
-
-The error identifies the first missing flag but not the full set of required
-flags (`--provider`, `--refactoring`, `--file`), nor does it list valid
-providers or refactoring operations.
-
-**Remedy.** Return a comprehensive error listing all required parameters, valid
-provider names, and valid refactoring operations:
-
-```plaintext
-error: act refactor requires the following arguments:
-
-  --provider <PLUGIN>        Registered plugin name (rope, rust-analyzer)
-  --refactoring <OPERATION>  Refactoring to perform (rename)
-  --file <PATH>              Workspace-relative file path
-
-  KEY=VALUE...               Extra arguments forwarded to the plugin
-
-Run 'weaver list-plugins' to see registered plugins.
-```
-
-______________________________________________________________________
-
-## Level 6 — configuration flags invisible in help
-
-The five configuration flags (`--config-path`, `--daemon-socket`,
-`--log-filter`, `--log-format`, `--capability-overrides`) are consumed by
-`split_config_arguments` before the remaining tokens reach clap. They work
-correctly at runtime, but are completely absent from all help output.
-
-An operator who runs `weaver --help` to discover how to connect to a
-non-default daemon socket finds no relevant flag listed. The flags are
-documented only in [`docs/users-guide.md`](users-guide.md) and the source code.
-
-**Recommended remedy.** Register the five flags as clap arguments on `Cli` so
-they appear in `--help`. They do not need to participate in clap's parsing
-pipeline (they can be `global = true, hide = false` arguments that are read by
-the config splitter), but they must be visible in the help output.
-
-*Alternative:* document them in an `after_help` block if registering them as
-clap arguments would conflict with the `ortho-config` loader.
-
-______________________________________________________________________
-
-## Level 7 — plugin discoverability
-
-There is no command to list plugins. The user must know the provider name
-(`rope`, `rust-analyzer`) from the documentation or source code. There is no
-way to discover which plugins are registered, which languages each plugin
-supports, which refactoring operations a plugin offers, or the version of each
-plugin.
-
-The plugin registry (`PluginRegistry`) has the application programming
-interface (API) surface to answer all of these queries (`find_by_kind`,
-`find_for_language`, `find_actuator_for_language`), but this information is not
-exposed through the CLI.
-
-**Remedy.** Add one or more introspection commands:
-
-```plaintext
-weaver list-plugins               List all registered plugins
-weaver list-plugins --kind actuator   Filter by kind
-weaver list-plugins --language python  Filter by language
-```
-
-Example output:
-
-```plaintext
-NAME             KIND      LANGUAGES  VERSION  TIMEOUT
-rope             actuator  python     0.1.0    30s
-rust-analyzer    actuator  rust       0.1.0    60s
-```
-
-**Recommended implementation:** add a new top-level clap subcommand
-`list-plugins` alongside `daemon` that constructs the same static registry the
-daemon uses and queries it locally (no daemon round-trip required).
-
-*Alternative:* implement `list-plugins` as a daemon operation, so the output
-always reflects the live registry.
-
-______________________________________________________________________
-
-## Level 8 — `daemon` subcommand help
-
-`weaver daemon --help` is adequate — it lists `start`, `stop`, and `status`
-with one-line descriptions.
-
-`weaver daemon start --help` shows only `Usage: weaver daemon start` and the
-`-h` / `--help` option. It does not mention the configuration flags that affect
-startup (`--daemon-socket`, `--log-filter`, `--config-path`), nor does it
-describe the `WEAVERD_BIN` or `WEAVER_FOREGROUND` environment variable
-overrides.
-
-**Remedy.** Once configuration flags are surfaced in help (level 6 remedy),
-they will naturally appear in the `daemon start` help if marked as
-`global = true`. Additionally, mention `WEAVERD_BIN` and `WEAVER_FOREGROUND` in
-the `long_about` or `after_help` text for `daemon start`.
-
-______________________________________________________________________
-
-## Level 9 — `--capabilities` output
-
-`weaver --capabilities` prints a JavaScript Object Notation (JSON) document
-showing capability overrides. When no overrides are configured, it prints:
-
-```json
-{
-  "languages": {}
-}
-```
-
-The capabilities probe shows overrides only, not the full negotiated matrix. A
-user cannot determine which operations are actually available for which
-languages without starting a daemon and exercising each operation.
-
-**Remedy (lower priority).** Consider extending the capabilities probe to merge
-the server-reported capabilities with the overrides, producing a complete
-available-capabilities matrix. This requires daemon interaction and is a larger
-change, so it may be deferred. At minimum, the current output should include a
-note explaining that the matrix shows overrides only and that actual capability
-negotiation occurs at runtime.
-
-______________________________________________________________________
-
-## Level 10 — error messages and exit codes
-
-| #   | Scenario                             | Current message                                                         | Missing guidance                                                |
-| --- | ------------------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------- |
-| 10a | Daemon not running, auto-start fails | `failed to spawn weaverd binary '"weaverd"': No such file or directory` | Does not suggest installing `weaverd` or setting `WEAVERD_BIN`. |
-| 10b | Unknown domain (daemon)              | `unknown domain: bogus`                                                 | Does not list valid domains.                                    |
-| 10c | Unknown operation (daemon)           | `unknown operation 'x' for domain 'y'`                                  | Does not list valid operations.                                 |
-| 10d | Missing domain                       | `the command domain must be provided`                                   | Does not list domains or point to `--help`.                     |
-| 10e | Missing operation                    | `the command operation must be provided`                                | Does not list operations or point to domain help.               |
-
-**Remedy.** Each error message should include actionable next steps. A
-consistent pattern would be:
-
-```plaintext
-error: <what went wrong>
-
-<list of valid alternatives or required arguments>
-
-Run 'weaver --help' for more information.
-```
-
-______________________________________________________________________
-
-## Level 11 — manpage
-
-A manual page is auto-generated via `clap_mangen` during the build. It reflects
-the same clap-derived content that `--help` shows.
-
-Because the manpage is generated from the same clap model that lacks domain
-enumeration, operation listing, configuration flags, and per-operation help,
-the manpage inherits all the same deficiencies.
-
-**Remedy.** Fixing the clap model (levels 1–6 above) will automatically improve
-the manpage. No separate manpage-specific work is required beyond ensuring
-`after_help` content renders correctly in troff.
-
-______________________________________________________________________
-
-## Level 12 — `weaver help` subcommand
-
-`weaver help` is parsed as `DOMAIN = "help"` because
-`disable_help_subcommand = true` is set. This produces:
-
-```plaintext
-the command operation must be provided
-```
-
-The `help` subcommand is a universal CLI convention. Disabling it creates a
-trap for users who reflexively type `weaver help`.
-
-**Recommended remedy.** Re-enable the help subcommand by removing
-`disable_help_subcommand = true`.
-
-*Alternative (enhanced):* extend the re-enabled subcommand to support
-topic-based help:
-
-```plaintext
-weaver help                 Show general help
-weaver help observe         List operations in the observe domain
-weaver help act refactor    Show act refactor parameter reference
-weaver help plugins         List registered plugins
-```
-
-______________________________________________________________________
-
-## Summary of gaps and priority
-
-| Priority | Level | Gap summary                                  | Effort         |
-| -------- | ----- | -------------------------------------------- | -------------- |
-| P0       | 0     | Bare invocation gives no guidance            | Small          |
-| P0       | 1a    | Domains not listed in help                   | Small          |
-| P0       | 1b    | Operations not listed in help                | Small          |
-| P0       | 2     | Missing operation gives no alternatives      | Small          |
-| P0       | 1d    | No `--version` flag                          | Trivial        |
-| P1       | 1c    | Config flags invisible in help               | Medium         |
-| P1       | 3     | Unknown domain gives no suggestions          | Small          |
-| P1       | 4     | Unknown operation gives no suggestions       | Small          |
-| P1       | 5a    | No operation-level help                      | Medium–Large   |
-| P1       | 5b    | Refactor error lists only first missing flag | Small          |
-| P1       | 10    | Error messages lack actionable guidance      | Medium         |
-| P1       | 12    | `weaver help` broken                         | Small          |
-| P2       | 1e    | No long description or after-help            | Small          |
-| P2       | 1f    | `help` subcommand disabled                   | Small          |
-| P2       | 7     | No plugin listing command                    | Medium         |
-| P2       | 8     | Daemon start help lacks config/env detail    | Small          |
-| P3       | 9     | Capabilities probe shows overrides only      | Medium         |
-
-______________________________________________________________________
-
-## Recommended implementation order
-
-1. **Quick wins (P0):** Add `version` to `Cli`. List domains and
-   operations in `after_help`. Improve bare-invocation and missing-operation
-   error messages. These changes touch only
-   [`cli.rs`](../crates/weaver-cli/src/cli.rs), [`command.rs`](../crates/weaver-cli/src/command.rs),
-    and [`errors.rs`](../crates/weaver-cli/src/errors.rs).
-
-2. **Error message enrichment (P1):** Add valid-alternative listings
-   to unknown-domain and unknown-operation errors in both the CLI and the
-   daemon router. Surface all required arguments in `act refactor` errors.
-
-3. **Configuration flag visibility (P1):** Register the five config
-   flags as clap arguments (even if parsing remains in `ortho-config`) so they
-   appear in help output.
-
-4. **Help subcommand and operation-level help (P1–P2):** Re-enable
-   the help subcommand and implement topic-based help. Optionally restructure
-   the clap model to use nested subcommands for full per-operation `--help`.
-
-5. **Plugin introspection (P2):** Add a `list-plugins` command.
-
-6. **Capability matrix enrichment (P3):** Extend `--capabilities` to
-   merge runtime capabilities.
+The optional filter in an observe-to-act pipeline may be any ordinary UNIX
+filter that preserves compatible selector records. Act commands that consume
+selectors must state zero-match, one-match, and many-match behaviour. Selector
+records must preserve enough provenance for safe mutation and auditability.
+
+Roadmap phases 2, 3, and 5 own the vertical slices that make these examples
+real.
+
+## Historical prototype findings
+
+The following older findings are retained as historical evidence. They should
+not be implemented literally if doing so would preserve the superseded public
+grammar:
+
+- Bare `weaver` produced only `the command domain must be provided`.
+- Top-level help listed `DOMAIN`, `OPERATION`, and `ARG` placeholders rather
+  than a resource command tree.
+- Domains and operations were not enumerated in generated help.
+- `weaver help` was disabled by clap configuration.
+- Configuration flags were stripped before clap and therefore invisible in
+  help.
+- Missing operations, unknown domains, and unknown operations did not
+  universally enumerate alternatives.
+- `act refactor` errors exposed provider-first workflow details.
+- Plugin listing was absent.
+- Root `--capabilities` reported overrides rather than the full runtime
+  capability picture.
+
+ADR 007 and `roadmap.md` supersede the specific remedies that would merely
+patch those behaviours in place. The durable remedies are generated command
+metadata, resource-first commands, human and machine renderers, structured
+introspection, capability-routed providers, and drift gates.
+
+## Acceptance checklist
+
+The gap analysis is resolved when the following checks have concrete evidence:
+
+- The command-surface adapter can generate or validate public commands, help,
+  docs snippets, router metadata, schemas, and tests from one source.
+- `weaver --help`, `weaver help`, generated manpages, and completions expose
+  the same command tree.
+- Every data-returning command accepts `--json`.
+- JSON success and JSON failure outputs are parseable and non-localized where
+  protocol stability requires it.
+- Every enum-shaped validation error enumerates valid values.
+- Every collection command has bounded defaults and narrowing hints.
+- Every mutating command declares selector forms, dry-run support, idempotency,
+  safety policy, and transaction metadata.
+- `weaver context --json`, `weaver capabilities list --json`, and
+  `weaver skill-path` exist and are validated against the command contract.
+- Profiles, jobs, delivery, and feedback are discoverable through context
+  metadata and have redaction rules where needed.
+- Provider IDs appear in provenance and expert policy, not as required normal
+  workflow syntax.
+- Roadmap tasks that depend on reusable command-contract work cite the
+  relevant OrthoConfig task instead of recreating generic infrastructure in
+  Weaver.

--- a/docs/ui-gap-analysis.md
+++ b/docs/ui-gap-analysis.md
@@ -58,7 +58,7 @@ Target contract: no command prompts unless `--interactive` or a review command
 is used; non-TTY paths fail fast; destructive operations require `--force`;
 mutating commands declare `--dry-run` and idempotency policy.
 
-Roadmap owner: `roadmap.md` 13.3, 15.2, 15.3, and 16.1.
+Roadmap owner: `roadmap.md` 13.2, 16.1, 16.2, and 19.2.
 
 ### Structured, parseable output
 
@@ -72,7 +72,7 @@ Target contract: every data-returning command accepts `--json`; success JSON
 goes to stdout; structured error JSON goes to stderr; protocol identifiers are
 non-localized.
 
-Roadmap owner: `roadmap.md` 13.3.2.
+Roadmap owner: `roadmap.md` 13.2.2.
 
 ### Errors that teach and enumerate
 
@@ -86,7 +86,7 @@ Target contract: every enum-shaped rejection includes the invalid value, valid
 values, source registry, stable error code, exit class, and a working next
 command.
 
-Roadmap owner: `roadmap.md` 13.3.3.
+Roadmap owner: `roadmap.md` 13.2.3 and 18.1.3.
 
 ### Safe retries and mutation boundaries
 
@@ -101,7 +101,7 @@ Target contract: actuator output is always planned, verified, committed
 atomically, and reported with transaction metadata; retries reuse idempotency
 keys or safe natural keys.
 
-Roadmap owner: `roadmap.md` 15.2 and 15.3.
+Roadmap owner: `roadmap.md` 16.1 and 16.2.
 
 ### Bounded responses
 
@@ -114,7 +114,7 @@ collection command or future tool description.
 Target contract: lists expose `--limit`, cursor or continuation state,
 truncation markers, budget metadata, and narrowing hints.
 
-Roadmap owner: `roadmap.md` 13.3.3 and 14.2.
+Roadmap owner: `roadmap.md` 13.2.3, 14.1, 14.2, and 17.1.
 
 ### Cross-CLI vocabulary consistency
 
@@ -127,7 +127,7 @@ Target contract: resource-first commands use canonical verbs including `get`,
 `list`, `create`, `update`, `delete`, `apply`, `run`, `prune`, `save`, `show`,
 `rename`, `move`, and `send`; CI rejects off-policy names.
 
-Roadmap owner: `roadmap.md` 13.2.
+Roadmap owner: `roadmap.md` 13.1 and 13.3.4.
 
 ### Three-layer introspection
 
@@ -141,7 +141,7 @@ Target contract: human help, structured `context --json`,
 `capabilities list --json`, and `skill-path` all derive from or validate
 against the same command contract.
 
-Roadmap owner: `roadmap.md` 13.4.
+Roadmap owner: `roadmap.md` 13.3.
 
 ### Async-aware execution
 
@@ -155,7 +155,7 @@ Target contract: async-submit commands support `--wait`; `weaver jobs list`,
 `weaver jobs get`, and `weaver jobs prune` expose a durable ledger and retry
 recovery.
 
-Roadmap owner: `roadmap.md` 16.1.
+Roadmap owner: `roadmap.md` 19.1.2 and 19.1.3.
 
 ### Persistent identity through profiles
 
@@ -169,7 +169,7 @@ Target contract: `weaver profiles save`, `weaver profiles list`,
 `weaver profiles show`, `weaver profiles delete`, and root `--profile` provide
 named agent and human identities with redaction and explicit precedence.
 
-Roadmap owner: `roadmap.md` 16.2.
+Roadmap owner: `roadmap.md` 19.1.1.
 
 ### Two-way I/O
 
@@ -184,7 +184,7 @@ Target contract: `--deliver stdout`, `--deliver file:<path>`, and
 `weaver feedback list`, and `weaver feedback send` record local and optional
 upstream friction reports.
 
-Roadmap owner: `roadmap.md` 16.3.
+Roadmap owner: `roadmap.md` 19.1.3 and 19.1.4.
 
 ## Human-interface gaps
 
@@ -206,9 +206,9 @@ contract must supply:
   `--interactive` or a dedicated review command and must fail fast without a
   terminal.
 
-These gaps are primarily owned by `roadmap.md` 13.3.1. They depend on
-OrthoConfig behavioural metadata, but the human layouts and recovery text are
-Weaver-owned because they must explain semantic code work.
+These gaps are primarily owned by `roadmap.md` 13.2.1 and 19.2.2. They depend
+on OrthoConfig behavioural metadata, but the human layouts and recovery text
+are Weaver-owned because they must explain semantic code work.
 
 ## Agent-interface gaps
 
@@ -231,7 +231,7 @@ agent-native by construction. The missing pieces are:
 - delivery sinks for artefacts; and
 - feedback commands for reporting friction.
 
-These gaps are distributed across roadmap phases 13 through 16. They are not a
+These gaps are distributed across roadmap phases 13 through 19. They are not a
 request to duplicate OrthoConfig. The reusable metadata, naming, renderer,
 profile, delivery, feedback, and ledger contracts remain explicit dependencies
 on OrthoConfig; Weaver owns the semantic editing and safety integration.
@@ -291,8 +291,9 @@ filter that preserves compatible selector records. Act commands that consume
 selectors must state zero-match, one-match, and many-match behaviour. Selector
 records must preserve enough provenance for safe mutation and auditability.
 
-Roadmap phases 14, 15, and 17 own the vertical slices that make these examples
-real.
+Roadmap phases 15 and 16 own the core selector and mutation slices that make
+these examples real. Phase 14 supplies the read-command outputs, and phase 17
+adds richer graph context once the core loop is proven.
 
 ## Historical prototype findings
 

--- a/docs/ui-gap-analysis.md
+++ b/docs/ui-gap-analysis.md
@@ -42,7 +42,7 @@ reset:
   documentation and workflows.
 
 These are not separate defects to fix one by one under the old grammar. They
-are acceptance evidence for the command-surface reset in roadmap phase 1.
+are acceptance evidence for the command-surface reset in roadmap phase 13.
 
 ## Principle gap matrix
 
@@ -58,7 +58,7 @@ Target contract: no command prompts unless `--interactive` or a review command
 is used; non-TTY paths fail fast; destructive operations require `--force`;
 mutating commands declare `--dry-run` and idempotency policy.
 
-Roadmap owner: `roadmap.md` 1.3, 3.2, 3.3, and 4.1.
+Roadmap owner: `roadmap.md` 13.3, 15.2, 15.3, and 16.1.
 
 ### Structured, parseable output
 
@@ -72,7 +72,7 @@ Target contract: every data-returning command accepts `--json`; success JSON
 goes to stdout; structured error JSON goes to stderr; protocol identifiers are
 non-localized.
 
-Roadmap owner: `roadmap.md` 1.3.2.
+Roadmap owner: `roadmap.md` 13.3.2.
 
 ### Errors that teach and enumerate
 
@@ -86,7 +86,7 @@ Target contract: every enum-shaped rejection includes the invalid value, valid
 values, source registry, stable error code, exit class, and a working next
 command.
 
-Roadmap owner: `roadmap.md` 1.3.3.
+Roadmap owner: `roadmap.md` 13.3.3.
 
 ### Safe retries and mutation boundaries
 
@@ -101,7 +101,7 @@ Target contract: actuator output is always planned, verified, committed
 atomically, and reported with transaction metadata; retries reuse idempotency
 keys or safe natural keys.
 
-Roadmap owner: `roadmap.md` 3.2 and 3.3.
+Roadmap owner: `roadmap.md` 15.2 and 15.3.
 
 ### Bounded responses
 
@@ -114,7 +114,7 @@ collection command or future tool description.
 Target contract: lists expose `--limit`, cursor or continuation state,
 truncation markers, budget metadata, and narrowing hints.
 
-Roadmap owner: `roadmap.md` 1.3.3 and 2.2.
+Roadmap owner: `roadmap.md` 13.3.3 and 14.2.
 
 ### Cross-CLI vocabulary consistency
 
@@ -127,7 +127,7 @@ Target contract: resource-first commands use canonical verbs including `get`,
 `list`, `create`, `update`, `delete`, `apply`, `run`, `prune`, `save`, `show`,
 `rename`, `move`, and `send`; CI rejects off-policy names.
 
-Roadmap owner: `roadmap.md` 1.2.
+Roadmap owner: `roadmap.md` 13.2.
 
 ### Three-layer introspection
 
@@ -141,7 +141,7 @@ Target contract: human help, structured `context --json`,
 `capabilities list --json`, and `skill-path` all derive from or validate
 against the same command contract.
 
-Roadmap owner: `roadmap.md` 1.4.
+Roadmap owner: `roadmap.md` 13.4.
 
 ### Async-aware execution
 
@@ -155,7 +155,7 @@ Target contract: async-submit commands support `--wait`; `weaver jobs list`,
 `weaver jobs get`, and `weaver jobs prune` expose a durable ledger and retry
 recovery.
 
-Roadmap owner: `roadmap.md` 4.1.
+Roadmap owner: `roadmap.md` 16.1.
 
 ### Persistent identity through profiles
 
@@ -169,7 +169,7 @@ Target contract: `weaver profiles save`, `weaver profiles list`,
 `weaver profiles show`, `weaver profiles delete`, and root `--profile` provide
 named agent and human identities with redaction and explicit precedence.
 
-Roadmap owner: `roadmap.md` 4.2.
+Roadmap owner: `roadmap.md` 16.2.
 
 ### Two-way I/O
 
@@ -184,7 +184,7 @@ Target contract: `--deliver stdout`, `--deliver file:<path>`, and
 `weaver feedback list`, and `weaver feedback send` record local and optional
 upstream friction reports.
 
-Roadmap owner: `roadmap.md` 4.3 and 4.4.
+Roadmap owner: `roadmap.md` 16.3.
 
 ## Human-interface gaps
 
@@ -206,7 +206,7 @@ contract must supply:
   `--interactive` or a dedicated review command and must fail fast without a
   terminal.
 
-These gaps are primarily owned by `roadmap.md` 1.3.1. They depend on
+These gaps are primarily owned by `roadmap.md` 13.3.1. They depend on
 OrthoConfig behavioural metadata, but the human layouts and recovery text are
 Weaver-owned because they must explain semantic code work.
 
@@ -231,7 +231,7 @@ agent-native by construction. The missing pieces are:
 - delivery sinks for artefacts; and
 - feedback commands for reporting friction.
 
-These gaps are distributed across roadmap phases 1 through 4. They are not a
+These gaps are distributed across roadmap phases 13 through 16. They are not a
 request to duplicate OrthoConfig. The reusable metadata, naming, renderer,
 profile, delivery, feedback, and ledger contracts remain explicit dependencies
 on OrthoConfig; Weaver owns the semantic editing and safety integration.
@@ -259,8 +259,8 @@ require `--provider` by default are out of contract. Provider IDs remain useful
 in JSON provenance, verbose diagnostics, policy, profiles, and expert
 overrides. They are not the everyday grammar.
 
-Roadmap phase 6 owns this migration behind the command-surface adapter defined
-in phase 1.
+Roadmap phase 18 owns this migration behind the command-surface adapter defined
+in phase 13.
 
 ## Selector and pipeline gaps
 
@@ -291,7 +291,7 @@ filter that preserves compatible selector records. Act commands that consume
 selectors must state zero-match, one-match, and many-match behaviour. Selector
 records must preserve enough provenance for safe mutation and auditability.
 
-Roadmap phases 2, 3, and 5 own the vertical slices that make these examples
+Roadmap phases 14, 15, and 17 own the vertical slices that make these examples
 real.
 
 ## Historical prototype findings

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,9 +1,54 @@
 # Weaver user's guide
 
-This guide summarizes the behaviour exposed to operators by the initial CLI and
-daemon foundation. Configuration is currently the primary focus because both
-binaries share the same loading pipeline and rely on the `weaver-config` crate
-to merge settings from files, environment variables, and command-line arguments.
+This guide summarizes the behaviour exposed to operators by the current
+pre-0.1.0 CLI and daemon foundation. Configuration is currently the primary
+focus because both binaries share the same loading pipeline and rely on the
+`weaver-config` crate to merge settings from files, environment variables, and
+command-line arguments.
+
+## 0.1.0 command-surface target
+
+Weaver is pre-0.1.0, so the current public command grammar is not a
+compatibility promise. [ADR 007](adr-007-agent-native-command-surface.md) and
+the [roadmap](roadmap.md) reset the future public interface around a
+human-friendly, agent-native command contract.
+
+The 0.1.0 target keeps the human terminal experience first-class while making
+agent usage reliable:
+
+- default output remains localized, readable, and accessible for humans;
+- `--json` is the canonical machine-readable output switch;
+- resource-first commands replace the prototype `observe`, `act`, and
+  `verify` domain grammar;
+- Sempai one-liner queries are first-class selectors alongside file-position
+  selectors;
+- observe-style commands can emit structured selector records that act-style
+  commands consume directly or after ordinary UNIX filtering;
+- capabilities are public, while providers such as Rope and rust-analyzer are
+  implementation details surfaced through provenance, diagnostics, policy, and
+  expert overrides; and
+- reusable command metadata, renderer metadata, profile, delivery, feedback,
+  skill, and execution-ledger contracts depend on OrthoConfig where the
+  OrthoConfig roadmap already owns the generic machinery.
+
+Representative target commands look like this:
+
+```sh
+weaver definitions get --uri file:///src/main.rs --position 10:5
+weaver references list --uri file:///src/main.rs --position 10:5 --json
+weaver symbols list --query 'fn $name(...)' --json \
+  | jq 'select(.name | startswith("old_"))' \
+  | weaver symbols rename --from-stdin --replace-prefix old_ --with-prefix new_
+weaver symbols rename --query 'fn process_request(...)' --new-name run_request
+weaver patches apply --file changes.patch --dry-run
+weaver context --json
+weaver capabilities list --json
+```
+
+The command reference below records the current prototype implementation. It is
+useful for operating this branch today, but future roadmap work should follow
+the target contract above unless a later ADR explicitly changes the 0.1.0
+surface.
 
 ## Configuration layering
 
@@ -261,12 +306,14 @@ Next command:
   WEAVER_FOREGROUND=1 weaver daemon start
 ```
 
-## Command reference
+## Current prototype command reference
 
 `weaver` exposes three command families: the `--capabilities` probe, daemon
 lifecycle commands, and domain operations (`observe`, `act`, `verify`). Domain
 commands are sent to the daemon as JSONL; any arguments after the operation are
-forwarded verbatim without CLI validation.
+forwarded verbatim without CLI validation. This section describes the current
+implementation only; the 0.1.0 target command surface is resource-first and is
+summarized at the start of this guide.
 
 ### Bare invocation
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1377,7 +1377,7 @@ structured error is returned to the caller.
 
 ## Language server capability detection
 
-The `weaver-lsp-host` crate initialises the LSP servers for Rust, Python, and
+The `weaver-lsp-host` crate initializes the LSP servers for Rust, Python, and
 TypeScript and records which core requests each server advertises:
 `textDocument/definition`, `textDocument/references`, diagnostics, and call
 hierarchy (`textDocument/prepareCallHierarchy` plus incoming/outgoing calls).
@@ -1409,7 +1409,7 @@ required tooling before retrying. Example:
 failed to spawn rust language server: command 'rust-analyzer' not found
 ```
 
-Language servers are initialised lazily when the first operation for that
+Language servers are initialized lazily when the first operation for that
 language is requested. The daemon sends the LSP `initialize` handshake followed
 by `initialized`, then routes subsequent requests through the established
 session.
@@ -1483,7 +1483,7 @@ Tree-sitter parsers for Rust, Python, and TypeScript. When validating a file,
 the lock parses the content and inspects the resulting syntax tree for ERROR
 nodes. Files containing structural errors—such as unbalanced braces, missing
 semicolons, or malformed declarations—are rejected before the semantic lock
-runs. Files with extensions not recognised by any configured parser are skipped
+runs. Files with extensions not recognized by any configured parser are skipped
 (pass through) to avoid blocking edits to configuration files, documentation,
 or other non-code artefacts.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -944,11 +944,11 @@ spillover metadata:
 
 The `constraints` object reflects the applied request parameters after defaults
 are resolved. The `cards` array contains the extracted symbol cards within the
-budget. For roadmap item 7.2.1, Weaver builds a deterministic same-file slice:
-the entry card plus additional same-file symbol cards that fit within
-`budget.max_cards`. The `edges` array is therefore currently empty in runtime
-responses, while the stable schema already reserves the typed edge shape for
-later milestones. The `--max-edges` CLI flag is accepted for forward
+budget. For prototype archive roadmap item 7.2.1, Weaver builds a deterministic
+same-file slice: the entry card plus additional same-file symbol cards that fit
+within `budget.max_cards`. The `edges` array is therefore currently empty in
+runtime responses, while the stable schema already reserves the typed edge
+shape for later milestones. The `--max-edges` CLI flag is accepted for forward
 compatibility but has no runtime effect in 7.2.1; only `budget.max_cards`
 limits the number of cards produced.
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -674,7 +674,7 @@ The current CLI preserves that payload unchanged in prototype `--output json`
 mode. The 0.1.0 machine renderer will instead use universal `--json` and
 structured error JSON on stderr. Human mode renders the payload into an
 actionable guidance block following the unified three-part error template
-(roadmap 2.3.3):
+(prototype archive roadmap 2.3.3):
 
 ```plaintext
 error: unknown operation 'nonexistent' for domain 'observe'
@@ -791,7 +791,8 @@ ensures the CLI only attempts auto-start when the daemon genuinely isn't
 running, rather than masking configuration errors or network issues.
 
 When auto-start fails, the CLI renders the failure using the unified three-part
-error template (roadmap 2.3.3). For a missing `weaverd` binary:
+error template (prototype archive roadmap 2.3.3). For a missing `weaverd`
+binary:
 
 ```plaintext
 error: failed to spawn weaverd binary 'weaverd'
@@ -1371,11 +1372,11 @@ protocol or plugin execution environment. Invalid locale identifiers are
 reported as configuration errors instead of silently falling back, preserving
 the fail-fast behaviour expected from the rest of the config loader.
 
-For roadmap item `3.2.1`, `locale` ships as a validated `weaver-config` newtype
-that accepts only well-formed BCP 47 identifiers and defaults to `en-US`. The
-later bootstrap-localizer work in roadmap `3.3.1` remains responsible for
-honouring that setting before clap-only help and parse-error surfaces are
-constructed.
+For prototype archive roadmap item `3.2.1`, `locale` ships as a validated
+`weaver-config` newtype that accepts only well-formed BCP 47 identifiers and
+defaults to `en-US`. The later bootstrap-localizer work in prototype archive
+roadmap `3.3.1` remains responsible for honouring that setting before clap-only
+help and parse-error surfaces are constructed.
 
 The capability override matrix is expressed as a sequence of directives using
 the syntax `language:capability=directive`. The directive may be `allow`,

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -3,21 +3,24 @@
 ## Executive Summary
 
 This document presents the fourth-generation design and strategic roadmap for
-`Weaver`, a semantics-aware command-line tool engineered for AI coding agents.
-Moving beyond the initial proof-of-concept, this design solidifies `Weaver` as
-a high-performance, secure, and composable tool built entirely in Rust. Its
-core mission is to provide a robust, agent-friendly interface for understanding
-and modifying codebases by orchestrating semantic operations across a wide
-array of programming languages.
+`Weaver`, a human-friendly, agent-native semantic command-line tool. Moving
+beyond the initial proof-of-concept, this design solidifies `Weaver` as a
+high-performance, secure, and composable tool built entirely in Rust. Its core
+mission is to provide a robust interface for understanding and modifying
+codebases by orchestrating semantic operations across a wide array of
+programming languages while keeping humans, scripts, and agents on one command
+contract.
 
 The architectural philosophy of `Weaver` represents a deliberate departure from
 monolithic, integrated solutions like the Serena Model Context Protocol Server.
 Instead, `Weaver` is conceived as a suite of composable UNIX-style primitives.
-It leverages JSON Lines (JSONL) as its native protocol for input and output,
-ensuring seamless integration with the rich ecosystem of existing command-line
-utilities such as `jq`, `find`, and `xargs`. This approach treats semantic
-operations not as features within a closed application, but as fundamental
-verbs in the developer's shell.
+It keeps JSON Lines (JSONL) as the internal daemon and provider transport,
+while the public `weaver` command exposes two first-class renderers from one
+schema-backed command contract. The default renderer is localized and readable
+for humans at a terminal. The `--json` renderer is stable, non-localized, and
+parseable for agents and scripts. This approach treats semantic operations not
+as features within a closed application, but as fundamental resources in the
+developer's shell.
 
 The system's intelligence is derived from a layered "Semantic Fusion Engine"
 that integrates data from three distinct sources: the Language Server Protocol
@@ -41,11 +44,11 @@ This document provides a comprehensive survey of the existing tooling and
 academic literature that informs these design decisions. It details the refined
 system architecture, presents a technical deep dive into each core component,
 outlines the strategy for security and sandboxing, and describes advanced
-capabilities tailored for AI agents, such as capability-aware orchestration and
-project onboarding via Retrieval-Augmented Generation (RAG). The report
-culminates in a revised, phased development roadmap that prioritizes safety,
-incremental value delivery, and the progressive enhancement of the tool's
-intelligence.
+capabilities tailored for agents, such as capability-aware orchestration,
+structured introspection, selector pipelines, and project onboarding via
+Retrieval-Augmented Generation (RAG). The report culminates in a revised,
+phased development roadmap that prioritizes safety, incremental value delivery,
+and the progressive enhancement of the tool's intelligence.
 
 ## 1. Vision and Strategic Positioning
 
@@ -67,35 +70,44 @@ be locked away within monolithic applications or proprietary protocols.
 Instead, they must be exposed as fundamental, composable primitives, accessible
 directly from the command line.
 
-The choice of JSON Lines (JSONL) as the native communication protocol is the
-modern embodiment of this philosophy for structured data. Just as traditional
-UNIX tools operate on streams of plain text, `Weaver` operates on streams of
-structured JSON objects. This decision ensures immediate and universal
-interoperability with a vast ecosystem of existing tools. An AI agent, or a
-human user, can pipe the output of a `weaver` command directly into powerful
-utilities like `jq` for filtering and transformation, `find` for file system
-operations, and `xargs` for batch processing.^3^ This creates a powerful,
-flexible, and extensible environment for scripting complex software engineering
-tasks.
+The public command contract is the modern embodiment of this philosophy for
+structured data. Just as traditional UNIX tools operate on streams of plain
+text, `Weaver` operates on resources that can be rendered for humans by default
+or as structured JSON with `--json`. This decision ensures immediate and
+universal interoperability with a vast ecosystem of existing tools. An AI
+agent, or a human user, can pipe selector records from a `weaver` command
+directly into utilities like `jq` for filtering and transformation, `less` for
+inspection, and `xargs` for batch processing.^3^
 
-Within this paradigm, `Weaver` introduces a new vocabulary of semantic verbs to
-the developer's shell. Commands are grouped into intuitive categories:
+Within this paradigm, `Weaver` adopts resource-first command names and
+community-consistent verbs. The 0.1.0 target grammar uses examples such as:
 
-- **`observe`**: Commands for querying the state of the codebase (e.g.,
-    `observe get-definition`, `observe find-references`, `observe grep`).
+```sh
+weaver definitions get --uri file:///src/main.rs --position 10:5
+weaver references list --uri file:///src/main.rs --position 10:5
+weaver diagnostics list --workspace .
+weaver symbols list --query 'fn $name(...)'
+weaver symbols rename --query 'fn process_request(...)' --new-name run_request
+weaver symbols rename --uri file:///src/main.rs --position 10:5 --new-name run
+weaver patches apply --file changes.patch --dry-run
+weaver context --json
+```
 
-- **`act`**: Commands for modifying the codebase (e.g., `act rename-symbol`,
-    `act apply-edits`, `act apply-patch`, `act refactor`).
+The historical `observe` / `act` / `verify` domain grammar is useful prototype
+evidence, but it is superseded by ADR 007 for the 0.1.0 target. The future
+public surface describes resources, selectors, and capabilities directly.
+Observe-style resource commands emit selector records that act-style mutation
+commands can consume directly or after ordinary UNIX filtering:
 
-- **`verify`**: Commands for checking the integrity of the codebase (e.g.,
-    `verify diagnostics`).
+```sh
+weaver symbols list --query 'fn $name(...)' --json \
+  | jq 'select(.name | startswith("old_"))' \
+  | weaver symbols rename --from-stdin --replace-prefix old_ --with-prefix new_
+```
 
-These commands are designed to be chained together, allowing agents to
-construct sophisticated workflows. For example, an agent could find all
-implementations of an interface, refactor each one, and then verify that no new
-errors were introduced, all through a series of piped commands. This approach
-transforms code semantics from a feature into a fundamental, scriptable
-building block of the development environment.
+Sempai one-liner queries are a first-class selector form, peer to position
+references. This keeps code semantics a scriptable building block without
+forcing callers through provider-specific commands or hidden session state.
 
 ### 1.2. Architectural Counterpoint: A Comparative Analysis of Weaver and Serena
 
@@ -341,8 +353,17 @@ near-instantaneous response times for subsequent commands, amortizing the
 initial cost over the entire development session.
 
 Crucially, this client-daemon model is implemented in a way that remains
-faithful to the UNIX pipe-and-filter paradigm. The `weaver` client's sole
-responsibilities are to:
+faithful to the UNIX pipe-and-filter paradigm. The 0.1.0 target separates the
+public command contract from the internal daemon transport:
+
+- the public `weaver` CLI parses resource-first commands, selectors, and flags;
+- default CLI output is localized human output;
+- `--json` emits stable operation result schemas on stdout and structured
+  error schemas on stderr;
+- JSONL remains the internal request and response transport between the CLI,
+  daemon, and providers.
+
+At the transport boundary, the `weaver` client's responsibilities are to:
 
 1. Parse command-line arguments and flags using the `clap` library.
 
@@ -361,19 +382,217 @@ more JSONL objects---representing either successful results or structured
 errors---to its standard output.
 
 This design ensures that while a daemon is used for performance, the
-public-facing *interface* is indistinguishable from any other standard
-command-line tool. A user or script could bypass the `weaver` client entirely
-and interact with the daemon directly. For example:
+public-facing *interface* behaves like a standard command-line tool. Internal
+debugging tools may still interact with the daemon transport directly. For
+example:
 
 ```sh
 echo '{"command": "observe", "subcommand": "get-definition"}' | weaverd
 ```
 
-This strict adherence to the standard streams protocol preserves the tool's
-composability and ensures it remains a well-behaved citizen of the shell
-environment.^1^
+That transport envelope is not the 0.1.0 public CLI contract. It is a
+current-state diagnostic example of the daemon protocol. Public documentation
+and examples should prefer resource-first `weaver` commands and `--json`
+operation result schemas.
 
-#### 2.1.1. JSONL command envelope and capability probe
+#### 2.1.1. Agent-native command surface
+
+ADR 007 defines the 0.1.0 command surface as a generated or validated contract
+with two first-class renderers. Weaver depends on OrthoConfig for reusable
+documentation intermediate representation, agent-context, policy, renderer,
+profile, delivery, feedback, and execution-ledger contracts where the
+OrthoConfig roadmap provides them. Weaver owns the semantic adapter that maps
+application resources to capabilities, providers, safety classes, transaction
+semantics, selectors, examples, output schemas, and error schemas.
+
+The semantic adapter records, at minimum:
+
+- resource path and canonical verb,
+- capability ID,
+- selector forms accepted by the command,
+- whether structured stdin is accepted,
+- mutability and async class,
+- pagination and bounded-output behaviour,
+- profile and delivery participation,
+- provider selection policy,
+- safety and transaction behaviour,
+- human message identifiers and examples,
+- JSON success and error schemas,
+- skill manifest references.
+
+Generated or validated outputs include clap definitions, daemon router
+metadata, localized help, manpages, shell completions, documentation snippets,
+`weaver context --json`, skill manifests, JSON Schema fixtures, vocabulary
+linting, and tests. Adding or renaming a public command requires one semantic
+adapter or OrthoConfig metadata change. CI must fail when router metadata,
+help, docs, tests, or `context --json` drift.
+
+Local generic command-contract code is temporary by default. If Weaver must
+ship a local adapter before the corresponding OrthoConfig dependency is
+available, the roadmap task must state the dependency, the temporary scope, and
+the removal condition.
+
+#### 2.1.2. Selector and pipeline contract
+
+Selectors are first-class inputs. A selector is any stable way to identify one
+symbol or a collection of symbols. The initial selector forms are Sempai
+one-liner queries, position references, and structured selector streams.
+
+Sempai one-liner queries use a canonical flag such as
+`--query <sempai-one-liner>`. They are not a secondary search feature; they are
+a peer to `--uri` plus `--position`. Any symbol-consuming command must state
+which selector forms it accepts and what happens for zero, one, and many
+matches.
+
+Observe-style resource commands must emit selector records that downstream
+act-style commands can consume either directly or after ordinary UNIX
+filtering. For example:
+
+```sh
+weaver symbols list --query 'fn $name(...)' --json \
+  | weaver symbols rename --from-stdin --suffix _renamed
+
+weaver symbols list --query 'fn $name(...)' --json \
+  | jq 'select(.name | startswith("old_"))' \
+  | weaver symbols rename --from-stdin --replace-prefix old_ --with-prefix new_
+
+weaver symbols rename --query 'fn process_request(...)' --new-name run_request
+
+weaver symbols rename \
+  --uri file:///src/main.rs \
+  --position 10:5 \
+  --new-name run_request
+
+weaver symbols list --query 'class $name' --json | less
+```
+
+Selector records must preserve enough provenance for safe mutation: source URI,
+range or point, resolved symbol identity when available, query provenance,
+provider provenance, workspace root, and capability compatibility. This lets a
+filtered observe stream remain a trustworthy act input.
+
+#### 2.1.3. Human and machine renderer contracts
+
+The default renderer is for humans. It emits localized, readable output with
+stable headings, examples, recovery guidance, terminal-width-aware layouts, and
+accessible plain-output fallbacks. Human output must not convey meaning by
+colour alone. ANSI styling, spinners, and pagers are disabled outside terminal
+contexts unless explicitly forced. Progress and diagnostics go to stderr.
+Primary command results go to stdout.
+
+Human rendering flags are:
+
+```plaintext
+--plain
+--color auto|always|never
+--no-pager
+--width <columns>
+--locale <tag>
+```
+
+The machine renderer is selected with `--json`. Every data-returning command
+accepts it. In JSON mode, success writes only the operation result to stdout.
+Failure writes a structured error object to stderr and exits with a stable
+non-zero exit class. Field names, enum values, schema versions, error codes,
+capability IDs, and exit classes are protocol identifiers and are not
+localized. Agents must not need localized prose to decide the next action.
+
+The 0.1.0 target does not use root `--output auto|human|json` or
+operation-local `--format` as public machine-output controls. The canonical
+machine switch is `--json`.
+
+#### 2.1.4. Structured introspection and skills
+
+Weaver exposes three introspection layers:
+
+```sh
+weaver --help
+weaver context --json
+weaver skill-path
+```
+
+Human help remains localized and accessible. `weaver context --json` returns
+the OrthoConfig-shaped agent-context payload: CLI version, schema version,
+commands, flags, enum values, output schemas, error taxonomy, installed
+capabilities, provider summaries, profiles, jobs, delivery schemes, feedback
+state, and skill paths. The public command name follows the OrthoConfig 6.2.3
+downstream naming convention. Weaver must not add a public `agent-context`
+alias before 0.1.0 unless a later ADR records the reason.
+
+Runtime capability availability is exposed separately:
+
+```sh
+weaver capabilities list --json
+```
+
+`weaver skill-path` prints the directory containing workflow `SKILL.md`
+manifests. Skill manifest metadata and validation should be delegated to
+OrthoConfig 6.3 where possible.
+
+#### 2.1.5. Agent state and recoverable workflows
+
+The public contract includes durable state surfaces for workflows that cannot
+be represented as one stateless call:
+
+```sh
+weaver jobs list --json
+weaver jobs get <job-id> --json
+weaver jobs prune --older-than 7d
+weaver profiles save <name>
+weaver profiles list --json
+weaver profiles show <name> --json
+weaver profiles delete <name> --force
+```
+
+Async-submitting commands support `--wait` and write recoverable records to a
+durable XDG state job ledger. Mutations and async submissions accept
+idempotency keys. Retrying the same request with the same idempotency key
+returns the existing in-flight or completed job instead of duplicating work.
+
+Profiles are named bundles of durable configuration. The precedence order is:
+
+```plaintext
+built-in defaults < config files < selected profile < environment < flags
+```
+
+Profiles appear in `weaver context --json` by name and metadata only. Secrets
+must remain redacted or represented as secret references. Weaver depends on
+OrthoConfig 9.1 for profile contracts and redaction metadata, and on
+OrthoConfig 9.3 for reusable execution-ledger metadata. Weaver owns the
+semantic job record contents, workspace safety integration, idempotency
+semantics, storage path choice, and public `jobs` behaviour.
+
+#### 2.1.6. Two-way I/O
+
+Weaver supports delivery sinks for artefacts that need to land somewhere other
+than stdout:
+
+```plaintext
+--deliver stdout
+--deliver file:<path>
+--deliver webhook:<url>
+```
+
+File delivery writes atomically. Webhook delivery surfaces the HTTP status and
+does not retry forever. Unknown schemes return structured refusals that
+enumerate valid schemes.
+
+Feedback is the reverse channel:
+
+```sh
+weaver feedback create "the enum error did not list valid values"
+weaver feedback list --json
+weaver feedback send --force
+```
+
+Feedback writes local JSONL by default. Upstream submission is optional and
+only enabled when explicitly configured. Feedback availability appears in
+`weaver context --json`. Weaver depends on OrthoConfig 9.2 for reusable
+delivery target parsing and feedback storage contracts. Weaver owns the
+semantic payloads, safety checks, webhook payload shape, and how delivered
+artefacts relate to code-edit transactions.
+
+#### 2.1.7. Current JSONL envelope and capability probe
 
 The initial CLI implementation serializes every invocation into a single JSONL
 object. The object contains a `command` descriptor comprising the command
@@ -407,11 +626,10 @@ reader abandons the session after ten consecutive blank lines and treats the
 absence of a terminating `exit` message as a failure. This ensures operators do
 not mistake a partial or stalled response for a successful execution.
 
-The capability probe specified in the roadmap is exposed as
-`weaver --capabilities`. The command loads the shared configuration, renders
-the negotiated capability matrix as pretty-printed JSON, and exits without
-contacting the daemon. This keeps the probe side effect free and allows agents
-to cache the matrix easily.
+The prototype capability probe is exposed as `weaver --capabilities`. ADR 007
+supersedes that root flag for the 0.1.0 target. Runtime capability availability
+moves to `weaver capabilities list --json`, while full command and workflow
+introspection moves to `weaver context --json`.
 
 Known-domain invocations that omit the operation (for example,
 `weaver observe`) are also handled entirely on the client side. The CLI now
@@ -452,9 +670,11 @@ structured stderr payload inside the existing JSONL `stream` envelope:
 }
 ```
 
-The CLI preserves that payload unchanged in `--output json` mode. In
-`--output human` mode it renders the payload into an actionable guidance block
-following the unified three-part error template (roadmap 2.3.3):
+The current CLI preserves that payload unchanged in prototype `--output json`
+mode. The 0.1.0 machine renderer will instead use universal `--json` and
+structured error JSON on stderr. Human mode renders the payload into an
+actionable guidance block following the unified three-part error template
+(roadmap 2.3.3):
 
 ```plaintext
 error: unknown operation 'nonexistent' for domain 'observe'
@@ -477,7 +697,7 @@ paths. The CLI does not consult its own discoverability catalogue for unknown
 operations, preventing drift between client help text and daemon dispatch
 authority.
 
-#### 2.1.2. Lifecycle orchestration
+#### 2.1.8. Lifecycle orchestration
 
 Operators now control the daemon lifecycle directly through the CLI via
 `weaver daemon start`, `weaver daemon stop`, and `weaver daemon status`. These
@@ -502,14 +722,14 @@ Because lifecycle commands operate exclusively on shared filesystem artefacts
 they remain side-effect free with respect to the JSONL transport and can be
 used safely from automation tooling.
 
-#### 2.1.3. Automatic daemon startup
+#### 2.1.9. Automatic daemon startup
 
 When a domain command is invoked and the daemon is not running, the CLI
 automatically attempts to start the daemon rather than failing immediately.
 This removes friction for operators who expect commands to "just work" without
 explicit daemon management. The CLI prints "Waiting for daemon start…" to
 stderr while waiting, and uses a 30-second timeout to allow sufficient time for
-daemon initialisation. If the daemon fails to start, the CLI reports the
+daemon initialization. If the daemon fails to start, the CLI reports the
 failure and exits; if it starts successfully, the original command proceeds.
 
 The following sequence diagram illustrates the auto-start flow within
@@ -601,7 +821,7 @@ This consistent structure—error statement, alternatives block, and next
 command—applies across all Level 10 failure paths including bare invocation,
 unknown domains, unknown operations, and startup failures.
 
-#### 2.1.4. Human-readable output and code context blocks
+#### 2.1.10. Current human-readable output and code context blocks
 
 Weaver continues to treat JSONL as the canonical, machine-readable transport,
 but the CLI may emit human-readable output when the daemon streams plain text
@@ -613,11 +833,12 @@ output. This applies to any response containing `Location`, `Range`, or
 hierarchy edges, structural matches, rewrite results, and verification failures
 surfaced by the safety harness.
 
-The CLI exposes an `--output` flag with `auto`, `human`, and `json` values.
-`auto` selects `human` when stdout is a terminal (TTY) and `json` when output
-is redirected, ensuring pipelines remain stable while still providing rich
-context for interactive use. The human renderer follows `miette`-style ASCII
-output even when a direct `miette` dependency is not used.
+The current prototype CLI exposes an `--output` flag with `auto`, `human`, and
+`json` values. ADR 007 supersedes that public target. The 0.1.0 design keeps
+the human context-block requirement but replaces `--output json` with universal
+`--json`, `--plain`, `--color`, `--no-pager`, and `--width` controls. The human
+renderer follows `miette`-style ASCII output even when a direct `miette`
+dependency is not used.
 
 Context blocks are required because line-and-column tuples alone are
 insufficient for fast triage. The renderer should show a labelled header with
@@ -644,7 +865,7 @@ error: Undefined variable `new_function_name`
    |           ^^^^^^^^^^^^^^^^^ not found in this scope
 ```
 
-#### 2.1.5. Localized help and reference surfaces
+#### 2.1.11. Localized help and reference surfaces
 
 Weaver's human-facing text should be localized without changing the JSONL
 protocol or daemon routing semantics. The daemon continues to emit stable
@@ -1078,17 +1299,17 @@ modularity, and maintainability. Based on the expanded technical analysis, the
 original structure is refined to better isolate complex functionalities and
 elevate the importance of key components.
 
-| Crate             | Purpose and Key Responsibilities                                                                                                                                                                                                                                |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `weaver-common`   | Defines core serializable types (using `serde`) and structured error enums (using `thiserror`). This includes critical types like `CapabilityError` and the request/response objects for the JSONL protocol.                                                    |
-| `weaver-config`   | Manages hierarchical configuration using `ortho-config`. Defines the crucial **Language Capability Matrix**, allowing users to override or supplement the capabilities reported by LSP servers, thus hardening the system against buggy servers.                |
-| `weaver-cli`      | The thin client executable (`weaver`). Uses `clap` for argument parsing and is responsible for serializing commands into JSONL and communicating with the `weaverd` daemon. Includes the `--capabilities` command for agent-side planning.                      |
-| `weaverd`         | The main daemon executable. Acts as the central orchestrator and **broker process**. Manages the project registry, hosts the analysis backends, dispatches commands to the appropriate crates, and implements the "Double-Lock" verification logic.             |
-| `weaver-lsp-host` | Manages the lifecycle of external LSP servers. Handles initialization, capability detection, request/response multiplexing, and enforces back-pressure on overloaded servers. Contains logic for language-specific workarounds.                                 |
-| `weaver-syntax`   | The Tree-sitter powered syntax layer. Implements the `ast-grep` and `srgn`-inspired engine for structural search (`observe grep`) and rewriting (`act apply-rewrite`). Provides the "Syntactic Lock" for the safety harness and context-aware code slicing.     |
-| `weaver-sandbox`  | A new, dedicated crate encapsulating all security and sandboxing logic. It is responsible for creating and managing the restrictive environments in which all external tools (LSPs, plugins) are executed, using OS primitives like namespaces and seccomp-bpf. |
-| `weaver-graph`    | Implements the relational intelligence layer. Orchestrates multiple providers (LSP, static analysis plugins, dynamic profilers) to generate and fuse call graphs and other relational models of the codebase.                                                   |
-| `weaver-plugins`  | Implements the plugin management and execution framework. Defines the IPC protocol between `weaverd` (as the broker) and sandboxed plugins, and manages the lifecycle of specialist tools.                                                                      |
+| Crate             | Purpose and Key Responsibilities                                                                                                                                                                                                                                                                            |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `weaver-common`   | Defines core serializable types (using `serde`) and structured error enums (using `thiserror`). This includes critical types like `CapabilityError` and the request/response objects for the JSONL protocol.                                                                                                |
+| `weaver-config`   | Manages hierarchical configuration using `ortho-config`. Defines the crucial **Language Capability Matrix**, allowing users to override or supplement the capabilities reported by LSP servers, thus hardening the system against buggy servers.                                                            |
+| `weaver-cli`      | The thin client executable (`weaver`). Uses `clap` for argument parsing and is responsible for serializing commands into JSONL and communicating with the `weaverd` daemon. The 0.1.0 target consumes the command-surface adapter for `context --json`, `capabilities list`, human rendering, and `--json`. |
+| `weaverd`         | The main daemon executable. Acts as the central orchestrator and **broker process**. Manages the project registry, hosts the analysis backends, dispatches commands to the appropriate crates, and implements the "Double-Lock" verification logic.                                                         |
+| `weaver-lsp-host` | Manages the lifecycle of external LSP servers. Handles initialization, capability detection, request/response multiplexing, and enforces back-pressure on overloaded servers. Contains logic for language-specific workarounds.                                                                             |
+| `weaver-syntax`   | The Tree-sitter powered syntax layer. Implements the `ast-grep` and `srgn`-inspired engine for structural search and rewriting behind resource-first commands such as `symbols list` and `patches apply`. Provides the "Syntactic Lock" for the safety harness and context-aware code slicing.              |
+| `weaver-sandbox`  | A new, dedicated crate encapsulating all security and sandboxing logic. It is responsible for creating and managing the restrictive environments in which all external tools (LSPs, plugins) are executed, using OS primitives like namespaces and seccomp-bpf.                                             |
+| `weaver-graph`    | Implements the relational intelligence layer. Orchestrates multiple providers (LSP, static analysis plugins, dynamic profilers) to generate and fuse call graphs and other relational models of the codebase.                                                                                               |
+| `weaver-plugins`  | Implements the plugin management and execution framework. Defines the IPC protocol between `weaverd` (as the broker) and sandboxed plugins, and manages the lifecycle of specialist tools.                                                                                                                  |
 
 #### 2.3.1. Configuration contract
 
@@ -1163,8 +1384,10 @@ a feature on when a server under-reports its support. Inputs are normalized by
 lowercasing identifiers and trimming surrounding whitespace, while duplicate
 entries are resolved by honouring the last directive supplied for a given
 language and capability pair. These directives merge with the daemon's runtime
-discovery to produce the negotiated capability surface exposed by
-`weaver --capabilities`.
+discovery to produce the negotiated capability surface. The prototype surface
+exposes that matrix through `weaver --capabilities`; the 0.1.0 target exposes
+runtime availability through `weaver capabilities list --json` and broader
+command introspection through `weaver context --json`.
 
 #### 2.3.2. Daemon bootstrap decisions
 
@@ -1214,7 +1437,7 @@ A `SystemShutdownSignal` built on `signal-hook` listens for `SIGTERM`,
 `SIGINT`, `SIGQUIT`, and `SIGHUP`, logging the event and giving the runtime a
 ten-second budget to shut down gracefully. Developers can opt into a foreground
 mode for debugging by setting the `WEAVER_FOREGROUND` environment variable,
-which bypasses daemonisation while preserving the same PID/lock/health
+which bypasses daemonization while preserving the same PID/lock/health
 choreography.
 
 ```mermaid
@@ -1254,7 +1477,7 @@ backend starts lazily via `ensure_backend`, keeping the process lightweight
 until a command requires a specific capability. The supervisor records whether
 a backend has already started and surfaces errors using a dedicated
 `BackendStartupError`. Behavioural tests exercise both successful and failing
-paths, ensuring that lazy initialisation and error propagation behave as
+paths, ensuring that lazy initialization and error propagation behave as
 designed.
 
 ## 3. Core Components: A Technical Deep Dive
@@ -1340,27 +1563,25 @@ several critical functions within the
 `Weaver` architecture.
 
 The design of this crate is heavily inspired by the capabilities of modern,
-Tree-sitter-based command-line tools like `ast-grep` and `srgn`. The
-`observe grep` command, Weaver's primary structural search tool, will emulate
-the intuitive pattern language of `ast-grep`. Instead of complex regular
-expressions, users and agents can provide code-like patterns with metavariables
-(e.g., `console.log($ARG)`) to find and capture specific abstract syntax tree
-(AST) nodes.^13^ This approach is more readable, less error-prone, and far more
-powerful than text-based searching, as it understands concepts like scope,
-nesting, and language grammar.
+Tree-sitter-based command-line tools like `ast-grep` and `srgn`. In the 0.1.0
+target, structural search is exposed through resource-first commands such as
+`weaver symbols list --query 'fn $name(...)'`. Instead of complex regular
+expressions, users and agents can provide code-like Sempai one-liners or
+patterns with metavariables (for example, `console.log($ARG)`) to find and
+capture specific abstract syntax tree (AST) nodes.^13^ This approach is more
+readable, less error-prone, and far more powerful than text-based searching, as
+it understands concepts like scope, nesting, and language grammar.
 
-Similarly, the `act apply-rewrite` command will draw inspiration from the
-rewriting capabilities of these tools. `srgn`, for example, demonstrates the
-power of combining Tree-sitter queries for precise scoping with a set of
-actions like `delete` or `replace`.^21^ Weaver will adopt this model, allowing
-an agent to perform large-scale, structurally-aware refactoring. For example,
-an agent could convert all instances of a legacy function call to a new format
-across an entire codebase with a single, precise command.
+Similarly, patch and rewrite commands draw inspiration from the rewriting
+capabilities of these tools. `srgn`, for example, demonstrates the power of
+combining Tree-sitter queries for precise scoping with a set of actions like
+`delete` or `replace`.^21^ Weaver adopts this model behind capability-routed
+commands such as `symbols rename`, `symbols move`, and `patches apply`.
 
 The key responsibilities of the `weaver-syntax` crate are:
 
-1. **High-Precision Search and Analysis:** Powering the `observe grep` command
-    for structural queries and providing the raw data for advanced analysis,
+1. **High-Precision Search and Analysis:** Powering structural resource
+    commands and providing the raw data for advanced analysis,
     such as identifying all function definitions or generating a preliminary
     call graph based on call expressions.^12^
 
@@ -1378,10 +1599,11 @@ The key responsibilities of the `weaver-syntax` crate are:
 
 4. **LSP Fallback Mechanism:** When an LSP server does not support a specific
     semantic operation (e.g., `rename`), the syntactic layer provides a robust
-    fallback. The agent can be instructed to use `observe grep` to find all
-    textual occurrences within the correct syntactic scope (e.g., not inside
-    comments or strings) and then use `act apply-edits` to perform a safe,
-    syntactic replacement.
+    fallback. The agent can be instructed to use
+    `weaver symbols list --query ... --json` to find all textual occurrences
+    within the correct syntactic scope (for example, not inside comments or
+    strings) and then use `weaver patches apply --dry-run` before committing a
+    safe syntactic replacement.
 
 ### 3.3. Relational Insight: A Pragmatic Approach to Call Graph Generation
 
@@ -1461,42 +1683,47 @@ best-in-class, specialized tools developed by language experts. This allows
 `Weaver` to provide a unified, safe, and consistent interface while leveraging
 the deep capabilities of the broader open-source ecosystem.
 
-Plugins are categorized based on their function, primarily as "sensors"
-(providing data to the intelligence engine) or "actuators" (performing actions
-on the codebase). The Python tooling landscape provides an excellent case study
-for this model:
+Plugins are categorized by the capability contract they implement. A perceptor
+is a read-only provider that observes the codebase and returns facts,
+diagnostics, cards, graph slices, matches, selector records, or provenance. An
+actuator is a mutation-planning provider that returns proposed edits, diffs,
+patches, plans, or workspace changes. Actuators never commit directly; the
+daemon broker owns provider selection, idempotency, jobs, safety verification,
+and final rendering. The Python tooling landscape provides an excellent case
+study for this model:
 
-- **`jedi` as a Sensor Plugin:** `jedi` is a powerful static analysis library
-    with a primary focus on autocompletion, goto definition, and finding
-    references.^29^ While there is some overlap with LSP functionality,
+- **`jedi` as a perceptor provider:** `jedi` is a powerful static analysis
+    library with a primary focus on autocompletion, goto definition, and
+    finding references.^29^ While there is some overlap with LSP
+    functionality,
 
     `jedi` can often provide supplementary or alternative analysis. It can be
     integrated as a sensor plugin, offering another data stream to the Semantic
     Fusion Engine, which can be particularly useful for cross-validation or
     when an LSP server is unavailable.
 
-- **`rope` as an Actuator Plugin:** `rope` is a dedicated and mature Python
+- **`rope` as an actuator provider:** `rope` is a dedicated and mature Python
     refactoring library, recognized as being more powerful and comprehensive
     for refactoring tasks than `jedi`.^31^ It supports a wide range of complex
     operations, such as "Extract Method," "Change Signature," and "Move
     Method".^33^
 
-    `rope` will be integrated as a primary actuator plugin for Python, callable
-    via a command like
-    `weaver act refactor --provider rope --refactoring rename --file src/main.py
-    offset=123 new_name=new_function_name`. More advanced rope operations
-    remain future work, but the shipped `act refactor` contract uses the
-    canonical `--provider`, `--refactoring`, and `--file` flags plus trailing
-    `KEY=VALUE` arguments. This allows an agent to perform sophisticated,
-    language-aware refactorings through the standard `Weaver` interface.
+    `rope` remains a primary actuator provider for Python. In the 0.1.0 target
+    the ordinary public command is capability-first, for example
+    `weaver symbols rename --uri file:///src/main.py --position 10:5
+    --new-name new_function_name` or `weaver symbols rename --query
+    'def old_name(…)' --new-name new_name`. The prototype `act refactor
+    --provider rope --refactoring rename` workflow remains current
+    implementation evidence, but it is not the future public grammar. Provider
+    names appear in provenance, diagnostics, `--verbose` output, JSON, and
+    expert policy overrides.
 
-This model extends to other domains as well. Tools like `srgn` and `ast-grep`,
-which excel at high-speed, structural search and rewrite operations, can be
-integrated as "precision editing" actuators.^13^ This gives agents a spectrum
-of tools to choose from, ranging from fast, syntactic transformations to
-slower, fully semantic-aware refactorings, all orchestrated and secured by the
-
-`weaverd` daemon.
+This model extends to other domains as well. Tools like `srgn`, `ast-grep`,
+Sempai, rust-analyzer, and Tree-sitter can provide perceptor or actuator
+capabilities behind stable Weaver commands.^13^ This gives agents and humans a
+spectrum of semantic operations without asking them to learn provider-specific
+incantations. Provider choice remains deterministic, inspectable, and secured
+by the `weaverd` daemon.
 
 #### 4.1.1. Implementation decisions (Phase 3.1.1)
 
@@ -1515,7 +1742,7 @@ during the initial implementation:
   request body as `FilePayload` objects (path + full text content). This avoids
   requiring the sandboxed plugin to have filesystem access and is consistent
   with how `act apply-patch` passes patch content. File descriptor passing can
-  be added as a future optimisation.
+  be added as a future optimization.
 
 - **Plugin trait with process-based implementation.** A `PluginExecutor` trait
   defines the execution contract. `SandboxExecutor` provides the concrete
@@ -1611,28 +1838,31 @@ following decisions govern this rollout:
 ### 4.2. The "Double-Lock" Safety Harness: Ensuring Syntactic and Semantic Integrity
 
 The "Double-Lock" safety harness is the single most critical feature for
-ensuring the safety and reliability of AI agent-driven code modifications. It
+ensuring the safety and reliability of agent-driven code modifications. It
 addresses the fundamental problem that powerful external tools, while
 effective, can sometimes produce incorrect results or have unintended side
-effects. The harness wraps every action from an actuator plugin in a
+effects. The harness wraps every action from an actuator provider in a
 verifiable, atomic transaction, guaranteeing that no change is committed to the
 filesystem unless it is proven to be both syntactically and semantically sound.
 
-The workflow for any modification command (e.g., `act refactor`) is as follows:
+The workflow for any modification command (for example, `symbols rename`) is as
+follows:
 
 1. **Agent Request:** An agent issues a command such as:
 
     ```sh
-    weaver act refactor --provider rope --refactoring rename \
-      --file src/main.py \
-      offset=123 \
-      new_name=new_function_name
+    weaver symbols rename \
+      --uri file:///src/main.py \
+      --position 10:5 \
+      --new-name new_function_name
     ```
 
-2. **Sandboxed Execution:** The `weaverd` daemon invokes the specified plugin
-    (`rope`) within the secure, resource-limited sandbox (detailed in Section
-    5). The plugin is provided with the necessary context (e.g., file contents,
-    arguments) via its standard input.
+2. **Capability routing and sandboxed execution:** The `weaverd` daemon maps
+    the command to a capability such as `symbol.rename`, resolves an eligible
+    provider such as `rope`, and invokes that provider within the secure,
+    resource-limited sandbox (detailed in Section 5). The provider is supplied
+    with the necessary context, such as file contents and arguments, via its
+    standard input.
 
 3. **Diff Capture:** The plugin executes the refactoring logic and, instead of
     writing directly to the filesystem, it outputs a set of proposed changes
@@ -2044,7 +2274,7 @@ other `act` commands. The parsed patch is applied to in-memory buffers, then:
   to ensure they remain syntactically valid. If the parser is unavailable or a
   timeout elapses, the command fails fast with a structured backend-unavailable
   error.
-- **Semantic Lock (LSP)**: The modified content is synchronised to the LSP
+- **Semantic Lock (LSP)**: The modified content is synchronized to the LSP
   server and diagnostics are checked for newly introduced errors. If the LSP
   backend is unavailable or times out, the command fails fast without falling
   back to a weaker validation mode.
@@ -2294,13 +2524,13 @@ classDiagram
     RuntimeHelpers --> BirdcageSandbox : preflight for spawn
 ```
 
-## 6. Advanced Capabilities for AI Agents
+## 6. Advanced Capabilities for Agents
 
-Beyond core observation and action primitives, `Weaver` is designed with
-specific features to enhance the planning and execution capabilities of
-sophisticated AI agents. These features address the practical realities of the
-software development toolchain and leverage modern AI techniques to provide
-agents with superior context.
+Beyond core semantic resources, `Weaver` is designed with specific features to
+enhance the planning and execution capabilities of sophisticated agents while
+remaining useful to humans and scripts. These features address the practical
+realities of the software development toolchain and provide superior context
+without giving up local command-line composability.
 
 ### 6.1. Capability-Aware Orchestration and Graceful Degradation
 
@@ -2310,26 +2540,27 @@ An AI agent that assumes uniform capabilities will be brittle and ineffective.
 `Weaver` addresses this head-on with its capability-aware orchestration layer.
 
 On startup, `weaverd` performs a capability-discovery process. It queries each
-configured LSP server for its `ServerCapabilities` and combines this
-information with the user-defined override matrix from `weaver-config`.^10^
-This fused data is stored in a Capability Registry. Before planning a complex
-sequence of actions, an agent can query this registry via
-
-`weaver --capabilities` to get a definitive, JSONL-formatted list of supported
-features for the target language. This allows the agent to tailor its strategy
-to the known strengths and weaknesses of the available tooling.
+configured LSP server and plugin provider for its declared support, combines
+that information with the user-defined override matrix from `weaver-config`,
+and stores the fused data in a capability registry.^10^ Before planning a
+complex sequence of actions, an agent can query the full command surface via
+`weaver context --json` and the runtime capability availability via
+`weaver capabilities list --json`. This allows the agent to tailor its strategy
+to the known strengths and weaknesses of the available tooling without parsing
+localized prose or provider-specific help text.
 
 When an agent requests an operation that is not supported, `weaverd` does not
 simply fail. It returns a structured `MissingCapability` error that is
 machine-readable and actionable. Critically, this error response can include a
 suggested fallback strategy. For example:
 
-- **Request:** `act rename-symbol` for Swift, where LSP rename support is
-    known to be limited.
+- **Request:** `weaver symbols rename` for Swift, where rename support is known
+    to be limited.
 
 - **Response:** `{"status": "error", "type": "MissingCapability", "details":
-    {"language": "swift", "feature": "rename"}, "suggestion": "Use 'observe
-    grep' to find occurrences and 'act apply-edits' for syntactic
+    {"language": "swift", "feature": "symbol.rename"}, "suggestion": "Use
+    'weaver symbols list --query … --json' to find occurrences and
+    'weaver patches apply --dry-run' for syntactic
     replacement."}`
 
 This mechanism for graceful degradation transforms failures from dead ends into

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -173,7 +173,7 @@ classDiagram
         -HashMap~Language, Session~ sessions
         +new(overrides: CapabilityMatrix) LspHost
         +register_language(language: Language, server: Box~LanguageServer~) Result~(), LspHostError~
-        +initialise(language: Language) Result~CapabilitySummary, LspHostError~
+        +initialize(language: Language) Result~CapabilitySummary, LspHostError~
         +capabilities(language: Language) Option~CapabilitySummary~
         +goto_definition(language: Language, params: GotoDefinitionParams) Result~GotoDefinitionResponse, LspHostError~
         +references(language: Language, params: ReferenceParams) Result~Vec~Location~, LspHostError~
@@ -207,7 +207,7 @@ classDiagram
 
     class LanguageServer {
         <<interface>>
-        +initialise() Result~ServerCapabilitySet, LanguageServerError~
+        +initialize() Result~ServerCapabilitySet, LanguageServerError~
         +goto_definition(params: GotoDefinitionParams) Result~GotoDefinitionResponse, LanguageServerError~
         +references(params: ReferenceParams) Result~Vec~Location~, LanguageServerError~
         +diagnostics(uri: Uri) Result~Vec~Diagnostic~, LanguageServerError~
@@ -318,7 +318,7 @@ classDiagram
     LspHostError --> CapabilitySource : references
     LspHostError --> HostOperation : references
     LspHostError --> LanguageServerError : wraps
-    LanguageServerError --> ServerCapabilitySet : produced by initialise
+    LanguageServerError --> ServerCapabilitySet : produced by initialize
     ServerCapabilitySet --> CapabilityKind : describes support for
     Language --> LanguageParseError : parse failure
     CapabilityMatrix ..> Language : keyed by
@@ -1772,7 +1772,7 @@ routes the notifications to the appropriate server.
 
 - Document sync notifications are routed through `LspHost` without capability
   gating because they are required to prepare diagnostics at real URIs.
-- `LspHost` always initialises the server before invoking `did_open`,
+- `LspHost` always initializes the server before invoking `did_open`,
   `did_change`, or `did_close`, so document sync behaves consistently with the
   request methods.
 - Failures in document sync map to `HostOperation::DidOpen`, `DidChange`, or

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -2008,7 +2008,12 @@ routes the notifications to the appropriate server.
 - Failures in document sync map to `HostOperation::DidOpen`, `DidChange`, or
   `DidClose` for clearer error reporting in the safety harness.
 
-### 4.3. The `act apply-patch` command: safety-locked patch application
+### 4.3. The current `act apply-patch` command and target patch surface
+
+This section records the implemented prototype patch path and the safety
+properties it proves. ADR 007 supersedes the public `act apply-patch` spelling
+for the 0.1.0 target; the future resource-first surface is
+`weaver patches apply`, backed by the same safety-locked transaction model.
 
 `act apply-patch` provides a deterministic, command-line interface (CLI)-first
 way to apply structured patches while still benefiting from Weaver's
@@ -2615,12 +2620,19 @@ high-level "map" of the codebase, enabling it to formulate more effective plans
 and identify the specific files and symbols it needs to examine in more detail
 using other `weaver` commands.
 
-## 7. Development Roadmap (v4)
+## 7. Historical Development Roadmap Context (v4)
 
-The development of `Weaver` will proceed in a series of phased milestones. This
-revised roadmap prioritizes the establishment of core safety features early in
-the development cycle and structures the implementation of advanced features in
-a logical, incremental progression.
+This section records the roadmap context that preceded ADR 007. It remains
+useful as history and as evidence for completed foundation work, but
+`docs/roadmap.md` and ADR 007 supersede any future public command grammar here.
+Prototype names such as `observe`, `act`, and `verify` in this section should
+be read as historical planning language until they are migrated under the
+resource-first 0.1.0 command contract.
+
+The historical plan organized `Weaver` in a series of phased milestones. It
+prioritized the establishment of core safety features early in the development
+cycle and structured the implementation of advanced features in a logical,
+incremental progression.
 
 ### Phase 0: Foundation & Tooling (Complete)
 

--- a/docs/weaver-design.md
+++ b/docs/weaver-design.md
@@ -1719,6 +1719,12 @@ study for this model:
     names appear in provenance, diagnostics, `--verbose` output, JSON, and
     expert policy overrides.
 
+    The `extricate-symbol` capability maps to the public command
+    `weaver symbols move`: it relocates a selected symbol to another module or
+    file while preserving behaviour. It must not be conflated with Rope's
+    "Extract Method" operation. `extract-method` remains a distinct future
+    capability for turning a selected code region into a new callable.
+
 This model extends to other domains as well. Tools like `srgn`, `ast-grep`,
 Sempai, rust-analyzer, and Tree-sitter can provide perceptor or actuator
 capabilities behind stable Weaver commands.^13^ This gives agents and humans a


### PR DESCRIPTION
## Summary

This branch carries the Weaver 0.1.0 command-surface reset from plan into the first implementation slice. It records the human-friendly, agent-native product direction, preserves and assesses the historical prototype roadmap, recasts the live roadmap as fail-fast vertical validation slices, implements the first resource-first read command adapter, documents how that temporary adapter retires once OrthoConfig can own the generic command metadata, separates `extricate-symbol` from `extract-method`, restores the full Sempai and Jacquard task fidelity from the archive, and keeps the canonical command vocabulary aligned with the planned public examples.

Roadmap tasks: (13.1.2), (13.1.3); phase 15, 16, and 17 planning corrections
Execplan: [docs/execplans/weaver-agent-roadmap.md](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/docs/execplans/weaver-agent-roadmap.md)

## Review walkthrough

- Start with [ADR 007](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/docs/adr-007-agent-native-command-surface.md) for the single-schema, dual-renderer command contract, resource-first grammar, Sempai selector composition, capability routing, OrthoConfig boundary, temporary-adapter removal policy, and the `symbols move` versus `extract-method` distinction.
- Then review [docs/weaver-design.md](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/docs/weaver-design.md) for the product rationale behind the target command surface, renderers, introspection, jobs, profiles, delivery, feedback, and provider-hidden perceptor and actuator plugins.
- Read [docs/roadmap.md](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/docs/roadmap.md) for the live forward plan, now numbered from phase `12` onward, shaped around hypotheses, expanded so archive 4.2 and 4.3 remain distinct Sempai backend and integration tasks, archive 7.2 through 7.5 remain distinct Jacquard graph/history/matching/ledger tasks under phase 17, and archived 5.3 and 5.4 become separate `extricate-symbol` workstreams in 16.3 and 16.4.
- Use [docs/archive/prototype-roadmap.md](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/docs/archive/prototype-roadmap.md) to audit the archived `1` through `11` task ledger and the relevance matrix that maps each prototype step to foundation, migrated scope, conditional validation work, or superseded grammar.
- Check [docs/repository-layout.md](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/docs/repository-layout.md) for the planned component ownership, including the new graph history ledger cache entry tied to roadmap 17.4.
- Review [crates/weaver-cli/src/command_surface.rs](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/crates/weaver-cli/src/command_surface.rs) for the temporary Weaver-owned adapter metadata for `definitions get` and `references list`, including the OrthoConfig replacement notes on each local helper.
- Check [crates/weaver-cli/src/cli.rs](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/crates/weaver-cli/src/cli.rs) and [crates/weaver-cli/src/command.rs](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/crates/weaver-cli/src/command.rs) for the structured `definitions get` CLI path and the mapping onto the existing daemon `observe/get-definition` request.
- Finish with [crates/weaver-cli/tests/features/weaver_cli.feature](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/crates/weaver-cli/tests/features/weaver_cli.feature), [crates/weaver-cli/tests/golden/request_definitions_get.jsonl](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/crates/weaver-cli/tests/golden/request_definitions_get.jsonl), and [crates/weaver-cli/src/tests/unit/command_surface.rs](https://github.com/leynos/weaver/blob/b4656e2df12126fd1587bfffb00218d977a0272b/crates/weaver-cli/src/tests/unit/command_surface.rs) for behavioural, golden, and unit coverage.

## Validation

- `cargo test -p weaver-cli --test main_entry`: passed; 10 tests passed.
- `make fmt`: passed.
- `make markdownlint`: passed with 0 errors.
- `make nixie`: passed; all Mermaid diagrams validated.
- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed; 1368 nextest tests passed with 4 skipped, and workspace doctests passed.
- `coderabbit review --agent --base-commit HEAD~1 --type committed`: passed with 0 findings for commit `8f4ed1e9eca64a912c33439651029b6d6a99ad85`.
- `coderabbit review --agent --base-commit HEAD~1 --type committed`: passed with 0 findings for commit `3635cb33ea01ecac5876acb0b56bb792002c2593`.
- `coderabbit review --agent --base-commit HEAD~1 --type committed`: passed with 0 findings for commit `8a77095ad091ed9c96aec57a35ab917c54615f55`.
- `coderabbit review --agent --base-commit HEAD~1 --type committed`: passed with 0 findings for commit `14dada9863b90e85ef8151a1599caca220b86751`.
- `coderabbit review --agent --base-commit HEAD~1 --type committed`: passed with 0 findings for commit `9e18276bacb0be13dc9ec0803fa789fbc96bdf72`.
- `coderabbit review --agent --base-commit HEAD~1 --type committed`: passed with 0 findings for commit `b4656e2df12126fd1587bfffb00218d977a0272b`.

## Notes

- The PR is currently open for review.
- The current head is `b4656e2df12126fd1587bfffb00218d977a0272b`.
- Remote push target reported by Git: `https://github.com/leynos/weaver.git`.
