### PR TITLE
Use capability-based filesystem access in weaverd (#49)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,6 +3358,7 @@ name = "weaverd"
 version = "0.1.0"
 dependencies = [
  "camino",
+ "cap-std 4.0.2",
  "daemonize-me",
  "derive_more 1.0.0",
  "dirs 5.0.1",

--- a/crates/weaverd/Cargo.toml
+++ b/crates/weaverd/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 test-support = []
 
 [dependencies]
+cap-std = { workspace = true }
 daemonize-me = "2.0.2"
 dirs = "5.0"
 lsp-types.workspace = true

--- a/crates/weaverd/src/cap_fs.rs
+++ b/crates/weaverd/src/cap_fs.rs
@@ -1,0 +1,32 @@
+//! Capability-based filesystem utilities shared inside the daemon.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use cap_std::fs::Dir;
+
+/// Opens a path's parent directory and returns the capability plus filename.
+///
+/// `Dir::open_ambient_dir` is used with `cap_std::ambient_authority()` here as
+/// the daemon's explicit capability escape hatch for caller-selected workspace
+/// paths. Callers must validate their path boundary before using this helper;
+/// once opened, the returned directory capability grants access within the
+/// selected parent directory.
+pub(crate) fn open_parent_dir(path: &Path) -> io::Result<(Dir, PathBuf)> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path has no parent directory: {}", path.display()),
+        )
+    })?;
+    let filename = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path has no file name: {}", path.display()),
+        )
+    })?;
+    let dir = Dir::open_ambient_dir(parent, cap_std::ambient_authority())?;
+    Ok((dir, PathBuf::from(filename)))
+}

--- a/crates/weaverd/src/dispatch/act/apply_patch/mod.rs
+++ b/crates/weaverd/src/dispatch/act/apply_patch/mod.rs
@@ -9,12 +9,14 @@ mod parser;
 mod payloads;
 mod semantic_lock;
 mod types;
+mod workspace;
 
 use std::{
     io::Write,
     path::{Path, PathBuf},
 };
 
+use cap_std::fs::Dir;
 use tracing::debug;
 
 pub(crate) use self::errors::ApplyPatchError;
@@ -24,6 +26,7 @@ use self::{
     payloads::{ApplyPatchSummary, GenericErrorEnvelope, VerificationErrorEnvelope},
     semantic_lock::LspSemanticLockAdapter,
     types::{FileContent, FilePath, PatchOperation, PatchText, SearchReplaceBlock},
+    workspace::{ValidatedPath, path_exists, read_patch_target, resolve_path},
 };
 use crate::{
     backends::{BackendKind, FusionBackends},
@@ -120,14 +123,20 @@ impl<'a> ApplyPatchExecutor<'a> {
     }
 
     pub(crate) fn execute(&self, patch: &str) -> Result<ApplyPatchSummary, ApplyPatchFailure> {
+        let workspace_dir =
+            Dir::open_ambient_dir(&self.workspace_root, cap_std::ambient_authority()).map_err(
+                |error| ApplyPatchFailure::Io(format!("failed to open workspace: {error}")),
+            )?;
         let patch = PatchText::new(patch);
         let operations = parse_patch(&patch).map_err(map_patch_error)?;
-        let changes = self.build_changes(&operations).map_err(map_patch_error)?;
+        let changes = self
+            .build_changes(&workspace_dir, &operations)
+            .map_err(map_patch_error)?;
 
         let mut transaction = ContentTransaction::new(self.syntactic_lock, self.semantic_lock);
         transaction.add_changes(changes.iter().cloned());
 
-        match transaction.execute() {
+        match transaction.execute(&workspace_dir, &self.workspace_root) {
             Ok(TransactionOutcome::Committed { files_modified }) => {
                 let files_deleted = changes
                     .iter()
@@ -166,18 +175,19 @@ impl<'a> ApplyPatchExecutor<'a> {
 
     fn build_changes(
         &self,
+        workspace_dir: &Dir,
         operations: &[PatchOperation],
     ) -> Result<Vec<ContentChange>, ApplyPatchError> {
         let mut changes = Vec::new();
         for operation in operations {
             let change = match operation {
                 PatchOperation::Modify { path, blocks } => {
-                    self.build_modify_change(path, blocks)?
+                    self.build_modify_change(workspace_dir, path, blocks)?
                 }
                 PatchOperation::Create { path, content } => {
-                    self.build_create_change(path, content)?
+                    self.build_create_change(workspace_dir, path, content)?
                 }
-                PatchOperation::Delete { path } => self.build_delete_change(path)?,
+                PatchOperation::Delete { path } => self.build_delete_change(workspace_dir, path)?,
             };
             changes.push(change);
         }
@@ -186,53 +196,70 @@ impl<'a> ApplyPatchExecutor<'a> {
 
     fn build_modify_change(
         &self,
+        workspace_dir: &Dir,
         path: &FilePath,
         blocks: &[SearchReplaceBlock],
     ) -> Result<ContentChange, ApplyPatchError> {
-        let resolved = self.resolve_and_validate(path)?;
-        let original = read_patch_target(&resolved, path)?;
+        let resolved = self.resolve_and_validate(workspace_dir, path)?;
+        let original = read_patch_target(workspace_dir, &resolved.relative, path)?;
         let original = FileContent::new(original);
         let modified = apply_search_replace(path, &original, blocks)?;
-        Ok(ContentChange::write(resolved, modified.into_string()))
+        Ok(ContentChange::write(
+            resolved.absolute,
+            modified.into_string(),
+        ))
     }
 
     fn build_create_change(
         &self,
+        workspace_dir: &Dir,
         path: &FilePath,
         content: &FileContent,
     ) -> Result<ContentChange, ApplyPatchError> {
-        self.build_validated_change(path, ChangeKind::Create(content.clone()))
+        self.build_validated_change(workspace_dir, path, ChangeKind::Create(content.clone()))
     }
 
-    fn build_delete_change(&self, path: &FilePath) -> Result<ContentChange, ApplyPatchError> {
-        self.build_validated_change(path, ChangeKind::Delete)
+    fn build_delete_change(
+        &self,
+        workspace_dir: &Dir,
+        path: &FilePath,
+    ) -> Result<ContentChange, ApplyPatchError> {
+        self.build_validated_change(workspace_dir, path, ChangeKind::Delete)
     }
 
     /// Resolves and validates a patch path within the workspace.
-    fn resolve_and_validate(&self, path: &FilePath) -> Result<PathBuf, ApplyPatchError> {
-        resolve_path(&self.workspace_root, path)
+    fn resolve_and_validate(
+        &self,
+        workspace_dir: &Dir,
+        path: &FilePath,
+    ) -> Result<ValidatedPath, ApplyPatchError> {
+        resolve_path(workspace_dir, &self.workspace_root, path)
     }
 
     /// Builds a validated content change after checking existence constraints.
     fn build_validated_change(
         &self,
+        workspace_dir: &Dir,
         path: &FilePath,
         kind: ChangeKind,
     ) -> Result<ContentChange, ApplyPatchError> {
-        let resolved = self.resolve_and_validate(path)?;
+        let resolved = self.resolve_and_validate(workspace_dir, path)?;
 
         match kind {
             ChangeKind::Create(content) => {
-                if resolved.exists() {
+                if path_exists(workspace_dir, &resolved.relative, path)? {
                     return Err(ApplyPatchError::FileAlreadyExists { path: path.clone() });
                 }
-                Ok(ContentChange::write(resolved, content.into_string()))
+                Ok(ContentChange::write(
+                    resolved.absolute,
+                    content.into_string(),
+                ))
             }
             ChangeKind::Delete => {
-                if !resolved.exists() {
+                if !path_exists(workspace_dir, &resolved.relative, path)? {
                     return Err(ApplyPatchError::DeleteMissing { path: path.clone() });
                 }
-                Ok(ContentChange::delete(resolved))
+                Ok(ContentChange::delete(resolved.absolute))
             }
         }
     }
@@ -266,75 +293,6 @@ fn map_patch_error(error: ApplyPatchError) -> ApplyPatchFailure {
         error @ ApplyPatchError::Io { .. } => ApplyPatchFailure::Io(error.to_string()),
         other => ApplyPatchFailure::Patch(other),
     }
-}
-
-/// Validates that a path component is safe (not a symlink).
-fn validate_path_component(
-    resolved: &Path,
-    original_path: &FilePath,
-) -> Result<(), ApplyPatchError> {
-    match std::fs::symlink_metadata(resolved) {
-        Ok(metadata) if metadata.file_type().is_symlink() => Err(ApplyPatchError::InvalidPath {
-            path: original_path.clone(),
-            reason: String::from("symlink traversal is not allowed"),
-        }),
-        Ok(_) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(ApplyPatchError::InvalidPath {
-            path: original_path.clone(),
-            reason: format!("failed to inspect path component: {err}"),
-        }),
-    }
-}
-
-fn resolve_path(workspace_root: &Path, path: &FilePath) -> Result<PathBuf, ApplyPatchError> {
-    if path.as_str().trim().is_empty() {
-        return Err(ApplyPatchError::InvalidPath {
-            path: path.clone(),
-            reason: String::from("path is empty"),
-        });
-    }
-    let candidate = Path::new(path.as_str());
-    if candidate.is_absolute() {
-        return Err(ApplyPatchError::InvalidPath {
-            path: path.clone(),
-            reason: String::from("absolute paths are not allowed"),
-        });
-    }
-    let mut resolved = workspace_root.to_path_buf();
-    for component in candidate.components() {
-        match component {
-            std::path::Component::ParentDir | std::path::Component::Prefix(_) => {
-                return Err(ApplyPatchError::InvalidPath {
-                    path: path.clone(),
-                    reason: String::from("path traversal is not allowed"),
-                });
-            }
-            std::path::Component::Normal(part) => {
-                resolved.push(part);
-                validate_path_component(&resolved, path)?;
-            }
-            std::path::Component::CurDir => {}
-            std::path::Component::RootDir => {
-                return Err(ApplyPatchError::InvalidPath {
-                    path: path.clone(),
-                    reason: String::from("absolute paths are not allowed"),
-                });
-            }
-        }
-    }
-    Ok(resolved)
-}
-
-fn read_patch_target(resolved: &Path, path: &FilePath) -> Result<String, ApplyPatchError> {
-    std::fs::read_to_string(resolved).map_err(|err| match err.kind() {
-        std::io::ErrorKind::NotFound => ApplyPatchError::FileNotFound { path: path.clone() },
-        _ => ApplyPatchError::Io {
-            path: path.clone(),
-            kind: err.kind(),
-            message: err.to_string(),
-        },
-    })
 }
 
 /// Generic helper to write serializable error payloads to stderr.

--- a/crates/weaverd/src/dispatch/act/apply_patch/tests.rs
+++ b/crates/weaverd/src/dispatch/act/apply_patch/tests.rs
@@ -19,7 +19,14 @@ fn temp_dir() -> Result<TempDir, String> {
 #[rstest]
 fn resolve_path_rejects_parent_dir(temp_dir: Result<TempDir, String>) -> Result<(), String> {
     let temp_dir = temp_dir?;
-    let result = resolve_path(temp_dir.path(), &FilePath::new("../escape.txt"));
+    let workspace_dir =
+        cap_std::fs::Dir::open_ambient_dir(temp_dir.path(), cap_std::ambient_authority())
+            .map_err(|error| format!("open workspace dir: {error}"))?;
+    let result = resolve_path(
+        &workspace_dir,
+        temp_dir.path(),
+        &FilePath::new("../escape.txt"),
+    );
     assert!(result.is_err(), "parent traversal should fail");
     Ok(())
 }

--- a/crates/weaverd/src/dispatch/act/apply_patch/workspace.rs
+++ b/crates/weaverd/src/dispatch/act/apply_patch/workspace.rs
@@ -12,6 +12,14 @@ pub(super) struct ValidatedPath {
 }
 
 /// Resolves and validates a patch path within the workspace.
+///
+/// Validation rejects symlink components before the transaction is built. The
+/// later read and commit operations still address paths by name through the
+/// workspace [`Dir`], so a malicious process that can concurrently rewrite the
+/// workspace tree could swap a checked component before use. The daemon treats
+/// the workspace as trusted during an apply-patch transaction; hardening beyond
+/// that threat model requires descriptor-relative path walking for every
+/// operation.
 pub(super) fn resolve_path(
     workspace_dir: &Dir,
     workspace_root: &Path,

--- a/crates/weaverd/src/dispatch/act/apply_patch/workspace.rs
+++ b/crates/weaverd/src/dispatch/act/apply_patch/workspace.rs
@@ -1,0 +1,118 @@
+//! Workspace path validation and capability-based reads for apply-patch.
+
+use std::path::{Path, PathBuf};
+
+use cap_std::fs::Dir;
+
+use super::{ApplyPatchError, types::FilePath};
+
+pub(super) struct ValidatedPath {
+    pub(super) absolute: PathBuf,
+    pub(super) relative: PathBuf,
+}
+
+/// Resolves and validates a patch path within the workspace.
+pub(super) fn resolve_path(
+    workspace_dir: &Dir,
+    workspace_root: &Path,
+    path: &FilePath,
+) -> Result<ValidatedPath, ApplyPatchError> {
+    if path.as_str().trim().is_empty() {
+        return Err(ApplyPatchError::InvalidPath {
+            path: path.clone(),
+            reason: String::from("path is empty"),
+        });
+    }
+    let candidate = Path::new(path.as_str());
+    if candidate.is_absolute() {
+        return Err(ApplyPatchError::InvalidPath {
+            path: path.clone(),
+            reason: String::from("absolute paths are not allowed"),
+        });
+    }
+    let mut resolved = workspace_root.to_path_buf();
+    let mut relative = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            std::path::Component::ParentDir | std::path::Component::Prefix(_) => {
+                return Err(ApplyPatchError::InvalidPath {
+                    path: path.clone(),
+                    reason: String::from("path traversal is not allowed"),
+                });
+            }
+            std::path::Component::Normal(part) => {
+                resolved.push(part);
+                relative.push(part);
+                validate_path_component(workspace_dir, &relative, path)?;
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::RootDir => {
+                unreachable!("absolute paths are rejected before component validation");
+            }
+        }
+    }
+    Ok(ValidatedPath {
+        absolute: resolved,
+        relative,
+    })
+}
+
+/// Checks whether `relative` exists in `dir` for the requested patch path.
+///
+/// Returns `Ok(true)` or `Ok(false)` for normal existence checks and maps
+/// other I/O failures to [`ApplyPatchError`].
+pub(super) fn path_exists(
+    dir: &Dir,
+    relative: &Path,
+    path: &FilePath,
+) -> Result<bool, ApplyPatchError> {
+    match dir.metadata(relative) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(ApplyPatchError::Io {
+            path: path.clone(),
+            kind: err.kind(),
+            message: err.to_string(),
+        }),
+    }
+}
+
+/// Reads the current patch target content from the workspace capability.
+///
+/// Missing files become [`ApplyPatchError::FileNotFound`]; other read failures
+/// are reported as [`ApplyPatchError::Io`].
+pub(super) fn read_patch_target(
+    dir: &Dir,
+    relative: &Path,
+    path: &FilePath,
+) -> Result<String, ApplyPatchError> {
+    dir.read_to_string(relative)
+        .map_err(|err| match err.kind() {
+            std::io::ErrorKind::NotFound => ApplyPatchError::FileNotFound { path: path.clone() },
+            _ => ApplyPatchError::Io {
+                path: path.clone(),
+                kind: err.kind(),
+                message: err.to_string(),
+            },
+        })
+}
+
+/// Validates that a path component is safe (not a symlink).
+fn validate_path_component(
+    workspace_dir: &Dir,
+    relative: &Path,
+    original_path: &FilePath,
+) -> Result<(), ApplyPatchError> {
+    match workspace_dir.symlink_metadata(relative) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(ApplyPatchError::InvalidPath {
+            path: original_path.clone(),
+            reason: String::from("symlink traversal is not allowed"),
+        }),
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(ApplyPatchError::InvalidPath {
+            path: original_path.clone(),
+            reason: format!("failed to inspect path component: {err}"),
+        }),
+    }
+}

--- a/crates/weaverd/src/dispatch/act/refactor/behaviour.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/behaviour.rs
@@ -35,6 +35,7 @@ use super::{
     resolution::*,
     *,
 };
+use crate::tests::support::fs as test_fs;
 
 #[derive(Clone, Copy, Default)]
 enum RuntimeMode {
@@ -202,7 +203,7 @@ impl RefactorWorld {
     }
 
     fn write_file(&self, relative: &str, content: &str) -> Result<(), String> {
-        std::fs::write(self.path(relative), content).map_err(|e| format!("write file: {e}"))
+        test_fs::write(self.path(relative), content).map_err(|e| format!("write file: {e}"))
     }
 
     fn prepare_routed_fixture(&self, target_file: &str) -> Result<(), String> {
@@ -217,7 +218,7 @@ impl RefactorWorld {
     }
 
     fn read_file(&self, relative: &str) -> Result<String, String> {
-        std::fs::read_to_string(self.path(relative)).map_err(|e| format!("read file: {e}"))
+        test_fs::read_to_string(self.path(relative)).map_err(|e| format!("read file: {e}"))
     }
 
     fn execute(&mut self) -> Result<(), String> {

--- a/crates/weaverd/src/dispatch/act/refactor/contract_tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/contract_tests.rs
@@ -8,21 +8,24 @@ use url::Url;
 use weaver_plugins::{CapabilityId, PluginError, PluginOutput, PluginRequest, PluginResponse};
 use weaver_test_macros::allow_fixture_expansion_lints;
 
-use crate::dispatch::act::refactor::{
-    RefactorContext,
-    RefactorPluginRuntime,
-    ResponseWriter,
-    handle,
-    refactor_helpers::builders::{build_backends, command_request},
-    resolution::{
-        CandidateEvaluation,
-        CapabilityResolutionDetails,
-        CapabilityResolutionEnvelope,
-        ResolutionOutcome,
-        ResolutionRequest,
-        SelectionMode,
+use crate::{
+    dispatch::act::refactor::{
+        RefactorContext,
+        RefactorPluginRuntime,
+        ResponseWriter,
+        handle,
+        refactor_helpers::builders::{build_backends, command_request},
+        resolution::{
+            CandidateEvaluation,
+            CapabilityResolutionDetails,
+            CapabilityResolutionEnvelope,
+            ResolutionOutcome,
+            ResolutionRequest,
+            SelectionMode,
+        },
+        rust_analyzer_manifest,
     },
-    rust_analyzer_manifest,
+    tests::support::fs as test_fs,
 };
 
 struct InspectingRuntime {
@@ -115,7 +118,7 @@ fn dispatch_inspecting_rename(
 ) -> Result<(PluginRequest, PathBuf), String> {
     let workspace = TempDir::new().map_err(|e| format!("workspace: {e}"))?;
     let file_path = workspace.path().join(config.file);
-    std::fs::write(&file_path, "hello world\n").map_err(|e| format!("write: {e}"))?;
+    test_fs::write(&file_path, "hello world\n").map_err(|e| format!("write: {e}"))?;
     let runtime = InspectingRuntime {
         captured: Mutex::new(None),
         response: PluginResponse::success(PluginOutput::Diff {

--- a/crates/weaverd/src/dispatch/act/refactor/request_building.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/request_building.rs
@@ -15,7 +15,7 @@ use super::{
         effective_operation as supported_effective_operation,
     },
 };
-use crate::dispatch::errors::DispatchError;
+use crate::dispatch::{errors::DispatchError, filesystem};
 
 struct ResolvedFile {
     path: PathBuf,
@@ -136,7 +136,7 @@ fn resolve_file(workspace_root: &Path, file: &str) -> Result<ResolvedFile, Dispa
 }
 
 fn load_file_contents(path: &Path) -> Result<String, DispatchError> {
-    std::fs::read_to_string(path).map_err(|error| {
+    filesystem::read_to_string(path).map_err(|error| {
         DispatchError::invalid_arguments(format!("cannot read file '{}': {error}", path.display()))
     })
 }

--- a/crates/weaverd/src/dispatch/act/refactor/rollback_tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/rollback_tests.rs
@@ -9,7 +9,10 @@ use super::refactor_helpers::{
     resolutions::{RefusedResolution, SelectedResolution, refused_resolution},
     rollback::{ExecuteResult, RollbackRuntime, rollback_runtime, selected_runtime},
 };
-use crate::dispatch::act::refactor::{RefactorContext, ResponseWriter, handle};
+use crate::{
+    dispatch::act::refactor::{RefactorContext, ResponseWriter, handle},
+    tests::support::fs as test_fs,
+};
 
 struct RollbackOutcome {
     status: i32,
@@ -48,7 +51,7 @@ fn run_failure_case(runtime: RollbackRuntime) -> Result<RollbackOutcome, String>
     let workspace = TempDir::new().map_err(|e| format!("workspace: {e}"))?;
     let file = "notes.py";
     let file_path = workspace.path().join(file);
-    std::fs::write(&file_path, original_content_for(file_path.as_path()))
+    test_fs::write(&file_path, original_content_for(file_path.as_path()))
         .map_err(|e| format!("write file: {e}"))?;
 
     let request = command_request(standard_rename_args_for_provider(file, "rope"));
@@ -71,7 +74,7 @@ fn run_failure_case(runtime: RollbackRuntime) -> Result<RollbackOutcome, String>
     Ok(RollbackOutcome {
         status: result.status,
         stderr: String::from_utf8(output).map_err(|e| format!("stderr utf8: {e}"))?,
-        content: std::fs::read_to_string(&file_path).map_err(|e| format!("read file: {e}"))?,
+        content: test_fs::read_to_string(&file_path).map_err(|e| format!("read file: {e}"))?,
     })
 }
 

--- a/crates/weaverd/src/dispatch/act/refactor/tests.rs
+++ b/crates/weaverd/src/dispatch/act/refactor/tests.rs
@@ -5,24 +5,27 @@ use tempfile::TempDir;
 use weaver_plugins::{PluginError, PluginOutput, PluginRequest, PluginResponse};
 use weaver_test_macros::allow_fixture_expansion_lints;
 
-use crate::dispatch::act::refactor::{
-    DispatchError,
-    RefactorContext,
-    RefactorPluginRuntime,
-    ResponseWriter,
-    default_runtime,
-    handle,
-    refactor_helpers::builders::{build_backends, command_request},
-    resolution::{
-        CandidateEvaluation,
-        CapabilityResolutionDetails,
-        CapabilityResolutionEnvelope,
-        ResolutionOutcome,
-        ResolutionRequest,
-        SelectionMode,
+use crate::{
+    dispatch::act::refactor::{
+        DispatchError,
+        RefactorContext,
+        RefactorPluginRuntime,
+        ResponseWriter,
+        default_runtime,
+        handle,
+        refactor_helpers::builders::{build_backends, command_request},
+        resolution::{
+            CandidateEvaluation,
+            CapabilityResolutionDetails,
+            CapabilityResolutionEnvelope,
+            ResolutionOutcome,
+            ResolutionRequest,
+            SelectionMode,
+        },
+        resolve_rope_plugin_path,
+        resolve_rust_analyzer_plugin_path,
     },
-    resolve_rope_plugin_path,
-    resolve_rust_analyzer_plugin_path,
+    tests::support::fs as test_fs,
 };
 
 enum MockRuntimeResult {
@@ -89,7 +92,7 @@ fn run_rename_handle(
         Ok(workspace) => workspace,
         Err(error) => panic!("workspace: {error}"),
     };
-    if let Err(error) = std::fs::write(workspace.path().join(file), "hello\n") {
+    if let Err(error) = test_fs::write(workspace.path().join(file), "hello\n") {
         panic!("write: {error}");
     }
 
@@ -166,7 +169,7 @@ fn handle_non_diff_output_returns_status_one(
     socket_dir: TempDir,
 ) {
     let workspace = TempDir::new().expect("workspace");
-    std::fs::write(workspace.path().join("notes.py"), "hello\n").expect("write");
+    test_fs::write(workspace.path().join("notes.py"), "hello\n").expect("write");
 
     let request = command_request(vec![
         String::from("--provider"),
@@ -206,7 +209,7 @@ fn handle_diff_output_applies_patch_through_apply_patch_pipeline(socket_dir: Tem
     let workspace = TempDir::new().expect("workspace");
     let relative_file = String::from("notes.txt");
     let file_path = workspace.path().join(&relative_file);
-    std::fs::write(&file_path, "hello world\n").expect("write");
+    test_fs::write(&file_path, "hello world\n").expect("write");
 
     let diff = concat!(
         "diff --git a/notes.txt b/notes.txt\n",
@@ -247,7 +250,7 @@ fn handle_diff_output_applies_patch_through_apply_patch_pipeline(socket_dir: Tem
     .expect("dispatch result");
 
     assert_eq!(result.status, 0);
-    let updated = std::fs::read_to_string(workspace.path().join(relative_file)).expect("read");
+    let updated = test_fs::read_to_string(workspace.path().join(relative_file)).expect("read");
     assert_eq!(updated, "hello woven\n");
     let stderr = String::from_utf8(output).expect("stderr utf8");
     assert!(stderr.contains("CapabilityResolution"));

--- a/crates/weaverd/src/dispatch/filesystem.rs
+++ b/crates/weaverd/src/dispatch/filesystem.rs
@@ -1,0 +1,11 @@
+//! Capability-based filesystem helpers for dispatch handlers.
+
+use std::{io, path::Path};
+
+use crate::cap_fs::open_parent_dir;
+
+/// Reads a file by opening its parent directory as a capability.
+pub(super) fn read_to_string(path: &Path) -> io::Result<String> {
+    let (dir, filename) = open_parent_dir(path)?;
+    dir.read_to_string(filename)
+}

--- a/crates/weaverd/src/dispatch/mod.rs
+++ b/crates/weaverd/src/dispatch/mod.rs
@@ -30,6 +30,7 @@
 pub mod act;
 mod backend_manager;
 mod errors;
+mod filesystem;
 mod handler;
 pub mod observe;
 mod request;

--- a/crates/weaverd/src/dispatch/observe/get_card.rs
+++ b/crates/weaverd/src/dispatch/observe/get_card.rs
@@ -4,7 +4,7 @@
 //! backed card extraction to `weaver-cards`, and optionally enriches the card
 //! with LSP hover data when `--detail semantic` or higher is requested.
 
-use std::{fs, io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf};
 
 use url::Url;
 use weaver_cards::{
@@ -22,6 +22,7 @@ use crate::{
     backends::FusionBackends,
     dispatch::{
         errors::DispatchError,
+        filesystem,
         request::CommandRequest,
         response::ResponseWriter,
         router::DispatchResult,
@@ -47,7 +48,7 @@ pub fn handle<W: Write>(
         DispatchError::invalid_arguments(format!("invalid URI '{}': {error}", card_request.uri))
     })?;
     let path = resolve_file_path(&parsed_uri)?;
-    let source = fs::read_to_string(&path)?;
+    let source = filesystem::read_to_string(&path)?;
     let extractor = backends.provider().card_extractor();
 
     let response = match extractor.extract_shared(CardExtractionInput {

--- a/crates/weaverd/src/dispatch/observe/get_card_tests.rs
+++ b/crates/weaverd/src/dispatch/observe/get_card_tests.rs
@@ -1,7 +1,5 @@
 //! Unit tests for `observe::get_card`.
 
-use std::fs;
-
 use rstest::{fixture, rstest};
 use tempfile::TempDir;
 use url::Url;
@@ -22,6 +20,7 @@ use crate::{
         request::CommandRequest,
     },
     semantic_provider::SemanticBackendProvider,
+    tests::support::fs as test_fs,
 };
 
 #[path = "get_card_semantic_tests.rs"]
@@ -73,7 +72,7 @@ struct RefusalCase<'a> {
 
 fn write_source(temp_dir: &TempDir, file: SourceFile<'_>) -> PathBuf {
     let path = temp_dir.path().join(file.name);
-    if let Err(error) = fs::write(&path, file.content) {
+    if let Err(error) = test_fs::write(&path, file.content) {
         panic!("write source: {error}");
     }
     path
@@ -348,7 +347,7 @@ fn handle_invalidates_stale_revisions_when_file_changes(
     let request = make_request(&uri, 1, 4, DetailLevel::Structure);
 
     let (_, first_payload) = dispatch_payload(&request, &mut backends);
-    fs::write(&path, "fn welcome() -> usize {\n    2\n}\n").expect("rewrite source");
+    test_fs::write(&path, "fn welcome() -> usize {\n    2\n}\n").expect("rewrite source");
     let (_, second_payload) = dispatch_payload(&request, &mut backends);
     let extractor = backends.provider().card_extractor();
     let stats = extractor.cache_stats();

--- a/crates/weaverd/src/dispatch/observe/graph_slice.rs
+++ b/crates/weaverd/src/dispatch/observe/graph_slice.rs
@@ -4,7 +4,6 @@
 
 use std::{
     collections::BTreeMap,
-    fs,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -31,6 +30,7 @@ use crate::{
     backends::FusionBackends,
     dispatch::{
         errors::DispatchError,
+        filesystem,
         request::CommandRequest,
         response::ResponseWriter,
         router::DispatchResult,
@@ -61,12 +61,6 @@ pub fn handle<W: Write>(
     let parsed_uri = Url::parse(slice_request.uri())
         .map_err(|error| DispatchError::invalid_arguments(format!("invalid URI: {error}")))?;
     let path = resolve_file_path(&parsed_uri)?;
-    let path = fs::canonicalize(&path).map_err(|error| {
-        DispatchError::invalid_arguments(format!(
-            "unable to read source file '{}': {error}",
-            display_filename(&path)
-        ))
-    })?;
     let source = read_slice_source(&path)?;
     let response = build_response(&slice_request, &path, &source, backends)?;
 
@@ -358,7 +352,7 @@ fn resolve_file_path(uri: &Url) -> Result<PathBuf, DispatchError> {
 }
 /// Reads the source file at `path`, mapping IO failures to invalid-arguments errors.
 fn read_slice_source(path: &Path) -> Result<String, DispatchError> {
-    fs::read_to_string(path).map_err(|error| {
+    filesystem::read_to_string(path).map_err(|error| {
         DispatchError::invalid_arguments(format!(
             "unable to read source file '{}': {error}",
             display_filename(path)

--- a/crates/weaverd/src/dispatch/observe/graph_slice_tests.rs
+++ b/crates/weaverd/src/dispatch/observe/graph_slice_tests.rs
@@ -1,5 +1,5 @@
 //! Unit tests for the `observe graph-slice` dispatch handler.
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use rstest::{fixture, rstest};
 use tempfile::TempDir;
@@ -12,6 +12,7 @@ use crate::{
     backends::FusionBackends,
     dispatch::{request::CommandRequest, response::ResponseWriter},
     semantic_provider::SemanticBackendProvider,
+    tests::support::fs as test_fs,
 };
 #[fixture]
 fn backends_fixture() -> Result<(FusionBackends<SemanticBackendProvider>, TempDir), String> {
@@ -31,7 +32,7 @@ fn backends_fixture() -> Result<(FusionBackends<SemanticBackendProvider>, TempDi
 }
 fn write_source(temp_dir: &TempDir, name: &str, content: &str) -> Result<PathBuf, std::io::Error> {
     let path = temp_dir.path().join(name);
-    fs::write(&path, content)?;
+    test_fs::write(&path, content)?;
     Ok(path)
 }
 fn make_request(arguments: &[&str]) -> CommandRequest {

--- a/crates/weaverd/src/dispatch/router/tests.rs
+++ b/crates/weaverd/src/dispatch/router/tests.rs
@@ -10,7 +10,7 @@ use weaver_config::{CapabilityMatrix, Config, SocketEndpoint};
 use weaver_test_macros::allow_fixture_expansion_lints;
 
 use super::*;
-use crate::dispatch::request::CommandRequest;
+use crate::{dispatch::request::CommandRequest, tests::support::fs as test_fs};
 
 fn make_request(domain: &str, operation: &str) -> CommandRequest {
     let json = format!(
@@ -177,7 +177,7 @@ fn get_card_returns_structured_refusal(mut backends: FusionBackends<SemanticBack
     let router = build_router();
     let temp_dir = TempDir::new().expect("temp dir");
     let path = temp_dir.path().join("empty.py");
-    std::fs::write(&path, "").expect("write fixture");
+    test_fs::write(&path, "").expect("write fixture");
     let uri = Url::from_file_path(&path).expect("file uri").to_string();
     let json = format!(
         concat!(

--- a/crates/weaverd/src/lib.rs
+++ b/crates/weaverd/src/lib.rs
@@ -30,6 +30,7 @@
 
 mod backends;
 mod bootstrap;
+mod cap_fs;
 mod dispatch;
 mod health;
 mod process;

--- a/crates/weaverd/src/process/files.rs
+++ b/crates/weaverd/src/process/files.rs
@@ -29,7 +29,7 @@ pub(super) fn atomic_write(dir: &Dir, filename: &Path, contents: &[u8]) -> io::R
             Ok(()) => return persist_temp_file(dir, temp_name.as_path(), filename),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(error) => {
-                let _ = dir.remove_file(temp_name.as_path());
+                dir.remove_file(temp_name.as_path()).ok();
                 return Err(error);
             }
         }
@@ -57,7 +57,7 @@ fn write_temp_file(dir: &Dir, temp_name: &Path, contents: &[u8]) -> io::Result<(
 fn persist_temp_file(dir: &Dir, temp_name: &Path, filename: &Path) -> io::Result<()> {
     let write_result = dir.rename(temp_name, dir, filename);
     if write_result.is_err() {
-        let _ = dir.remove_file(temp_name);
+        dir.remove_file(temp_name).ok();
     }
     write_result
 }
@@ -73,8 +73,7 @@ fn unique_temp_name(filename: &Path, attempt: u8) -> io::Result<PathBuf> {
         .duration_since(UNIX_EPOCH)
         .map_err(io::Error::other)?
         .as_nanos();
-    let mut temp_name = PathBuf::from(".");
-    temp_name.push(format!(
+    let temp_name = PathBuf::from(format!(
         ".{}.{}.{}.{}.tmp",
         name.to_string_lossy(),
         std::process::id(),

--- a/crates/weaverd/src/process/files.rs
+++ b/crates/weaverd/src/process/files.rs
@@ -1,41 +1,85 @@
 //! Provides atomic write helpers for daemon runtime artefacts.
 
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::{
     io::{self, Write},
-    path::Path,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
-use tempfile::Builder;
+#[cfg(unix)]
+use cap_std::fs::OpenOptionsExt;
+use cap_std::fs::{Dir, OpenOptions};
+
+/// Opens the daemon runtime directory with ambient authority at startup.
+///
+/// Production filesystem access below this point is expressed relative to the
+/// returned capability handle.
+pub(super) fn open_runtime_dir(path: &Path) -> io::Result<Dir> {
+    Dir::open_ambient_dir(path, cap_std::ambient_authority())
+}
 
 /// Writes the provided bytes to the path using an atomic persist step.
 ///
 /// Data is flushed and fsync'd before the temporary file is renamed into
 /// place so readers never observe a partially written payload.
-pub(super) fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let directory = path.parent().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::NotFound,
-            "target path did not have a parent directory",
-        )
-    })?;
+pub(super) fn atomic_write(dir: &Dir, filename: &Path, contents: &[u8]) -> io::Result<()> {
+    for attempt in 0..16 {
+        let temp_name = unique_temp_name(filename, attempt)?;
+        match write_temp_file(dir, temp_name.as_path(), contents) {
+            Ok(()) => return persist_temp_file(dir, temp_name.as_path(), filename),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                let _ = dir.remove_file(temp_name.as_path());
+                return Err(error);
+            }
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not create a unique temporary runtime file",
+    ))
+}
 
-    let mut builder = Builder::new();
-    builder.prefix(
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("weaver"),
-    );
+fn write_temp_file(dir: &Dir, temp_name: &Path, contents: &[u8]) -> io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
     #[cfg(unix)]
     {
-        use std::fs::Permissions;
-        builder.permissions(Permissions::from_mode(0o600));
+        options.mode(0o600);
     }
 
-    let mut file = builder.tempfile_in(directory)?;
+    let mut file = dir.open_with(temp_name, &options)?;
     file.write_all(contents)?;
-    file.as_file().sync_all()?;
-    file.persist(path).map_err(|error| error.error)?;
+    file.sync_all()?;
     Ok(())
+}
+
+fn persist_temp_file(dir: &Dir, temp_name: &Path, filename: &Path) -> io::Result<()> {
+    let write_result = dir.rename(temp_name, dir, filename);
+    if write_result.is_err() {
+        let _ = dir.remove_file(temp_name);
+    }
+    write_result
+}
+
+fn unique_temp_name(filename: &Path, attempt: u8) -> io::Result<PathBuf> {
+    let name = filename.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "target filename did not have a file name",
+        )
+    })?;
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_nanos();
+    let mut temp_name = PathBuf::from(".");
+    temp_name.push(format!(
+        ".{}.{}.{}.{}.tmp",
+        name.to_string_lossy(),
+        std::process::id(),
+        unique,
+        attempt
+    ));
+    Ok(temp_name)
 }

--- a/crates/weaverd/src/process/guard.rs
+++ b/crates/weaverd/src/process/guard.rs
@@ -6,12 +6,14 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 use std::{
-    fs::{self, File, OpenOptions},
     io,
     path::Path,
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(unix)]
+use cap_std::fs::OpenOptionsExt;
+use cap_std::fs::{Dir, File, OpenOptions};
 use nix::{errno::Errno, sys::signal::kill, unistd::Pid};
 use serde::Serialize;
 use tracing::{info, warn};
@@ -25,15 +27,17 @@ static HEALTH_EVENTS: OnceLock<Mutex<HashMap<PathBuf, Vec<&'static str>>>> = Onc
 #[derive(Debug)]
 pub(super) struct ProcessGuard {
     paths: RuntimePaths,
+    runtime_dir: Dir,
     _lock: File,
     pid: Option<u32>,
 }
 
 impl ProcessGuard {
-    pub(super) fn acquire(paths: RuntimePaths) -> Result<Self, LaunchError> {
-        let lock = acquire_lock(&paths)?;
+    pub(super) fn acquire(runtime_dir: Dir, paths: RuntimePaths) -> Result<Self, LaunchError> {
+        let lock = acquire_lock(&runtime_dir, &paths)?;
         Ok(Self {
             paths,
+            runtime_dir,
             _lock: lock,
             pid: None,
         })
@@ -42,7 +46,12 @@ impl ProcessGuard {
     pub(super) fn write_pid(&mut self, pid: u32) -> Result<(), LaunchError> {
         let path = self.paths.pid_path();
         let payload = format!("{pid}\n");
-        atomic_write(path, payload.as_bytes()).map_err(|source| LaunchError::PidWrite {
+        atomic_write(
+            &self.runtime_dir,
+            runtime_filename(path)?,
+            payload.as_bytes(),
+        )
+        .map_err(|source| LaunchError::PidWrite {
             path: path.to_path_buf(),
             source,
         })?;
@@ -62,9 +71,11 @@ impl ProcessGuard {
         let snapshot = HealthSnapshot::new(status, pid)?;
         let mut payload = serde_json::to_vec(&snapshot)?;
         payload.push(b'\n');
-        atomic_write(path, &payload).map_err(|source| LaunchError::HealthWrite {
-            path: path.to_path_buf(),
-            source,
+        atomic_write(&self.runtime_dir, runtime_filename(path)?, &payload).map_err(|source| {
+            LaunchError::HealthWrite {
+                path: path.to_path_buf(),
+                source,
+            }
         })?;
         #[cfg(test)]
         {
@@ -94,7 +105,7 @@ impl ProcessGuard {
             self.paths.pid_path(),
             self.paths.health_path(),
         ] {
-            remove_runtime_file(path);
+            remove_runtime_file(&self.runtime_dir, path);
         }
     }
 }
@@ -103,8 +114,16 @@ impl Drop for ProcessGuard {
     fn drop(&mut self) { self.cleanup(); }
 }
 
-fn remove_runtime_file(path: &Path) {
-    match fs::remove_file(path) {
+fn remove_runtime_file(dir: &Dir, path: &Path) {
+    let Ok(filename) = runtime_filename(path) else {
+        warn!(
+            target: PROCESS_TARGET,
+            file = %path.display(),
+            "failed to resolve runtime artefact filename",
+        );
+        return;
+    };
+    match dir.remove_file(filename) {
         Ok(()) => {}
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
         Err(error) => warn!(
@@ -154,15 +173,15 @@ impl<'a> HealthSnapshot<'a> {
     }
 }
 
-fn acquire_lock(paths: &RuntimePaths) -> Result<File, LaunchError> {
+fn acquire_lock(dir: &Dir, paths: &RuntimePaths) -> Result<File, LaunchError> {
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
-    match options.open(paths.lock_path()) {
+    let filename = runtime_filename(paths.lock_path())?;
+    match dir.open_with(filename, &options) {
         Ok(file) => {
             info!(
                 target: PROCESS_TARGET,
@@ -171,7 +190,9 @@ fn acquire_lock(paths: &RuntimePaths) -> Result<File, LaunchError> {
             );
             Ok(file)
         }
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => handle_existing_lock(paths),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            handle_existing_lock(dir, paths)
+        }
         Err(source) => Err(LaunchError::LockCreate {
             path: paths.lock_path().to_path_buf(),
             source,
@@ -179,8 +200,8 @@ fn acquire_lock(paths: &RuntimePaths) -> Result<File, LaunchError> {
     }
 }
 
-fn handle_existing_lock(paths: &RuntimePaths) -> Result<File, LaunchError> {
-    if !paths.pid_path().exists() {
+fn handle_existing_lock(dir: &Dir, paths: &RuntimePaths) -> Result<File, LaunchError> {
+    if !runtime_file_exists(dir, paths.pid_path())? {
         info!(
             target: PROCESS_TARGET,
             lock = %paths.lock_path().display(),
@@ -192,7 +213,7 @@ fn handle_existing_lock(paths: &RuntimePaths) -> Result<File, LaunchError> {
         });
     }
 
-    match read_pid(paths.pid_path()) {
+    match read_pid(dir, paths.pid_path()) {
         Some(0) => {
             warn!(
                 target: PROCESS_TARGET,
@@ -224,19 +245,19 @@ fn handle_existing_lock(paths: &RuntimePaths) -> Result<File, LaunchError> {
         }
     }
 
-    remove_file(paths.lock_path())?;
-    remove_file(paths.pid_path())?;
-    remove_file(paths.health_path())?;
-    acquire_lock(paths)
+    remove_file(dir, paths.lock_path())?;
+    remove_file(dir, paths.pid_path())?;
+    remove_file(dir, paths.health_path())?;
+    acquire_lock(dir, paths)
 }
 
-fn read_pid(path: &Path) -> Option<u32> {
-    let content = fs::read_to_string(path).ok()?;
+fn read_pid(dir: &Dir, path: &Path) -> Option<u32> {
+    let content = dir.read_to_string(runtime_filename(path).ok()?).ok()?;
     content.trim().parse::<u32>().ok()
 }
 
-fn remove_file(path: &Path) -> Result<(), LaunchError> {
-    match fs::remove_file(path) {
+fn remove_file(dir: &Dir, path: &Path) -> Result<(), LaunchError> {
+    match dir.remove_file(runtime_filename(path)?) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(source) => Err(LaunchError::Cleanup {
@@ -244,6 +265,29 @@ fn remove_file(path: &Path) -> Result<(), LaunchError> {
             source,
         }),
     }
+}
+
+fn runtime_file_exists(dir: &Dir, path: &Path) -> Result<bool, LaunchError> {
+    match dir.metadata(runtime_filename(path)?) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(LaunchError::Cleanup {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn runtime_filename(path: &Path) -> Result<&Path, LaunchError> {
+    path.file_name()
+        .map(Path::new)
+        .ok_or_else(|| LaunchError::Cleanup {
+            path: path.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "runtime artefact path has no file name",
+            ),
+        })
 }
 
 fn check_process(pid: u32) -> Result<bool, LaunchError> {

--- a/crates/weaverd/src/process/guard.rs
+++ b/crates/weaverd/src/process/guard.rs
@@ -256,10 +256,18 @@ fn read_pid(dir: &Dir, path: &Path) -> Option<u32> {
     content.trim().parse::<u32>().ok()
 }
 
-fn remove_file(dir: &Dir, path: &Path) -> Result<(), LaunchError> {
-    match dir.remove_file(runtime_filename(path)?) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+fn with_runtime_file<T, F>(
+    dir: &Dir,
+    path: &Path,
+    not_found_value: T,
+    op: F,
+) -> Result<T, LaunchError>
+where
+    F: FnOnce(&Dir, &Path) -> io::Result<T>,
+{
+    match op(dir, runtime_filename(path)?) {
+        Ok(value) => Ok(value),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(not_found_value),
         Err(source) => Err(LaunchError::Cleanup {
             path: path.to_path_buf(),
             source,
@@ -267,15 +275,12 @@ fn remove_file(dir: &Dir, path: &Path) -> Result<(), LaunchError> {
     }
 }
 
+fn remove_file(dir: &Dir, path: &Path) -> Result<(), LaunchError> {
+    with_runtime_file(dir, path, (), |d, name| d.remove_file(name))
+}
+
 fn runtime_file_exists(dir: &Dir, path: &Path) -> Result<bool, LaunchError> {
-    match dir.metadata(runtime_filename(path)?) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(source) => Err(LaunchError::Cleanup {
-            path: path.to_path_buf(),
-            source,
-        }),
-    }
+    with_runtime_file(dir, path, false, |d, name| d.metadata(name).map(|_| true))
 }
 
 fn runtime_filename(path: &Path) -> Result<&Path, LaunchError> {

--- a/crates/weaverd/src/process/guard/tests.rs
+++ b/crates/weaverd/src/process/guard/tests.rs
@@ -25,6 +25,11 @@ fn build_paths() -> Result<(TempDir, RuntimePaths), String> {
     Ok((dir, paths))
 }
 
+fn open_runtime_dir(paths: &RuntimePaths) -> Result<cap_std::fs::Dir, String> {
+    cap_std::fs::Dir::open_ambient_dir(paths.runtime_dir(), cap_std::ambient_authority())
+        .map_err(|error| format!("failed to open runtime directory: {error}"))
+}
+
 #[fixture]
 fn seeded_runtime_paths(#[default("0\n")] pid: &str) -> Result<(TempDir, RuntimePaths), String> {
     let (dir, paths) = build_paths()?;
@@ -41,7 +46,8 @@ fn setup_guard_with_health(
     state: HealthState,
 ) -> Result<ProcessGuard, String> {
     test_support::clear_health_events(paths.health_path())?;
-    let mut guard = ProcessGuard::acquire(paths.clone())
+    let runtime_dir = open_runtime_dir(paths)?;
+    let mut guard = ProcessGuard::acquire(runtime_dir, paths.clone())
         .map_err(|error| format!("lock should be acquired: {error}"))?;
     let pid = std::process::id();
     guard
@@ -58,7 +64,8 @@ fn missing_pid_file_refuses_reacquire() -> Result<(), String> {
     let (_dir, paths) = build_paths()?;
     fs::write(paths.lock_path(), b"")
         .map_err(|error| format!("failed to seed lock file: {error}"))?;
-    match ProcessGuard::acquire(paths.clone()) {
+    let runtime_dir = open_runtime_dir(&paths)?;
+    match ProcessGuard::acquire(runtime_dir, paths.clone()) {
         Err(LaunchError::StartupInProgress { .. }) => {
             assert!(
                 paths.lock_path().exists(),
@@ -92,7 +99,8 @@ fn stale_pid_is_reclaimed(
             .map_err(|error| format!("failed to seed health file: {error}"))?;
     }
 
-    let mut guard = ProcessGuard::acquire(paths.clone())
+    let runtime_dir = open_runtime_dir(&paths)?;
+    let mut guard = ProcessGuard::acquire(runtime_dir, paths.clone())
         .map_err(|error| format!("stale runtime should be reclaimed: {error}"))?;
     if write_health {
         assert!(
@@ -114,7 +122,8 @@ fn existing_pid_rejects_launch() -> Result<(), String> {
     let pid = std::process::id();
     fs::write(paths.pid_path(), format!("{pid}\n"))
         .map_err(|error| format!("failed to seed pid file: {error}"))?;
-    match ProcessGuard::acquire(paths) {
+    let runtime_dir = open_runtime_dir(&paths)?;
+    match ProcessGuard::acquire(runtime_dir, paths) {
         Err(LaunchError::AlreadyRunning { pid: recorded }) => {
             assert_eq!(recorded, pid, "pid should match recorded process");
             Ok(())

--- a/crates/weaverd/src/process/guard/tests.rs
+++ b/crates/weaverd/src/process/guard/tests.rs
@@ -1,7 +1,5 @@
 //! Unit tests for process guard health checking.
 
-use std::fs;
-
 use rstest::{fixture, rstest};
 use tempfile::TempDir;
 use weaver_config::{Config, SocketEndpoint};
@@ -30,13 +28,35 @@ fn open_runtime_dir(paths: &RuntimePaths) -> Result<cap_std::fs::Dir, String> {
         .map_err(|error| format!("failed to open runtime directory: {error}"))
 }
 
+fn write_runtime_file(
+    paths: &RuntimePaths,
+    filename: &str,
+    content: impl AsRef<[u8]>,
+) -> Result<(), String> {
+    open_runtime_dir(paths)?
+        .write(filename, content)
+        .map_err(|error| format!("failed to write {filename}: {error}"))
+}
+
+fn read_runtime_file(paths: &RuntimePaths, filename: &str) -> Result<String, String> {
+    open_runtime_dir(paths)?
+        .read_to_string(filename)
+        .map_err(|error| format!("failed to read {filename}: {error}"))
+}
+
+fn runtime_file_exists(paths: &RuntimePaths, filename: &str) -> Result<bool, String> {
+    match open_runtime_dir(paths)?.metadata(filename) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!("failed to inspect {filename}: {error}")),
+    }
+}
+
 #[fixture]
 fn seeded_runtime_paths(#[default("0\n")] pid: &str) -> Result<(TempDir, RuntimePaths), String> {
     let (dir, paths) = build_paths()?;
-    fs::write(paths.lock_path(), b"")
-        .map_err(|error| format!("failed to seed lock file: {error}"))?;
-    fs::write(paths.pid_path(), pid)
-        .map_err(|error| format!("failed to seed pid file: {error}"))?;
+    write_runtime_file(&paths, "weaverd.lock", b"")?;
+    write_runtime_file(&paths, "weaverd.pid", pid)?;
     Ok((dir, paths))
 }
 
@@ -62,13 +82,12 @@ fn setup_guard_with_health(
 #[test]
 fn missing_pid_file_refuses_reacquire() -> Result<(), String> {
     let (_dir, paths) = build_paths()?;
-    fs::write(paths.lock_path(), b"")
-        .map_err(|error| format!("failed to seed lock file: {error}"))?;
+    write_runtime_file(&paths, "weaverd.lock", b"")?;
     let runtime_dir = open_runtime_dir(&paths)?;
     match ProcessGuard::acquire(runtime_dir, paths.clone()) {
         Err(LaunchError::StartupInProgress { .. }) => {
             assert!(
-                paths.lock_path().exists(),
+                runtime_file_exists(&paths, "weaverd.lock")?,
                 "lock should remain whilst startup is in progress",
             );
             Ok(())
@@ -86,8 +105,7 @@ fn stale_pid_is_reclaimed(
     #[with(pid)] seeded_runtime_paths: Result<(TempDir, RuntimePaths), String>,
 ) -> Result<(), String> {
     let (_dir, paths) = seeded_runtime_paths?;
-    let seeded_pid = fs::read_to_string(paths.pid_path())
-        .map_err(|error| format!("failed to read seeded pid file: {error}"))?;
+    let seeded_pid = read_runtime_file(&paths, "weaverd.pid")?;
     if seeded_pid != pid {
         return Err(format!(
             "unexpected seeded pid content: expected {:?}, got {:?}",
@@ -95,8 +113,7 @@ fn stale_pid_is_reclaimed(
         ));
     }
     if write_health {
-        fs::write(paths.health_path(), b"stale")
-            .map_err(|error| format!("failed to seed health file: {error}"))?;
+        write_runtime_file(&paths, "weaverd.health", b"stale")?;
     }
 
     let runtime_dir = open_runtime_dir(&paths)?;
@@ -104,7 +121,7 @@ fn stale_pid_is_reclaimed(
         .map_err(|error| format!("stale runtime should be reclaimed: {error}"))?;
     if write_health {
         assert!(
-            !paths.health_path().exists(),
+            !runtime_file_exists(&paths, "weaverd.health")?,
             "stale health file should be removed before reacquiring",
         );
     }
@@ -117,11 +134,9 @@ fn stale_pid_is_reclaimed(
 #[test]
 fn existing_pid_rejects_launch() -> Result<(), String> {
     let (_dir, paths) = build_paths()?;
-    fs::write(paths.lock_path(), b"")
-        .map_err(|error| format!("failed to seed lock file: {error}"))?;
+    write_runtime_file(&paths, "weaverd.lock", b"")?;
     let pid = std::process::id();
-    fs::write(paths.pid_path(), format!("{pid}\n"))
-        .map_err(|error| format!("failed to seed pid file: {error}"))?;
+    write_runtime_file(&paths, "weaverd.pid", format!("{pid}\n"))?;
     let runtime_dir = open_runtime_dir(&paths)?;
     match ProcessGuard::acquire(runtime_dir, paths) {
         Err(LaunchError::AlreadyRunning { pid: recorded }) => {
@@ -136,8 +151,7 @@ fn existing_pid_rejects_launch() -> Result<(), String> {
 fn health_snapshot_is_written_with_newline() -> Result<(), String> {
     let (_dir, paths) = build_paths()?;
     let _guard = setup_guard_with_health(&paths, HealthState::Ready)?;
-    let content = fs::read_to_string(paths.health_path())
-        .map_err(|error| format!("health file should be readable: {error}"))?;
+    let content = read_runtime_file(&paths, "weaverd.health")?;
     assert!(
         content.ends_with('\n'),
         "health snapshot should end with newline"

--- a/crates/weaverd/src/process/launch.rs
+++ b/crates/weaverd/src/process/launch.rs
@@ -109,7 +109,14 @@ where
     let config = loader.load()?;
     config.daemon_socket().prepare_filesystem()?;
     let runtime_paths = RuntimePaths::from_config(&config)?;
-    let mut guard = ProcessGuard::acquire(runtime_paths)?;
+    let runtime_dir =
+        super::files::open_runtime_dir(runtime_paths.runtime_dir()).map_err(|source| {
+            LaunchError::RuntimeDirectory {
+                path: runtime_paths.runtime_dir().to_path_buf(),
+                source,
+            }
+        })?;
+    let mut guard = ProcessGuard::acquire(runtime_dir, runtime_paths)?;
     let workspace_root =
         env::current_dir().map_err(|source| LaunchError::WorkspaceRoot { source })?;
     if matches!(mode, LaunchMode::Background) {

--- a/crates/weaverd/src/safety_harness/transaction.rs
+++ b/crates/weaverd/src/safety_harness/transaction.rs
@@ -14,12 +14,11 @@ mod test_support;
 #[cfg(test)]
 mod tests;
 
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-use self::commit::{DeletePlan, commit_changes_with_deletes};
+use cap_std::fs::Dir;
+
+use self::commit::{CommitPlan, DeletePlan, commit_changes_with_deletes};
 use super::{
     edit::FileEdit,
     error::{SafetyHarnessError, VerificationFailure},
@@ -124,7 +123,11 @@ impl<'a> ContentTransaction<'a> {
     /// Returns an error when:
     /// - A file cannot be read or written.
     /// - The semantic backend is unavailable.
-    pub fn execute(self) -> Result<TransactionOutcome, SafetyHarnessError> {
+    pub fn execute(
+        self,
+        workspace_dir: &Dir,
+        workspace_root: &Path,
+    ) -> Result<TransactionOutcome, SafetyHarnessError> {
         let ContentTransaction {
             changes,
             syntactic_lock,
@@ -142,13 +145,13 @@ impl<'a> ContentTransaction<'a> {
             match change {
                 ContentChange::Write { path, content } => {
                     // Allow create operations by treating missing files as empty content.
-                    let original = read_file(&path)?;
+                    let original = read_file(workspace_dir, workspace_root, &path)?;
                     context.add_original(path.clone(), original);
                     context.add_modified(path.clone(), content);
                     paths_to_write.push(path);
                 }
                 ContentChange::Delete { path } => {
-                    let original = read_existing_file(&path)?;
+                    let original = read_existing_file(workspace_dir, workspace_root, &path)?;
                     deletions.push(DeletePlan { path, original });
                 }
             }
@@ -158,6 +161,8 @@ impl<'a> ContentTransaction<'a> {
             context: &context,
             paths_to_write: &paths_to_write,
             deletions: &deletions,
+            workspace_dir,
+            workspace_root,
             syntactic_lock,
             semantic_lock,
         })
@@ -212,7 +217,11 @@ impl<'a> EditTransaction<'a> {
     /// - A file cannot be read or written.
     /// - Edits cannot be applied to the in-memory buffer.
     /// - The semantic backend is unavailable.
-    pub fn execute(self) -> Result<TransactionOutcome, SafetyHarnessError> {
+    pub fn execute(
+        self,
+        workspace_dir: &Dir,
+        workspace_root: &Path,
+    ) -> Result<TransactionOutcome, SafetyHarnessError> {
         if self.file_edits.is_empty() {
             return Ok(TransactionOutcome::NoChanges);
         }
@@ -223,7 +232,7 @@ impl<'a> EditTransaction<'a> {
 
         for file_edit in &self.file_edits {
             let path = file_edit.path();
-            let original = read_file(path)?;
+            let original = read_file(workspace_dir, workspace_root, path)?;
 
             // Step 2: Apply edits to produce modified content
             let modified = apply_edits(&original, file_edit)?;
@@ -237,6 +246,8 @@ impl<'a> EditTransaction<'a> {
             context: &context,
             paths_to_write: &paths_to_write,
             deletions: &[],
+            workspace_dir,
+            workspace_root,
             syntactic_lock: self.syntactic_lock,
             semantic_lock: self.semantic_lock,
         })
@@ -244,8 +255,10 @@ impl<'a> EditTransaction<'a> {
 }
 
 /// Reads file content or creates an empty file entry for new files.
-fn read_file(path: &std::path::Path) -> Result<String, SafetyHarnessError> {
-    match fs::read_to_string(path) {
+fn read_file(dir: &Dir, workspace_root: &Path, path: &Path) -> Result<String, SafetyHarnessError> {
+    let relative = relative_workspace_path(path, workspace_root)
+        .map_err(|err| SafetyHarnessError::file_read(path.to_path_buf(), err))?;
+    match dir.read_to_string(relative) {
         Ok(content) => Ok(content),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             // New file creation: start with empty content
@@ -256,8 +269,15 @@ fn read_file(path: &std::path::Path) -> Result<String, SafetyHarnessError> {
 }
 
 /// Reads file content, returning an error if the file does not exist.
-fn read_existing_file(path: &std::path::Path) -> Result<String, SafetyHarnessError> {
-    fs::read_to_string(path).map_err(|err| SafetyHarnessError::file_read(path.to_path_buf(), err))
+fn read_existing_file(
+    dir: &Dir,
+    workspace_root: &Path,
+    path: &Path,
+) -> Result<String, SafetyHarnessError> {
+    let relative = relative_workspace_path(path, workspace_root)
+        .map_err(|err| SafetyHarnessError::file_read(path.to_path_buf(), err))?;
+    dir.read_to_string(relative)
+        .map_err(|err| SafetyHarnessError::file_read(path.to_path_buf(), err))
 }
 
 /// Executes the Double-Lock validation pipeline and commits changes on success.
@@ -274,11 +294,13 @@ fn execute_with_locks(
         return Ok(TransactionOutcome::SemanticLockFailed { failures });
     }
 
-    commit_changes_with_deletes(
-        execution.context,
-        execution.paths_to_write,
-        execution.deletions,
-    )?;
+    commit_changes_with_deletes(CommitPlan {
+        dir: execution.workspace_dir,
+        workspace_root: execution.workspace_root,
+        context: execution.context,
+        paths: execution.paths_to_write,
+        deletions: execution.deletions,
+    })?;
 
     Ok(TransactionOutcome::Committed {
         files_modified: execution.paths_to_write.len() + execution.deletions.len(),
@@ -293,6 +315,24 @@ struct TransactionExecution<'a> {
     context: &'a VerificationContext,
     paths_to_write: &'a [PathBuf],
     deletions: &'a [DeletePlan],
+    workspace_dir: &'a Dir,
+    workspace_root: &'a Path,
     syntactic_lock: &'a dyn SyntacticLock,
     semantic_lock: &'a dyn SemanticLock,
+}
+
+pub(super) fn relative_workspace_path<'a>(
+    path: &'a Path,
+    workspace_root: &Path,
+) -> Result<&'a Path, std::io::Error> {
+    path.strip_prefix(workspace_root).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "path '{}' is outside workspace '{}': {error}",
+                path.display(),
+                workspace_root.display()
+            ),
+        )
+    })
 }

--- a/crates/weaverd/src/safety_harness/transaction/commit.rs
+++ b/crates/weaverd/src/safety_harness/transaction/commit.rs
@@ -315,8 +315,19 @@ mod tests {
     //! Tests for transaction commit cleanup helpers.
 
     use cap_std::ambient_authority;
+    use rstest::{fixture, rstest};
+    use tempfile::TempDir;
 
     use super::*;
+
+    #[fixture]
+    fn workspace_dir() -> Result<(TempDir, Dir), String> {
+        let tempdir =
+            tempfile::tempdir().map_err(|e| format!("create temporary directory: {e}"))?;
+        let dir = Dir::open_ambient_dir(tempdir.path(), ambient_authority())
+            .map_err(|e| format!("open temporary directory capability: {e}"))?;
+        Ok((tempdir, dir))
+    }
 
     fn prepared_file(path: &str, temp_path: &str) -> PreparedFile {
         PreparedFile {
@@ -327,20 +338,25 @@ mod tests {
         }
     }
 
-    #[test]
-    fn cleanup_prepared_temp_files_removes_existing_temps() {
-        let tempdir = tempfile::tempdir().expect("create temporary directory");
-        let dir = Dir::open_ambient_dir(tempdir.path(), ambient_authority())
-            .expect("open temporary directory capability");
+    #[rstest]
+    #[case::seeded(true)]
+    #[case::missing(false)]
+    fn cleanup_prepared_temp_files_handles_seeded_and_missing_temps(
+        #[case] seed_temps: bool,
+        workspace_dir: Result<(TempDir, Dir), String>,
+    ) -> Result<(), String> {
+        let (_tempdir, dir) = workspace_dir?;
         let prepared = [
             prepared_file("first.txt", ".first.tmp"),
             prepared_file("second.txt", ".second.tmp"),
         ];
 
-        dir.write(".first.tmp", "first")
-            .expect("write first temporary file");
-        dir.write(".second.tmp", "second")
-            .expect("write second temporary file");
+        if seed_temps {
+            dir.write(".first.tmp", "first")
+                .map_err(|e| format!("write first temporary file: {e}"))?;
+            dir.write(".second.tmp", "second")
+                .map_err(|e| format!("write second temporary file: {e}"))?;
+        }
 
         cleanup_prepared_temp_files(&dir, &prepared);
 
@@ -352,15 +368,6 @@ mod tests {
             dir.metadata(".second.tmp"),
             Err(err) if err.kind() == io::ErrorKind::NotFound
         ));
-    }
-
-    #[test]
-    fn cleanup_prepared_temp_files_ignores_missing_temps() {
-        let tempdir = tempfile::tempdir().expect("create temporary directory");
-        let dir = Dir::open_ambient_dir(tempdir.path(), ambient_authority())
-            .expect("open temporary directory capability");
-        let prepared = [prepared_file("missing.txt", ".missing.tmp")];
-
-        cleanup_prepared_temp_files(&dir, &prepared);
+        Ok(())
     }
 }

--- a/crates/weaverd/src/safety_harness/transaction/commit.rs
+++ b/crates/weaverd/src/safety_harness/transaction/commit.rs
@@ -108,12 +108,15 @@ fn persist_prepared_files(
     prepared: Vec<PreparedFile>,
 ) -> Result<Vec<CommittedFile>, SafetyHarnessError> {
     let mut committed: Vec<CommittedFile> = Vec::new();
+    let mut prepared_iter = prepared.into_iter();
 
-    for prepared_file in prepared {
+    while let Some(prepared_file) = prepared_iter.next() {
         let relative = relative_workspace_path(&prepared_file.path, workspace_root)
             .map_err(|err| SafetyHarnessError::file_write(prepared_file.path.clone(), err))?;
         if let Err(err) = dir.rename(&prepared_file.temp_path, dir, relative) {
             rollback_writes(dir, workspace_root, &committed);
+            cleanup_temp_file(dir, &prepared_file.temp_path);
+            cleanup_prepared_temp_files(dir, prepared_iter.as_slice());
             return Err(SafetyHarnessError::file_write(prepared_file.path, err));
         }
         committed.push(CommittedFile {
@@ -124,6 +127,24 @@ fn persist_prepared_files(
     }
 
     Ok(committed)
+}
+
+fn cleanup_prepared_temp_files(dir: &Dir, prepared: &[PreparedFile]) {
+    for prepared_file in prepared {
+        cleanup_temp_file(dir, &prepared_file.temp_path);
+    }
+}
+
+fn cleanup_temp_file(dir: &Dir, temp_path: &Path) {
+    if let Err(err) = dir.remove_file(temp_path)
+        && err.kind() != io::ErrorKind::NotFound
+    {
+        warn!(
+            path = %temp_path.display(),
+            error = %err,
+            "failed to remove transaction temporary file",
+        );
+    }
 }
 
 /// Removes files slated for deletion, rolling back changes on failure.
@@ -279,4 +300,59 @@ fn unique_temp_path(relative: &Path, attempt: u8) -> io::Result<PathBuf> {
         attempt
     ));
     Ok(temp_path)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for transaction commit cleanup helpers.
+
+    use cap_std::ambient_authority;
+
+    use super::*;
+
+    fn prepared_file(path: &str, temp_path: &str) -> PreparedFile {
+        PreparedFile {
+            path: PathBuf::from(path),
+            temp_path: PathBuf::from(temp_path),
+            original: String::new(),
+            existed: false,
+        }
+    }
+
+    #[test]
+    fn cleanup_prepared_temp_files_removes_existing_temps() {
+        let tempdir = tempfile::tempdir().expect("create temporary directory");
+        let dir = Dir::open_ambient_dir(tempdir.path(), ambient_authority())
+            .expect("open temporary directory capability");
+        let prepared = [
+            prepared_file("first.txt", ".first.tmp"),
+            prepared_file("second.txt", ".second.tmp"),
+        ];
+
+        dir.write(".first.tmp", "first")
+            .expect("write first temporary file");
+        dir.write(".second.tmp", "second")
+            .expect("write second temporary file");
+
+        cleanup_prepared_temp_files(&dir, &prepared);
+
+        assert!(matches!(
+            dir.metadata(".first.tmp"),
+            Err(err) if err.kind() == io::ErrorKind::NotFound
+        ));
+        assert!(matches!(
+            dir.metadata(".second.tmp"),
+            Err(err) if err.kind() == io::ErrorKind::NotFound
+        ));
+    }
+
+    #[test]
+    fn cleanup_prepared_temp_files_ignores_missing_temps() {
+        let tempdir = tempfile::tempdir().expect("create temporary directory");
+        let dir = Dir::open_ambient_dir(tempdir.path(), ambient_authority())
+            .expect("open temporary directory capability");
+        let prepared = [prepared_file("missing.txt", ".missing.tmp")];
+
+        cleanup_prepared_temp_files(&dir, &prepared);
+    }
 }

--- a/crates/weaverd/src/safety_harness/transaction/commit.rs
+++ b/crates/weaverd/src/safety_harness/transaction/commit.rs
@@ -1,14 +1,18 @@
 //! Commit helpers for applying verified changes.
 
 use std::{
-    fs,
-    io::Write as IoWrite,
+    io::{self, Write as IoWrite},
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
+use cap_std::fs::{Dir, OpenOptions};
 use tracing::warn;
 
-use super::super::{error::SafetyHarnessError, verification::VerificationContext};
+use super::{
+    super::{error::SafetyHarnessError, verification::VerificationContext},
+    relative_workspace_path,
+};
 
 /// Planned file deletion with rollback context.
 ///
@@ -26,7 +30,7 @@ pub(super) struct DeletePlan {
 #[derive(Debug)]
 struct PreparedFile {
     path: PathBuf,
-    temp_file: tempfile::NamedTempFile,
+    temp_path: PathBuf,
     original: String,
     existed: bool,
 }
@@ -37,6 +41,20 @@ struct CommittedFile {
     path: PathBuf,
     original: String,
     existed: bool,
+}
+
+/// Capability and content context required to commit a transaction.
+pub(super) struct CommitPlan<'a> {
+    /// Workspace capability used for every file operation.
+    pub(super) dir: &'a Dir,
+    /// Absolute workspace root used to derive capability-relative paths.
+    pub(super) workspace_root: &'a Path,
+    /// Verified original and modified file contents.
+    pub(super) context: &'a VerificationContext,
+    /// Paths whose modified content should be written.
+    pub(super) paths: &'a [PathBuf],
+    /// Files to delete after writes are committed.
+    pub(super) deletions: &'a [DeletePlan],
 }
 
 /// Writes all modified content to the filesystem using two-phase commit.
@@ -53,51 +71,50 @@ struct CommittedFile {
 ///
 /// Rollback is best-effort: if a catastrophic failure occurs during rollback
 /// (e.g., disk removed), some files may remain in an inconsistent state.
-pub(super) fn commit_changes_with_deletes(
-    context: &VerificationContext,
-    paths: &[PathBuf],
-    deletions: &[DeletePlan],
-) -> Result<(), SafetyHarnessError> {
+pub(super) fn commit_changes_with_deletes(plan: CommitPlan<'_>) -> Result<(), SafetyHarnessError> {
     // Phase 1: Prepare all files (write to temps)
     let mut prepared: Vec<PreparedFile> = Vec::new();
 
-    for path in paths {
-        let content = context
+    for path in plan.paths {
+        let content = plan
+            .context
             .modified(path)
             .ok_or_else(|| SafetyHarnessError::ModifiedContentMissing { path: path.clone() })?;
 
-        let original = context
+        let original = plan
+            .context
             .original(path)
             .cloned()
             .ok_or_else(|| SafetyHarnessError::OriginalContentMissing { path: path.clone() })?;
-        let existed = path.exists();
-        let temp_file = prepare_file(path, content)?;
+        let existed = file_exists(plan.dir, plan.workspace_root, path)?;
+        let temp_path = prepare_file(plan.dir, plan.workspace_root, path, content)?;
         prepared.push(PreparedFile {
             path: path.clone(),
-            temp_file,
+            temp_path,
             original,
             existed,
         });
     }
     // Phase 2: Commit all files (atomic renames)
-    let committed = persist_prepared_files(prepared)?;
-    apply_deletions(deletions, &committed)?;
+    let committed = persist_prepared_files(plan.dir, plan.workspace_root, prepared)?;
+    apply_deletions(plan.dir, plan.workspace_root, plan.deletions, &committed)?;
     Ok(())
 }
 
 /// Persists prepared temp files, rolling back if any commit fails.
 fn persist_prepared_files(
+    dir: &Dir,
+    workspace_root: &Path,
     prepared: Vec<PreparedFile>,
 ) -> Result<Vec<CommittedFile>, SafetyHarnessError> {
     let mut committed: Vec<CommittedFile> = Vec::new();
 
     for prepared_file in prepared {
-        if let Err(err) = prepared_file.temp_file.persist(&prepared_file.path) {
-            rollback_writes(&committed);
-            return Err(SafetyHarnessError::file_write(
-                prepared_file.path,
-                err.error,
-            ));
+        let relative = relative_workspace_path(&prepared_file.path, workspace_root)
+            .map_err(|err| SafetyHarnessError::file_write(prepared_file.path.clone(), err))?;
+        if let Err(err) = dir.rename(&prepared_file.temp_path, dir, relative) {
+            rollback_writes(dir, workspace_root, &committed);
+            return Err(SafetyHarnessError::file_write(prepared_file.path, err));
         }
         committed.push(CommittedFile {
             path: prepared_file.path,
@@ -111,14 +128,18 @@ fn persist_prepared_files(
 
 /// Removes files slated for deletion, rolling back changes on failure.
 fn apply_deletions(
+    dir: &Dir,
+    workspace_root: &Path,
     deletions: &[DeletePlan],
     committed: &[CommittedFile],
 ) -> Result<(), SafetyHarnessError> {
     let mut deleted: Vec<&DeletePlan> = Vec::new();
 
     for deletion in deletions {
-        if let Err(err) = fs::remove_file(&deletion.path) {
-            rollback_deletes_and_writes(&deleted, committed);
+        let relative = relative_workspace_path(&deletion.path, workspace_root)
+            .map_err(|err| SafetyHarnessError::file_delete(deletion.path.clone(), err))?;
+        if let Err(err) = dir.remove_file(relative) {
+            rollback_deletes_and_writes(dir, workspace_root, &deleted, committed);
             return Err(SafetyHarnessError::file_delete(deletion.path.clone(), err));
         }
         deleted.push(deletion);
@@ -132,32 +153,56 @@ fn apply_deletions(
 /// The temp file is created in the same directory as the target to ensure
 /// atomic rename is possible (same filesystem). Parent directories are
 /// created if they don't exist.
-fn prepare_file(path: &Path, content: &str) -> Result<tempfile::NamedTempFile, SafetyHarnessError> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+fn prepare_file(
+    dir: &Dir,
+    workspace_root: &Path,
+    path: &Path,
+    content: &str,
+) -> Result<PathBuf, SafetyHarnessError> {
+    let relative = relative_workspace_path(path, workspace_root)
+        .map_err(|err| SafetyHarnessError::file_write(path.to_path_buf(), err))?;
+    let parent = relative.parent().unwrap_or_else(|| Path::new("."));
 
     // Create parent directories if they don't exist (for nested new files)
-    fs::create_dir_all(parent)
-        .map_err(|err| SafetyHarnessError::file_write(path.to_path_buf(), err))?;
+    if parent != Path::new("") && parent != Path::new(".") {
+        dir.create_dir_all(parent)
+            .map_err(|err| SafetyHarnessError::file_write(path.to_path_buf(), err))?;
+    }
 
-    let mut temp_file = tempfile::NamedTempFile::new_in(parent)
-        .map_err(|err| SafetyHarnessError::file_write(path.to_path_buf(), err))?;
+    for attempt in 0..16 {
+        let temp_path = unique_temp_path(relative, attempt)
+            .map_err(|err| SafetyHarnessError::file_write(path.to_path_buf(), err))?;
+        match write_temp_file(dir, temp_path.as_path(), content) {
+            Ok(()) => return Ok(temp_path),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(err) => {
+                let _ = dir.remove_file(temp_path.as_path());
+                return Err(SafetyHarnessError::file_write(path.to_path_buf(), err));
+            }
+        }
+    }
 
-    temp_file
-        .write_all(content.as_bytes())
-        .map_err(|err| SafetyHarnessError::file_write(path.to_path_buf(), err))?;
-
-    Ok(temp_file)
+    Err(SafetyHarnessError::file_write(
+        path.to_path_buf(),
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not create a unique transaction temporary file",
+        ),
+    ))
 }
 
 /// Rolls back committed files to their original content.
 ///
 /// This is a best-effort operation: if restoration fails for any file,
 /// we continue attempting to restore the remaining files.
-fn rollback_writes(committed: &[CommittedFile]) {
+fn rollback_writes(dir: &Dir, workspace_root: &Path, committed: &[CommittedFile]) {
     for committed_file in committed {
+        let Ok(relative) = relative_workspace_path(&committed_file.path, workspace_root) else {
+            continue;
+        };
         if !committed_file.existed {
             // File was newly created, remove it
-            if let Err(err) = std::fs::remove_file(&committed_file.path) {
+            if let Err(err) = dir.remove_file(relative) {
                 warn!(
                     path = %committed_file.path.display(),
                     error = %err,
@@ -166,7 +211,7 @@ fn rollback_writes(committed: &[CommittedFile]) {
             }
         } else {
             // Restore original content (best effort)
-            if let Err(err) = std::fs::write(&committed_file.path, &committed_file.original) {
+            if let Err(err) = dir.write(relative, &committed_file.original) {
                 warn!(
                     path = %committed_file.path.display(),
                     error = %err,
@@ -178,9 +223,17 @@ fn rollback_writes(committed: &[CommittedFile]) {
 }
 
 /// Restores deleted files before rolling back committed writes.
-fn rollback_deletes_and_writes(deleted: &[&DeletePlan], committed: &[CommittedFile]) {
+fn rollback_deletes_and_writes(
+    dir: &Dir,
+    workspace_root: &Path,
+    deleted: &[&DeletePlan],
+    committed: &[CommittedFile],
+) {
     for deletion in deleted {
-        if let Err(err) = std::fs::write(&deletion.path, &deletion.original) {
+        let Ok(relative) = relative_workspace_path(&deletion.path, workspace_root) else {
+            continue;
+        };
+        if let Err(err) = dir.write(relative, &deletion.original) {
             warn!(
                 path = %deletion.path.display(),
                 error = %err,
@@ -188,5 +241,42 @@ fn rollback_deletes_and_writes(deleted: &[&DeletePlan], committed: &[CommittedFi
             );
         }
     }
-    rollback_writes(committed);
+    rollback_writes(dir, workspace_root, committed);
+}
+
+fn file_exists(dir: &Dir, workspace_root: &Path, path: &Path) -> Result<bool, SafetyHarnessError> {
+    let relative = relative_workspace_path(path, workspace_root)
+        .map_err(|err| SafetyHarnessError::file_write(path.to_path_buf(), err))?;
+    match dir.metadata(relative) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(SafetyHarnessError::file_write(path.to_path_buf(), err)),
+    }
+}
+
+fn write_temp_file(dir: &Dir, temp_path: &Path, content: &str) -> io::Result<()> {
+    let mut file = dir.open_with(temp_path, OpenOptions::new().write(true).create_new(true))?;
+    file.write_all(content.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn unique_temp_path(relative: &Path, attempt: u8) -> io::Result<PathBuf> {
+    let parent = relative.parent().unwrap_or_else(|| Path::new("."));
+    let name = relative.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "target path has no file name")
+    })?;
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_nanos();
+    let mut temp_path = parent.to_path_buf();
+    temp_path.push(format!(
+        ".{}.{}.{}.{}.tmp",
+        name.to_string_lossy(),
+        std::process::id(),
+        unique,
+        attempt
+    ));
+    Ok(temp_path)
 }

--- a/crates/weaverd/src/safety_harness/transaction/commit.rs
+++ b/crates/weaverd/src/safety_harness/transaction/commit.rs
@@ -102,6 +102,12 @@ pub(super) fn commit_changes_with_deletes(plan: CommitPlan<'_>) -> Result<(), Sa
 }
 
 /// Persists prepared temp files, rolling back if any commit fails.
+///
+/// Paths have already been validated by apply-patch before reaching this
+/// commit phase. cap-std keeps operations relative to the workspace capability,
+/// but `rename` and `remove_file` still resolve the final path at operation
+/// time. Concurrent hostile mutation of the workspace namespace is outside the
+/// transaction threat model.
 fn persist_prepared_files(
     dir: &Dir,
     workspace_root: &Path,
@@ -287,15 +293,17 @@ fn unique_temp_path(relative: &Path, attempt: u8) -> io::Result<PathBuf> {
     let name = relative.file_name().ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "target path has no file name")
     })?;
+    let thread_id = std::thread::current().id();
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(io::Error::other)?
         .as_nanos();
     let mut temp_path = parent.to_path_buf();
     temp_path.push(format!(
-        ".{}.{}.{}.{}.tmp",
+        ".{}.{}.{:?}.{}.{}.tmp",
         name.to_string_lossy(),
         std::process::id(),
+        thread_id,
         unique,
         attempt
     ));

--- a/crates/weaverd/src/safety_harness/transaction/content_transaction_tests.rs
+++ b/crates/weaverd/src/safety_harness/transaction/content_transaction_tests.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 
 use super::{
     super::{ContentChange, ContentTransaction, SafetyHarnessError, TransactionOutcome},
-    test_support::{LockFailureKind, temp_file},
+    test_support::{LockFailureKind, file_exists, open_workspace_dir, read_file, temp_file},
 };
 use crate::safety_harness::{
     error::VerificationFailure,
@@ -16,35 +16,6 @@ use crate::safety_harness::{
         SyntacticLock,
     },
 };
-
-fn open_workspace_dir(path: &std::path::Path) -> cap_std::fs::Dir {
-    match cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority()) {
-        Ok(dir) => dir,
-        Err(error) => panic!("open workspace dir: {error}"),
-    }
-}
-
-fn read_file(path: &std::path::Path) -> Result<String, String> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| String::from("path has no parent"))?;
-    let filename = path
-        .file_name()
-        .ok_or_else(|| String::from("path has no file name"))?;
-    open_workspace_dir(parent)
-        .read_to_string(filename)
-        .map_err(|e| format!("read file: {e}"))
-}
-
-fn file_exists(path: &std::path::Path) -> bool {
-    let Some(parent) = path.parent() else {
-        return false;
-    };
-    let Some(filename) = path.file_name() else {
-        return false;
-    };
-    open_workspace_dir(parent).metadata(filename).is_ok()
-}
 
 fn build_content_transaction<'a>(
     syntactic: &'a dyn SyntacticLock,
@@ -73,7 +44,7 @@ fn content_transaction_commits_writes_and_deletes() -> Result<(), String> {
         String::from("hello world"),
     ));
     transaction.add_change(ContentChange::delete(delete_path.clone()));
-    let workspace_dir = open_workspace_dir(dir.path());
+    let workspace_dir = open_workspace_dir(dir.path())?;
 
     let outcome = transaction
         .execute(&workspace_dir, dir.path())
@@ -81,7 +52,7 @@ fn content_transaction_commits_writes_and_deletes() -> Result<(), String> {
     assert!(matches!(outcome, TransactionOutcome::Committed { .. }));
     assert_eq!(outcome.files_modified(), Some(2));
     assert_eq!(read_file(&keep_path)?, "hello world");
-    assert!(!file_exists(&delete_path), "delete file should be removed");
+    assert!(!file_exists(&delete_path)?, "delete file should be removed");
     Ok(())
 }
 
@@ -114,7 +85,7 @@ fn content_transaction_rejects_lock_failure(
         keep_path.clone(),
         delete_path.clone(),
     );
-    let workspace_dir = open_workspace_dir(dir.path());
+    let workspace_dir = open_workspace_dir(dir.path())?;
     let outcome = transaction
         .execute(&workspace_dir, dir.path())
         .map_err(|e| format!("transaction failed: {e}"))?;
@@ -133,13 +104,13 @@ fn content_transaction_rejects_lock_failure(
         }
     }
     assert_eq!(read_file(&keep_path)?, "hello");
-    assert!(file_exists(&delete_path), "delete file should remain");
+    assert!(file_exists(&delete_path)?, "delete file should remain");
     Ok(())
 }
 
 #[test]
-fn content_transaction_rejects_missing_delete() {
-    let dir = TempDir::new().expect("temp dir");
+fn content_transaction_rejects_missing_delete() -> Result<(), String> {
+    let dir = TempDir::new().map_err(|e| format!("temp dir: {e}"))?;
     let missing = dir.path().join("missing.txt");
 
     let syntactic = ConfigurableSyntacticLock::passing();
@@ -147,10 +118,11 @@ fn content_transaction_rejects_missing_delete() {
 
     let mut transaction = ContentTransaction::new(&syntactic, &semantic);
     transaction.add_change(ContentChange::delete(missing.clone()));
-    let workspace_dir = open_workspace_dir(dir.path());
+    let workspace_dir = open_workspace_dir(dir.path())?;
 
     let error = transaction
         .execute(&workspace_dir, dir.path())
         .expect_err("should error");
     assert!(matches!(error, SafetyHarnessError::FileReadError { .. }));
+    Ok(())
 }

--- a/crates/weaverd/src/safety_harness/transaction/content_transaction_tests.rs
+++ b/crates/weaverd/src/safety_harness/transaction/content_transaction_tests.rs
@@ -17,6 +17,35 @@ use crate::safety_harness::{
     },
 };
 
+fn open_workspace_dir(path: &std::path::Path) -> cap_std::fs::Dir {
+    match cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority()) {
+        Ok(dir) => dir,
+        Err(error) => panic!("open workspace dir: {error}"),
+    }
+}
+
+fn read_file(path: &std::path::Path) -> Result<String, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| String::from("path has no parent"))?;
+    let filename = path
+        .file_name()
+        .ok_or_else(|| String::from("path has no file name"))?;
+    open_workspace_dir(parent)
+        .read_to_string(filename)
+        .map_err(|e| format!("read file: {e}"))
+}
+
+fn file_exists(path: &std::path::Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(filename) = path.file_name() else {
+        return false;
+    };
+    open_workspace_dir(parent).metadata(filename).is_ok()
+}
+
 fn build_content_transaction<'a>(
     syntactic: &'a dyn SyntacticLock,
     semantic: &'a dyn SemanticLock,
@@ -44,17 +73,15 @@ fn content_transaction_commits_writes_and_deletes() -> Result<(), String> {
         String::from("hello world"),
     ));
     transaction.add_change(ContentChange::delete(delete_path.clone()));
+    let workspace_dir = open_workspace_dir(dir.path());
 
     let outcome = transaction
-        .execute()
+        .execute(&workspace_dir, dir.path())
         .map_err(|e| format!("transaction failed: {e}"))?;
     assert!(matches!(outcome, TransactionOutcome::Committed { .. }));
     assert_eq!(outcome.files_modified(), Some(2));
-    assert_eq!(
-        std::fs::read_to_string(&keep_path).map_err(|e| format!("read keep file: {e}"))?,
-        "hello world"
-    );
-    assert!(!delete_path.exists(), "delete file should be removed");
+    assert_eq!(read_file(&keep_path)?, "hello world");
+    assert!(!file_exists(&delete_path), "delete file should be removed");
     Ok(())
 }
 
@@ -87,8 +114,9 @@ fn content_transaction_rejects_lock_failure(
         keep_path.clone(),
         delete_path.clone(),
     );
+    let workspace_dir = open_workspace_dir(dir.path());
     let outcome = transaction
-        .execute()
+        .execute(&workspace_dir, dir.path())
         .map_err(|e| format!("transaction failed: {e}"))?;
     match kind {
         LockFailureKind::Syntactic => {
@@ -104,11 +132,8 @@ fn content_transaction_rejects_lock_failure(
             ));
         }
     }
-    assert_eq!(
-        std::fs::read_to_string(&keep_path).map_err(|e| format!("read keep file: {e}"))?,
-        "hello"
-    );
-    assert!(delete_path.exists(), "delete file should remain");
+    assert_eq!(read_file(&keep_path)?, "hello");
+    assert!(file_exists(&delete_path), "delete file should remain");
     Ok(())
 }
 
@@ -122,7 +147,10 @@ fn content_transaction_rejects_missing_delete() {
 
     let mut transaction = ContentTransaction::new(&syntactic, &semantic);
     transaction.add_change(ContentChange::delete(missing.clone()));
+    let workspace_dir = open_workspace_dir(dir.path());
 
-    let error = transaction.execute().expect_err("should error");
+    let error = transaction
+        .execute(&workspace_dir, dir.path())
+        .expect_err("should error");
     assert!(matches!(error, SafetyHarnessError::FileReadError { .. }));
 }

--- a/crates/weaverd/src/safety_harness/transaction/test_support.rs
+++ b/crates/weaverd/src/safety_harness/transaction/test_support.rs
@@ -1,14 +1,16 @@
 //! Shared helpers for transaction tests.
 
-use std::{fs, io::Write, path::PathBuf};
+use std::path::PathBuf;
 
 use tempfile::TempDir;
 
 /// Creates a temporary file with the given content.
 pub(super) fn temp_file(dir: &TempDir, name: &str, content: &str) -> Result<PathBuf, String> {
     let path = dir.path().join(name);
-    let mut file = fs::File::create(&path).map_err(|e| format!("create temp file: {e}"))?;
-    file.write_all(content.as_bytes())
+    let workspace = cap_std::fs::Dir::open_ambient_dir(dir.path(), cap_std::ambient_authority())
+        .map_err(|e| format!("open temp dir: {e}"))?;
+    workspace
+        .write(name, content)
         .map_err(|e| format!("write temp file: {e}"))?;
     Ok(path)
 }

--- a/crates/weaverd/src/safety_harness/transaction/test_support.rs
+++ b/crates/weaverd/src/safety_harness/transaction/test_support.rs
@@ -1,14 +1,43 @@
 //! Shared helpers for transaction tests.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
+
+/// Opens a workspace directory capability for transaction tests.
+pub(crate) fn open_workspace_dir(path: &Path) -> Result<cap_std::fs::Dir, String> {
+    cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority())
+        .map_err(|e| format!("open workspace dir: {e}"))
+}
+
+/// Reads a test file through its parent directory capability.
+pub(crate) fn read_file(path: &Path) -> Result<String, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| String::from("path has no parent"))?;
+    let filename = path
+        .file_name()
+        .ok_or_else(|| String::from("path has no file name"))?;
+    open_workspace_dir(parent)?
+        .read_to_string(filename)
+        .map_err(|e| format!("read file: {e}"))
+}
+
+/// Checks whether a test file exists through its parent directory capability.
+pub(crate) fn file_exists(path: &Path) -> Result<bool, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| String::from("path has no parent"))?;
+    let filename = path
+        .file_name()
+        .ok_or_else(|| String::from("path has no file name"))?;
+    Ok(open_workspace_dir(parent)?.metadata(filename).is_ok())
+}
 
 /// Creates a temporary file with the given content.
 pub(super) fn temp_file(dir: &TempDir, name: &str, content: &str) -> Result<PathBuf, String> {
     let path = dir.path().join(name);
-    let workspace = cap_std::fs::Dir::open_ambient_dir(dir.path(), cap_std::ambient_authority())
-        .map_err(|e| format!("open temp dir: {e}"))?;
+    let workspace = open_workspace_dir(dir.path())?;
     workspace
         .write(name, content)
         .map_err(|e| format!("write temp file: {e}"))?;

--- a/crates/weaverd/src/safety_harness/transaction/test_support.rs
+++ b/crates/weaverd/src/safety_harness/transaction/test_support.rs
@@ -31,7 +31,12 @@ pub(crate) fn file_exists(path: &Path) -> Result<bool, String> {
     let filename = path
         .file_name()
         .ok_or_else(|| String::from("path has no file name"))?;
-    Ok(open_workspace_dir(parent)?.metadata(filename).is_ok())
+    let dir = open_workspace_dir(parent)?;
+    match dir.metadata(filename) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(format!("file_exists metadata error: {err}")),
+    }
 }
 
 /// Creates a temporary file with the given content.

--- a/crates/weaverd/src/safety_harness/transaction/tests.rs
+++ b/crates/weaverd/src/safety_harness/transaction/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for edit and content transaction management.
 
-use std::{fs, path::PathBuf};
+use std::path::{Path, PathBuf};
 
 use rstest::rstest;
 use tempfile::TempDir;
@@ -30,11 +30,8 @@ fn failure_scenario_builder() -> TransactionTestBuilder {
 }
 
 /// Asserts that the file at the given path contains "hello world".
-fn assert_file_unchanged(path: &PathBuf) {
-    let content = match fs::read_to_string(path) {
-        Ok(content) => content,
-        Err(error) => panic!("read file: {error}"),
-    };
+fn assert_file_unchanged(path: &Path) {
+    let content = read_file(path);
     assert_eq!(content, "hello world");
 }
 
@@ -91,6 +88,30 @@ struct TransactionTestBuilder {
     dir: TempDir,
     files: Vec<(PathBuf, String)>,
     edits: Vec<FileEdit>,
+}
+
+fn open_workspace_dir(path: &std::path::Path) -> cap_std::fs::Dir {
+    match cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority()) {
+        Ok(dir) => dir,
+        Err(error) => panic!("open workspace dir: {error}"),
+    }
+}
+
+fn read_file(path: &std::path::Path) -> String {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let filename = path.file_name().unwrap_or_default();
+    let dir = open_workspace_dir(parent);
+    match dir.read_to_string(filename) {
+        Ok(content) => content,
+        Err(error) => panic!("read file: {error}"),
+    }
+}
+
+fn file_exists(path: &std::path::Path) -> bool {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let filename = path.file_name().unwrap_or_default();
+    let dir = open_workspace_dir(parent);
+    dir.metadata(filename).is_ok()
 }
 
 impl TransactionTestBuilder {
@@ -167,7 +188,8 @@ impl TransactionTestBuilder {
         for edit in self.edits {
             transaction.add_edit(edit);
         }
-        let outcome = transaction.execute();
+        let workspace_dir = open_workspace_dir(self.dir.path());
+        let outcome = transaction.execute(&workspace_dir, self.dir.path());
         (outcome, paths, self.dir)
     }
 }
@@ -177,8 +199,12 @@ fn empty_transaction_returns_no_changes() {
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::passing();
     let transaction = EditTransaction::new(&syntactic, &semantic);
+    let dir = TempDir::new().expect("create temp dir");
+    let workspace_dir = open_workspace_dir(dir.path());
 
-    let outcome = transaction.execute().expect("should succeed");
+    let outcome = transaction
+        .execute(&workspace_dir, dir.path())
+        .expect("should succeed");
     assert!(matches!(outcome, TransactionOutcome::NoChanges));
 }
 
@@ -197,7 +223,7 @@ fn successful_transaction_commits_changes() {
     assert!(outcome.committed());
     assert_eq!(outcome.files_modified(), Some(1));
 
-    let content = fs::read_to_string(&paths[0]).expect("read file");
+    let content = read_file(&paths[0]);
     assert_eq!(content, "greetings world");
 }
 
@@ -260,7 +286,7 @@ fn handles_new_file_creation() {
         .with_insert_edit(0, "new content");
 
     // Path doesn't exist yet
-    assert!(!builder.file_path(0).exists());
+    assert!(!file_exists(builder.file_path(0)));
 
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::passing();
@@ -270,7 +296,7 @@ fn handles_new_file_creation() {
 
     assert!(outcome.committed());
 
-    let content = fs::read_to_string(&paths[0]).expect("read file");
+    let content = read_file(&paths[0]);
     assert_eq!(content, "new content");
 }
 
@@ -303,9 +329,12 @@ fn handles_multiple_files() {
     let mut transaction = EditTransaction::new(&syntactic, &semantic);
     transaction.add_edits([edit1, edit2]);
 
-    let outcome = transaction.execute().expect("should succeed");
+    let workspace_dir = open_workspace_dir(dir.path());
+    let outcome = transaction
+        .execute(&workspace_dir, dir.path())
+        .expect("should succeed");
     assert_eq!(outcome.files_modified(), Some(2));
 
-    assert_eq!(fs::read_to_string(&path1).expect("read"), "AAA");
-    assert_eq!(fs::read_to_string(&path2).expect("read"), "BBB");
+    assert_eq!(read_file(&path1), "AAA");
+    assert_eq!(read_file(&path2), "BBB");
 }

--- a/crates/weaverd/src/safety_harness/transaction/tests.rs
+++ b/crates/weaverd/src/safety_harness/transaction/tests.rs
@@ -9,7 +9,7 @@ use super::{
     EditTransaction,
     SafetyHarnessError,
     TransactionOutcome,
-    test_support::{LockFailureKind, temp_file},
+    test_support::{LockFailureKind, file_exists, open_workspace_dir, read_file, temp_file},
 };
 use crate::safety_harness::{
     edit::{FileEdit, Position, TextEdit},
@@ -30,16 +30,17 @@ fn failure_scenario_builder() -> TransactionTestBuilder {
 }
 
 /// Asserts that the file at the given path contains "hello world".
-fn assert_file_unchanged(path: &Path) {
-    let content = read_file(path);
+fn assert_file_unchanged(path: &Path) -> Result<(), String> {
+    let content = read_file(path)?;
     assert_eq!(content, "hello world");
+    Ok(())
 }
 
 /// Tests lock failure scenarios, eliminating duplication between syntactic and semantic tests.
 ///
 /// The `configure_locks` closure receives the file path and returns configured locks.
 /// The `verify_outcome` closure performs test-specific assertions on the outcome.
-fn test_lock_failure<F, V>(configure_locks: F, verify_outcome: V)
+fn test_lock_failure<F, V>(configure_locks: F, verify_outcome: V) -> Result<(), String>
 where
     F: FnOnce(PathBuf) -> (ConfigurableSyntacticLock, ConfigurableSemanticLock),
     V: FnOnce(&TransactionOutcome),
@@ -48,14 +49,15 @@ where
     let path = builder.file_path(0).clone();
     let (syntactic, semantic) = configure_locks(path.clone());
 
-    let (result, _, _dir) = builder.execute_with_locks(&syntactic, &semantic);
+    let (result, _, _dir) = builder.execute_with_locks(&syntactic, &semantic)?;
     let outcome = match result {
         Ok(outcome) => outcome,
         Err(error) => panic!("should succeed: {error}"),
     };
 
     verify_outcome(&outcome);
-    assert_file_unchanged(&path);
+    assert_file_unchanged(&path)?;
+    Ok(())
 }
 
 /// Parameter object for line replacement edits.
@@ -90,29 +92,11 @@ struct TransactionTestBuilder {
     edits: Vec<FileEdit>,
 }
 
-fn open_workspace_dir(path: &std::path::Path) -> cap_std::fs::Dir {
-    match cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority()) {
-        Ok(dir) => dir,
-        Err(error) => panic!("open workspace dir: {error}"),
-    }
-}
-
-fn read_file(path: &std::path::Path) -> String {
-    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let filename = path.file_name().unwrap_or_default();
-    let dir = open_workspace_dir(parent);
-    match dir.read_to_string(filename) {
-        Ok(content) => content,
-        Err(error) => panic!("read file: {error}"),
-    }
-}
-
-fn file_exists(path: &std::path::Path) -> bool {
-    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let filename = path.file_name().unwrap_or_default();
-    let dir = open_workspace_dir(parent);
-    dir.metadata(filename).is_ok()
-}
+type TransactionExecution = (
+    Result<TransactionOutcome, SafetyHarnessError>,
+    Vec<PathBuf>,
+    TempDir,
+);
 
 impl TransactionTestBuilder {
     /// Creates a new builder with a fresh temporary directory.
@@ -178,38 +162,35 @@ impl TransactionTestBuilder {
         self,
         syntactic: &dyn SyntacticLock,
         semantic: &dyn SemanticLock,
-    ) -> (
-        Result<TransactionOutcome, SafetyHarnessError>,
-        Vec<PathBuf>,
-        TempDir,
-    ) {
+    ) -> Result<TransactionExecution, String> {
         let paths: Vec<PathBuf> = self.files.iter().map(|(p, _)| p.clone()).collect();
         let mut transaction = EditTransaction::new(syntactic, semantic);
         for edit in self.edits {
             transaction.add_edit(edit);
         }
-        let workspace_dir = open_workspace_dir(self.dir.path());
+        let workspace_dir = open_workspace_dir(self.dir.path())?;
         let outcome = transaction.execute(&workspace_dir, self.dir.path());
-        (outcome, paths, self.dir)
+        Ok((outcome, paths, self.dir))
     }
 }
 
 #[test]
-fn empty_transaction_returns_no_changes() {
+fn empty_transaction_returns_no_changes() -> Result<(), String> {
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::passing();
     let transaction = EditTransaction::new(&syntactic, &semantic);
-    let dir = TempDir::new().expect("create temp dir");
-    let workspace_dir = open_workspace_dir(dir.path());
+    let dir = TempDir::new().map_err(|e| format!("create temp dir: {e}"))?;
+    let workspace_dir = open_workspace_dir(dir.path())?;
 
     let outcome = transaction
         .execute(&workspace_dir, dir.path())
         .expect("should succeed");
     assert!(matches!(outcome, TransactionOutcome::NoChanges));
+    Ok(())
 }
 
 #[test]
-fn successful_transaction_commits_changes() {
+fn successful_transaction_commits_changes() -> Result<(), String> {
     let builder = TransactionTestBuilder::new()
         .with_file("test.txt", "hello world")
         .with_replacement_edit(0, LineReplacement::from_start(5, "greetings"));
@@ -217,20 +198,21 @@ fn successful_transaction_commits_changes() {
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::passing();
 
-    let (result, paths, _dir) = builder.execute_with_locks(&syntactic, &semantic);
+    let (result, paths, _dir) = builder.execute_with_locks(&syntactic, &semantic)?;
     let outcome = result.expect("should succeed");
 
     assert!(outcome.committed());
     assert_eq!(outcome.files_modified(), Some(1));
 
-    let content = read_file(&paths[0]);
+    let content = read_file(&paths[0])?;
     assert_eq!(content, "greetings world");
+    Ok(())
 }
 
 #[rstest]
 #[case::syntactic(LockFailureKind::Syntactic)]
 #[case::semantic(LockFailureKind::Semantic)]
-fn lock_failure_prevents_commit(#[case] kind: LockFailureKind) {
+fn lock_failure_prevents_commit(#[case] kind: LockFailureKind) -> Result<(), String> {
     let configure_locks = |path: PathBuf| -> (ConfigurableSyntacticLock, ConfigurableSemanticLock) {
         let failures = vec![VerificationFailure::new(path, "test error")];
         match kind {
@@ -260,51 +242,52 @@ fn lock_failure_prevents_commit(#[case] kind: LockFailureKind) {
         }
     };
 
-    test_lock_failure(configure_locks, verify_outcome);
+    test_lock_failure(configure_locks, verify_outcome)
 }
 
 #[test]
-fn semantic_backend_error_propagates() {
+fn semantic_backend_error_propagates() -> Result<(), String> {
     let builder = failure_scenario_builder();
     let path = builder.file_path(0).clone();
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::unavailable("LSP crashed");
 
-    let (result, _, _dir) = builder.execute_with_locks(&syntactic, &semantic);
+    let (result, _, _dir) = builder.execute_with_locks(&syntactic, &semantic)?;
     assert!(result.is_err());
     assert!(matches!(
         result.expect_err("should propagate backend error"),
         SafetyHarnessError::SemanticBackendUnavailable { .. }
     ));
-    assert_file_unchanged(&path);
+    assert_file_unchanged(&path)
 }
 
 #[test]
-fn handles_new_file_creation() {
+fn handles_new_file_creation() -> Result<(), String> {
     let builder = TransactionTestBuilder::new()
         .with_new_file_path("new_file.txt")
         .with_insert_edit(0, "new content");
 
     // Path doesn't exist yet
-    assert!(!file_exists(builder.file_path(0)));
+    assert!(!file_exists(builder.file_path(0))?);
 
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::passing();
 
-    let (result, paths, _dir) = builder.execute_with_locks(&syntactic, &semantic);
+    let (result, paths, _dir) = builder.execute_with_locks(&syntactic, &semantic)?;
     let outcome = result.expect("should succeed");
 
     assert!(outcome.committed());
 
-    let content = read_file(&paths[0]);
+    let content = read_file(&paths[0])?;
     assert_eq!(content, "new content");
+    Ok(())
 }
 
 #[test]
-fn handles_multiple_files() {
-    let dir = TempDir::new().expect("create temp dir");
-    let path1 = temp_file(&dir, "file1.txt", "aaa").expect("temp file");
-    let path2 = temp_file(&dir, "file2.txt", "bbb").expect("temp file");
+fn handles_multiple_files() -> Result<(), String> {
+    let dir = TempDir::new().map_err(|e| format!("create temp dir: {e}"))?;
+    let path1 = temp_file(&dir, "file1.txt", "aaa")?;
+    let path2 = temp_file(&dir, "file2.txt", "bbb")?;
 
     let edit1 = FileEdit::with_edits(
         path1.clone(),
@@ -329,12 +312,13 @@ fn handles_multiple_files() {
     let mut transaction = EditTransaction::new(&syntactic, &semantic);
     transaction.add_edits([edit1, edit2]);
 
-    let workspace_dir = open_workspace_dir(dir.path());
+    let workspace_dir = open_workspace_dir(dir.path())?;
     let outcome = transaction
         .execute(&workspace_dir, dir.path())
         .expect("should succeed");
     assert_eq!(outcome.files_modified(), Some(2));
 
-    assert_eq!(read_file(&path1), "AAA");
-    assert_eq!(read_file(&path2), "BBB");
+    assert_eq!(read_file(&path1)?, "AAA");
+    assert_eq!(read_file(&path2)?, "BBB");
+    Ok(())
 }

--- a/crates/weaverd/src/safety_harness/transaction/tests.rs
+++ b/crates/weaverd/src/safety_harness/transaction/tests.rs
@@ -23,10 +23,10 @@ use crate::safety_harness::{
 };
 
 /// Creates a standard failure scenario builder with a test file and replacement edit.
-fn failure_scenario_builder() -> TransactionTestBuilder {
-    TransactionTestBuilder::new()
-        .with_file("test.txt", "hello world")
-        .with_replacement_edit(0, LineReplacement::from_start(5, "greetings"))
+fn failure_scenario_builder() -> Result<TransactionTestBuilder, String> {
+    Ok(TransactionTestBuilder::new()?
+        .with_file("test.txt", "hello world")?
+        .with_replacement_edit(0, LineReplacement::from_start(5, "greetings")))
 }
 
 /// Asserts that the file at the given path contains "hello world".
@@ -45,15 +45,12 @@ where
     F: FnOnce(PathBuf) -> (ConfigurableSyntacticLock, ConfigurableSemanticLock),
     V: FnOnce(&TransactionOutcome),
 {
-    let builder = failure_scenario_builder();
+    let builder = failure_scenario_builder()?;
     let path = builder.file_path(0).clone();
     let (syntactic, semantic) = configure_locks(path.clone());
 
     let (result, _, _dir) = builder.execute_with_locks(&syntactic, &semantic)?;
-    let outcome = match result {
-        Ok(outcome) => outcome,
-        Err(error) => panic!("should succeed: {error}"),
-    };
+    let outcome = result.map_err(|e| format!("should succeed: {e}"))?;
 
     verify_outcome(&outcome);
     assert_file_unchanged(&path)?;
@@ -100,25 +97,19 @@ type TransactionExecution = (
 
 impl TransactionTestBuilder {
     /// Creates a new builder with a fresh temporary directory.
-    fn new() -> Self {
-        Self {
-            dir: match TempDir::new() {
-                Ok(dir) => dir,
-                Err(error) => panic!("create temp dir: {error}"),
-            },
+    fn new() -> Result<Self, String> {
+        Ok(Self {
+            dir: TempDir::new().map_err(|e| format!("create temp dir: {e}"))?,
             files: Vec::new(),
             edits: Vec::new(),
-        }
+        })
     }
 
     /// Creates a file with the given content and adds it to the tracked files.
-    fn with_file(mut self, name: &str, content: &str) -> Self {
-        let path = match temp_file(&self.dir, name, content) {
-            Ok(path) => path,
-            Err(error) => panic!("temp file: {error}"),
-        };
+    fn with_file(mut self, name: &str, content: &str) -> Result<Self, String> {
+        let path = temp_file(&self.dir, name, content).map_err(|e| format!("temp file: {e}"))?;
         self.files.push((path, content.to_string()));
-        self
+        Ok(self)
     }
 
     /// Adds a non-existent file path to the tracked files (for new file creation tests).
@@ -184,22 +175,22 @@ fn empty_transaction_returns_no_changes() -> Result<(), String> {
 
     let outcome = transaction
         .execute(&workspace_dir, dir.path())
-        .expect("should succeed");
+        .map_err(|e| format!("should succeed: {e}"))?;
     assert!(matches!(outcome, TransactionOutcome::NoChanges));
     Ok(())
 }
 
 #[test]
 fn successful_transaction_commits_changes() -> Result<(), String> {
-    let builder = TransactionTestBuilder::new()
-        .with_file("test.txt", "hello world")
+    let builder = TransactionTestBuilder::new()?
+        .with_file("test.txt", "hello world")?
         .with_replacement_edit(0, LineReplacement::from_start(5, "greetings"));
 
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::passing();
 
     let (result, paths, _dir) = builder.execute_with_locks(&syntactic, &semantic)?;
-    let outcome = result.expect("should succeed");
+    let outcome = result.map_err(|e| format!("should succeed: {e}"))?;
 
     assert!(outcome.committed());
     assert_eq!(outcome.files_modified(), Some(1));
@@ -247,7 +238,7 @@ fn lock_failure_prevents_commit(#[case] kind: LockFailureKind) -> Result<(), Str
 
 #[test]
 fn semantic_backend_error_propagates() -> Result<(), String> {
-    let builder = failure_scenario_builder();
+    let builder = failure_scenario_builder()?;
     let path = builder.file_path(0).clone();
     let syntactic = ConfigurableSyntacticLock::passing();
     let semantic = ConfigurableSemanticLock::unavailable("LSP crashed");
@@ -263,7 +254,7 @@ fn semantic_backend_error_propagates() -> Result<(), String> {
 
 #[test]
 fn handles_new_file_creation() -> Result<(), String> {
-    let builder = TransactionTestBuilder::new()
+    let builder = TransactionTestBuilder::new()?
         .with_new_file_path("new_file.txt")
         .with_insert_edit(0, "new content");
 
@@ -274,7 +265,7 @@ fn handles_new_file_creation() -> Result<(), String> {
     let semantic = ConfigurableSemanticLock::passing();
 
     let (result, paths, _dir) = builder.execute_with_locks(&syntactic, &semantic)?;
-    let outcome = result.expect("should succeed");
+    let outcome = result.map_err(|e| format!("should succeed: {e}"))?;
 
     assert!(outcome.committed());
 
@@ -315,7 +306,7 @@ fn handles_multiple_files() -> Result<(), String> {
     let workspace_dir = open_workspace_dir(dir.path())?;
     let outcome = transaction
         .execute(&workspace_dir, dir.path())
-        .expect("should succeed");
+        .map_err(|e| format!("should succeed: {e}"))?;
     assert_eq!(outcome.files_modified(), Some(2));
 
     assert_eq!(read_file(&path1)?, "AAA");

--- a/crates/weaverd/src/tests/apply_patch_behaviour.rs
+++ b/crates/weaverd/src/tests/apply_patch_behaviour.rs
@@ -1,6 +1,6 @@
 //! Behavioural tests for the apply-patch command.
 
-use std::{cell::RefCell, fs, path::PathBuf};
+use std::{cell::RefCell, path::PathBuf};
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
@@ -10,6 +10,7 @@ use weaver_test_macros::allow_fixture_expansion_lints;
 use crate::{
     dispatch::act::apply_patch::{ApplyPatchError, ApplyPatchExecutor, ApplyPatchFailure},
     safety_harness::{ConfigurableSemanticLock, ConfigurableSyntacticLock, VerificationFailure},
+    tests::support::fs as test_fs,
 };
 
 const DEFAULT_SOURCE: &str = "fn main() {\n    println!(\"Old Message\");\n}\n";
@@ -84,16 +85,18 @@ impl ApplyPatchWorld {
     fn create_file(&self, relative: &str, content: &str) {
         let path = self.path(relative);
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).expect("create parent dirs");
+            test_fs::create_dir_all(parent).expect("create parent dirs");
         }
-        fs::write(&path, content).expect("write file");
+        test_fs::write(&path, content).expect("write file");
     }
 
     fn read_file(&self, relative: &str) -> String {
-        fs::read_to_string(self.path(relative)).expect("read file")
+        test_fs::read_to_string(self.path(relative)).expect("read file")
     }
 
-    fn file_exists(&self, relative: &str) -> bool { self.path(relative).exists() }
+    fn file_exists(&self, relative: &str) -> bool {
+        test_fs::exists(self.path(relative)).expect("check file existence")
+    }
 
     fn path(&self, relative: &str) -> PathBuf { self.temp_dir.path().join(relative) }
 

--- a/crates/weaverd/src/tests/get_card_behaviour.rs
+++ b/crates/weaverd/src/tests/get_card_behaviour.rs
@@ -3,7 +3,6 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
-    fs,
     io::{BufRead, BufReader, Write},
     net::{SocketAddr, TcpStream},
     path::PathBuf,
@@ -22,6 +21,7 @@ use crate::{
     backends::FusionBackends,
     dispatch::{BackendManager, DispatchConnectionHandler},
     semantic_provider::SemanticBackendProvider,
+    tests::support::fs as test_fs,
     transport::{ListenerHandle, SocketListener},
 };
 
@@ -94,7 +94,7 @@ impl GetCardWorld {
 
     fn write_fixture(&mut self, key: &str, name: &str, source: &str) {
         let path = self.temp_dir.path().join(name);
-        fs::write(&path, source).expect("write fixture");
+        test_fs::write(&path, source).expect("write fixture");
         let uri = Url::from_file_path(&path).expect("file uri").to_string();
         self.paths.insert(String::from(key), path);
         self.uris.insert(String::from(key), uri);
@@ -150,7 +150,7 @@ impl GetCardWorld {
 
     fn rewrite_fixture(&mut self, key: &str, source: &str) {
         let path = self.paths.get(key).expect("fixture path");
-        fs::write(path, source).expect("rewrite fixture");
+        test_fs::write(path, source).expect("rewrite fixture");
     }
 
     fn latest_stdout_contains(&self, needle: &str) -> bool { self.stdout_contains(needle) }

--- a/crates/weaverd/src/tests/mod.rs
+++ b/crates/weaverd/src/tests/mod.rs
@@ -9,5 +9,5 @@ mod process_behaviour;
 mod safety_harness_behaviour;
 mod safety_harness_types;
 mod socket_behaviour;
-mod support;
+pub(crate) mod support;
 mod unit;

--- a/crates/weaverd/src/tests/process_behaviour.rs
+++ b/crates/weaverd/src/tests/process_behaviour.rs
@@ -1,6 +1,6 @@
 //! Behavioural tests covering daemon process supervision and lifecycle files.
 
-use std::{cell::RefCell, fs};
+use std::cell::RefCell;
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
@@ -8,7 +8,7 @@ use weaver_test_macros::allow_fixture_expansion_lints;
 
 use crate::{
     process::{LaunchError, LaunchMode},
-    tests::support::{ProcessTestWorld, snapshot_status},
+    tests::support::{ProcessTestWorld, fs as test_fs, snapshot_status},
 };
 
 #[allow_fixture_expansion_lints]
@@ -87,7 +87,7 @@ fn then_lock_file_exists(world: &RefCell<ProcessTestWorld>) {
     world
         .borrow()
         .wait_for_condition(
-            |state| state.lock_path().exists(),
+            |state| test_fs::exists(state.lock_path()).expect("check lock file"),
             "lock file to be written",
         )
         .expect("lock file should exist whilst daemon is running");
@@ -98,12 +98,15 @@ fn then_pid_file_exists(world: &RefCell<ProcessTestWorld>) {
     {
         let world_ref = world.borrow();
         world_ref
-            .wait_for_condition(|state| state.pid_path().exists(), "pid file to be written")
+            .wait_for_condition(
+                |state| test_fs::exists(state.pid_path()).expect("check pid file"),
+                "pid file to be written",
+            )
             .expect("pid file should be written");
     }
     let world = world.borrow();
     let path = world.pid_path();
-    let content = fs::read_to_string(&path).expect("pid file should be readable");
+    let content = test_fs::read_to_string(&path).expect("pid file should be readable");
     let pid: u32 = content
         .trim()
         .parse()
@@ -156,15 +159,15 @@ fn then_health_stopping(world: &RefCell<ProcessTestWorld>) {
 fn then_runtime_removed(world: &RefCell<ProcessTestWorld>) {
     let world = world.borrow();
     assert!(
-        !world.lock_path().exists(),
+        !test_fs::exists(world.lock_path()).expect("check lock file"),
         "lock file should be removed after shutdown",
     );
     assert!(
-        !world.pid_path().exists(),
+        !test_fs::exists(world.pid_path()).expect("check pid file"),
         "pid file should be removed after shutdown",
     );
     assert!(
-        !world.health_path().exists(),
+        !test_fs::exists(world.health_path()).expect("check health file"),
         "health file should be removed after shutdown",
     );
 }

--- a/crates/weaverd/src/tests/safety_harness_behaviour.rs
+++ b/crates/weaverd/src/tests/safety_harness_behaviour.rs
@@ -1,6 +1,6 @@
 //! Behavioural tests for the Double-Lock safety harness.
 
-use std::{cell::RefCell, collections::HashMap, fs, io::Write, path::PathBuf};
+use std::{cell::RefCell, collections::HashMap, path::PathBuf};
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
@@ -8,20 +8,23 @@ use tempfile::TempDir;
 use weaver_test_macros::allow_fixture_expansion_lints;
 
 use super::safety_harness_types::{DiagnosticMessage, FileContent, FileName, TextPattern};
-use crate::safety_harness::{
-    ConfigurableSemanticLock,
-    ConfigurableSyntacticLock,
-    EditTransaction,
-    FileEdit,
-    Position,
-    SafetyHarnessError,
-    SyntacticLock,
-    SyntacticLockResult,
-    TextEdit,
-    TransactionOutcome,
-    TreeSitterSyntacticLockAdapter,
-    VerificationContext,
-    VerificationFailure,
+use crate::{
+    safety_harness::{
+        ConfigurableSemanticLock,
+        ConfigurableSyntacticLock,
+        EditTransaction,
+        FileEdit,
+        Position,
+        SafetyHarnessError,
+        SyntacticLock,
+        SyntacticLockResult,
+        TextEdit,
+        TransactionOutcome,
+        TreeSitterSyntacticLockAdapter,
+        VerificationContext,
+        VerificationFailure,
+    },
+    tests::support::fs as test_fs,
 };
 
 /// Syntactic lock variant for BDD test scenarios.
@@ -74,8 +77,7 @@ impl SafetyHarnessWorld {
     /// Creates a file with the given content.
     fn create_file(&mut self, name: &FileName, content: &FileContent) {
         let path = name.to_path(self.temp_dir.path());
-        let mut file = fs::File::create(&path).expect("create file");
-        file.write_all(content.as_bytes()).expect("write content");
+        test_fs::write(&path, content.as_bytes()).expect("write content");
         let name_str = name.as_str().to_string();
         self.files.insert(name_str.clone(), path);
         self.original_content
@@ -104,14 +106,14 @@ impl SafetyHarnessWorld {
     /// Reads the current content of a file.
     fn read_file(&self, name: &FileName) -> String {
         let path = self.file_path(name);
-        fs::read_to_string(&path).expect("read file")
+        test_fs::read_to_string(&path).expect("read file")
     }
 
     /// Adds an edit that replaces text.
     fn add_replacement_edit(&mut self, name: &FileName, old: &TextPattern, new: &TextPattern) {
         let path = self.file_path(name);
-        let content = if path.exists() {
-            fs::read_to_string(&path).expect("read file")
+        let content = if test_fs::exists(&path).expect("check file existence") {
+            test_fs::read_to_string(&path).expect("read file")
         } else {
             String::new()
         };
@@ -148,7 +150,10 @@ impl SafetyHarnessWorld {
         for edit in self.pending_edits.drain(..) {
             transaction.add_edit(edit);
         }
-        self.outcome = Some(transaction.execute());
+        let workspace_dir =
+            cap_std::fs::Dir::open_ambient_dir(self.temp_dir.path(), cap_std::ambient_authority())
+                .expect("open workspace dir");
+        self.outcome = Some(transaction.execute(&workspace_dir, self.temp_dir.path()));
     }
 
     /// Returns the transaction outcome.
@@ -171,7 +176,10 @@ fn given_source_file(world: &RefCell<SafetyHarnessWorld>, name: FileName, conten
 #[given("no existing file {name}")]
 fn given_no_file(world: &RefCell<SafetyHarnessWorld>, name: FileName) {
     let path = world.borrow().file_path(&name);
-    assert!(!path.exists(), "file should not exist: {path:?}");
+    assert!(
+        !test_fs::exists(&path).expect("check file existence"),
+        "file should not exist: {path:?}"
+    );
 }
 
 #[given("a syntactic lock that passes")]

--- a/crates/weaverd/src/tests/support/fs.rs
+++ b/crates/weaverd/src/tests/support/fs.rs
@@ -1,0 +1,29 @@
+//! Capability-based filesystem helpers for tests.
+
+use std::{io, path::Path};
+
+use crate::cap_fs::open_parent_dir;
+
+pub fn write(path: impl AsRef<Path>, content: impl AsRef<[u8]>) -> io::Result<()> {
+    let (dir, filename) = open_parent_dir(path.as_ref())?;
+    dir.write(filename, content)
+}
+
+pub fn read_to_string(path: impl AsRef<Path>) -> io::Result<String> {
+    let (dir, filename) = open_parent_dir(path.as_ref())?;
+    dir.read_to_string(filename)
+}
+
+pub fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
+    let (dir, filename) = open_parent_dir(path.as_ref())?;
+    dir.create_dir_all(filename)
+}
+
+pub fn exists(path: impl AsRef<Path>) -> io::Result<bool> {
+    let (dir, filename) = open_parent_dir(path.as_ref())?;
+    match dir.metadata(filename) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/weaverd/src/tests/support/fs.rs
+++ b/crates/weaverd/src/tests/support/fs.rs
@@ -4,21 +4,55 @@ use std::{io, path::Path};
 
 use crate::cap_fs::open_parent_dir;
 
+/// Writes `content` to `path` through the capability-backed parent directory.
+///
+/// `path` identifies the target file, and `content` provides the bytes to
+/// persist.
+///
+/// Returns `Ok(())` when the write succeeds.
+///
+/// Propagates any I/O error from locating the parent directory or performing
+/// the write.
 pub fn write(path: impl AsRef<Path>, content: impl AsRef<[u8]>) -> io::Result<()> {
     let (dir, filename) = open_parent_dir(path.as_ref())?;
     dir.write(filename, content)
 }
 
+/// Reads the file at `path` into a UTF-8 `String`.
+///
+/// `path` identifies the file to read.
+///
+/// Returns the file contents on success.
+///
+/// Propagates any I/O error from locating the parent directory or reading the
+/// file contents.
 pub fn read_to_string(path: impl AsRef<Path>) -> io::Result<String> {
     let (dir, filename) = open_parent_dir(path.as_ref())?;
     dir.read_to_string(filename)
 }
 
+/// Creates `path` and all missing parent directories through the parent
+/// capability.
+///
+/// `path` identifies the directory to create.
+///
+/// Returns `Ok(())` when the directory tree exists.
+///
+/// Propagates any I/O error from locating the parent directory or creating
+/// the directory tree.
 pub fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
     let (dir, filename) = open_parent_dir(path.as_ref())?;
     dir.create_dir_all(filename)
 }
 
+/// Checks whether `path` exists using the parent capability.
+///
+/// `path` identifies the file or directory to probe.
+///
+/// Returns `Ok(true)` when the path exists and `Ok(false)` when it does not.
+///
+/// Propagates any I/O error from locating the parent directory or querying
+/// metadata.
 pub fn exists(path: impl AsRef<Path>) -> io::Result<bool> {
     let (dir, filename) = open_parent_dir(path.as_ref())?;
     match dir.metadata(filename) {

--- a/crates/weaverd/src/tests/support/mod.rs
+++ b/crates/weaverd/src/tests/support/mod.rs
@@ -2,6 +2,7 @@
 
 mod backend_provider;
 mod config_loader;
+pub mod fs;
 mod process_world;
 mod reporter;
 mod world;

--- a/crates/weaverd/src/tests/support/process_world.rs
+++ b/crates/weaverd/src/tests/support/process_world.rs
@@ -2,7 +2,6 @@
 
 use std::{
     cell::RefCell,
-    fs,
     path::PathBuf,
     sync::{
         Arc,
@@ -26,7 +25,7 @@ use crate::{
         shutdown::{ShutdownError, ShutdownSignal},
         test_support,
     },
-    tests::support::{FailingConfigLoader, RecordingHealthReporter, TestConfigLoader},
+    tests::support::{FailingConfigLoader, RecordingHealthReporter, TestConfigLoader, fs},
 };
 
 pub const WAIT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -223,7 +222,7 @@ impl ProcessTestWorld {
                 .any(|status| status == expected)
     }
 
-    pub fn lock_exists(&self) -> bool { self.lock_path().exists() }
+    pub fn lock_exists(&self) -> bool { fs::exists(self.lock_path()).expect("check lock file") }
 
     pub fn daemonizer_calls(&self) -> usize { self.daemonizer.calls() }
 

--- a/crates/weaverd/src/transport/listener_tests.rs
+++ b/crates/weaverd/src/transport/listener_tests.rs
@@ -81,10 +81,8 @@ fn unix_listener_cleans_stale_socket_files(
     {
         let _stale = std::os::unix::net::UnixListener::bind(&path).expect("bind stale listener");
     }
-    assert!(
-        test_fs::exists(&path).expect("check stale socket"),
-        "stale socket should remain"
-    );
+    let exists = test_fs::exists(&path).map_err(|e| format!("check stale socket: {e}"))?;
+    assert!(exists, "stale socket should remain");
 
     let endpoint = SocketEndpoint::unix(path.to_str().expect("utf8 path").to_string());
     let listener = SocketListener::bind(&endpoint).expect("bind new listener");
@@ -95,10 +93,8 @@ fn unix_listener_cleans_stale_socket_files(
 
     handle.shutdown();
     handle.join().expect("join listener");
-    assert!(
-        !test_fs::exists(&path).expect("check unix socket"),
-        "listener should remove unix socket on shutdown"
-    );
+    let exists = test_fs::exists(&path).map_err(|e| format!("check unix socket: {e}"))?;
+    assert!(!exists, "listener should remove unix socket on shutdown");
     Ok(())
 }
 

--- a/crates/weaverd/src/transport/listener_tests.rs
+++ b/crates/weaverd/src/transport/listener_tests.rs
@@ -14,6 +14,7 @@ use weaver_config::SocketEndpoint;
 use weaver_test_macros::allow_fixture_expansion_lints;
 
 use super::{ConnectionHandler, CountingHandler, ListenerError, listener::SocketListener};
+use crate::tests::support::fs as test_fs;
 
 #[derive(Clone)]
 struct CountingFixture {
@@ -80,7 +81,10 @@ fn unix_listener_cleans_stale_socket_files(
     {
         let _stale = std::os::unix::net::UnixListener::bind(&path).expect("bind stale listener");
     }
-    assert!(path.exists(), "stale socket should remain");
+    assert!(
+        test_fs::exists(&path).expect("check stale socket"),
+        "stale socket should remain"
+    );
 
     let endpoint = SocketEndpoint::unix(path.to_str().expect("utf8 path").to_string());
     let listener = SocketListener::bind(&endpoint).expect("bind new listener");
@@ -92,7 +96,7 @@ fn unix_listener_cleans_stale_socket_files(
     handle.shutdown();
     handle.join().expect("join listener");
     assert!(
-        !path.exists(),
+        !test_fs::exists(&path).expect("check unix socket"),
         "listener should remove unix socket on shutdown"
     );
     Ok(())

--- a/crates/weaverd/src/transport/listener_unix.rs
+++ b/crates/weaverd/src/transport/listener_unix.rs
@@ -51,11 +51,14 @@ fn remove_stale_unix_socket(dir: &Dir, filename: &Path, path: &Path) -> Result<(
             path: path.display().to_string(),
         }),
         Err(error) if stale_unix_socket_error(&error) => {
-            dir.remove_file(filename)
-                .map_err(|source| ListenerError::UnixCleanup {
+            if let Err(source) = dir.remove_file(filename)
+                && source.kind() != io::ErrorKind::NotFound
+            {
+                return Err(ListenerError::UnixCleanup {
                     path: path.display().to_string(),
                     source,
-                })?;
+                });
+            }
             Ok(())
         }
         Err(error) => Err(ListenerError::UnixConnect {
@@ -112,7 +115,7 @@ fn socket_parent_dir(path: &Path) -> Result<(Dir, PathBuf), ListenerError> {
 }
 
 fn socket_path_exists(dir: &Dir, filename: &Path, path: &Path) -> Result<bool, ListenerError> {
-    match dir.metadata(filename) {
+    match dir.symlink_metadata(filename) {
         Ok(_) => Ok(true),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
         Err(source) => Err(ListenerError::UnixMetadata {

--- a/crates/weaverd/src/transport/listener_unix.rs
+++ b/crates/weaverd/src/transport/listener_unix.rs
@@ -1,15 +1,12 @@
 //! Unix-socket helpers for the daemon listener.
 
 use std::{
-    fs,
     io,
-    os::unix::{
-        fs::FileTypeExt,
-        net::{UnixListener, UnixStream},
-    },
-    path::Path,
+    os::unix::net::{UnixListener, UnixStream},
+    path::{Path, PathBuf},
 };
 
+use cap_std::fs::{Dir, FileTypeExt};
 use tracing::warn;
 use weaver_config::SocketEndpoint;
 
@@ -24,18 +21,21 @@ pub(super) fn bind_unix(path: &Path) -> Result<UnixListener, ListenerError> {
 }
 
 fn ensure_bindable_unix_path(path: &Path) -> Result<(), ListenerError> {
-    if !path.exists() {
+    let (dir, filename) = socket_parent_dir(path)?;
+    if !socket_path_exists(&dir, &filename, path)? {
         return Ok(());
     }
-    ensure_unix_socket_file(path)?;
-    remove_stale_unix_socket(path)
+    ensure_unix_socket_file(&dir, &filename, path)?;
+    remove_stale_unix_socket(&dir, &filename, path)
 }
 
-fn ensure_unix_socket_file(path: &Path) -> Result<(), ListenerError> {
-    let metadata = fs::symlink_metadata(path).map_err(|source| ListenerError::UnixMetadata {
-        path: path.display().to_string(),
-        source,
-    })?;
+fn ensure_unix_socket_file(dir: &Dir, filename: &Path, path: &Path) -> Result<(), ListenerError> {
+    let metadata =
+        dir.symlink_metadata(filename)
+            .map_err(|source| ListenerError::UnixMetadata {
+                path: path.display().to_string(),
+                source,
+            })?;
     if metadata.file_type().is_socket() {
         Ok(())
     } else {
@@ -45,16 +45,17 @@ fn ensure_unix_socket_file(path: &Path) -> Result<(), ListenerError> {
     }
 }
 
-fn remove_stale_unix_socket(path: &Path) -> Result<(), ListenerError> {
+fn remove_stale_unix_socket(dir: &Dir, filename: &Path, path: &Path) -> Result<(), ListenerError> {
     match UnixStream::connect(path) {
         Ok(_stream) => Err(ListenerError::UnixInUse {
             path: path.display().to_string(),
         }),
         Err(error) if stale_unix_socket_error(&error) => {
-            fs::remove_file(path).map_err(|source| ListenerError::UnixCleanup {
-                path: path.display().to_string(),
-                source,
-            })?;
+            dir.remove_file(filename)
+                .map_err(|source| ListenerError::UnixCleanup {
+                    path: path.display().to_string(),
+                    source,
+                })?;
             Ok(())
         }
         Err(error) => Err(ListenerError::UnixConnect {
@@ -75,7 +76,10 @@ pub(super) fn cleanup_unix_socket(endpoint: &SocketEndpoint) {
     let SocketEndpoint::Unix { path } = endpoint else {
         return;
     };
-    if let Err(error) = fs::remove_file(path.as_std_path())
+    let Ok((dir, filename)) = socket_parent_dir(path.as_std_path()) else {
+        return;
+    };
+    if let Err(error) = dir.remove_file(filename)
         && error.kind() != io::ErrorKind::NotFound
     {
         warn!(
@@ -84,5 +88,36 @@ pub(super) fn cleanup_unix_socket(endpoint: &SocketEndpoint) {
             path = %path,
             "failed to remove unix socket file"
         );
+    }
+}
+
+fn socket_parent_dir(path: &Path) -> Result<(Dir, PathBuf), ListenerError> {
+    let parent = path.parent().ok_or_else(|| ListenerError::UnixMetadata {
+        path: path.display().to_string(),
+        source: io::Error::new(io::ErrorKind::InvalidInput, "socket path has no parent"),
+    })?;
+    let filename = path
+        .file_name()
+        .ok_or_else(|| ListenerError::UnixMetadata {
+            path: path.display().to_string(),
+            source: io::Error::new(io::ErrorKind::InvalidInput, "socket path has no file name"),
+        })?;
+    let dir = Dir::open_ambient_dir(parent, cap_std::ambient_authority()).map_err(|source| {
+        ListenerError::UnixMetadata {
+            path: path.display().to_string(),
+            source,
+        }
+    })?;
+    Ok((dir, PathBuf::from(filename)))
+}
+
+fn socket_path_exists(dir: &Dir, filename: &Path, path: &Path) -> Result<bool, ListenerError> {
+    match dir.metadata(filename) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(ListenerError::UnixMetadata {
+            path: path.display().to_string(),
+            source,
+        }),
     }
 }

--- a/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
+++ b/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
@@ -26,10 +26,10 @@ Observable behaviour after implementation:
 
 1. `weaver observe graph-slice --uri <Uniform Resource Identifier (URI)>
    --position <LINE:COL>
-   ` parses into a typed request with explicit default values for `depth`, `
-   direction`, `edge_types`, `min_confidence`, `budget.max_cards`, `
-   budget.max_edges`, `budget.max_estimated_tokens`, `entry_detail`, and `
-   node_detail`.
+   ` parses into a typed request with explicit default values for `depth`,
+   `direction`, `edge_types`, `min_confidence`, `budget.max_cards`,
+   `budget.max_edges`, `budget.max_estimated_tokens`, `entry_detail`,
+   and `node_detail`.
 2. Stable JSON snapshots lock at least one successful slice, one
    truncated slice with spillover metadata, and one structured refusal.
 3. Every serialized edge reports its resolution scope as exactly one of

--- a/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
+++ b/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
@@ -25,11 +25,10 @@ constraints, and any spillover that was excluded when the traversal truncated.
 Observable behaviour after implementation:
 
 1. `weaver observe graph-slice --uri <Uniform Resource Identifier (URI)>
-   --position <LINE:COL>
-   ` parses into a typed request with explicit default values for `depth`,
-   `direction`, `edge_types`, `min_confidence`, `budget.max_cards`,
-   `budget.max_edges`, `budget.max_estimated_tokens`, `entry_detail`,
-   and `node_detail`.
+   --position <LINE:COL>` parses into a typed request with explicit default
+   values for `depth`, `direction`, `edge_types`, `min_confidence`,
+   `budget.max_cards`, `budget.max_edges`, `budget.max_estimated_tokens`,
+   `entry_detail`, and `node_detail`.
 2. Stable JSON snapshots lock at least one successful slice, one
    truncated slice with spillover metadata, and one structured refusal.
 3. Every serialized edge reports its resolution scope as exactly one of

--- a/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
+++ b/docs/execplans/7-2-1-define-stable-jsonl-request-and-response-schemas-for-observe-graph-slice.md
@@ -4,10 +4,9 @@
 > in [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md);
 > dotted task references are archive numbers unless explicitly stated otherwise.
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -26,9 +25,9 @@ constraints, and any spillover that was excluded when the traversal truncated.
 Observable behaviour after implementation:
 
 1. `weaver observe graph-slice --uri <Uniform Resource Identifier (URI)>
-   --position
-   <LINE:COL>` parses into a typed request with explicit default values for `
-   depth`, `direction`, `edge_types`, `min_confidence`, `budget.max_cards`, `
+   --position <LINE:COL>
+   ` parses into a typed request with explicit default values for `depth`, `
+   direction`, `edge_types`, `min_confidence`, `budget.max_cards`, `
    budget.max_edges`, `budget.max_estimated_tokens`, `entry_detail`, and `
    node_detail`.
 2. Stable JSON snapshots lock at least one successful slice, one
@@ -78,9 +77,9 @@ This plan covers roadmap item 7.2.1 in
    must use `assert_cmd` and `insta`.
 8. Documentation updates are part of the feature:
    [docs/jacquard-card-first-symbol-graph-design.md](../jacquard-card-first-symbol-graph-design.md),
-   [docs/users-guide.md](../users-guide.md), and
-   [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md) must
-   all be updated before the work is complete.
+   [docs/users-guide.md](../users-guide.md),
+   and [docs/archive/prototype-roadmap.md](../archive/prototype-roadmap.md)
+   must all be updated before the work is complete.
 9. The roadmap checkbox for 7.2.1 must not be marked done until all code,
    tests, e2e snapshots, documentation, and validation gates pass.
 
@@ -166,7 +165,7 @@ This plan covers roadmap item 7.2.1 in
 - There is no `observe graph-slice` implementation yet anywhere in the
   codebase. The current observe router in
   [crates/weaverd/src/dispatch/router.rs](../../crates/weaverd/src/dispatch/router.rs)
-   only recognizes `get-definition`, `find-references`, `grep`, `diagnostics`,
+  only recognizes `get-definition`, `find-references`, `grep`, `diagnostics`,
   `call-hierarchy`, and `get-card`.
 - `crates/weaver-cards/` already matches the stable-contract pattern used
   for `observe get-card`: request parsing, serde schema types, snapshot tests,
@@ -198,8 +197,8 @@ This plan covers roadmap item 7.2.1 in
 - The local Markdown formatter toolchain in this runner is partially broken:
   `fd` is unavailable and `/root/.local/bin/mdtablefix` is an empty,
   non-executable file. `make fmt` still completed successfully by using a
-  temporary PATH shim and then relying on `make markdownlint`, `make nixie`,
-  and `make check-fmt` to verify the resulting tree.
+  temporary PATH shim and then relying on `make markdownlint`, `make nixie`, and
+  `make check-fmt` to verify the resulting tree.
 - Review follow-up found one contract hole that the original milestone left
   open: the parser accepted `--max-cards 0` even though the runtime always
   returned at least the entry card. The fix now enforces `max_cards >= 1` at
@@ -239,7 +238,7 @@ This plan covers roadmap item 7.2.1 in
   card/slice surfaces aligned.
 - Decision: record all of these schema decisions back into
   [docs/jacquard-card-first-symbol-graph-design.md](../jacquard-card-first-symbol-graph-design.md)
-   during implementation, so the design stays authoritative.
+  during implementation, so the design stays authoritative.
 - Decision: implement a deterministic same-file schema exercise in the daemon
   for 7.2.1 instead of keeping the operation refusal-only. Rationale: this
   delivers real success responses and budget-driven truncation for the stable
@@ -450,7 +449,7 @@ Expected files:
   [crates/weaverd/src/dispatch/observe/graph_slice.rs](../../crates/weaverd/src/dispatch/observe/graph_slice.rs)
 - CLI discoverability surfaces in
   [crates/weaver-cli/src/discoverability.rs](../../crates/weaver-cli/src/discoverability.rs)
-   and any related help/localization files
+  and any related help/localization files
 
 This milestone should keep the runtime narrow:
 
@@ -498,7 +497,7 @@ Expected files:
   [crates/weaver-e2e/tests/test_support/mod.rs](../../crates/weaver-e2e/tests/test_support/mod.rs)
 - a dedicated
   [crates/weaver-e2e/src/graph_slice_fixtures/](../../crates/weaver-e2e/src/graph_slice_fixtures/)
-   module tree for graph-shaped workspaces
+  module tree for graph-shaped workspaces
 
 The e2e suite must cover:
 

--- a/dylint.toml
+++ b/dylint.toml
@@ -2,6 +2,5 @@
 # require std::fs access:
 # - weaver_sandbox: provides filesystem isolation and sandboxing capabilities
 # - weaver_config: performs configuration file I/O operations
-# - weaverd: daemon requires direct filesystem access for runtime operations
 [no_std_fs_operations]
-excluded_crates = ["weaver_sandbox", "weaver_config", "weaverd"]
+excluded_crates = ["weaver_sandbox", "weaver_config"]


### PR DESCRIPTION
Summary
- Refactor weaverd runtime, transaction, apply-patch, dispatch read, and Unix socket cleanup paths to use cap_std::fs::Dir capabilities.
- Add shared capability helpers for daemon and test filesystem operations.
- Remove weaverd from the Whitaker no_std_fs_operations exclusion list.

Closes #49

Validation
- make check-fmt
- make lint
- make test
- whitaker --all -- --workspace --all-targets --all-features
- coderabbit review --agent: fixed reported findings; final retry was blocked by CodeRabbit service rate limit after local gates passed.

## Summary by Sourcery

Adopt capability-based filesystem access throughout the weaverd daemon, routing runtime, transaction, patch-application, and Unix socket operations through cap-std directory capabilities and shared helpers while updating tests and lint configuration accordingly.

Enhancements:
- Refactor content and edit transactions, patch application, and Unix socket lifecycle to operate via cap_std::fs::Dir capabilities instead of direct std::fs access.
- Introduce shared capability-based filesystem helpers for daemon runtime artefacts, dispatch filesystem reads, and test code to centralize path handling and parent-directory resolution.
- Tighten workspace path validation for apply-patch by separating absolute and relative paths and enforcing symlink and traversal checks through capability handles.
- Adjust process guard and launch logic to open and reuse a runtime directory capability for PID, health, and lock file management.

Build:
- Add cap-std as a dependency for the weaverd crate and enable capability-based filesystem APIs.

CI:
- Update the Dylint no_std_fs_operations configuration to remove weaverd from the exclusion list, enforcing the new capability-based filesystem access patterns.

Tests:
- Update daemon, dispatch, transaction, and integration tests to use capability-based filesystem helpers and to pass workspace/runtime directory capabilities into transaction execution and path resolution.