### PR TITLE
Wire CodeScene coverage upload and ratchet

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Build weaver-cli
       - name: Build weaver-cli release binary
-        uses: leynos/shared-actions/.github/actions/rust-build-release@8c8e8a38f1f9a783ba7e25ba2c0f9bfda5bf2cb3
+        uses: leynos/shared-actions/.github/actions/rust-build-release@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           target: ${{ inputs.target }}
           bin-name: weaver
@@ -64,7 +64,7 @@ jobs:
 
       # Build weaverd
       - name: Build weaverd release binary
-        uses: leynos/shared-actions/.github/actions/rust-build-release@8c8e8a38f1f9a783ba7e25ba2c0f9bfda5bf2cb3
+        uses: leynos/shared-actions/.github/actions/rust-build-release@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           target: ${{ inputs.target }}
           bin-name: weaverd
@@ -73,7 +73,7 @@ jobs:
       # Linux packaging
       - name: Package weaver-cli for Linux
         if: inputs.platform == 'linux'
-        uses: leynos/shared-actions/.github/actions/linux-packages@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/linux-packages@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           project-dir: .
           package-name: weaver-cli
@@ -90,7 +90,7 @@ jobs:
 
       - name: Package weaverd for Linux
         if: inputs.platform == 'linux'
-        uses: leynos/shared-actions/.github/actions/linux-packages@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/linux-packages@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           project-dir: .
           package-name: weaverd
@@ -135,7 +135,7 @@ jobs:
       - name: Stage weaver-cli artefacts for macOS
         if: inputs.platform == 'macos'
         id: stage-weaver-cli
-        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           config-file: .github/release-staging.toml
           target: ${{ steps.macos-target.outputs.target }}
@@ -143,7 +143,7 @@ jobs:
       - name: Build weaver-cli macOS installer package
         if: inputs.platform == 'macos'
         id: package-weaver-cli-macos
-        uses: leynos/shared-actions/.github/actions/macos-package@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/macos-package@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           name: weaver-cli
           identifier: ${{ env.MAC_IDENTIFIER }}.cli
@@ -167,7 +167,7 @@ jobs:
       - name: Stage weaverd artefacts for macOS
         if: inputs.platform == 'macos'
         id: stage-weaverd
-        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           config-file: .github/release-staging-weaverd.toml
           target: ${{ steps.macos-target.outputs.target }}
@@ -175,7 +175,7 @@ jobs:
       - name: Build weaverd macOS installer package
         if: inputs.platform == 'macos'
         id: package-weaverd-macos
-        uses: leynos/shared-actions/.github/actions/macos-package@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/macos-package@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           name: weaverd
           identifier: ${{ env.MAC_IDENTIFIER }}.daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
       WHITAKER_INSTALLER_REV: f768c2e53c47df13658af1168a67851d388750bf
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         run: make check-fmt
       - name: Markdown lint
@@ -62,16 +64,22 @@ jobs:
       - name: Workflow contract tests
         run: make test-workflow-contracts
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@d0fd973d07088c2120329a93035a5ba91e077014
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 71837 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro hit the byte-identical error). The
+      # bespoke `mode: upload` step that used to run here is removed too:
+      # CodeScene only accepts uploads for branches it analyses (main),
+      # so running it on pull-request heads would fail once the access
+      # token is set. Uploads now happen only from coverage-main.yml on
+      # push to main. Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the
+      # gate is confirmed to resolve, or once CodeScene confirms the
+      # project's coverage gate is enabled.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,43 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push (or on manual dispatch,
+# to re-run the upload without waiting for a new commit); pull requests
+# only run the test-and-coverage step in ci.yml, with no CodeScene
+# upload. This workflow also advances the coverage ratchet baseline:
+# caches saved on main are readable by every pull-request run, so the
+# baseline written here is the one ci.yml's ratchet check compares
+# against.
+
+'on':
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # All workspace crates live under crates/; there is no root src/.
       paths: "crates/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,13 +57,13 @@ jobs:
         run: echo "value=${GITHUB_REPOSITORY#*/}" >>"$GITHUB_OUTPUT"
       - id: release_modes
         name: Determine release modes
-        uses: leynos/shared-actions/.github/actions/determine-release-modes@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/determine-release-modes@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           dry-run: ${{ inputs.dry-run }}
           publish: ${{ inputs.publish }}
       - id: ensure_version
         name: Read package version from Cargo.toml
-        uses: leynos/shared-actions/.github/actions/ensure-cargo-version@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/ensure-cargo-version@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs.should-publish) }}
           manifests: crates/weaver-cli/Cargo.toml
@@ -150,7 +150,7 @@ jobs:
           pattern: ${{ needs.metadata.outputs.repo_name }}-*
       - id: upload_assets
         name: Upload artefacts to release
-        uses: leynos/shared-actions/.github/actions/upload-release-assets@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
+        uses: leynos/shared-actions/.github/actions/upload-release-assets@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: weaver

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -21,9 +21,11 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The pinned leynos/shared-actions commit; this revision preserves
-#: shard artefacts on timeout. Bump the workflow and this test together.
-PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
+#: The pinned commit of leynos/shared-actions (shared-actions#334, which
+#: adds the `mode: check` coverage gate used by the CodeScene coverage
+#: rollout; the estate keeps a single repo-wide pin). Bump the workflow
+#: and this test together.
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

- Bump every `leynos/shared-actions` pin in this repository to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (shared-actions#334, which
  builds on #333), fixing the `upload-codescene-coverage` tool
  installer and adding the `mode: check` coverage gate for a future
  fast-follow.
- Check out with `fetch-depth: 0` in `ci.yml` and enable the coverage
  ratchet (`with-ratchet: 'true'`), ready for that fast-follow.
- Remove `ci.yml`'s existing bespoke "Upload coverage data to
  CodeScene" step. It ran with the action's default mode (upload) on
  every pull-request head; CodeScene only accepts uploads for branches
  it analyses (`main`), so once `CS_ACCESS_TOKEN` is set that step
  would fail on every PR. A comment documents why the `mode: check`
  gate is not wired in yet either (see below).
- Add
  [`coverage-main.yml`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml),
  which uploads coverage (`mode: upload`, the default) on every push to
  `main`, and on manual dispatch, and writes the ratchet baseline that
  pull-request runs will compare against once the ratchet is exercised
  (caches saved on `main` are readable by every PR; caches saved by a
  PR are scoped to that PR branch, so the baseline must be written on
  `main`).
- Set `CS_ACCESS_TOKEN` in both the Actions and Dependabot secret
  stores so guarded steps run under both trigger types (done
  immediately before merge, once this PR's head no longer runs the old
  unguarded upload step).
- Update the mutation-testing workflow contract test's pinned SHA to
  match the repo-wide pin bump.

CodeScene project 71837 has no coverage-gates configuration yet, so
`cs-coverage check` would fail every run with "HTTP call succeeded, but
the received project-config isn't valid. Lacks the gates
configuration." — a CodeScene-side per-project setting, not a CI
defect (`leynos/ddlint` and `leynos/chutoro` hit the byte-identical
error). Wiring the check step now would turn the required `build-test`
check permanently red, so it is left documented in a comment and
deferred to a fast-follow PR once the gate resolves.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/.github/workflows/ci.yml) —
  pin bump, `fetch-depth: 0`, ratchet, removal of the bespoke upload
  step, and a comment documenting the deferred `mode: check` gate.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml) —
  new push-to-main (and manual-dispatch) upload workflow, modelled on
  [mxd#362](https://github.com/leynos/mxd/pull/362) and
  [ddlint#287](https://github.com/leynos/ddlint/pull/287).
- [`.github/workflows/build-and-package.yml`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/.github/workflows/build-and-package.yml),
  [`.github/workflows/release.yml`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/.github/workflows/release.yml),
  [`.github/workflows/dependabot-automerge.yml`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml),
  and
  [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml) —
  pin bump only, no behavioural change (single repo-wide
  `shared-actions` pin).
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/weaver/blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py) —
  pinned-SHA contract updated alongside the workflow it checks.

Note for reviewers: the `CodeScene Code Coverage` check the CodeScene
GitHub App posts is not a required check in this repository's ruleset
— it feeds the overall commit-status rollup instead, which is what
Dependabot's automerge gate reads. A stuck or timed-out CodeScene
check can therefore silently block automerge without appearing in the
required-checks list. This change keeps the PR side free of any step
that could time out or fail against CodeScene, while wiring the
main-branch upload so the project's dashboard and future gate have
real data to work from. Enabling CodeScene's coverage gate itself is a
CodeScene-side, per-project setting this PR cannot flip.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(...))"` for every
  workflow file under `.github/workflows/`.
- `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
  tests/workflow_contracts -q` — 6 passed.
- The repo's full build/lint/test suite was not run locally per the
  rollout's execution mechanics (shared, heavy machine); this PR's own
  CI head is the validation surface for the coverage job.

## Summary by Sourcery

Wire CodeScene coverage uploads and ratchet baseline into CI while aligning workflow pins to the latest shared-actions revision.

Build:
- Add a coverage-main workflow that generates coverage on main, uploads it to CodeScene, and advances the coverage ratchet baseline.
- Bump all leynos/shared-actions workflow and action pins across CI, build-and-package, release, dependabot-automerge, and mutation-testing to a single updated commit.

CI:
- Enable full-history checkout in ci.yml to support CodeScene coverage ratchet.
- Remove the bespoke CodeScene coverage upload step from pull-request CI runs and document the deferred coverage-gate check.

Tests:
- Update the mutation-testing workflow contract test to track the new shared-actions pinned SHA.