### PR TITLE
Document constraint validation boundary (#114)

### DIFF
--- a/crates/sempai-core/src/formula.rs
+++ b/crates/sempai-core/src/formula.rs
@@ -201,5 +201,9 @@ pub enum Constraint {
         pattern: String,
     },
     /// A currently unmodelled constraint, preserved lossily as JSON text.
+    ///
+    /// This is the sole format-aware exception in the core constraint model so
+    /// adapters can retain unknown shapes. New constraint variants must remain
+    /// format-agnostic domain types.
     Other(String),
 }

--- a/crates/sempai-core/src/formula.rs
+++ b/crates/sempai-core/src/formula.rs
@@ -179,6 +179,11 @@ pub struct WhereClause {
 }
 
 /// A normalized `where` constraint payload.
+///
+/// `Constraint` is a domain type rather than a serialized rule fragment. The
+/// `sempai` adapter crate is responsible for parsing YAML-backed JSON values
+/// into these variants before the formula reaches semantic validation or plan
+/// compilation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Constraint {
     /// A metavariable must match the given regular expression.

--- a/crates/sempai/src/engine.rs
+++ b/crates/sempai/src/engine.rs
@@ -20,7 +20,7 @@ use sempai_yaml::{Rule, RulePrincipal, parse_rule_file};
 use crate::{
     mode_validation::validate_supported_modes,
     normalize::normalize_search_principal,
-    semantic_check::validate_formula,
+    semantic_check::{validate_constraints, validate_formula},
 };
 
 /// A compiled query plan for one rule and target language.
@@ -123,6 +123,7 @@ impl Engine {
 
                 tracing::debug!(rule_id = rule.id(), "validating normalized formula");
                 validate_formula(&formula)?;
+                validate_constraints(&formula)?;
 
                 tracing::debug!(
                     rule_id = rule.id(),

--- a/crates/sempai/src/normalize_constraints.rs
+++ b/crates/sempai/src/normalize_constraints.rs
@@ -1,4 +1,9 @@
 //! Constraint parsing for canonical formula normalization.
+//!
+//! This module is the serialization boundary for rule `where` clauses. It
+//! accepts raw YAML-backed JSON values from the parser and lowers them into
+//! `sempai_core` domain constraints. Core formula types must stay independent
+//! of YAML, JSON, and other transport formats.
 
 use sempai_core::{DiagnosticCode, DiagnosticReport, SourceSpan, formula::Constraint};
 use serde_json::Value;

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -10,6 +10,11 @@
 //!   disjunction contexts are structurally invalid.
 //! - **`MissingPositiveTermInAnd`**: `And` branches must contain at least one positive
 //!   match-producing term (not `Not`, `Inside`, or `Anywhere`).
+//! - **Depth limit**: formula nesting must stay within [`MAX_FORMULA_DEPTH`].
+//!
+//! Constraint payloads attached to `where` clauses have their own validation
+//! stage. [`validate_formula`] checks the shape of the formula tree only; use
+//! [`validate_constraints`] for constraint payload semantics.
 //!
 //! # Example
 //!
@@ -25,12 +30,17 @@ use sempai_core::{
     DiagnosticCode,
     DiagnosticReport,
     SourceSpan,
-    formula::{Decorated, Formula},
+    formula::{Constraint, Decorated, Formula},
 };
 
 pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
 
-/// Validates semantic constraints on a normalized formula.
+/// Validates structural semantic constraints on a normalized formula.
+///
+/// This function validates the formula tree shape only. It does not validate
+/// `where` clause payload semantics such as whether a metavariable regular
+/// expression compiles; those checks belong in [`validate_constraints`] or the
+/// execution layer when the required matcher context is available.
 ///
 /// # Errors
 ///
@@ -48,6 +58,46 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
         tracing::warn!(code = ?diagnostic.code(), "semantic validation failed");
     }
     result
+}
+
+/// Validates semantic constraints attached to formula `where` clauses.
+///
+/// The current domain model normalizes known constraint shapes before this
+/// point, but execution-time matcher context is still required for semantic
+/// checks such as regex compilation and pattern compatibility. This hook walks
+/// every decorated formula node so those checks can be added without changing
+/// the engine pipeline.
+///
+/// # Errors
+///
+/// Currently returns `Ok(())`. Future validation should return a diagnostic
+/// report when a normalized constraint payload is semantically invalid.
+#[tracing::instrument(level = "debug", skip_all)]
+pub(crate) fn validate_constraints(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
+    validate_constraints_inner(formula)
+}
+
+fn validate_constraints_inner(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
+    for clause in &formula.where_clauses {
+        match &clause.constraint {
+            Constraint::MetavariableRegex { .. }
+            | Constraint::MetavariablePattern { .. }
+            | Constraint::Other(_) => {}
+        }
+    }
+
+    match &formula.node {
+        Formula::Atom(_) => Ok(()),
+        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
+            validate_constraints_inner(inner)
+        }
+        Formula::And(branches) | Formula::Or(branches) => {
+            for branch in branches {
+                validate_constraints_inner(branch)?;
+            }
+            Ok(())
+        }
+    }
 }
 
 fn validate_formula_inner(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -133,7 +133,7 @@ where
 }
 
 fn validate_formula_inner(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    let analysis = analyze_formula_with_depth(
+    let analysis = analyse_formula_with_depth(
         formula,
         AnalysisScope {
             depth: 1,
@@ -191,12 +191,12 @@ impl<'a> AnalysisScope<'a> {
 }
 
 /// Analyses a `Not` node, marking negation and recording the first negation span.
-fn analyze_not_arm(
+fn analyse_not_arm(
     inner: &Decorated<Formula>,
     scope: AnalysisScope<'_>,
     formula_span: Option<&SourceSpan>,
 ) -> Result<FormulaAnalysis, DiagnosticReport> {
-    let mut analysis = analyze_formula_with_depth(
+    let mut analysis = analyse_formula_with_depth(
         inner,
         scope.child_with_fallback(formula_span.or(scope.fallback_span)),
     )?;
@@ -207,12 +207,12 @@ fn analyze_not_arm(
 }
 
 /// Analyses an `Inside` or `Anywhere` node (no negation tracking).
-fn analyze_inside_anywhere_arm(
+fn analyse_inside_anywhere_arm(
     inner: &Decorated<Formula>,
     scope: AnalysisScope<'_>,
     formula_span: Option<&SourceSpan>,
 ) -> Result<FormulaAnalysis, DiagnosticReport> {
-    let mut analysis = analyze_formula_with_depth(
+    let mut analysis = analyse_formula_with_depth(
         inner,
         scope.child_with_fallback(formula_span.or(scope.fallback_span)),
     )?;
@@ -222,12 +222,12 @@ fn analyze_inside_anywhere_arm(
 
 /// Analyses a conjunction (`And`) node and attaches a
 /// `MissingPositiveTermInAnd` site when no positive descendant is found.
-fn analyze_and_arm(
+fn analyse_and_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
     scope: AnalysisScope<'_>,
 ) -> Result<FormulaAnalysis, DiagnosticReport> {
-    let mut analysis = analyze_branches(
+    let mut analysis = analyse_branches(
         branches,
         scope.child_with_fallback(formula.span.as_ref().or(scope.fallback_span)),
     )?;
@@ -245,7 +245,7 @@ fn analyze_and_arm(
 
 /// Analyses a disjunction (`Or`) node and attaches an `InvalidNotInOr` site
 /// the first time a branch containing a `Not` is encountered.
-fn analyze_or_arm(
+fn analyse_or_arm(
     formula: &Decorated<Formula>,
     branches: &[Decorated<Formula>],
     scope: AnalysisScope<'_>,
@@ -254,7 +254,7 @@ fn analyze_or_arm(
     let child_fallback = formula.span.as_ref().or(scope.fallback_span);
     let child_scope = scope.child_with_fallback(child_fallback);
     for branch in branches {
-        let branch_analysis = analyze_formula_with_depth(branch, child_scope)?;
+        let branch_analysis = analyse_formula_with_depth(branch, child_scope)?;
         if branch_analysis.contains_not && analysis.invalid_not_in_or.is_none() {
             analysis.invalid_not_in_or = Some(DiagnosticSite {
                 primary_span: branch_analysis
@@ -280,7 +280,7 @@ fn analyze_or_arm(
     Ok(analysis)
 }
 
-fn analyze_formula_with_depth(
+fn analyse_formula_with_depth(
     formula: &Decorated<Formula>,
     scope: AnalysisScope<'_>,
 ) -> Result<FormulaAnalysis, DiagnosticReport> {
@@ -303,22 +303,22 @@ fn analyze_formula_with_depth(
             has_positive_term: true,
             ..FormulaAnalysis::default()
         }),
-        Formula::Not(inner) => analyze_not_arm(inner, scope, formula.span.as_ref()),
+        Formula::Not(inner) => analyse_not_arm(inner, scope, formula.span.as_ref()),
         Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            analyze_inside_anywhere_arm(inner, scope, formula.span.as_ref())
+            analyse_inside_anywhere_arm(inner, scope, formula.span.as_ref())
         }
-        Formula::And(branches) => analyze_and_arm(formula, branches, scope),
-        Formula::Or(branches) => analyze_or_arm(formula, branches, scope),
+        Formula::And(branches) => analyse_and_arm(formula, branches, scope),
+        Formula::Or(branches) => analyse_or_arm(formula, branches, scope),
     }
 }
 
-fn analyze_branches(
+fn analyse_branches(
     branches: &[Decorated<Formula>],
     scope: AnalysisScope<'_>,
 ) -> Result<FormulaAnalysis, DiagnosticReport> {
     let mut analysis = FormulaAnalysis::default();
     for branch in branches {
-        let branch_analysis = analyze_formula_with_depth(branch, scope)?;
+        let branch_analysis = analyse_formula_with_depth(branch, scope)?;
         analysis.has_positive_term |= branch_analysis.has_positive_term;
         analysis.contains_not |= branch_analysis.contains_not;
         analysis.first_negation_span = analysis

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -35,6 +35,21 @@ use sempai_core::{
 
 pub(crate) const MAX_FORMULA_DEPTH: usize = 1000;
 
+#[cfg(test)]
+thread_local! {
+    static VALIDATE_CONSTRAINTS_CALL_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_validate_constraints_call_count() {
+    VALIDATE_CONSTRAINTS_CALL_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn validate_constraints_call_count() -> usize {
+    VALIDATE_CONSTRAINTS_CALL_COUNT.with(std::cell::Cell::get)
+}
+
 /// Validates structural semantic constraints on a normalized formula.
 ///
 /// This function validates the formula tree shape only. It does not validate
@@ -77,11 +92,20 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
 /// depth has already been bounded.
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_constraints(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
+    #[cfg(test)]
+    VALIDATE_CONSTRAINTS_CALL_COUNT.with(|count| {
+        count.set(count.get().saturating_add(1));
+    });
+
     walk_formula_tree(formula, |decorated| {
         for clause in &decorated.where_clauses {
             // Exhaustiveness guard: adding a `Constraint` variant must classify
             // its future semantic validation before this stage can compile.
-            let _pending_check = pending_constraint_validation(&clause.constraint);
+            #[expect(
+                unused_variables,
+                reason = "exhaustiveness guard; semantic checks pending -- see issue #152"
+            )]
+            let pending_check = pending_constraint_validation(&clause.constraint);
         }
         Ok(())
     })

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -74,26 +74,58 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
 /// report when a normalized constraint payload is semantically invalid.
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_constraints(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    validate_constraints_inner(formula)
+    walk_formula_tree(formula, |decorated| {
+        for clause in &decorated.where_clauses {
+            let _pending_check = pending_constraint_validation(&clause.constraint);
+        }
+        Ok(())
+    })
 }
 
-fn validate_constraints_inner(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
-    for clause in &formula.where_clauses {
-        match &clause.constraint {
-            Constraint::MetavariableRegex { .. }
-            | Constraint::MetavariablePattern { .. }
-            | Constraint::Other(_) => {}
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingConstraintValidation {
+    /// TODO: Validate regex syntax once diagnostics can point at the normalized
+    /// `where` clause source span.
+    RegexSyntax,
+    /// TODO: Validate pattern compatibility when matcher-language context is
+    /// available in this validation stage.
+    PatternCompatibility,
+    /// TODO: Emit unsupported-constraint diagnostics once unknown constraints
+    /// are no longer intentionally preserved for adapters.
+    UnsupportedConstraint,
+}
 
+const fn pending_constraint_validation(constraint: &Constraint) -> PendingConstraintValidation {
+    match constraint {
+        Constraint::MetavariableRegex { .. } => PendingConstraintValidation::RegexSyntax,
+        Constraint::MetavariablePattern { .. } => PendingConstraintValidation::PatternCompatibility,
+        Constraint::Other(_) => PendingConstraintValidation::UnsupportedConstraint,
+    }
+}
+
+fn walk_formula_tree<F>(formula: &Decorated<Formula>, mut visit: F) -> Result<(), DiagnosticReport>
+where
+    F: FnMut(&Decorated<Formula>) -> Result<(), DiagnosticReport>,
+{
+    walk_formula_tree_inner(formula, &mut visit)
+}
+
+fn walk_formula_tree_inner<F>(
+    formula: &Decorated<Formula>,
+    visit: &mut F,
+) -> Result<(), DiagnosticReport>
+where
+    F: FnMut(&Decorated<Formula>) -> Result<(), DiagnosticReport>,
+{
+    visit(formula)?;
     match &formula.node {
         Formula::Atom(_) => Ok(()),
         Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
-            validate_constraints_inner(inner)
+            walk_formula_tree_inner(inner, visit)
         }
         Formula::And(branches) | Formula::Or(branches) => {
             for branch in branches {
-                validate_constraints_inner(branch)?;
+                walk_formula_tree_inner(branch, visit)?;
             }
             Ok(())
         }

--- a/crates/sempai/src/semantic_check.rs
+++ b/crates/sempai/src/semantic_check.rs
@@ -72,14 +72,33 @@ pub(crate) fn validate_formula(formula: &Decorated<Formula>) -> Result<(), Diagn
 ///
 /// Currently returns `Ok(())`. Future validation should return a diagnostic
 /// report when a normalized constraint payload is semantically invalid.
+///
+/// Callers must run [`validate_formula`] first; this walker assumes formula
+/// depth has already been bounded.
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn validate_constraints(formula: &Decorated<Formula>) -> Result<(), DiagnosticReport> {
     walk_formula_tree(formula, |decorated| {
         for clause in &decorated.where_clauses {
+            // Exhaustiveness guard: adding a `Constraint` variant must classify
+            // its future semantic validation before this stage can compile.
             let _pending_check = pending_constraint_validation(&clause.constraint);
         }
         Ok(())
     })
+}
+
+#[cfg(test)]
+pub(crate) fn count_constraint_validation_visits(
+    formula: &Decorated<Formula>,
+) -> Result<(usize, usize), DiagnosticReport> {
+    let mut node_count = 0;
+    let mut where_clause_count = 0;
+    walk_formula_tree(formula, |decorated| {
+        node_count += 1;
+        where_clause_count += decorated.where_clauses.len();
+        Ok(())
+    })?;
+    Ok((node_count, where_clause_count))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/sempai/src/tests/constraint_walker_proptest.rs
+++ b/crates/sempai/src/tests/constraint_walker_proptest.rs
@@ -1,0 +1,147 @@
+//! Property tests for the constraint walker traversal.
+
+use proptest::{collection::vec, prelude::*};
+use sempai_core::{
+    SourceSpan,
+    formula::{Atom, Constraint, Decorated, Formula, PatternAtom, RegexAtom, WhereClause},
+};
+
+use crate::semantic_check::count_constraint_validation_visits;
+
+const MAX_DEPTH: u32 = 7;
+const MAX_SIZE: u32 = 48;
+const MAX_BRANCHES: u32 = 4;
+const MAX_WHERE_CLAUSES: u32 = 3;
+
+#[derive(Clone, Copy)]
+struct TreeCounts {
+    nodes: usize,
+    where_clauses: usize,
+}
+
+fn span_strategy() -> impl Strategy<Value = Option<SourceSpan>> {
+    (0_u32..1000_u32, 1_u32..20)
+        .prop_map(|(start, len)| Some(SourceSpan::new(start, start.saturating_add(len), None)))
+}
+
+fn where_clauses_strategy() -> impl Strategy<Value = Vec<WhereClause>> {
+    vec(0_u16..1000_u16, 0..=MAX_WHERE_CLAUSES as usize).prop_map(|values| {
+        values
+            .into_iter()
+            .map(|value| WhereClause {
+                constraint: Constraint::Other(format!("constraint:{value}")),
+            })
+            .collect()
+    })
+}
+
+fn text_strategy() -> impl Strategy<Value = String> {
+    vec(b'a'..=b'z', 1..=6).prop_map(|bytes| {
+        bytes
+            .into_iter()
+            .map(|byte| byte as char)
+            .collect::<String>()
+    })
+}
+
+fn atom_strategy() -> impl Strategy<Value = Atom> {
+    prop_oneof![
+        text_strategy().prop_map(|text| Atom::Pattern(PatternAtom { text })),
+        text_strategy().prop_map(|pattern| Atom::Regex(RegexAtom { pattern })),
+    ]
+}
+
+fn decorate(
+    node: Formula,
+    where_clauses: Vec<WhereClause>,
+    span: Option<SourceSpan>,
+) -> Decorated<Formula> {
+    Decorated {
+        node,
+        where_clauses,
+        as_name: None,
+        fix: None,
+        span,
+    }
+}
+
+fn formula_strategy() -> impl Strategy<Value = Decorated<Formula>> {
+    let leaf = (atom_strategy(), where_clauses_strategy(), span_strategy())
+        .prop_map(|(atom, where_clauses, span)| decorate(Formula::Atom(atom), where_clauses, span));
+
+    leaf.prop_recursive(MAX_DEPTH, MAX_SIZE, MAX_BRANCHES, |inner| {
+        let unary = (
+            0_u8..3,
+            inner.clone(),
+            where_clauses_strategy(),
+            span_strategy(),
+        )
+            .prop_map(|(variant, child, where_clauses, span)| {
+                let node = match variant {
+                    0 => Formula::Not(Box::new(child)),
+                    1 => Formula::Inside(Box::new(child)),
+                    _ => Formula::Anywhere(Box::new(child)),
+                };
+                decorate(node, where_clauses, span)
+            });
+
+        let nary = (
+            any::<bool>(),
+            vec(inner.clone(), 0..=MAX_BRANCHES as usize),
+            where_clauses_strategy(),
+            span_strategy(),
+        )
+            .prop_map(|(is_and, branches, where_clauses, span)| {
+                if is_and {
+                    decorate(Formula::And(branches), where_clauses, span)
+                } else {
+                    decorate(Formula::Or(branches), where_clauses, span)
+                }
+            });
+
+        prop_oneof![unary, nary]
+    })
+}
+
+fn count_formula_nodes(formula: &Decorated<Formula>) -> TreeCounts {
+    let mut counts = TreeCounts {
+        nodes: 1,
+        where_clauses: formula.where_clauses.len(),
+    };
+
+    match &formula.node {
+        Formula::Atom(_) => counts,
+        Formula::Not(inner) | Formula::Inside(inner) | Formula::Anywhere(inner) => {
+            let child = count_formula_nodes(inner);
+            counts.nodes += child.nodes;
+            counts.where_clauses += child.where_clauses;
+            counts
+        }
+        Formula::And(branches) | Formula::Or(branches) => {
+            for branch in branches {
+                let child = count_formula_nodes(branch);
+                counts.nodes += child.nodes;
+                counts.where_clauses += child.where_clauses;
+            }
+            counts
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        max_shrink_iters: 128,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn prop_formula_walk_counts_match_manual_formula(formula in formula_strategy()) {
+        let expected = count_formula_nodes(&formula);
+        let actual = count_constraint_validation_visits(&formula)
+            .expect("constraint walk should succeed");
+
+        prop_assert_eq!(actual.0, expected.nodes);
+        prop_assert_eq!(actual.1, expected.where_clauses);
+    }
+}

--- a/crates/sempai/src/tests/engine_integration_tests.rs
+++ b/crates/sempai/src/tests/engine_integration_tests.rs
@@ -2,7 +2,11 @@
 
 use sempai_core::formula::{Atom, Constraint, Decorated, Formula};
 
-use crate::{Engine, EngineConfig};
+use crate::{
+    Engine,
+    EngineConfig,
+    semantic_check::{reset_validate_constraints_call_count, validate_constraints_call_count},
+};
 
 fn compile_yaml(yaml: &str) -> Vec<crate::engine::QueryPlan> {
     Engine::new(EngineConfig::default())
@@ -72,4 +76,30 @@ fn compile_yaml_arc_reuse_across_languages() {
     let first = plans.first().expect("expected first plan");
     let second = plans.get(1).expect("expected second plan");
     assert!(std::ptr::eq(first.formula(), second.formula()));
+}
+
+#[test]
+fn compile_yaml_invokes_validate_constraints_for_where_clauses() {
+    let yaml = concat!(
+        "rules:\n",
+        "  - id: demo.constraints.validate\n",
+        "    message: validates constraint stage\n",
+        "    languages: [rust]\n",
+        "    severity: ERROR\n",
+        "    match:\n",
+        "      pattern: foo($X)\n",
+        "      where:\n",
+        "        - metavariable-pattern:\n",
+        "            metavariable: $X\n",
+        "            pattern: $X\n",
+    );
+
+    reset_validate_constraints_call_count();
+
+    let plans = compile_yaml(yaml);
+    assert!(!plans.is_empty());
+    let formula = plans.first().expect("should have one plan").formula();
+
+    assert_eq!(validate_constraints_call_count(), 1);
+    assert!(!formula.where_clauses.is_empty());
 }

--- a/crates/sempai/src/tests/mod.rs
+++ b/crates/sempai/src/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Unit tests for the `sempai` facade crate.
 
 mod behaviour;
+mod constraint_walker_proptest;
 mod diagnostic_snapshot_tests;
 mod engine_integration_tests;
 mod engine_tests;

--- a/crates/sempai/src/tests/semantic_validation_tests.rs
+++ b/crates/sempai/src/tests/semantic_validation_tests.rs
@@ -4,10 +4,14 @@ use rstest::rstest;
 use sempai_core::{
     DiagnosticCode,
     SourceSpan,
-    formula::{Atom, Decorated, Formula, PatternAtom},
+    formula::{Atom, Constraint, Decorated, Formula, PatternAtom, WhereClause},
 };
 
-use crate::semantic_check::validate_formula;
+use crate::semantic_check::{
+    count_constraint_validation_visits,
+    validate_constraints,
+    validate_formula,
+};
 
 fn make_pattern(text: &str) -> Decorated<Formula> {
     Decorated {
@@ -92,6 +96,23 @@ fn make_inside(inner: Decorated<Formula>) -> Decorated<Formula> {
     }
 }
 
+fn make_anywhere(inner: Decorated<Formula>) -> Decorated<Formula> {
+    Decorated {
+        node: Formula::Anywhere(Box::new(inner)),
+        where_clauses: vec![],
+        as_name: None,
+        fix: None,
+        span: None,
+    }
+}
+
+fn with_constraint(mut formula: Decorated<Formula>, name: &str) -> Decorated<Formula> {
+    formula.where_clauses = vec![WhereClause {
+        constraint: Constraint::Other(name.to_owned()),
+    }];
+    formula
+}
+
 fn sp(uri: &str, start: usize, end: usize) -> SourceSpan {
     let uri_opt = if uri.is_empty() {
         None
@@ -153,6 +174,53 @@ fn or_with_nested_not_branch_fails() {
 fn valid_and_with_positive_term_passes() {
     let formula = make_and(vec![make_pattern("foo"), make_not(make_pattern("bar"))]);
     assert!(validate_formula(&formula).is_ok());
+}
+
+#[test]
+fn validate_constraints_counts_single_node_without_where_clauses() {
+    let formula = make_pattern("foo");
+
+    validate_constraints(&formula).expect("constraint validation should pass");
+
+    assert_eq!(
+        count_constraint_validation_visits(&formula)
+            .expect("visit counting should use the constraint walker"),
+        (1, 0)
+    );
+}
+
+#[test]
+fn validate_constraints_visits_nested_nodes_and_where_clauses() {
+    let formula = with_constraint(
+        make_and(vec![
+            with_constraint(
+                make_or(vec![
+                    with_constraint(
+                        make_not(with_constraint(make_pattern("bad"), "not-pattern")),
+                        "not",
+                    ),
+                    with_constraint(make_pattern("ok"), "or-pattern"),
+                ]),
+                "or",
+            ),
+            with_constraint(
+                make_inside(with_constraint(
+                    make_anywhere(with_constraint(make_pattern("ctx"), "anywhere-pattern")),
+                    "anywhere",
+                )),
+                "inside",
+            ),
+        ]),
+        "root",
+    );
+
+    validate_constraints(&formula).expect("constraint validation should pass");
+
+    assert_eq!(
+        count_constraint_validation_visits(&formula)
+            .expect("visit counting should use the constraint walker"),
+        (8, 8)
+    );
 }
 
 #[test]

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -77,6 +77,32 @@ per-language query plans for later execution.
     per-language `QueryPlan`
   - `QueryPlan::formula()` exposure for tests and integration
 
+### Constraint boundary and validation passes
+
+`crates/sempai/src/normalize_constraints.rs` is the serialisation boundary for
+rule `where` clauses. It receives raw YAML-backed JSON values from the parser
+and converts them into `sempai_core::formula::Constraint` domain values so that
+core formula types can remain independent of transport formats.
+
+`sempai_core::formula::Constraint` currently has three variants:
+
+- `MetavariableRegex`
+- `MetavariablePattern`
+- `Other(String)`
+
+The `Other` variant is the only format-aware exception. It preserves unknown
+constraint shapes as JSON text so adapters can round-trip unsupported input,
+while any new domain variants are expected to be pure model types without
+serialisation-format concerns.
+
+Engine validation runs in two stages after normalization:
+
+- `validate_formula` checks formula-tree structure and enforces
+  `MAX_FORMULA_DEPTH`.
+- `validate_constraints` walks each decorated formula node to check constraint
+  payload semantics; it is currently a placeholder pending execution-layer
+  context, including issue `#152`.
+
 ## Configuration framework internals
 
 ### `ortho_config` v0.8.0 integration


### PR DESCRIPTION
## Summary

This branch documents and enforces the boundary between `sempai` adapter parsing
and the `sempai_core` formula domain model for issue #114.

Closes #114.

The core model already represents `WhereClause` as a domain `Constraint`, and
this branch makes that contract explicit while adding a dedicated constraint
validation stage after formula structural validation.

## Review walkthrough

- Start with [crates/sempai-core/src/formula.rs](https://github.com/leynos/weaver/blob/38f4525799d10815450b4db2b93874b09fdd6891/crates/sempai-core/src/formula.rs) to see the documented domain-level `Constraint` boundary.
- Then review [crates/sempai/src/normalize_constraints.rs](https://github.com/leynos/weaver/blob/38f4525799d10815450b4db2b93874b09fdd6891/crates/sempai/src/normalize_constraints.rs) for the YAML-backed JSON adapter boundary.
- Finish with [crates/sempai/src/semantic_check.rs](https://github.com/leynos/weaver/blob/38f4525799d10815450b4db2b93874b09fdd6891/crates/sempai/src/semantic_check.rs) and [crates/sempai/src/engine.rs](https://github.com/leynos/weaver/blob/38f4525799d10815450b4db2b93874b09fdd6891/crates/sempai/src/engine.rs) for the explicit constraint validation hook in the compilation pipeline.

## Validation

- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed, 1389 tests passed and 4 skipped.
- `cargo test -p sempai_core`: passed, 78 unit tests and 19 doctests passed.
- `cargo test -p sempai`: passed, 78 unit tests and 2 doctests passed.
- `cargo build -p sempai_core --no-default-features`: passed.
- `coderabbit review --agent`: passed with 0 findings.

## Notes

- `cargo test -p sempai-core` was not runnable because the Cargo package is
  named `sempai_core`; the equivalent package selector was used instead.
- `make fmt` currently fails on pre-existing Markdown line-length violations in
  unrelated documentation files, so only Rust formatting was retained for this
  branch.

## Summary by Sourcery

Document and enforce the separation between structural formula validation and where-clause constraint validation in the compilation pipeline.

Enhancements:
- Clarify that constraint payloads are validated separately from formula structure and document the constraint validation depth limit semantics.
- Introduce a dedicated validate_constraints pass that walks normalized formulas to support future semantic checks on where-clause constraints without altering the engine pipeline.
- Document Constraint as a domain-level type produced by the sempai adapter rather than a serialized rule fragment, reinforcing the adapter/core boundary.