### PR TITLE
Point the Whitaker installer rev at v0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_REV: f768c2e53c47df13658af1168a67851d388750bf
+      WHITAKER_INSTALLER_REV: 764d5a3199fa2999ae979255e467c9d96fd65780
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:


### PR DESCRIPTION
## Summary

- Points `WHITAKER_INSTALLER_REV` at the Whitaker v0.2.6 release commit, [`764d5a3`](https://github.com/leynos/weaver/blob/bump-whitaker-installer-rev/.github/workflows/ci.yml#L16).

## Why

The previously pinned revision provisions cargo-dylint 4.1.0, whose dylint driver cannot build on the suite's nightly-2026-05-28 pin. The v0.2.6 commit provisions cargo-dylint 6.0.1, which is compatible.

## Files changed

- [`.github/workflows/ci.yml`](https://github.com/leynos/weaver/blob/bump-whitaker-installer-rev/.github/workflows/ci.yml)

## Test plan

- [ ] CI passes with the updated Whitaker installer rev.
