### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -80,6 +80,66 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy lifting
+— running `cargo-mutants`, sharding, and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole workspace, fanned out across shards; select a
+branch in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — the change-detection globs that decide whether a scheduled run has
+  anything to mutate; here `crates/`, because every workspace crate lives
+  under that directory and there is no root `src/`.
+- `exclude-globs` — test infrastructure whose surviving mutants are noise
+  rather than genuine test gaps: the end-to-end harness crate
+  (`weaver-e2e`), the proc-macro fixture helpers (`weaver-test-macros`), and
+  the feature-gated `test_support` modules in `sempai-core` and
+  `weaver-plugins`.
+- `extra-args` — `--all-features --test-workspace=true`, so the mutation run
+  matches the CI baseline (`make test` runs `--all-features` across the whole
+  workspace): feature-gated code is exercised, and each crate's mutants also
+  face the dependent crates' tests, avoiding false survivors in crates that
+  are only covered by a sibling crate's suite.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit, per the shape-only policy described
+above.
+
+Because the caller is configuration rather than code, a contract test in
+`tests/workflow_contracts/mutation_testing_test.py` pins the shape it must
+uphold, failing the pull request when the caller drifts — repointing the pin
+at a branch, widening the token scope, or dropping a configuration input —
+rather than letting the breakage surface only in a scheduled run. Run it
+locally with `make test-workflow-contracts`. The test validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block is exactly the expected configuration (the workspace
+  path, scaffolding excludes, and feature-baseline arguments above);
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.
+
 ## Adding or renaming public commands
 
 ADR 007 makes the 0.1.0 public command surface resource-first and generated


### PR DESCRIPTION
## Summary

Adds a `## Mutation-testing workflow contract tests` section to
`docs/developers-guide.md`, documenting the informational mutation-testing
caller workflow (`.github/workflows/mutation-testing.yml`, which delegates to
`leynos/shared-actions/.github/workflows/mutation-cargo.yml`) and the pytest
contract test at `tests/workflow_contracts/mutation_testing_test.py` that
pins its shape.

The section is placed immediately after the existing "Workflow pins and
Dependabot" section, since it documents a concrete application of that
general shape-only pinning policy, rather than as a new detached top-level
section.

## Details

- **Permutation**: Rust workspace (weaver's crates live under `crates/`,
  with no root `src/`; the caller mutates the whole workspace on manual
  dispatch, using `--test-workspace=true` so mutants also face dependent
  crates' tests).
- **Contract-test style**: the `uses:` pin is asserted shape-only (`USES_RE`
  matches `...@[0-9a-f]{40}`, no hard-coded SHA — Dependabot bumps freely).
  The `with:` block, by contrast, is asserted for exact equality against an
  `EXPECTED_WITH` dict, so any change to `paths`, `exclude-globs`, or
  `extra-args` requires an accompanying test edit. There is no
  `pytestmark = pytest.mark.skipif(...)` guard on the module — unlike a
  mutmut-based Python repo, weaver's mutation runner is `cargo-mutants`, so
  there is no sandbox that omits `.github/`.
- **Local run command documented**: `make test-workflow-contracts` (exists
  in the `Makefile` and simply invokes
  `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q`).
- **Roadmap/execplan tracking**: none applies. `docs/roadmap.md` and
  `docs/execplans/*` only mention "mutation" in the sense of Weaver's own
  code-mutation/refactor commands, not mutation-testing CI infrastructure.
  No task was ticked or annotated.
- **TOC/cross-link**: `docs/developers-guide.md` has no internal
  section-level table of contents to update. The top-level `docs/contents.md`
  index already links the whole file (`- [Developer's guide]
  (developers-guide.md)`), so no additional cross-link was needed.
- **Docs-lint result**: `make markdownlint` passes (spelling gate, coverage
  gate, and `markdownlint-cli2` all clean). Two `-ise` spellings copied from
  a draft template (`summarising`, `serialises`) were caught by the spelling
  gate and corrected to `-ize` per this repository's oxendict policy before
  the gate passed.

## File changed

- [`docs/developers-guide.md`](../../blob/docs/mutation-contract-tests/docs/developers-guide.md)

## Test plan

- [x] `make markdownlint` (spelling + markdownlint-cli2) — passes
- [ ] Rust/Python test suites — intentionally not run; this is a docs-only
      change per the task brief
