### PR TITLE
Stop pinning the mutation-cargo SHA in the workflow contract test

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -45,6 +45,41 @@ repository's 400-line limit.
 
 The workspace targets `ortho_config` v0.8.0 and Rust 1.88.
 
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Adding or renaming public commands
 
 ADR 007 makes the 0.1.0 public command surface resource-first and generated

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,16 +3,21 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; weaver's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the pin
-at a branch, widening permissions, or losing the workspace paths,
-scaffolding excludes, or feature-flag configuration) fails CI on the
-pull request rather than surfacing in a scheduled or manual run.
+PyYAML and assert the contract it must uphold: the caller references the
+correct reusable workflow at a commit SHA (not a mutable branch or tag),
+and retains its permissions, triggers, and `with:` configuration. Drift
+(repointing the pin at a branch, widening permissions, or losing the
+workspace paths, scaffolding excludes, or feature-flag configuration)
+fails CI on the pull request rather than surfacing in a scheduled or
+manual run. Dependabot owns the pinned SHA's value; these tests do not
+assert which SHA is pinned.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,14 +26,8 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The pinned commit of leynos/shared-actions (shared-actions#334, which
-#: adds the `mode: check` coverage gate used by the CodeScene coverage
-#: rollout; the estate keeps a single repo-wide pin). Bump the workflow
-#: and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: the workspace lives under crates/
@@ -71,25 +70,19 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml pinned to a 40-hex commit SHA.
+
+    Dependabot owns the pinned SHA's value, so this only asserts the
+    shape of the pin (correct reusable workflow path, full commit SHA,
+    not a mutable branch or tag), not which SHA is pinned.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump both together with the workflow"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The mutation-testing workflow contract test pinned the caller's `uses:` ref to one exact `leynos/shared-actions` commit SHA, so every Dependabot bump of the caller failed CI until a human hand-edited the constant.
- Replaced the exact-SHA equality assertion with a shape assertion: the caller must reference `mutation-cargo.yml` at the correct path, pinned to a full 40-hex commit SHA (not a branch or tag). Dependabot now owns the SHA value; the test no longer asserts which SHA is pinned.
- All other structural guards are unchanged: single `mutation` job, least-privilege permissions, empty top-level default permissions, per-ref concurrency without cancellation, schedule/dispatch triggers, and the exact `with:` block (workspace paths, excludes, feature args).
- Documented the policy in `docs/developers-guide.md` under a new "Workflow pins and Dependabot" section, so future contract tests in this repo follow the same shape-only pattern.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry with `directory: "/"`, so no dependabot configuration change was needed.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: dropped `PINNED_SHA` and `EXPECTED_USES`; added a `USES_RE` regex (`^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`); renamed and rewrote `test_uses_reference_is_pinned_to_the_documented_sha` to `test_uses_reference_is_pinned_to_a_commit_sha`, which matches the regex instead of comparing to a hard-coded string. Updated the module docstring to describe the shape contract rather than "pinning" the SHA. No other test in the file changed.
- `docs/developers-guide.md`: added the canonical "Workflow pins and Dependabot" subsection (do/don't list plus a worked example) between "Workspace baseline" and "Adding or renaming public commands".

## Validation

- `make test-workflow-contracts` — all 6 tests pass against the current pinned SHA (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`), confirming the regex matches today's value.
- Reasoned check: the regex only constrains the path and requires 40 lowercase hex characters after `@`; it places no constraint on the specific digits, so it would equally match any other 40-hex commit SHA Dependabot substitutes in a future bump.
- `make spelling` — passes (45 tests, coverage 95.44%; Typos clean over the new prose).
