### PR TITLE
Deepen formula semantic invariant properties (#112)

### DIFF
--- a/crates/sempai/src/tests/property_tests.rs
+++ b/crates/sempai/src/tests/property_tests.rs
@@ -156,19 +156,32 @@ fn tree_with_not() -> BoxedStrategy<Decorated<Formula>> {
         .boxed()
 }
 
-fn or_with_not_descendant() -> BoxedStrategy<Decorated<Formula>> {
+fn nary_with_required_branch<S, R, W>(
+    sibling: S,
+    required: R,
+    wrap: W,
+) -> BoxedStrategy<Decorated<Formula>>
+where
+    S: Strategy<Value = Decorated<Formula>> + Clone + 'static,
+    R: Strategy<Value = Decorated<Formula>> + 'static,
+    W: Fn(Vec<Decorated<Formula>>) -> Formula + Send + Sync + Clone + 'static,
+{
     (
-        vec(formula_tree(), 0..=2),
-        tree_with_not(),
-        vec(formula_tree(), 0..=2),
+        vec(sibling.clone(), 0..=2),
+        required,
+        vec(sibling, 0..=2),
         span_strategy(),
     )
-        .prop_map(|(mut before, not_branch, after, span)| {
-            before.push(not_branch);
+        .prop_map(move |(mut before, required_branch, after, span)| {
+            before.push(required_branch);
             before.extend(after);
-            decorated(Formula::Or(before), span)
+            decorated(wrap(before), span)
         })
         .boxed()
+}
+
+fn or_with_not_descendant() -> BoxedStrategy<Decorated<Formula>> {
+    nary_with_required_branch(formula_tree(), tree_with_not(), Formula::Or)
 }
 
 fn atomless_tree_without_not_in_or() -> BoxedStrategy<Decorated<Formula>> {
@@ -193,18 +206,11 @@ fn atomless_tree_without_not_in_or() -> BoxedStrategy<Decorated<Formula>> {
 }
 
 fn and_without_positive_descendant() -> BoxedStrategy<Decorated<Formula>> {
-    (
-        vec(atomless_tree_without_not_in_or(), 0..=2),
+    nary_with_required_branch(
+        atomless_tree_without_not_in_or(),
         deep_atomless(MIN_PROPERTY_DEPTH - 1),
-        vec(atomless_tree_without_not_in_or(), 0..=2),
-        span_strategy(),
+        Formula::And,
     )
-        .prop_map(|(mut before, required, after, span)| {
-            before.push(required);
-            before.extend(after);
-            decorated(Formula::And(before), span)
-        })
-        .boxed()
 }
 
 fn valid_no_not_tree() -> BoxedStrategy<Decorated<Formula>> {

--- a/crates/sempai/src/tests/property_tests.rs
+++ b/crates/sempai/src/tests/property_tests.rs
@@ -12,6 +12,7 @@ use crate::semantic_check::validate_formula;
 const MAX_DEPTH: u32 = 5;
 const MAX_SIZE: u32 = 32;
 const MAX_BRANCHES: u32 = 3;
+const MIN_PROPERTY_DEPTH: usize = 4;
 
 fn decorated(node: Formula, span: Option<SourceSpan>) -> Decorated<Formula> {
     Decorated {
@@ -50,6 +51,75 @@ fn atom_strategy() -> BoxedStrategy<Decorated<Formula>> {
         .boxed()
 }
 
+fn unary_node(variant: u8, child: Decorated<Formula>) -> Formula {
+    match variant {
+        0 => Formula::Not(Box::new(child)),
+        1 => Formula::Inside(Box::new(child)),
+        _ => Formula::Anywhere(Box::new(child)),
+    }
+}
+
+fn valid_unary_node(is_inside: bool, child: Decorated<Formula>) -> Formula {
+    if is_inside {
+        Formula::Inside(Box::new(child))
+    } else {
+        Formula::Anywhere(Box::new(child))
+    }
+}
+
+fn deep_atom(min_depth: usize) -> BoxedStrategy<Decorated<Formula>> {
+    if min_depth <= 1 {
+        return atom_strategy();
+    }
+
+    (any::<bool>(), deep_atom(min_depth - 1), span_strategy())
+        .prop_map(|(is_inside, child, span)| decorated(valid_unary_node(is_inside, child), span))
+        .boxed()
+}
+
+fn deep_constraint_atom(min_depth: usize) -> BoxedStrategy<Decorated<Formula>> {
+    if min_depth <= 1 {
+        return atom_strategy();
+    }
+
+    (
+        any::<bool>(),
+        deep_constraint_atom(min_depth - 1),
+        span_strategy(),
+    )
+        .prop_map(|(is_not, child, span)| {
+            let node = if is_not {
+                Formula::Not(Box::new(child))
+            } else {
+                Formula::Inside(Box::new(child))
+            };
+            decorated(node, span)
+        })
+        .boxed()
+}
+
+fn deep_positive_atom(min_depth: usize) -> BoxedStrategy<Decorated<Formula>> {
+    if min_depth <= 1 {
+        return atom_strategy();
+    }
+
+    (deep_positive_atom(min_depth - 1), span_strategy())
+        .prop_map(|(child, span)| decorated(Formula::Or(vec![child]), span))
+        .boxed()
+}
+
+fn deep_atomless(min_depth: usize) -> BoxedStrategy<Decorated<Formula>> {
+    if min_depth <= 1 {
+        return span_strategy()
+            .prop_map(|span| decorated(Formula::And(vec![]), span))
+            .boxed();
+    }
+
+    (0_u8..3, deep_atomless(min_depth - 1), span_strategy())
+        .prop_map(|(variant, child, span)| decorated(unary_node(variant, child), span))
+        .boxed()
+}
+
 fn formula_tree() -> BoxedStrategy<Decorated<Formula>> {
     atom_strategy()
         .prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
@@ -81,7 +151,7 @@ fn formula_tree() -> BoxedStrategy<Decorated<Formula>> {
 }
 
 fn tree_with_not() -> BoxedStrategy<Decorated<Formula>> {
-    (formula_tree(), span_strategy())
+    (deep_atom(MIN_PROPERTY_DEPTH - 1), span_strategy())
         .prop_map(|(child, span)| decorated(Formula::Not(Box::new(child)), span))
         .boxed()
 }
@@ -124,15 +194,21 @@ fn atomless_tree_without_not_in_or() -> BoxedStrategy<Decorated<Formula>> {
 
 fn and_without_positive_descendant() -> BoxedStrategy<Decorated<Formula>> {
     (
-        vec(atomless_tree_without_not_in_or(), 0..=MAX_BRANCHES as usize),
+        vec(atomless_tree_without_not_in_or(), 0..=2),
+        deep_atomless(MIN_PROPERTY_DEPTH - 1),
+        vec(atomless_tree_without_not_in_or(), 0..=2),
         span_strategy(),
     )
-        .prop_map(|(branches, span)| decorated(Formula::And(branches), span))
+        .prop_map(|(mut before, required, after, span)| {
+            before.push(required);
+            before.extend(after);
+            decorated(Formula::And(before), span)
+        })
         .boxed()
 }
 
 fn valid_no_not_tree() -> BoxedStrategy<Decorated<Formula>> {
-    atom_strategy()
+    deep_atom(MIN_PROPERTY_DEPTH)
         .prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
             let unary = (any::<bool>(), inner.clone(), span_strategy()).prop_map(
                 |(is_inside, child, span)| {
@@ -152,17 +228,18 @@ fn valid_no_not_tree() -> BoxedStrategy<Decorated<Formula>> {
 }
 
 fn positive_tree() -> BoxedStrategy<Decorated<Formula>> {
-    atom_strategy()
+    deep_positive_atom(MIN_PROPERTY_DEPTH)
         .prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
-            let constraint =
-                (0_u8..3, atom_strategy(), span_strategy()).prop_map(|(variant, child, span)| {
+            let constraint = (0_u8..3, deep_constraint_atom(2), span_strategy()).prop_map(
+                |(variant, child, span)| {
                     let node = match variant {
                         0 => Formula::Not(Box::new(child)),
                         1 => Formula::Inside(Box::new(child)),
                         _ => Formula::Anywhere(Box::new(child)),
                     };
                     decorated(node, span)
-                });
+                },
+            );
             let and = (
                 vec(prop_oneof![inner.clone(), constraint], 0..=2),
                 inner.clone(),
@@ -176,7 +253,7 @@ fn positive_tree() -> BoxedStrategy<Decorated<Formula>> {
                 });
             let or = (
                 vec(valid_no_not_tree(), 0..=2),
-                atom_strategy(),
+                deep_positive_atom(MIN_PROPERTY_DEPTH - 1),
                 vec(valid_no_not_tree(), 0..=2),
                 span_strategy(),
             )
@@ -188,6 +265,18 @@ fn positive_tree() -> BoxedStrategy<Decorated<Formula>> {
             prop_oneof![and, or, inner]
         })
         .boxed()
+}
+
+fn tree_depth(formula: &Decorated<Formula>) -> usize {
+    match &formula.node {
+        Formula::Atom(_) => 1,
+        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
+            1 + tree_depth(inner)
+        }
+        Formula::And(branches) | Formula::Or(branches) => {
+            1 + branches.iter().map(tree_depth).max().unwrap_or_default()
+        }
+    }
 }
 
 fn first_diagnostic_code(formula: &Decorated<Formula>) -> DiagnosticCode {
@@ -207,6 +296,8 @@ proptest! {
 
     #[test]
     fn prop_or_branch_containing_negation_is_rejected(formula in or_with_not_descendant()) {
+        prop_assert!(tree_depth(&formula) >= MIN_PROPERTY_DEPTH);
+
         prop_assert_eq!(
             first_diagnostic_code(&formula),
             DiagnosticCode::ESempaiInvalidNotInOr
@@ -215,6 +306,8 @@ proptest! {
 
     #[test]
     fn prop_and_with_no_positive_term_is_rejected(formula in and_without_positive_descendant()) {
+        prop_assert!(tree_depth(&formula) >= MIN_PROPERTY_DEPTH);
+
         let expected_span = formula
             .span
             .clone()
@@ -234,6 +327,8 @@ proptest! {
 
     #[test]
     fn prop_valid_tree_with_positive_in_every_and_is_ok(formula in positive_tree()) {
+        prop_assert!(tree_depth(&formula) >= MIN_PROPERTY_DEPTH);
+
         prop_assert!(validate_formula(&formula).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

This branch deepens the property coverage for issue #112 by making the `sempai`
semantic invariant generators produce formula trees with at least four levels of
nesting. It keeps `proptest` as the existing `crates/sempai` dev-dependency,
adds depth-enforced generators for positive, constraint-only and atomless
formula shapes, and asserts the depth guarantee inside each property.

Closes #112.

## Review walkthrough

- Start with [crates/sempai/src/tests/property_tests.rs](https://github.com/leynos/weaver/blob/a60f95c8ca6a047481ad46969365905423b63e3f/crates/sempai/src/tests/property_tests.rs) to review the new depth-enforced strategies and `tree_depth` assertion helper.
- Then review the three property tests in the same file to see how `InvalidNotInOr`, `MissingPositiveTermInAnd`, and valid positive trees now exercise nested formula structures.

## Validation

- `cargo test -p sempai`: passed.
- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed; nextest ran 1,389 tests and workspace doctests passed.
- `git diff --check`: passed.

## Notes

`coderabbit review --agent` was attempted three times after the implementation
milestone, including after the reported wait windows. Each attempt stopped before
review with a recoverable CodeRabbit rate-limit error, so there were no review
concerns to clear locally.

## Summary by Sourcery

Strengthen semantic invariant property tests by generating and asserting on deeper, more complex formula trees.

Enhancements:
- Introduce depth-aware formula generator helpers for various formula shapes used in property tests.

Tests:
- Enforce a minimum tree depth for key formula-generating strategies and assert this invariant in the relevant property tests to exercise nested structures more thoroughly.