### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           whitaker-installer --cranelift
       - name: Lint
         run: make lint
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,39 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "20 3 * * *" # Daily, 03:20 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # All workspace crates live under crates/; there is no root src/.
+      paths: "crates/"
+      # Test infrastructure whose survivors are noise: the end-to-end
+      # harness crate, the proc-macro fixture helpers, and the
+      # feature-gated test-support modules compiled by --all-features.
+      exclude-globs: "crates/weaver-e2e/**,crates/weaver-test-macros/**,crates/sempai-core/src/test_support.rs,crates/weaver-plugins/src/capability/test_support.rs"
+      # Match the CI baseline (make test runs --all-features) so
+      # feature-gated tests run against mutants.
+      extra-args: "--all-features"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .*.sw?
 *~
 .*.un~
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie typecheck install
+.PHONY: help all clean test test-workflow-contracts build release lint fmt check-fmt markdownlint nixie typecheck install
 
 TARGET ?= weaver
 USER_CARGO := $(HOME)/.cargo/bin/cargo
@@ -33,6 +33,9 @@ clean: ## Remove build artifacts
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) $(TEST_CMD) $(TEST_FLAGS) $(BUILD_JOBS)
 	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc --workspace --all-features
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 target/%/$(TARGET): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(filter release,$*),--release) --bin $(TARGET)

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,149 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; weaver's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the workspace paths,
+scaffolding excludes, or feature-flag configuration) fails CI on the
+pull request rather than surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The merge commit of leynos/shared-actions PR #319, matching the
+#: estate-wide template (leynos/wireframe#572). Bump both together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: the workspace lives under crates/
+#: (no root src/), the end-to-end harness and proc-macro fixture crates
+#: plus the feature-gated test-support modules are noise, and the CI
+#: baseline runs --all-features.
+EXPECTED_WITH = {
+    "paths": "crates/",
+    "exclude-globs": (
+        "crates/weaver-e2e/**,"
+        "crates/weaver-test-macros/**,"
+        "crates/sempai-core/src/test_support.rs,"
+        "crates/weaver-plugins/src/capability/test_support.rs"
+    ),
+    "extra-args": "--all-features",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump both together with the workflow"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "20 3 * * *"}], (
+        f"on.schedule must be the daily 03:20 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes the workspace paths, excludes, and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        f"jobs.mutation.with must be exactly {EXPECTED_WITH!r} (workspace "
+        f"paths, scaffolding excludes, and the CI feature baseline), got "
+        f"{with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request adds scheduled mutation testing to weaver as a thin caller of the `leynos/shared-actions` `mutation-cargo.yml` reusable workflow, pinned to `47aea18960d24f33aedc4782ec6b73e365418313`. Runs are informational only: a daily guard at 03:20 UTC mutates just the files changed within the detection window, while manual dispatch fans a full mutation of the workspace out across shards. Survivors are reported in the job summary and as artefacts; pull requests are never gated.

## Configuration for this repository

- `paths: "crates/"` — every workspace crate lives under `crates/`; there is no root `src/`, so the default prefixes would match nothing.
- `exclude-globs` — keeps test scaffolding out of the survivors table: the `weaver-e2e` end-to-end harness crate, the `weaver-test-macros` proc-macro fixture crate, and the feature-gated test-support modules `crates/sempai-core/src/test_support.rs` and `crates/weaver-plugins/src/capability/test_support.rs`, which are compiled under `--all-features`.
- `extra-args: "--all-features"` — mirrors the CI baseline (`make test` runs `--workspace --all-targets --all-features`) so feature-gated tests run against mutants.

A contract test suite (`tests/workflow_contracts/mutation_testing_test.py`) pins the caller's shape — the exact SHA, least-privilege permissions, per-ref concurrency, the cron slot, and the `with:` block — and runs in the `build-test` CI job via the new `make test-workflow-contracts` target, reusing the uv toolchain the job already installs.

## Validation

- Both workflows parse with PyYAML and pass actionlint.
- `make test-workflow-contracts`: 6 passed, including a negative test (repointing the pin at `@v1` fails the SHA assertion; restoring it returns the suite to green).

See the [caller guide](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md) and the estate template leynos/wireframe#572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
