### PR TITLE
Gate PR coverage on CodeScene, now that project 71837 has gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,17 +73,14 @@ jobs:
           output-path: lcov.info
           format: lcov
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 71837 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro hit the byte-identical error). The
-      # bespoke `mode: upload` step that used to run here is removed too:
-      # CodeScene only accepts uploads for branches it analyses (main),
-      # so running it on pull-request heads would fail once the access
-      # token is set. Uploads now happen only from coverage-main.yml on
-      # push to main. Add the check step in a fast-follow PR once
-      # coverage-main.yml has uploaded to main at least once and the
-      # gate is confirmed to resolve, or once CodeScene confirms the
-      # project's coverage gate is enabled.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/71837
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene has enabled the coverage-gates configuration for weaver's
  project (71837), so `cs-coverage check` no longer errors with "Lacks
  the gates configuration".
- Replace the deferred-gate comment in `ci.yml`'s `build-test` job with
  the guarded `mode: check` step, using the shared-actions pin already
  in use elsewhere in this file (`927edd4`), `format: lcov` (matching
  `generate-coverage`), and `project-url:
  https://api.codescene.io/v2/projects/71837`.
- The step is scoped to `github.event_name == 'pull_request'` and an
  empty-token guard, so `workflow_dispatch` runs and token-less forks
  skip it cleanly; `coverage-main.yml` is untouched and keeps using the
  default `mode: upload` on push to main.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/weaver/blob/codescene-mode-check/.github/workflows/ci.yml):
  the deferred-gate comment block is replaced by the real "Check
  coverage against CodeScene gates" step, placed directly after "Test
  and Measure Coverage" in `build-test`.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [x] `make test-workflow-contracts` (no assertions target the coverage
      step; all 6 tests still pass)
- [ ] Confirm on this PR's own CI run that the "Check coverage against
      CodeScene gates" step executes (not skipped) and succeeds, and
      that the `CodeScene Code Coverage` check completes.
