### PR TITLE
Align roadmap with the roadmap grammar

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -216,6 +216,8 @@ local signals that support later read, mutation, and workflow slices. See RFC
 - [Health snapshot](rfcs/0001-o11y.md#health-snapshot)
 - [Acceptance criteria](rfcs/0001-o11y.md#acceptance-criteria)
 
+<!-- Separate the reference list above from the task checklist below. -->
+
 - [ ] 13.4.1. Define canonical daemon event names and structured fields.
   - Requires 13.2.2 and 13.2.3.
   - Success: lifecycle, request, dispatch, and listener events have stable
@@ -1066,6 +1068,8 @@ RFC 0001:
 - [metrics endpoint](rfcs/0001-o11y.md#deferred-path-optional-metrics-endpoint)
 - [options considered](rfcs/0001-o11y.md#options-considered)
 
+<!-- Separate the reference list above from the task checklist below. -->
+
 - [ ] 20.3.1. Decide whether CLI pre-daemon diagnostics need a minimal
       `tracing` subscriber.
   - Requires 13.4.6.
@@ -1096,7 +1100,7 @@ RFC 0001:
     or aggregation surface requires a follow-up RFC with local-binding,
     feature-flag, privacy, and latency rules.
 
-## Archive
+**Archive:**
 
 Historical prototype roadmap entries live in
 [`docs/archive/prototype-roadmap.md`](archive/prototype-roadmap.md). Those


### PR DESCRIPTION
## Summary

This branch aligns the roadmap with the mapsplice roadmap grammar.
Two classes of violation are fixed:

1. The trailing `## Archive` section broke the rule against unnumbered
   level-2 headings after the first numbered phase. It is an
   explanatory pointer to the archived prototype roadmap rather than a
   roadmap item, so the heading is demoted in place to a bold
   paragraph (`**Archive:**`).
2. In steps 13.4 and 20.3, the plain RFC 0001 reference-link bullets
   and the task checklists that follow them are separated only by a
   blank line, so CommonMark merges them into a single list and the
   checker stops registering the checklist items as task anchors. This
   made `Requires 13.4.1` and `Requires ... 20.3.2` resolve as dangling
   dependency anchors. An HTML comment now splits each pair of lists,
   restoring the `13.4.x` and `20.3.x` anchors while leaving the
   rendered document unchanged.

No phases, steps, tasks, numbering, or checkbox states change.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/weaver/blob/docs/roadmap-syntax/docs/roadmap.md) at steps 13.4 and 20.3 to see the two comment separators, then the demoted `**Archive:**` paragraph at the foot of the document.

## Validation

- `mapsplice append docs/roadmap.md <dummy-phase>`: exit 0 (grammar-clean)
- `bunx markdownlint-cli2 docs/roadmap.md`: 0 errors

## Notes

- The list-merging issue was reproduced against the checker with a
  minimal fixture before applying the fix; the HTML comment was chosen
  because it splits the lists without adding rendered content.
- The demoted paragraph ends with a colon so that markdownlint's MD036
  (emphasis-as-heading) rule does not fire on the bold line.

## Summary by Sourcery

Align the roadmap document with the roadmap grammar by fixing list structure around task anchors and demoting the archive section heading.

Bug Fixes:
- Restore checklist task anchors for steps 13.4 and 20.3 by preventing CommonMark from merging reference-link bullets with following task lists.

Documentation:
- Demote the trailing Archive heading to a bold paragraph so it no longer violates roadmap heading rules while keeping the content and meaning unchanged.