### PR TITLE
Scope the recording tracing subscriber to fix the mutation baseline

### DIFF
--- a/crates/weaverd/src/dispatch/handler/tests.rs
+++ b/crates/weaverd/src/dispatch/handler/tests.rs
@@ -16,7 +16,13 @@ mod receive_request_tests;
 #[path = "tests_helpers.rs"]
 mod tests_helpers;
 
-use tests_helpers::{HandlerTestHarness, capture_events, harness};
+use tests_helpers::{
+    BackendManagerFixture,
+    HandlerTestHarness,
+    backend_manager,
+    capture_events,
+    harness,
+};
 
 use super::{
     structured_event::{format_structured_event, serialize_structured_event},
@@ -268,6 +274,35 @@ fn emit_structured_event_returns_payload_without_sensitive_request_data() {
     let emitted_value = serde_json::from_str::<serde_json::Value>(emitted_payload)
         .expect("emitted payload should be JSON");
     assert_eq!(emitted_value["patch"], serde_json::json!("<redacted>"));
+}
+
+#[rstest]
+fn capture_events_records_server_thread_events(
+    backend_manager: Result<BackendManagerFixture, String>,
+) -> Result<(), String> {
+    let mut outcome: Result<(), String> = Ok(());
+    let events = capture_events(|| {
+        outcome = (|| {
+            let mut harness = tests_helpers::harness(backend_manager)?;
+            harness.send_and_collect(
+                b"{\"command\":{\"domain\":\"observe\",\"operation\":\"get-definition\"}}\n",
+            )?;
+            harness.join()
+        })();
+    });
+    outcome?;
+
+    assert!(
+        events.iter().any(|event| {
+            event.target == DISPATCH_TARGET
+                && event
+                    .fields
+                    .get("event")
+                    .is_some_and(|value| value == "dispatching_request")
+        }),
+        "expected a server-emitted dispatching_request event; captured: {events:?}",
+    );
+    Ok(())
 }
 
 #[test]

--- a/crates/weaverd/src/dispatch/handler/tests_helpers.rs
+++ b/crates/weaverd/src/dispatch/handler/tests_helpers.rs
@@ -184,7 +184,7 @@ where
 /// Use this helper when asserting on structured dispatch logging without wiring
 /// a bespoke subscriber in each test. The recording layer is installed as a
 /// scoped dispatcher rather than the process-wide default, so parallel tests
-/// (and the daemon's own telemetry initialisation) never contend for the
+/// (and the daemon's own telemetry initialization) never contend for the
 /// global dispatcher. Threads spawned inside `action` via [`harness`] inherit
 /// the recording dispatcher, so events emitted by the server thread are
 /// captured as well as events emitted on the calling thread.

--- a/crates/weaverd/src/dispatch/handler/tests_helpers.rs
+++ b/crates/weaverd/src/dispatch/handler/tests_helpers.rs
@@ -8,16 +8,18 @@ use std::{
     collections::BTreeMap,
     io::{BufRead, BufReader, Write},
     net::{SocketAddr, TcpListener, TcpStream},
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex},
     thread::{self, JoinHandle},
 };
 
 use rstest::fixture;
 use tempfile::TempDir;
 use tracing::{
+    Dispatch,
     Event,
     Level,
     Subscriber,
+    dispatcher,
     field::{Field, Visit},
 };
 use tracing_subscriber::{
@@ -31,10 +33,6 @@ use weaver_config::{CapabilityMatrix, Config, SocketEndpoint};
 
 use super::*;
 use crate::{backends::FusionBackends, semantic_provider::SemanticBackendProvider};
-
-static CAPTURED_EVENTS: OnceLock<Arc<Mutex<Vec<CapturedEvent>>>> = OnceLock::new();
-static CAPTURE_WINDOW_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-static RECORDING_SUBSCRIBER_INSTALLED: OnceLock<()> = OnceLock::new();
 
 /// Backend manager test fixture that keeps socket paths alive.
 pub(crate) struct BackendManagerFixture {
@@ -184,9 +182,12 @@ where
 /// Runs `action` while recording all emitted tracing events.
 ///
 /// Use this helper when asserting on structured dispatch logging without wiring
-/// a bespoke subscriber in each test. The recording layer is installed as the
-/// process-wide test subscriber, so events emitted by the server thread spawned
-/// by [`harness`] are captured as well as events emitted on the calling thread.
+/// a bespoke subscriber in each test. The recording layer is installed as a
+/// scoped dispatcher rather than the process-wide default, so parallel tests
+/// (and the daemon's own telemetry initialisation) never contend for the
+/// global dispatcher. Threads spawned inside `action` via [`harness`] inherit
+/// the recording dispatcher, so events emitted by the server thread are
+/// captured as well as events emitted on the calling thread.
 ///
 /// # Examples
 ///
@@ -197,52 +198,24 @@ where
 /// assert_eq!(events.len(), 1);
 /// ```
 pub(crate) fn capture_events(action: impl FnOnce()) -> Vec<CapturedEvent> {
-    let _capture_window = capture_window_mutex()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let events = captured_events();
-    clear_events(&events);
-    install_recording_subscriber(&events);
-    action();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = Registry::default().with(RecordingLayer {
+        events: Arc::clone(&events),
+    });
+    dispatcher::with_default(&Dispatch::new(subscriber), action);
     let mut events = events
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     events.drain(..).collect()
 }
 
-fn captured_events() -> Arc<Mutex<Vec<CapturedEvent>>> {
-    CAPTURED_EVENTS
-        .get_or_init(|| Arc::new(Mutex::new(Vec::new())))
-        .clone()
-}
-
-fn capture_window_mutex() -> &'static Mutex<()> {
-    CAPTURE_WINDOW_MUTEX.get_or_init(|| Mutex::new(()))
-}
-
-fn clear_events(events: &Arc<Mutex<Vec<CapturedEvent>>>) {
-    events
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .clear();
-}
-
-fn install_recording_subscriber(events: &Arc<Mutex<Vec<CapturedEvent>>>) {
-    RECORDING_SUBSCRIBER_INSTALLED.get_or_init(|| {
-        let subscriber = Registry::default().with(RecordingLayer {
-            events: Arc::clone(events),
-        });
-        if let Err(error) = tracing::subscriber::set_global_default(subscriber) {
-            panic!("failed to set global tracing subscriber: {error}");
-        }
-    });
-}
-
 /// Creates a connected dispatch handler harness with a temporary workspace.
 ///
 /// The returned harness owns the temporary directory for the listener,
 /// workspace root, and runtime socket path so tests can interact with the
-/// handler over a real TCP connection.
+/// handler over a real TCP connection. The server thread inherits the
+/// spawning thread's tracing dispatcher, so a harness created inside
+/// [`capture_events`] records events emitted while handling the connection.
 #[fixture]
 pub(crate) fn harness(
     backend_manager: Result<BackendManagerFixture, String>,
@@ -253,8 +226,10 @@ pub(crate) fn harness(
     let workspace_root = temp_dir.path().join("weaverd-test-workspace");
     let endpoint = temp_dir.path().join("weaverd-test/socket.sock");
     let runtime_dir = temp_dir.path().to_path_buf();
+    let dispatch = dispatcher::get_default(Dispatch::clone);
 
     let server_handle = thread::spawn(move || {
+        let _dispatch_guard = dispatcher::set_default(&dispatch);
         let (stream, _) = listener
             .accept()
             .map_err(|error| format!("accept: {error}"))?;


### PR DESCRIPTION
Closes #183.

## Summary

The `weaverd` mutation-testing baseline fails under plain `cargo test` because two parties race to claim the process-wide tracing dispatcher: the dispatch handler test helper (`install_recording_subscriber`) and `telemetry::initialise`, both calling `tracing::subscriber::set_global_default`. Under cargo-nextest (one process per test) the contention never surfaces; under plain `cargo test` — the runner cargo-mutants uses — the recording subscriber wins the race and six bootstrap tests fail with `SetGlobalDefaultError`, with `tests::process_behaviour::daemon_process` timing out as a knock-on.

This change removes the test helper's claim on the global dispatcher entirely. `capture_events` now builds a fresh event store per call and enters the recording subscriber as a scoped dispatcher via `tracing::dispatcher::with_default`, and the `harness` fixture propagates the spawning thread's dispatcher into its server thread so events emitted while handling a connection are still captured when the harness is created inside a capture window. `telemetry::install_subscriber` is untouched and remains the sole claimant of the global default, preserving production error semantics.

## Review walkthrough

- [`crates/weaverd/src/dispatch/handler/tests_helpers.rs`](https://github.com/leynos/weaver/blob/fix-mutation-baseline/crates/weaverd/src/dispatch/handler/tests_helpers.rs)
  - `capture_events` builds a per-call `Arc<Mutex<Vec<CapturedEvent>>>` and runs the action under `dispatcher::with_default`, replacing the global installation.
  - The `CAPTURED_EVENTS`, `CAPTURE_WINDOW_MUTEX`, and `RECORDING_SUBSCRIBER_INSTALLED` once-cells, the capture-window lock, and `install_recording_subscriber`/`captured_events`/`capture_window_mutex`/`clear_events` are deleted — per-call state makes the serialisation unnecessary.
  - `harness` captures the current dispatcher with `dispatcher::get_default(Dispatch::clone)` and enters it in the server thread with `dispatcher::set_default`, so scoped capture still observes server-side events.

## Validation

- `cargo test --workspace --all-features`: three consecutive runs, all green (previously 7 failures in the `weaverd` lib binary; now 289 passed, 0 failed). This matches the cargo-mutants baseline invocation.
- `make all` (check-fmt, clippy `-D warnings`, `cargo nextest run --workspace --all-targets --all-features`): green — 1465 tests passed, 4 skipped.

No caller-config change is needed: the failure was purely dispatcher contention in the test helper.
