### PR TITLE
Test the whole workspace against mutants and bump the workflow pin

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
     with:
       # All workspace crates live under crates/; there is no root src/.
       paths: "crates/"
@@ -34,6 +34,8 @@ jobs:
       # harness crate, the proc-macro fixture helpers, and the
       # feature-gated test-support modules compiled by --all-features.
       exclude-globs: "crates/weaver-e2e/**,crates/weaver-test-macros/**,crates/sempai-core/src/test_support.rs,crates/weaver-plugins/src/capability/test_support.rs"
-      # Match the CI baseline (make test runs --all-features) so
-      # feature-gated tests run against mutants.
-      extra-args: "--all-features"
+      # Match the CI baseline (make test runs --all-features across the
+      # whole workspace): feature-gated tests run against mutants, and
+      # each crate's mutants face the dependent crates' tests too,
+      # avoiding false survivors in crates covered by siblings.
+      extra-args: "--all-features --test-workspace=true"

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -21,9 +21,9 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The merge commit of leynos/shared-actions PR #319, matching the
-#: estate-wide template (leynos/wireframe#572). Bump both together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: The pinned leynos/shared-actions commit; this revision preserves
+#: shard artefacts on timeout. Bump the workflow and this test together.
+PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
@@ -32,7 +32,8 @@ EXPECTED_USES = (
 #: The exact caller configuration: the workspace lives under crates/
 #: (no root src/), the end-to-end harness and proc-macro fixture crates
 #: plus the feature-gated test-support modules are noise, and the CI
-#: baseline runs --all-features.
+#: baseline runs --all-features across the whole workspace (so mutants
+#: face the dependent crates' tests too).
 EXPECTED_WITH = {
     "paths": "crates/",
     "exclude-globs": (
@@ -41,7 +42,7 @@ EXPECTED_WITH = {
         "crates/sempai-core/src/test_support.rs,"
         "crates/weaver-plugins/src/capability/test_support.rs"
     ),
-    "extra-args": "--all-features",
+    "extra-args": "--all-features --test-workspace=true",
 }
 
 


### PR DESCRIPTION
## Summary

This pull request applies an estate-wide review finding (rstest-bdd#569) to weaver's mutation-testing caller. cargo-mutants runs only the mutated package's own tests by default, so workspace crates whose coverage lives in dependent crates' tests report false survivors. Weaver's CI baseline tests the whole workspace, so the caller now passes `--test-workspace=true`, making each crate's mutants face every crate's tests.

It also bumps the shared-workflow pin from `47aea18960d24f33aedc4782ec6b73e365418313` to `2b09d10192627fd6e1034e7c12625dd266b45503`; the new revision preserves shard artefacts when a leg times out.

## Changes

- `.github/workflows/mutation-testing.yml`: `extra-args` becomes `"--all-features --test-workspace=true"` and the `uses:` pin moves to `2b09d101`.
- `tests/workflow_contracts/mutation_testing_test.py`: `PINNED_SHA` and the expected `with:` block updated to match.

## Validation

- The workflow parses with PyYAML and passes actionlint.
- `make test-workflow-contracts`: 6 passed, including a negative test (repointing the pin at `@v1` fails the SHA assertion; restoring it returns the suite to green).

See the [caller guide](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md) and the estate template leynos/wireframe#572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
