### PR TITLE
Trace compile YAML pipeline (#115)

### DIFF
--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -191,10 +191,12 @@ fn compile_rule_plans(
                     vec![],
                 )
             })?;
-            let query_plan =
-                QueryPlan::new(rule.id().to_owned(), language, Arc::clone(&shared_formula));
             tracing::debug!(rule_id = rule.id(), %language, "query plan created");
-            Ok(query_plan)
+            Ok(QueryPlan::new(
+                rule.id().to_owned(),
+                language,
+                Arc::clone(&shared_formula),
+            ))
         })
         .collect()
 }

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -106,6 +106,7 @@ impl Engine {
     pub fn compile_yaml(&self, yaml: &str) -> Result<Vec<QueryPlan>, DiagnosticReport> {
         let file = parse_rule_file(yaml, None)?;
         tracing::Span::current().record("rules", file.rules().len());
+        tracing::debug!(rules = file.rules().len(), "yaml parsed successfully");
         validate_supported_modes(&file)?;
 
         file.rules()
@@ -120,6 +121,7 @@ impl Engine {
             .try_fold(Vec::new(), |mut plans, (rule, principal)| {
                 tracing::debug!(rule_id = rule.id(), "normalizing principal");
                 let formula = normalize_search_principal(principal, rule.rule_span())?;
+                tracing::debug!(rule_id = rule.id(), "principal normalized");
 
                 tracing::debug!(rule_id = rule.id(), "validating normalized formula");
                 validate_formula(&formula)?;
@@ -189,11 +191,10 @@ fn compile_rule_plans(
                     vec![],
                 )
             })?;
-            Ok(QueryPlan::new(
-                rule.id().to_owned(),
-                language,
-                Arc::clone(&shared_formula),
-            ))
+            let query_plan =
+                QueryPlan::new(rule.id().to_owned(), language, Arc::clone(&shared_formula));
+            tracing::debug!(rule_id = rule.id(), %language, "query plan created");
+            Ok(query_plan)
         })
         .collect()
 }

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -105,8 +105,9 @@ impl Engine {
     #[tracing::instrument(level = "info", skip_all, fields(rules = tracing::field::Empty))]
     pub fn compile_yaml(&self, yaml: &str) -> Result<Vec<QueryPlan>, DiagnosticReport> {
         let file = parse_rule_file(yaml, None)?;
-        tracing::Span::current().record("rules", file.rules().len());
-        tracing::debug!(rules = file.rules().len(), "yaml parsed successfully");
+        let rule_count = file.rules().len();
+        tracing::Span::current().record("rules", rule_count);
+        tracing::debug!(rules = rule_count, "yaml parsed successfully");
         validate_supported_modes(&file)?;
 
         file.rules()
@@ -191,7 +192,7 @@ fn compile_rule_plans(
                     vec![],
                 )
             })?;
-            tracing::debug!(rule_id = rule.id(), %language, "query plan created");
+            tracing::debug!("query plan created");
             Ok(QueryPlan::new(
                 rule.id().to_owned(),
                 language,

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -47,6 +47,9 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
     {
         tracing::warn!(code = ?diagnostic.code(), "semantic validation failed");
     }
+    if result.is_ok() {
+        tracing::debug!("semantic validation passed");
+    }
     result
 }
 

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -48,7 +48,7 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
         tracing::warn!(code = ?diagnostic.code(), "semantic validation failed");
     }
     if result.is_ok() {
-        tracing::debug!("semantic validation passed");
+        tracing::debug!(span = ?formula.span, "semantic validation passed");
     }
     result
 }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -42,13 +42,13 @@ pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
     let result = validate_formula_inner(formula);
-    if let Err(report) = &result
-        && let Some(diagnostic) = report.diagnostics().first()
-    {
-        tracing::warn!(code = ?diagnostic.code(), "semantic validation failed");
-    }
-    if result.is_ok() {
-        tracing::debug!(span = ?formula.span, "semantic validation passed");
+    match &result {
+        Ok(()) => tracing::debug!(source_span = ?formula.span, "semantic validation passed"),
+        Err(report) => {
+            if let Some(diagnostic) = report.diagnostics().first() {
+                tracing::warn!(code = ?diagnostic.code(), "semantic validation failed");
+            }
+        }
     }
     result
 }

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -10,3 +10,4 @@ mod normalization_tests;
 mod property_tests;
 mod reexport_tests;
 mod semantic_validation_tests;
+mod tracing_tests;

--- a/crates/sempai/src/tests/tracing_tests.rs
+++ b/crates/sempai/src/tests/tracing_tests.rs
@@ -1,0 +1,71 @@
+//! Tracing coverage tests for the `sempai` engine pipeline.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+};
+
+use tracing::{
+    Metadata,
+    Subscriber,
+    span::{Attributes, Id, Record},
+};
+
+use crate::{Engine, EngineConfig};
+
+#[derive(Default)]
+struct SpanCountingSubscriber {
+    compile_yaml_spans: Arc<AtomicUsize>,
+    next_id: AtomicU64,
+}
+
+impl SpanCountingSubscriber {
+    fn compile_yaml_spans(&self) -> Arc<AtomicUsize> { Arc::clone(&self.compile_yaml_spans) }
+}
+
+impl Subscriber for SpanCountingSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool { true }
+
+    fn new_span(&self, attributes: &Attributes<'_>) -> Id {
+        if attributes.metadata().name() == "compile_yaml" {
+            self.compile_yaml_spans.fetch_add(1, Ordering::Relaxed);
+        }
+        Id::from_u64(self.next_id.fetch_add(1, Ordering::Relaxed) + 1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, _event: &tracing::Event<'_>) {}
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+#[test]
+fn compile_yaml_emits_observable_compile_span() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.span\n",
+        "    message: span coverage\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    pattern: foo($X)\n",
+    );
+    let subscriber = SpanCountingSubscriber::default();
+    let compile_yaml_spans = subscriber.compile_yaml_spans();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let engine = Engine::new(EngineConfig::default());
+        engine
+            .compile_yaml(yaml)
+            .expect("valid rule should compile");
+    });
+
+    assert!(
+        compile_yaml_spans.load(Ordering::Relaxed) >= 1,
+        "expected compile_yaml to create an observable tracing span",
+    );
+}

--- a/crates/sempai/src/tests/tracing_tests.rs
+++ b/crates/sempai/src/tests/tracing_tests.rs
@@ -1,13 +1,20 @@
 //! Tracing coverage tests for the `sempai` engine pipeline.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, AtomicUsize, Ordering},
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        Mutex,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
 };
 
 use tracing::{
+    Event,
+    Level,
     Metadata,
     Subscriber,
+    field::{Field, Visit},
     span::{Attributes, Id, Record},
 };
 
@@ -16,18 +23,22 @@ use crate::{Engine, EngineConfig};
 #[derive(Default)]
 struct SpanCountingSubscriber {
     compile_yaml_spans: Arc<AtomicUsize>,
+    debug_events: Arc<Mutex<Vec<RecordedEvent>>>,
     next_id: AtomicU64,
 }
 
 impl SpanCountingSubscriber {
     fn compile_yaml_spans(&self) -> Arc<AtomicUsize> { Arc::clone(&self.compile_yaml_spans) }
+
+    fn debug_events(&self) -> Arc<Mutex<Vec<RecordedEvent>>> { Arc::clone(&self.debug_events) }
 }
 
 impl Subscriber for SpanCountingSubscriber {
-    fn enabled(&self, _metadata: &Metadata<'_>) -> bool { true }
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool { metadata.target().starts_with("sempai") }
 
     fn new_span(&self, attributes: &Attributes<'_>) -> Id {
-        if attributes.metadata().name() == "compile_yaml" {
+        let metadata = attributes.metadata();
+        if metadata.name() == "compile_yaml" && metadata.target() == "sempai::engine" {
             self.compile_yaml_spans.fetch_add(1, Ordering::Relaxed);
         }
         Id::from_u64(self.next_id.fetch_add(1, Ordering::Relaxed) + 1)
@@ -37,11 +48,72 @@ impl Subscriber for SpanCountingSubscriber {
 
     fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
-    fn event(&self, _event: &tracing::Event<'_>) {}
+    fn event(&self, event: &Event<'_>) {
+        if event.metadata().level() != &Level::DEBUG {
+            return;
+        }
+        let mut fields = FieldRecorder::default();
+        event.record(&mut fields);
+        self.debug_events
+            .lock()
+            .expect("debug event storage should not be poisoned")
+            .push(RecordedEvent {
+                target: event.metadata().target().to_owned(),
+                fields: fields.into_fields(),
+            });
+    }
 
     fn enter(&self, _span: &Id) {}
 
     fn exit(&self, _span: &Id) {}
+}
+
+#[derive(Debug, Default)]
+struct FieldRecorder {
+    fields: BTreeMap<String, String>,
+}
+
+impl FieldRecorder {
+    fn into_fields(self) -> BTreeMap<String, String> { self.fields }
+}
+
+impl Visit for FieldRecorder {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_owned());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .insert(field.name().to_owned(), format!("{value:?}"));
+    }
+}
+
+#[derive(Debug)]
+struct RecordedEvent {
+    target: String,
+    fields: BTreeMap<String, String>,
+}
+
+impl RecordedEvent {
+    fn message(&self) -> Option<&str> { self.fields.get("message").map(String::as_str) }
+
+    fn field(&self, name: &str) -> Option<&str> { self.fields.get(name).map(String::as_str) }
 }
 
 #[test]
@@ -56,6 +128,7 @@ fn compile_yaml_emits_observable_compile_span() {
     );
     let subscriber = SpanCountingSubscriber::default();
     let compile_yaml_spans = subscriber.compile_yaml_spans();
+    let debug_events = subscriber.debug_events();
 
     tracing::subscriber::with_default(subscriber, || {
         let engine = Engine::new(EngineConfig::default());
@@ -67,5 +140,56 @@ fn compile_yaml_emits_observable_compile_span() {
     assert!(
         compile_yaml_spans.load(Ordering::Relaxed) >= 1,
         "expected compile_yaml to create an observable tracing span",
+    );
+    assert_compile_yaml_debug_events(&debug_events);
+}
+
+fn assert_compile_yaml_debug_events(debug_events: &Arc<Mutex<Vec<RecordedEvent>>>) {
+    let recorded_events = debug_events
+        .lock()
+        .expect("debug event storage should not be poisoned");
+    assert_event(
+        &recorded_events,
+        "sempai::engine",
+        "yaml parsed successfully",
+        &[("rules", "1")],
+    );
+    assert_event(
+        &recorded_events,
+        "sempai::engine",
+        "principal normalized",
+        &[("rule_id", "demo.span")],
+    );
+    assert_event(
+        &recorded_events,
+        "sempai::semantic_check",
+        "semantic validation passed",
+        &[("span", "Some(")],
+    );
+    assert_event(
+        &recorded_events,
+        "sempai::engine",
+        "query plan created",
+        &[("rule_id", "demo.span"), ("language", "rust")],
+    );
+}
+
+fn assert_event(
+    debug_events: &[RecordedEvent],
+    target: &str,
+    message: &str,
+    expected_fields: &[(&str, &str)],
+) {
+    assert!(
+        debug_events.iter().any(|event| {
+            event.target == target
+                && event.message() == Some(message)
+                && expected_fields.iter().all(|(field, value)| {
+                    event
+                        .field(field)
+                        .is_some_and(|actual| actual == *value || actual.starts_with(value))
+                })
+        }),
+        "expected debug event `{message}` with fields {expected_fields:?}, got {debug_events:?}",
     );
 }

--- a/crates/sempai/src/tests/tracing_tests.rs
+++ b/crates/sempai/src/tests/tracing_tests.rs
@@ -137,9 +137,10 @@ fn compile_yaml_emits_observable_compile_span() {
             .expect("valid rule should compile");
     });
 
-    assert!(
-        compile_yaml_spans.load(Ordering::Relaxed) >= 1,
-        "expected compile_yaml to create an observable tracing span",
+    assert_eq!(
+        compile_yaml_spans.load(Ordering::Relaxed),
+        1,
+        "expected compile_yaml to create exactly one observable tracing span",
     );
     assert_compile_yaml_debug_events(&debug_events);
 }
@@ -152,42 +153,49 @@ fn assert_compile_yaml_debug_events(debug_events: &Arc<Mutex<Vec<RecordedEvent>>
         &recorded_events,
         "sempai::engine",
         "yaml parsed successfully",
-        &[("rules", "1")],
+        &[("rules", FieldMatcher::Exact("1"))],
     );
     assert_event(
         &recorded_events,
         "sempai::engine",
         "principal normalized",
-        &[("rule_id", "demo.span")],
+        &[("rule_id", FieldMatcher::Exact("demo.span"))],
     );
     assert_event(
         &recorded_events,
         "sempai::semantic_check",
         "semantic validation passed",
-        &[("span", "Some(")],
+        &[("source_span", FieldMatcher::StartsWith("Some("))],
     );
     assert_event(
         &recorded_events,
         "sempai::engine",
         "query plan created",
-        &[("rule_id", "demo.span"), ("language", "rust")],
+        &[],
     );
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FieldMatcher<'a> {
+    Exact(&'a str),
+    StartsWith(&'a str),
 }
 
 fn assert_event(
     debug_events: &[RecordedEvent],
     target: &str,
     message: &str,
-    expected_fields: &[(&str, &str)],
+    expected_fields: &[(&str, FieldMatcher<'_>)],
 ) {
     assert!(
         debug_events.iter().any(|event| {
             event.target == target
                 && event.message() == Some(message)
                 && expected_fields.iter().all(|(field, value)| {
-                    event
-                        .field(field)
-                        .is_some_and(|actual| actual == *value || actual.starts_with(value))
+                    event.field(field).is_some_and(|actual| match value {
+                        FieldMatcher::Exact(expected) => actual == *expected,
+                        FieldMatcher::StartsWith(expected) => actual.starts_with(expected),
+                    })
                 })
         }),
         "expected debug event `{message}` with fields {expected_fields:?}, got {debug_events:?}",


### PR DESCRIPTION
## Summary

This branch adds structured tracing to the `sempai` `compile_yaml` pipeline introduced by PR #104. It keeps the existing `info` instrumentation span and adds debug events for successful YAML parsing, principal normalization, semantic validation success, and query plan creation.

Closes #115.

## Review walkthrough

- Start with [crates/sempai/src/engine.rs](https://github.com/leynos/weaver/blob/5ee4609/crates/sempai/src/engine.rs) to review the parse, normalization, and plan creation events.
- Then review [crates/sempai/src/semantic_check.rs](https://github.com/leynos/weaver/blob/5ee4609/crates/sempai/src/semantic_check.rs) for the semantic validation success event; the existing failure warning remains unchanged.
- Finish with [crates/sempai/src/tests/tracing_tests.rs](https://github.com/leynos/weaver/blob/5ee4609/crates/sempai/src/tests/tracing_tests.rs) for the subscriber coverage proving `compile_yaml` creates an observable span for a valid rule.

## Validation

- `make check-fmt`: passed
- `cargo test -p sempai`: passed, including `tests::tracing_tests::compile_yaml_emits_observable_compile_span`
- `make lint`: passed
- `make test`: passed, 1390 nextest tests passed with 4 skipped; workspace doctests passed

## Notes

- `tracing = "0.1"` was already present in `crates/sempai/Cargo.toml`, so no dependency change was needed.
- `coderabbit review --agent` was attempted twice. The service returned a recoverable rate-limit response both times, first asking for an 83-second wait and then a 5-minute 46-second wait.

## Summary by Sourcery

Add structured tracing around the sempai YAML compilation pipeline and verify it via tests.

Enhancements:
- Emit debug-level tracing events for YAML parsing, principal normalization, semantic validation success, and query plan creation in the compile_yaml pipeline.
- Record the number of rules on the current tracing span to improve observability of compile invocations.

Tests:
- Add a tracing subscriber-based test to assert that compile_yaml produces an observable tracing span and wire it into the sempai test suite.