### PR TITLE
Add observability RFC roadmap tasks (#122)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,8 +187,10 @@ This step answers whether local users and automation can diagnose daemon
 startup, request, transport, and lifecycle failures without adding a metrics
 endpoint or distributed tracing backend. It converts RFC 0001 into bounded
 local signals that support later read, mutation, and workflow slices. See
-`docs/rfcs/0001-o11y.md` §§"Observability primitives", "Failure modes that
-warrant actionable signals", "Delivery mechanisms", and "Acceptance criteria".
+RFC 0001 §§[Observability primitives](rfcs/0001-o11y.md#observability-primitives),
+[Failure modes that warrant actionable signals](rfcs/0001-o11y.md#failure-modes-that-warrant-actionable-signals),
+[Delivery mechanisms](rfcs/0001-o11y.md#delivery-mechanisms), and
+[Acceptance criteria](rfcs/0001-o11y.md#acceptance-criteria).
 
 - [ ] 13.4.1. Define canonical daemon event names and structured fields.
   - Requires 13.2.2 and 13.2.3.
@@ -206,18 +208,18 @@ warrant actionable signals", "Delivery mechanisms", and "Acceptance criteria".
 - [ ] 13.4.4. Make request-size rejections diagnosable on both sides of the
       daemon boundary.
   - Requires 13.4.2.
-  - See `docs/rfcs/0001-o11y.md` §"RequestTooLarge rejection".
+  - See RFC 0001 §[RequestTooLarge rejection](rfcs/0001-o11y.md#requesttoolarge-rejection).
   - Success: CLI-side and daemon-side size failures include the observed
     request size, `JSONL_REQUEST_MAX_LINE_BYTES`, the affected command where
     known, and user guidance to reduce or split the payload.
 - [ ] 13.4.5. Bound `weaverd.health` retention and stale-state handling.
   - Requires 13.4.2.
-  - See `docs/rfcs/0001-o11y.md` §"Health snapshot".
+  - See RFC 0001 §[Health snapshot](rfcs/0001-o11y.md#health-snapshot).
   - Success: health persistence is bounded, rotates deterministically, and
     treats out-of-window data as stale.
 - [ ] 13.4.6. Cover RFC 0001 failure modes in documentation and regression
       tests.
-  - Requires 13.4.2 through 13.4.5.
+  - Requires completion of 13.4.2 through 13.4.5.
   - Success: tests and docs cover the RFC 0001 failure taxonomy and foreground
     debug recipe.
 
@@ -1007,10 +1009,12 @@ This step answers whether optional observability surfaces have earned a new
 design after the local-first RFC 0001 contract exists. It keeps metrics,
 distributed tracing, retained diagnostics, and status expansion out of the core
 promise until their privacy, retention, endpoint, and command-latency costs are
-explicit. See `docs/rfcs/0001-o11y.md` §§"Open questions", "Local request
-correlation", "Deferred path: status subcommand expansion", "Option D:
-Dedicated diagnostics artefact", "Deferred path: optional metrics endpoint",
-and "Options considered".
+explicit. See RFC 0001 §§[Open questions](rfcs/0001-o11y.md#open-questions),
+[Local request correlation](rfcs/0001-o11y.md#local-request-correlation),
+[Deferred path: status subcommand expansion](rfcs/0001-o11y.md#deferred-path-status-subcommand-expansion),
+[Option D: Dedicated diagnostics artefact](rfcs/0001-o11y.md#option-d-dedicated-diagnostics-artefact),
+[Deferred path: optional metrics endpoint](rfcs/0001-o11y.md#deferred-path-optional-metrics-endpoint),
+and [Options considered](rfcs/0001-o11y.md#options-considered).
 
 - [ ] 20.3.1. Decide whether CLI pre-daemon diagnostics need a minimal
       `tracing` subscriber.
@@ -1036,7 +1040,7 @@ and "Options considered".
     artefact with privacy, retention, cleanup rules, and rotation rules or keeps
     foreground logs as the supported debug path.
 - [ ] 20.3.5. Reconfirm the metrics endpoint and distributed tracing boundary.
-  - Requires 20.3.2 and 20.3.4.
+  - Requires completion of 20.3.2 and 20.3.4.
   - Success: any metrics, tracing, dashboard, or aggregation surface requires a
     follow-up RFC with local-binding, feature-flag, privacy, and latency rules.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1037,8 +1037,8 @@ and [Options considered](rfcs/0001-o11y.md#options-considered).
       diagnostics artefact.
   - Requires 13.4.6.
   - Success: the decision either specifies a separate retained diagnostics
-    artefact with privacy, retention, cleanup rules, and rotation rules or keeps
-    foreground logs as the supported debug path.
+    artefact with privacy, retention, cleanup procedures, and rotation rules or
+    keeps foreground logs as the supported debug path.
 - [ ] 20.3.5. Reconfirm the metrics endpoint and distributed tracing boundary.
   - Requires completion of 20.3.2 and 20.3.4.
   - Success: any metrics, tracing, dashboard, or aggregation surface requires a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,34 +187,22 @@ This step answers whether local users and automation can diagnose daemon
 startup, request, transport, and lifecycle failures without adding a metrics
 endpoint or distributed tracing backend. It converts RFC 0001 into bounded
 local signals that support later read, mutation, and workflow slices. See
-`docs/rfcs/0001-o11y.md`.
+`docs/rfcs/0001-o11y.md` §§"Observability primitives", "Failure modes that
+warrant actionable signals", "Delivery mechanisms", and "Acceptance criteria".
 
 - [ ] 13.4.1. Define canonical daemon event names and structured fields.
   - Requires 13.2.2 and 13.2.3.
-  - See `docs/rfcs/0001-o11y.md` §§"Observability primitives" and
-    "Acceptance criteria".
-  - Success: lifecycle, request acceptance, request rejection, dispatch
-    completion, and listener-failure events have stable names; required fields
-    cover lifecycle state, endpoint or runtime path, command domain and
-    operation, request size and limit, timeout or retry state, and error kind
-    plus display message.
+  - Success: lifecycle, request, dispatch, and listener events have stable
+    names and the minimum diagnostic fields required by RFC 0001.
 - [ ] 13.4.2. Emit bounded structured events for daemon lifecycle and
       transport paths.
   - Requires 13.4.1.
-  - See `docs/rfcs/0001-o11y.md` §§"Structured daemon events" and "Failure
-    modes that warrant actionable signals".
-  - Success: startup, readiness, shutdown, dispatch boundaries,
-    `RequestTooLarge`, listener saturation, read timeout, socket retry, and
-    socket timeout paths emit deterministic `tracing` fields without patch
-    bodies, source snippets, environment variables, or full JSONL payloads.
+  - Success: lifecycle, dispatch, request rejection, socket, and listener
+    paths emit deterministic `tracing` fields without sensitive payload data.
 - [ ] 13.4.3. Unify CLI guidance for pre-daemon and transport failures.
   - Requires 13.4.2 and 13.3.2.
-  - See `docs/rfcs/0001-o11y.md` §§"CLI actionable guidance" and "Failure
-    modes that warrant actionable signals".
-  - Success: daemon auto-start failures, abnormal startup exits, missing
-    runtime artefacts, starting-but-not-ready sockets, owned sockets, and
-    connection timeouts all report what failed, the relevant evidence path or
-    endpoint, and the next useful command or foreground-debug action.
+  - Success: pre-daemon and transport failures report what failed, the relevant
+    evidence path or endpoint, and the next useful operator action.
 - [ ] 13.4.4. Make request-size rejections diagnosable on both sides of the
       daemon boundary.
   - Requires 13.4.2.
@@ -225,20 +213,13 @@ local signals that support later read, mutation, and workflow slices. See
 - [ ] 13.4.5. Bound `weaverd.health` retention and stale-state handling.
   - Requires 13.4.2.
   - See `docs/rfcs/0001-o11y.md` §"Health snapshot".
-  - Success: health persistence has a fixed event or byte cap, a recent-state
-    retention window, deterministic rotation or truncation, and consumer
-    semantics that treat out-of-window data as stale while preserving
-    `weaver daemon status` as the current-state command.
+  - Success: health persistence is bounded, rotates deterministically, and
+    treats out-of-window data as stale.
 - [ ] 13.4.6. Cover RFC 0001 failure modes in documentation and regression
       tests.
   - Requires 13.4.2 through 13.4.5.
-  - See `docs/rfcs/0001-o11y.md` §§"Delivery mechanisms" and "Acceptance
-    criteria".
-  - Success: tests and docs cover daemon auto-start distinctions,
-    request-size failures, socket connection timeout classes, abnormal daemon
-    exit, inconsistent lock/PID/health/socket artefacts, listener read
-    timeouts, and a foreground debug recipe using `--log-filter` and
-    `--log-format json`.
+  - Success: tests and docs cover the RFC 0001 failure taxonomy and foreground
+    debug recipe.
 
 ## 14. Code-reading loop slice
 
@@ -1026,46 +1007,38 @@ This step answers whether optional observability surfaces have earned a new
 design after the local-first RFC 0001 contract exists. It keeps metrics,
 distributed tracing, retained diagnostics, and status expansion out of the core
 promise until their privacy, retention, endpoint, and command-latency costs are
-explicit.
+explicit. See `docs/rfcs/0001-o11y.md` §§"Open questions", "Local request
+correlation", "Deferred path: status subcommand expansion", "Option D:
+Dedicated diagnostics artefact", "Deferred path: optional metrics endpoint",
+and "Options considered".
 
 - [ ] 20.3.1. Decide whether CLI pre-daemon diagnostics need a minimal
       `tracing` subscriber.
   - Requires 13.4.6.
-  - See `docs/rfcs/0001-o11y.md` §"Open questions".
   - Success: the decision either keeps pre-daemon diagnostics as explicit
     stderr guidance or defines a local subscriber contract without adding a
     remote telemetry surface.
 - [ ] 20.3.2. Decide whether to add a local `request_id` to the CLI-to-daemon
       JSONL schema.
   - Requires 13.4.6.
-  - See `docs/rfcs/0001-o11y.md` §§"Local request correlation" and "Open
-    questions".
   - Success: the decision either accepts a bounded local correlation field with
     schema and privacy rules or records why structured event fields are enough.
 - [ ] 20.3.3. Decide whether `weaver daemon status --json` belongs in the
       command contract.
   - Requires 13.4.6 and 13.3.1.
-  - See `docs/rfcs/0001-o11y.md` §§"Deferred path: status subcommand
-    expansion" and "Open questions".
   - Success: the outcome is recorded as a bounded status-schema extension, a
     deliberate reliance on `weaverd.health` for machine-readable state, or a
     deferral with rationale.
 - [ ] 20.3.4. Decide whether abnormal exits need a dedicated bounded
       diagnostics artefact.
   - Requires 13.4.6.
-  - See `docs/rfcs/0001-o11y.md` §§"Option D: Dedicated diagnostics artefact"
-    and "Open questions".
   - Success: the decision either specifies a separate retained diagnostics
     artefact with privacy, retention, cleanup, and rotation rules or keeps
     foreground logs as the supported debug path.
 - [ ] 20.3.5. Reconfirm the metrics endpoint and distributed tracing boundary.
   - Requires 20.3.2 and 20.3.4.
-  - See `docs/rfcs/0001-o11y.md` §§"Deferred path: optional metrics endpoint"
-    and "Options considered".
-  - Success: any metrics exporter, Prometheus/OpenMetrics endpoint,
-    OpenTelemetry or W3C Trace Context propagation, dashboard, or remote
-    aggregation proposal requires a follow-up RFC and an explicit local-only
-    binding, feature-flag, privacy, and latency assessment.
+  - Success: any metrics, tracing, dashboard, or aggregation surface requires a
+    follow-up RFC with local-binding, feature-flag, privacy, and latency rules.
 
 ## Archive
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -189,8 +189,10 @@ endpoint or distributed tracing backend. It converts RFC 0001 into bounded
 local signals that support later read, mutation, and workflow slices. See
 RFC 0001 §§[Observability primitives](rfcs/0001-o11y.md#observability-primitives),
 [Failure modes that warrant actionable signals](rfcs/0001-o11y.md#failure-modes-that-warrant-actionable-signals),
-[Delivery mechanisms](rfcs/0001-o11y.md#delivery-mechanisms), and
-[Acceptance criteria](rfcs/0001-o11y.md#acceptance-criteria).
+[Delivery mechanisms](rfcs/0001-o11y.md#delivery-mechanisms),
+[RequestTooLarge rejection](rfcs/0001-o11y.md#requesttoolarge-rejection),
+[Health snapshot](rfcs/0001-o11y.md#health-snapshot), and [Acceptance
+criteria](rfcs/0001-o11y.md#acceptance-criteria).
 
 - [ ] 13.4.1. Define canonical daemon event names and structured fields.
   - Requires 13.2.2 and 13.2.3.
@@ -208,13 +210,11 @@ RFC 0001 §§[Observability primitives](rfcs/0001-o11y.md#observability-primitiv
 - [ ] 13.4.4. Make request-size rejections diagnosable on both sides of the
       daemon boundary.
   - Requires 13.4.2.
-  - See RFC 0001 §[RequestTooLarge rejection](rfcs/0001-o11y.md#requesttoolarge-rejection).
   - Success: CLI-side and daemon-side size failures include the observed
     request size, `JSONL_REQUEST_MAX_LINE_BYTES`, the affected command where
     known, and user guidance to reduce or split the payload.
 - [ ] 13.4.5. Bound `weaverd.health` retention and stale-state handling.
   - Requires 13.4.2.
-  - See RFC 0001 §[Health snapshot](rfcs/0001-o11y.md#health-snapshot).
   - Success: health persistence is bounded, rotates deterministically, and
     treats out-of-window data as stale.
 - [ ] 13.4.6. Cover RFC 0001 failure modes in documentation and regression
@@ -1019,30 +1019,32 @@ and [Options considered](rfcs/0001-o11y.md#options-considered).
 - [ ] 20.3.1. Decide whether CLI pre-daemon diagnostics need a minimal
       `tracing` subscriber.
   - Requires 13.4.6.
-  - Success: the decision either keeps pre-daemon diagnostics as explicit
-    stderr guidance or defines a local subscriber contract without adding a
-    remote telemetry surface.
+  - Success: an ADR records either explicit stderr guidance for pre-daemon
+    diagnostics or a local subscriber contract without a remote telemetry
+    surface.
 - [ ] 20.3.2. Decide whether to add a local `request_id` to the CLI-to-daemon
       JSONL schema.
   - Requires 13.4.6.
-  - Success: the decision either accepts a bounded local correlation field with
-    schema and privacy rules or records why structured event fields are enough.
+  - Success: an RFC 0001 update either accepts a bounded local correlation
+    field with schema and privacy rules or records why structured event fields
+    are enough.
 - [ ] 20.3.3. Decide whether `weaver daemon status --json` belongs in the
       command contract.
   - Requires 13.4.6 and 13.3.1.
-  - Success: the outcome is recorded as a bounded status-schema extension, a
+  - Success: a roadmap note records a bounded status-schema extension,
     deliberate reliance on `weaverd.health` for machine-readable state, or a
     deferral with rationale.
 - [ ] 20.3.4. Decide whether abnormal exits need a dedicated bounded
       diagnostics artefact.
   - Requires 13.4.6.
-  - Success: the decision either specifies a separate retained diagnostics
+  - Success: an ADR either specifies a separate retained diagnostics
     artefact with privacy, retention, cleanup procedures, and rotation rules or
     keeps foreground logs as the supported debug path.
 - [ ] 20.3.5. Reconfirm the metrics endpoint and distributed tracing boundary.
   - Requires completion of 20.3.2 and 20.3.4.
-  - Success: any metrics, tracing, dashboard, or aggregation surface requires a
-    follow-up RFC with local-binding, feature-flag, privacy, and latency rules.
+  - Success: an RFC 0001 update records that any metrics, tracing, dashboard,
+    or aggregation surface requires a follow-up RFC with local-binding,
+    feature-flag, privacy, and latency rules.
 
 ## Archive
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,11 +3,11 @@
 This roadmap translates `docs/weaver-design.md`,
 `docs/adr-007-agent-native-command-surface.md`,
 `docs/sempai-query-language-design.md`,
-`docs/jacquard-card-first-symbol-graph-design.md`, and the existing ADR set
-into an outcome-oriented delivery sequence. It does not promise dates. Phases
-carry testable product ideas, steps validate or falsify those ideas, and tasks
-are review-sized execution units with explicit dependencies and observable
-success criteria.
+`docs/jacquard-card-first-symbol-graph-design.md`, `docs/rfcs/0001-o11y.md`,
+and the existing ADR set into an outcome-oriented delivery sequence. It does
+not promise dates. Phases carry testable product ideas, steps validate or
+falsify those ideas, and tasks are review-sized execution units with explicit
+dependencies and observable success criteria.
 
 The current forward plan is the source of truth for future work. The historical
 ledger in [`docs/archive/prototype-roadmap.md`](archive/prototype-roadmap.md)
@@ -180,6 +180,65 @@ archive work 3.2.3 through 3.2.6, 5.7.1 through 5.7.5, and 11.3.2. See
   - Success: CI rejects schema, router, help, docs, localization, context,
     skill, vocabulary, stdout/stderr, and JSON-schema drift for the pilot
     command family.
+
+### 13.4. Prove the local daemon observability contract
+
+This step answers whether local users and automation can diagnose daemon
+startup, request, transport, and lifecycle failures without adding a metrics
+endpoint or distributed tracing backend. It converts RFC 0001 into bounded
+local signals that support later read, mutation, and workflow slices. See
+`docs/rfcs/0001-o11y.md`.
+
+- [ ] 13.4.1. Define canonical daemon event names and structured fields.
+  - Requires 13.2.2 and 13.2.3.
+  - See `docs/rfcs/0001-o11y.md` §§"Observability primitives" and
+    "Acceptance criteria".
+  - Success: lifecycle, request acceptance, request rejection, dispatch
+    completion, and listener-failure events have stable names; required fields
+    cover lifecycle state, endpoint or runtime path, command domain and
+    operation, request size and limit, timeout or retry state, and error kind
+    plus display message.
+- [ ] 13.4.2. Emit bounded structured events for daemon lifecycle and
+      transport paths.
+  - Requires 13.4.1.
+  - See `docs/rfcs/0001-o11y.md` §§"Structured daemon events" and "Failure
+    modes that warrant actionable signals".
+  - Success: startup, readiness, shutdown, dispatch boundaries,
+    `RequestTooLarge`, listener saturation, read timeout, socket retry, and
+    socket timeout paths emit deterministic `tracing` fields without patch
+    bodies, source snippets, environment variables, or full JSONL payloads.
+- [ ] 13.4.3. Unify CLI guidance for pre-daemon and transport failures.
+  - Requires 13.4.2 and 13.3.2.
+  - See `docs/rfcs/0001-o11y.md` §§"CLI actionable guidance" and "Failure
+    modes that warrant actionable signals".
+  - Success: daemon auto-start failures, abnormal startup exits, missing
+    runtime artefacts, starting-but-not-ready sockets, owned sockets, and
+    connection timeouts all report what failed, the relevant evidence path or
+    endpoint, and the next useful command or foreground-debug action.
+- [ ] 13.4.4. Make request-size rejections diagnosable on both sides of the
+      daemon boundary.
+  - Requires 13.4.2.
+  - See `docs/rfcs/0001-o11y.md` §"RequestTooLarge rejection".
+  - Success: CLI-side and daemon-side size failures include the observed
+    request size, `JSONL_REQUEST_MAX_LINE_BYTES`, the affected command where
+    known, and user guidance to reduce or split the payload.
+- [ ] 13.4.5. Bound `weaverd.health` retention and stale-state handling.
+  - Requires 13.4.2.
+  - See `docs/rfcs/0001-o11y.md` §"Health snapshot".
+  - Success: health persistence has a fixed event or byte cap, a recent-state
+    retention window, deterministic rotation or truncation, and consumer
+    semantics that treat out-of-window data as stale while preserving
+    `weaver daemon status` as the current-state command.
+- [ ] 13.4.6. Cover RFC 0001 failure modes in documentation and regression
+      tests.
+  - Requires 13.4.2 through 13.4.5.
+  - See `docs/rfcs/0001-o11y.md` §§"Delivery mechanisms" and "Acceptance
+    criteria".
+  - Success: tests and docs cover daemon auto-start distinctions,
+    request-size failures, socket connection timeout classes, abnormal daemon
+    exit, inconsistent lock/PID/health/socket artefacts, listener read
+    timeouts, and a foreground debug recipe using `--log-filter` and
+    `--log-format json`.
 
 ## 14. Code-reading loop slice
 
@@ -960,6 +1019,53 @@ new design rather than quiet re-entry into the core roadmap.
   - Success: further cache work resumes only if measured repository-scale
     performance shows the core ledger is insufficient for the supported
     history workflows.
+
+### 20.3. Evaluate deferred observability expansions
+
+This step answers whether optional observability surfaces have earned a new
+design after the local-first RFC 0001 contract exists. It keeps metrics,
+distributed tracing, retained diagnostics, and status expansion out of the core
+promise until their privacy, retention, endpoint, and command-latency costs are
+explicit.
+
+- [ ] 20.3.1. Decide whether CLI pre-daemon diagnostics need a minimal
+      `tracing` subscriber.
+  - Requires 13.4.6.
+  - See `docs/rfcs/0001-o11y.md` §"Open questions".
+  - Success: the decision either keeps pre-daemon diagnostics as explicit
+    stderr guidance or defines a local subscriber contract without adding a
+    remote telemetry surface.
+- [ ] 20.3.2. Decide whether to add a local `request_id` to the CLI-to-daemon
+      JSONL schema.
+  - Requires 13.4.6.
+  - See `docs/rfcs/0001-o11y.md` §§"Local request correlation" and "Open
+    questions".
+  - Success: the decision either accepts a bounded local correlation field with
+    schema and privacy rules or records why structured event fields are enough.
+- [ ] 20.3.3. Decide whether `weaver daemon status --json` belongs in the
+      command contract.
+  - Requires 13.4.6 and 13.3.1.
+  - See `docs/rfcs/0001-o11y.md` §§"Deferred path: status subcommand
+    expansion" and "Open questions".
+  - Success: the outcome is recorded as a bounded status-schema extension, a
+    deliberate reliance on `weaverd.health` for machine-readable state, or a
+    deferral with rationale.
+- [ ] 20.3.4. Decide whether abnormal exits need a dedicated bounded
+      diagnostics artefact.
+  - Requires 13.4.6.
+  - See `docs/rfcs/0001-o11y.md` §§"Option D: Dedicated diagnostics artefact"
+    and "Open questions".
+  - Success: the decision either specifies a separate retained diagnostics
+    artefact with privacy, retention, cleanup, and rotation rules or keeps
+    foreground logs as the supported debug path.
+- [ ] 20.3.5. Reconfirm the metrics endpoint and distributed tracing boundary.
+  - Requires 20.3.2 and 20.3.4.
+  - See `docs/rfcs/0001-o11y.md` §§"Deferred path: optional metrics endpoint"
+    and "Options considered".
+  - Success: any metrics exporter, Prometheus/OpenMetrics endpoint,
+    OpenTelemetry or W3C Trace Context propagation, dashboard, or remote
+    aggregation proposal requires a follow-up RFC and an explicit local-only
+    binding, feature-flag, privacy, and latency assessment.
 
 ## Archive
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1033,7 +1033,7 @@ and "Options considered".
       diagnostics artefact.
   - Requires 13.4.6.
   - Success: the decision either specifies a separate retained diagnostics
-    artefact with privacy, retention, cleanup, and rotation rules or keeps
+    artefact with privacy, retention, cleanup rules, and rotation rules or keeps
     foreground logs as the supported debug path.
 - [ ] 20.3.5. Reconfirm the metrics endpoint and distributed tracing boundary.
   - Requires 20.3.2 and 20.3.4.


### PR DESCRIPTION
## Summary

This branch records the outstanding implementation and follow-up planning work from RFC 0001 in the live roadmap. It makes the observability RFC an explicit roadmap source, adds core local-daemon observability tasks, and keeps metrics, distributed tracing and retained diagnostics as deferred decisions instead of implicit core scope.

Related issue: #122, which is already closed by the accepted RFC.

Roadmap task: not applicable; this branch updates the roadmap from RFC 0001.
Execplan: not applicable; this is a roadmap-only planning change.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/weaver/blob/466dd56f9a502d4960494c2adb1f15d93dd55a50/docs/roadmap.md#L3) to see RFC 0001 added to the roadmap source list.
- Then review [docs/roadmap.md](https://github.com/leynos/weaver/blob/466dd56f9a502d4960494c2adb1f15d93dd55a50/docs/roadmap.md#L184) for the tightened 13.4 workstream covering event contracts, bounded daemon events, actionable CLI guidance, request-size diagnostics, health retention, and failure-mode coverage.
- Finish with [docs/roadmap.md](https://github.com/leynos/weaver/blob/466dd56f9a502d4960494c2adb1f15d93dd55a50/docs/roadmap.md#L1004) for the deferred observability expansion decisions covering pre-daemon tracing, local request IDs, status JSON, retained diagnostics artefacts, metrics endpoints, and distributed tracing.

## Validation

- `make fmt`: passed before the review-follow-up edit.
- `make markdownlint`: passed after the latest review-follow-up edit.
- `make nixie`: passed after the latest review-follow-up edit.
- `make check-fmt`: passed after the latest review-follow-up edit.
- `git diff --check`: passed after the latest review-follow-up edit.

## Notes

The planning assessment used a Wyvern agent team to compare RFC 0001 with the live roadmap. Firecrawl was used to check prior-art boundaries for Prometheus/OpenMetrics, W3C Trace Context, Rust `tracing-subscriber`, and `metrics-exporter-prometheus`, which informed the deferred-observability wording.

`make fmt` was re-run during the review-follow-up edit, but the full mutating formatter stopped on pre-existing Markdown line-length issues outside this branch after producing broad unrelated reflow. Those generated changes were restored, and the non-mutating gates above passed on the final branch state.

## Summary by Sourcery

Align the roadmap with RFC 0001 by adding observability-focused workstreams for the local daemon and deferred observability expansions.

Documentation:
- Document RFC 0001 as a formal source for the roadmap alongside existing design and ADR documents.
- Add a new roadmap step detailing core local-daemon observability tasks and success criteria.
- Add a new roadmap step capturing deferred decisions around optional observability surfaces such as metrics, tracing, diagnostics artefacts, and status output.

## References

- [Lody session](https://lody.ai/leynos/sessions/8d3da726-76d7-4323-bea4-fde92d00b5b9)

